### PR TITLE
Portal network cross-client testing framework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  rust: circleci/rust@1.1.1
+  rust: circleci/rust@1.5.0
   win: circleci/windows@2.2.0
 jobs:
   lint-build-test:
@@ -8,7 +8,7 @@ jobs:
             Check linting with Clippy and rustfmt, build the crate, and run tests.
         executor:
             name: rust/default
-            tag: 1.52.1
+            tag: 1.55.0
         steps:
             - checkout
             - restore_cache:
@@ -34,7 +34,7 @@ jobs:
                 command: rustup component add clippy
             - run:
                 name: Run Clippy
-                command: cargo clippy --package trin -- --deny warnings
+                command: cargo clippy --all -- --deny warnings
             - rust/build:
                 release: false
                 with_cache: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethportal-peertest"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "discv5",
+ "log 0.4.14",
+ "rocksdb",
+ "structopt",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "trin-core",
+]
+
+[[package]]
 name = "ff"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,6 @@ git = "https://github.com/sigp/discv5"
 members = [
     "trin-history",
     "trin-state",
-    "trin-core"
+    "trin-core",
+    "ethportal-peertest"
 ]

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ethportal-peertest"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = "2.33.3"
+log = "0.4.14"
+rocksdb = "0.16.0"
+structopt = "0.3"
+tokio = {version = "1.8.0", features = ["full"]}
+tracing = "0.1.26"
+tracing-subscriber = "0.2.18"
+trin-core = { path = "../trin-core" }
+
+[dependencies.discv5]
+version = "0.1.0-beta.5"
+git = "https://github.com/sigp/discv5"

--- a/ethportal-peertest/README.md
+++ b/ethportal-peertest/README.md
@@ -1,0 +1,10 @@
+# ethportal-peertest
+
+Run a portal network node that you want to test and pass node's Enr as a target node argument.
+
+```sh
+cd ethportal-peertest
+
+RUST_LOG=debug cargo run -p ethportal-peertest -- --target_node enr:-IS4QBDHCSMoYoC5UziAwKSyTmMPrhMaEpaE52L8DDAkipqvZQe9fgLy2wVuuEJwO9l1KsYrRoFGCsNjylbd0CDNw60BgmlkgnY0gmlwhMCoXUSJc2VjcDI1NmsxoQJPAZUFErHK1DZYRTLjk3SCNgye9sS-MxoQI-gLiUdwc4N1ZHCCIyk
+
+```

--- a/ethportal-peertest/src/cli.rs
+++ b/ethportal-peertest/src/cli.rs
@@ -1,0 +1,58 @@
+use std::env;
+use std::ffi::OsString;
+use structopt::StructOpt;
+
+const DEFAULT_LISTEN_PORT: &str = "9876";
+const DEFAULT_WEB3_IPC_PATH: &str = "/tmp/json-rpc-peertest.ipc";
+
+#[derive(StructOpt, Debug, PartialEq)]
+#[structopt(
+    name = "ethportal-peertest",
+    version = "0.0.1",
+    about = "Testing framework for portal network peer-to-peer network calls"
+)]
+pub struct PeertestConfig {
+    #[structopt(
+        default_value(DEFAULT_LISTEN_PORT),
+        short = "p",
+        long = "listen_port",
+        help = "The UDP port to listen on."
+    )]
+    pub listen_port: u16,
+
+    #[structopt(
+        default_value(DEFAULT_WEB3_IPC_PATH),
+        long = "web3_ipc_path",
+        help = "path to json-rpc socket address over IPC"
+    )]
+    pub web3_ipc_path: String,
+
+    #[structopt(
+        short,
+        long = "target_node",
+        help = "Base64-encoded ENR's of the nodes under test"
+    )]
+    pub target_node: String,
+}
+
+impl PeertestConfig {
+    pub fn new() -> Self {
+        Self::new_from(env::args_os()).expect("Could not parse trin arguments")
+    }
+
+    pub fn new_from<I, T>(args: I) -> Result<Self, String>
+    where
+        I: Iterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        let config = Self::from_iter(args);
+
+        Ok(config)
+    }
+}
+
+impl Default for PeertestConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/ethportal-peertest/src/events.rs
+++ b/ethportal-peertest/src/events.rs
@@ -1,0 +1,109 @@
+use discv5::{Discv5Event, TalkRequest};
+use log::{debug, error, warn};
+use std::convert::TryInto;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use trin_core::portalnet::overlay::OverlayProtocol;
+use trin_core::portalnet::types::Message;
+use trin_core::portalnet::utp::UtpListener;
+
+pub const HISTORY_NETWORK: &str = "history";
+pub const STATE_NETWORK: &str = "state";
+pub const UTP_PROTOCOL: &str = "utp";
+
+pub struct PortalnetEvents {
+    pub overlay: Arc<OverlayProtocol>,
+    pub protocol_receiver: mpsc::Receiver<Discv5Event>,
+    pub utp_listener: UtpListener,
+}
+
+impl PortalnetEvents {
+    pub async fn new(overlay: Arc<OverlayProtocol>, utp_listener: UtpListener) -> Self {
+        let protocol_receiver = overlay
+            .discovery
+            .write()
+            .await
+            .discv5
+            .event_stream()
+            .await
+            .map_err(|e| e.to_string())
+            .unwrap();
+
+        Self {
+            overlay: Arc::clone(&overlay),
+            protocol_receiver,
+            utp_listener,
+        }
+    }
+
+    /// Receives a request from the talkreq handler and sends a response back
+    pub async fn process_discv5_requests(mut self) {
+        while let Some(event) = self.protocol_receiver.recv().await {
+            debug!("Got discv5 event {:?}", event);
+
+            let request = match event {
+                Discv5Event::TalkRequest(r) => r,
+                _ => continue,
+            };
+
+            match std::str::from_utf8(request.protocol()) {
+                Ok(protocol) => match protocol {
+                    HISTORY_NETWORK => {
+                        let reply = self.get_talk_req_reply(&request).await;
+
+                        if let Err(e) = request.respond(reply) {
+                            warn!("failed to send history network reply: {}", e);
+                        }
+                    }
+                    STATE_NETWORK => {
+                        let reply = self.get_talk_req_reply(&request).await;
+
+                        if let Err(e) = request.respond(reply) {
+                            warn!("failed to send state network reply: {}", e);
+                        }
+                    }
+                    UTP_PROTOCOL => {
+                        self.utp_listener
+                            .process_utp_request(request.body(), request.node_id())
+                            .await;
+                        self.process_utp_byte_stream().await
+                    }
+                    _ => {
+                        warn!("Non supported protocol : {}", protocol);
+                    }
+                },
+                Err(_) => warn!("Invalid utf8 protocol decode"),
+            }
+        }
+    }
+
+    async fn get_talk_req_reply(&self, request: &TalkRequest) -> Vec<u8> {
+        match self.overlay.process_one_request(request).await {
+            Ok(r) => Message::Response(r).to_bytes(),
+            Err(e) => {
+                error!("failed to process portal event: {}", e);
+                e.into_bytes()
+            }
+        }
+    }
+
+    // This could be handled in the UtpListener impl, but for consistency with data handling
+    // and clarity it can be put here
+    async fn process_utp_byte_stream(&mut self) {
+        for (_, conn) in self.utp_listener.utp_connections.iter_mut() {
+            let received_stream = conn.recv_data_stream.clone();
+            if received_stream.is_empty() {
+                continue;
+            }
+
+            let message_len = u32::from_be_bytes(received_stream[0..4].try_into().unwrap());
+
+            if message_len + 4 >= received_stream.len() as u32 {
+                // handle data function(&received_stream[4..(message_len + 4)]
+
+                // Removed the handled data from the buffer
+                conn.recv_data_stream = received_stream[((message_len + 4) as usize)..].to_owned();
+            }
+        }
+    }
+}

--- a/ethportal-peertest/src/lib.rs
+++ b/ethportal-peertest/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod cli;
+pub mod events;

--- a/ethportal-peertest/src/main.rs
+++ b/ethportal-peertest/src/main.rs
@@ -1,0 +1,86 @@
+use ethportal_peertest::cli::PeertestConfig;
+use ethportal_peertest::events::PortalnetEvents;
+use log::info;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use trin_core::portalnet::utp::UtpListener;
+use trin_core::portalnet::{
+    discovery::Discovery,
+    overlay::{OverlayConfig, OverlayProtocol},
+    types::{PortalnetConfig, ProtocolKind},
+    Enr, U256,
+};
+use trin_core::utils::setup_overlay_db;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    tokio::spawn(async move {
+        let peertest_config = PeertestConfig::default();
+        let portal_config = PortalnetConfig {
+            listen_port: peertest_config.listen_port,
+            ..Default::default()
+        };
+
+        let discovery = Arc::new(RwLock::new(Discovery::new(portal_config).unwrap()));
+        discovery.write().await.start().await.unwrap();
+
+        let db = Arc::new(setup_overlay_db(
+            discovery.read().await.local_enr().node_id(),
+        ));
+
+        let overlay = Arc::new(
+            OverlayProtocol::new(
+                OverlayConfig::default(),
+                Arc::clone(&discovery),
+                db,
+                U256::max_value(),
+            )
+            .await,
+        );
+
+        let utp_listener = UtpListener {
+            discovery: Arc::clone(&discovery),
+            utp_connections: HashMap::new(),
+        };
+
+        let events = PortalnetEvents::new(Arc::clone(&overlay), utp_listener).await;
+
+        tokio::spawn(events.process_discv5_requests());
+
+        let target_node: Enr = peertest_config.target_node.parse().unwrap();
+
+        // Test history and state network Ping request on target node
+        info!("Pinging {} on history network", target_node);
+        let ping_result = overlay
+            .send_ping(
+                U256::from(u64::MAX),
+                target_node.clone(),
+                ProtocolKind::History,
+            )
+            .await
+            .unwrap();
+        info!("History network Ping result: {:?}", ping_result);
+
+        info!("Pinging {} on state network", target_node);
+        let ping_result = overlay
+            .send_ping(
+                U256::from(u64::MAX),
+                target_node.clone(),
+                ProtocolKind::State,
+            )
+            .await
+            .unwrap();
+        info!("State network Ping result: {:?}", ping_result);
+
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to pause until ctrl-c");
+    })
+    .await
+    .unwrap();
+
+    Ok(())
+}


### PR DESCRIPTION
Following the discussion on https://github.com/carver/trin/issues/50, this is an experimental crate with a dummy node that sends request messages to a target node ( a node under test). A dummy peer is a minimal bare-bones node that is capable of executing request to a remote node and receive a response.

This crate may be useful for testing how a portal node responds to different network calls.

Current implementation is very primitive, it is just sending two ping requests to state and history network. This can be expanded by adding JSON-RPC API that will execute different test suite scenarios on the target node.

_JSON-RPC commands are not supported for now. I think we should first refactor the json-rpc code in `trin-core`, so we can make those parts reusable._