### PR TITLE
add a bootstrap script that starts a dummy node and test client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "devp2p"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "discv5",
+ "log 0.4.14",
+ "rocksdb",
+ "structopt",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "trin-core",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ trin-state = { path = "trin-state" }
 members = [
     "trin-state",
     "trin-history",
-    "trin-core"
+    "trin-core",
+    "devp2p"
 ]
 
 default-members = [

--- a/devp2p/Cargo.toml
+++ b/devp2p/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "devp2p"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+trin-core = { path = "../trin-core" }
+tokio = {version = "1.8.0", features = ["full"]}
+rocksdb = "0.16.0"
+log = "0.4.14"
+tracing = "0.1.26"
+tracing-subscriber = "0.2.18"
+structopt = "0.3"
+clap = "2.33.3"
+
+[dependencies.discv5]
+version = "0.1.0-beta.5"
+git = "https://github.com/sigp/discv5"

--- a/devp2p/README.md
+++ b/devp2p/README.md
@@ -2,9 +2,15 @@
 
 Run a portal network node that you want to test and pass node's Enr as a target node.
 
+## Running tests
+To test a target client against a dummy peer, do:
 ```sh
 cd devp2p
 
-TRIN_DATA_PATH="/tmp/devp2p" RUST_LOG=debug cargo run -p devp2p -- --target_node enr:-IS4QBDHCSMoYoC5UziAwKSyTmMPrhMaEpaE52L8DDAkipqvZQe9fgLy2wVuuEJwO9l1KsYrRoFGCsNjylbd0CDNw60BgmlkgnY0gmlwhMCoXUSJc2VjcDI1NmsxoQJPAZUFErHK1DZYRTLjk3SCNgye9sS-MxoQI-gLiUdwc4N1ZHCCIyk
-
+./boot.sh
 ```
+This runs a shell script which:
+1. Starts up the test client (currently, it just runs: `cargo run -p trin-state`)
+2. Grabs the test client's ENR
+3. Runs the portal network testing suite, which starts up a dummy node 
+and passes the test client ENR to connect the nodes.

--- a/devp2p/README.md
+++ b/devp2p/README.md
@@ -1,0 +1,10 @@
+# devp2p
+
+Run a portal network node that you want to test and pass node's Enr as a target node.
+
+```sh
+cd devp2p
+
+TRIN_DATA_PATH="/tmp/devp2p" RUST_LOG=debug cargo run -p devp2p -- --target_node enr:-IS4QBDHCSMoYoC5UziAwKSyTmMPrhMaEpaE52L8DDAkipqvZQe9fgLy2wVuuEJwO9l1KsYrRoFGCsNjylbd0CDNw60BgmlkgnY0gmlwhMCoXUSJc2VjcDI1NmsxoQJPAZUFErHK1DZYRTLjk3SCNgye9sS-MxoQI-gLiUdwc4N1ZHCCIyk
+
+```

--- a/devp2p/boot.sh
+++ b/devp2p/boot.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# start up target client, ie, the node you want to test
+cargo run -p trin-state &
+echo "LAUNCHING TARGET CLIENT (and grabbing ENR)"
+
+# grab the ENR of this node
+test_node_enr=$(python ipc_calls.py | cut -b 40-222)
+
+# Run the devp2p testing suite, which starts up a dummy node. Pass the ENR
+# obtained previously as a cmdln argument to connect the nodes.
+echo "STARTING DUMMY NODE & RUNNING TESTS..."
+TRIN_DATA_PATH="/tmp/devp2p" RUST_LOG=debug cargo run -p devp2p -- --target_node $test_node_enr | grep devp2p

--- a/devp2p/ipc_calls.py
+++ b/devp2p/ipc_calls.py
@@ -1,0 +1,11 @@
+import web3
+from pathlib import Path
+
+def ipc(method, params=None):
+    # put whatever path your trin ipc file is located at
+    ipc_path = Path("/tmp/trin-jsonrpc.ipc")
+    ipc_provider = web3.IPCProvider(ipc_path)
+    ipc_w3 = web3.Web3(ipc_provider)
+    return ipc_provider.make_request(method, params)
+
+print(ipc('discv5_nodeInfo'))

--- a/devp2p/src/cli.rs
+++ b/devp2p/src/cli.rs
@@ -1,0 +1,41 @@
+use std::env;
+use std::ffi::OsString;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug, PartialEq)]
+#[structopt(
+    name = "trin-devp2p2",
+    version = "0.0.1",
+    about = "Testing framework for portal network peer-to-peer network calls"
+)]
+pub struct DummyConfig {
+    #[structopt(
+        use_delimiter = true,
+        short = "tn",
+        long = "target_node",
+        help = "Base64-encoded ENR's of the nodes under test"
+    )]
+    pub target_nodes: Vec<String>,
+}
+
+impl DummyConfig {
+    pub fn new() -> Self {
+        Self::new_from(env::args_os()).expect("Could not parse trin arguments")
+    }
+
+    pub fn new_from<I, T>(args: I) -> Result<Self, String>
+    where
+        I: Iterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        let config = Self::from_iter(args);
+
+        Ok(config)
+    }
+}
+
+impl Default for DummyConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/devp2p/src/dummy_protocol.rs
+++ b/devp2p/src/dummy_protocol.rs
@@ -1,0 +1,95 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use trin_core::portalnet::discovery::{Config as DiscoveryConfig, Discovery};
+use trin_core::portalnet::protocol::PortalnetEvents;
+use trin_core::portalnet::types::{Enr, FindContent, FindNodes, Message, Ping, Request};
+use trin_core::portalnet::U256;
+use trin_core::socket;
+use trin_core::utils::get_data_dir;
+
+use discv5::Discv5ConfigBuilder;
+use rocksdb::{Options, DB};
+
+const LISTEN_PORT: u16 = 9876;
+
+#[derive(Clone)]
+pub struct DummyProtocol {
+    pub discovery: Arc<Discovery>,
+    data_radius: U256,
+}
+
+impl DummyProtocol {
+    pub async fn new() -> Result<(Self, PortalnetEvents), String> {
+        let listen_all_ips = SocketAddr::new("0.0.0.0".parse().unwrap(), LISTEN_PORT);
+        let external_addr = socket::default_local_address(LISTEN_PORT);
+
+        let config = DiscoveryConfig {
+            discv5_config: Discv5ConfigBuilder::default().build(),
+            // This is for defining the ENR:
+            listen_port: external_addr.port(),
+            listen_address: external_addr.ip(),
+            ..Default::default()
+        };
+
+        let mut discovery = Discovery::new(config).unwrap();
+        discovery.start(listen_all_ips).await?;
+
+        let protocol_receiver = discovery
+            .discv5
+            .event_stream()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let discovery = Arc::new(discovery);
+        let data_radius = U256::from(u64::MAX);
+
+        let proto = Self {
+            discovery: discovery.clone(),
+            data_radius,
+        };
+
+        let data_path = get_data_dir();
+
+        let mut db_opts = Options::default();
+        db_opts.create_if_missing(true);
+        let db = DB::open(&db_opts, data_path).unwrap();
+
+        let events = PortalnetEvents {
+            data_radius,
+            discovery,
+            protocol_receiver,
+            db,
+        };
+
+        Ok((proto, events))
+    }
+
+    pub async fn send_ping(&self, data_radius: U256, enr: Enr) -> Result<Vec<u8>, String> {
+        let enr_seq = self.discovery.local_enr().seq();
+        let msg = Ping {
+            enr_seq,
+            data_radius,
+        };
+        self.discovery
+            .send_talkreq(enr, Message::Request(Request::Ping(msg)).to_bytes())
+            .await
+    }
+
+    pub async fn send_find_nodes(&self, distances: Vec<u16>, enr: Enr) -> Result<Vec<u8>, String> {
+        let msg = FindNodes { distances };
+        self.discovery
+            .send_talkreq(enr, Message::Request(Request::FindNodes(msg)).to_bytes())
+            .await
+    }
+
+    pub async fn send_find_content(
+        &self,
+        content_key: Vec<u8>,
+        enr: Enr,
+    ) -> Result<Vec<u8>, String> {
+        let msg = FindContent { content_key };
+        self.discovery
+            .send_talkreq(enr, Message::Request(Request::FindContent(msg)).to_bytes())
+            .await
+    }
+}

--- a/devp2p/src/lib.rs
+++ b/devp2p/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod cli;
+pub mod dummy_protocol;

--- a/devp2p/src/main.rs
+++ b/devp2p/src/main.rs
@@ -1,0 +1,56 @@
+use devp2p::cli::DummyConfig;
+use devp2p::dummy_protocol::DummyProtocol;
+use log::info;
+use trin_core::portalnet::Enr;
+use trin_core::portalnet::U256;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    tokio::spawn(async move {
+        let (p2p, events) = DummyProtocol::new().await.unwrap();
+
+        tokio::spawn(events.process_discv5_requests());
+
+        let dummy_config = DummyConfig::new();
+
+        let target_enrs: Vec<Enr> = dummy_config
+            .target_nodes
+            .iter()
+            .map(|nodestr| nodestr.parse().unwrap())
+            .collect();
+
+        // Test Ping target nodes
+        for enr in &target_enrs {
+            info!("Pinging {} on portal network", enr);
+            let ping_result = p2p
+                .send_ping(U256::from(u64::MAX), enr.clone())
+                .await
+                .unwrap();
+            info!("Portal network Ping result: {:?}", ping_result);
+
+            info!("Sending FindNodes to {}", enr);
+            let nodes_result = p2p
+                .send_find_nodes(vec![122; 32], enr.clone())
+                .await
+                .unwrap();
+            info!("Got Nodes result: {:?}", nodes_result);
+
+            info!("Sending FindContent to {}", enr);
+            let content_result = p2p
+                .send_find_content(vec![100; 32], enr.clone())
+                .await
+                .unwrap();
+            info!("Got Nodes result: {:?}", content_result);
+        }
+
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to pause until ctrl-c");
+    })
+    .await
+    .unwrap();
+
+    Ok(())
+}

--- a/trin-core/src/portalnet/protocol.rs
+++ b/trin-core/src/portalnet/protocol.rs
@@ -65,10 +65,10 @@ pub struct PortalnetProtocol {
 }
 
 pub struct PortalnetEvents {
-    data_radius: U256,
-    discovery: Arc<Discovery>,
-    protocol_receiver: mpsc::Receiver<Discv5Event>,
-    db: DB,
+    pub data_radius: U256,
+    pub discovery: Arc<Discovery>,
+    pub protocol_receiver: mpsc::Receiver<Discv5Event>,
+    pub db: DB,
 }
 
 pub struct JsonRpcHandler {

--- a/trin-core/src/portalnet/types.rs
+++ b/trin-core/src/portalnet/types.rs
@@ -8,7 +8,7 @@ use ssz;
 use ssz::{Decode, DecodeError, Encode, SszDecoderBuilder, SszEncoder};
 use ssz_derive::{Decode, Encode};
 
-use super::{Enr, U256};
+pub use super::{Enr, U256};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ProtocolMessage {


### PR DESCRIPTION
I added a script that starts the test client, grabs its enr, then uses that to start testing with the dummy node. Here, I'm just assuming the test client is just an existing trin client from the codebase we have (specifically trin-state) since that is all we have to test against so far. Let me know if the test client is something different though.