### PR TITLE
Add block header structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
+
+[[package]]
 name = "bytecodec"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
@@ -550,7 +556,7 @@ checksum = "809869a1328bfb586b48c9c0f87761c47c41793a85bcb06f66074a87cafc1bcd"
 dependencies = [
  "base64",
  "bs58",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "ed25519-dalek",
  "hex",
  "k256",
@@ -581,7 +587,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5785a82b7bf7c817e2648d0159a0df29b16c2314e039b9789acc9643db86ab0a"
 dependencies = [
- "ethereum-types",
+ "ethereum-types 0.5.2",
 ]
 
 [[package]]
@@ -601,10 +607,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3932e82d64d347a045208924002930dc105a138995ccdc1479d0f05f0359f17c"
 dependencies = [
  "crunchy",
- "fixed-hash",
- "impl-rlp",
- "impl-serde",
- "tiny-keccak",
+ "fixed-hash 0.3.2",
+ "impl-rlp 0.2.1",
+ "impl-serde 0.2.3",
+ "tiny-keccak 1.5.0",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
+dependencies = [
+ "crunchy",
+ "fixed-hash 0.7.0",
+ "impl-rlp 0.3.0",
+ "impl-serde 0.3.1",
+ "tiny-keccak 2.0.2",
 ]
 
 [[package]]
@@ -614,11 +633,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b054df51e53f253837ea422681215b42823c02824bde982699d0dceecf6165a1"
 dependencies = [
  "crunchy",
- "ethbloom",
+ "ethbloom 0.6.4",
  "ethereum-types-serialize",
- "fixed-hash",
+ "fixed-hash 0.3.2",
  "serde",
  "uint 0.5.0",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd6bde671199089e601e8d47e153368b893ef885f11f365a3261ec58153c211"
+dependencies = [
+ "ethbloom 0.11.0",
+ "fixed-hash 0.7.0",
+ "impl-rlp 0.3.0",
+ "impl-serde 0.3.1",
+ "primitive-types",
+ "uint 0.9.1",
 ]
 
 [[package]]
@@ -652,6 +685,18 @@ dependencies = [
  "rand 0.5.6",
  "rustc-hex",
  "static_assertions 0.2.5",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand 0.8.4",
+ "rustc-hex",
+ "static_assertions 1.1.0",
 ]
 
 [[package]]
@@ -878,7 +923,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -983,7 +1028,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "fnv",
  "itoa",
 ]
@@ -994,7 +1039,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "http",
  "pin-project-lite",
 ]
@@ -1023,7 +1068,7 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1047,7 +1092,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "hyper",
  "native-tls",
  "tokio",
@@ -1072,6 +1117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f7280c75fb2e2fc47080ec80ccc481376923acb04501957fc38f935c3de5088"
 
 [[package]]
+name = "impl-codec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
 name = "impl-rlp"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,12 +1135,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp 0.5.0",
+]
+
+[[package]]
 name = "impl-serde"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58e3cae7e99c7ff5a995da2cf78dd0a5383740eda71d98cf7b1910c301ac69b8"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
+dependencies = [
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -1192,6 +1275,16 @@ name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+
+[[package]]
+name = "keccak-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2bd4c29270e724d3eaadf7bdc8700af4221fc0ed771b855eadcd1b98d52851"
+dependencies = [
+ "primitive-types",
+ "tiny-keccak 2.0.2",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -1539,6 +1632,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "parity-scale-codec"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8975095a2a03bbbdc70a74ab11a4f76a6d0b84680d87c68d722531b0ac28e8a9"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40dbbfef7f0a1143c5b06e0d76a6278e25dac0bc1af4be51a0fbb73f07e7ad09"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1791,29 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "primitive-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
+dependencies = [
+ "fixed-hash 0.7.0",
+ "impl-codec",
+ "impl-rlp 0.3.0",
+ "impl-serde 0.3.1",
+ "uint 0.9.1",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+dependencies = [
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -2069,7 +2211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
 dependencies = [
  "base64",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2111,7 +2253,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e54369147e3e7796c9b885c7304db87ca3d09a0a98f72843d532868675bbfba8"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "rustc-hex",
 ]
 
@@ -2524,6 +2666,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
+dependencies = [
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2560,6 +2722,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,7 +2752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg 1.0.1",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "libc",
  "memchr",
  "mio 0.7.11",
@@ -2720,13 +2891,22 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-core",
  "futures-sink",
  "log 0.4.14",
  "pin-project-lite",
  "slab",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2886,7 +3066,12 @@ dependencies = [
 name = "trin-history"
 version = "0.1.0"
 dependencies = [
+ "bytes 1.1.0",
+ "ethereum-types 0.12.0",
+ "hex",
+ "keccak-hash",
  "log 0.4.14",
+ "rlp 0.5.0",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -7,7 +7,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bytes = "1.1.0"
+ethereum-types = "0.12.0"
+hex = "0.4.3"
+keccak-hash = "0.8.0"
 log = "0.4.14"
+rlp = "0.5.0"
 tracing = "0.1.26"
 tracing-subscriber = "0.2.18"
 tokio = { version = "1.8.0", features = ["full"] }

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -9,8 +9,6 @@ use trin_core::portalnet::protocol::{
     JsonRpcHandler, PortalEndpoint, PortalnetConfig, PortalnetProtocol,
 };
 
-pub mod types;
-
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Launching trin-history...");
 

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -9,6 +9,8 @@ use trin_core::portalnet::protocol::{
     JsonRpcHandler, PortalEndpoint, PortalnetConfig, PortalnetProtocol,
 };
 
+pub mod types;
+
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Launching trin-history...");
 

--- a/trin-history/src/types/header.rs
+++ b/trin-history/src/types/header.rs
@@ -1,0 +1,187 @@
+use bytes::Bytes;
+use ethereum_types::{Bloom, H160, H256, U256};
+use keccak_hash;
+use rlp::{DecoderError, Encodable, Rlp, RlpStream};
+
+/// An Ethereum address.
+type Address = H160;
+
+/// A block header.
+#[derive(Debug, Clone)]
+pub struct Header {
+    /// Block parent hash.
+    pub parent_hash: H256,
+    /// Block uncles hash.
+    pub uncles_hash: H256,
+    /// Block author.
+    pub author: Address,
+    /// Block state root.
+    pub state_root: H256,
+    /// Block transactions root.
+    pub transactions_root: H256,
+    /// Block receipts root.
+    pub receipts_root: H256,
+    /// Block bloom filter.
+    pub log_bloom: Bloom,
+    /// Block difficulty.
+    pub difficulty: U256,
+    /// Block number.
+    pub number: u64,
+    /// Block gas limit.
+    pub gas_limit: U256,
+    /// Block gas used.
+    pub gas_used: U256,
+    /// Block timestamp.
+    pub timestamp: u64,
+    /// Block extra data.
+    pub extra_data: Bytes,
+    /// Block PoW mix hash.
+    pub mix_hash: Option<H256>,
+    /// Block PoW nonce.
+    pub nonce: Option<u64>,
+    /// Block base fee per gas. Introduced by EIP-1559.
+    pub base_fee_per_gas: Option<U256>,
+}
+
+// Based on https://github.com/openethereum/openethereum/blob/main/crates/ethcore/types/src/header.rs
+impl Header {
+    /// Returns the Keccak-256 hash of the header.
+    pub fn hash(&self) -> H256 {
+        keccak_hash::keccak(self.rlp(true))
+    }
+
+    /// Returns the RLP representation of the header.
+    fn rlp(&self, with_seal: bool) -> Bytes {
+        let mut s = RlpStream::new();
+        self.stream_rlp(&mut s, with_seal);
+        s.out().freeze()
+    }
+
+    /// Append header to RLP stream `s`, optionally `with_seal`.
+    fn stream_rlp(&self, s: &mut RlpStream, with_seal: bool) {
+        let stream_length_without_seal = if self.base_fee_per_gas.is_some() {
+            14
+        } else {
+            13
+        };
+
+        if with_seal && self.mix_hash.is_some() && self.nonce.is_some() {
+            s.begin_list(stream_length_without_seal + 2);
+        } else {
+            s.begin_list(stream_length_without_seal);
+        }
+
+        s.append(&self.parent_hash)
+            .append(&self.uncles_hash)
+            .append(&self.author)
+            .append(&self.state_root)
+            .append(&self.transactions_root)
+            .append(&self.receipts_root)
+            .append(&self.log_bloom)
+            .append(&self.difficulty)
+            .append(&self.number)
+            .append(&self.gas_limit)
+            .append(&self.gas_used)
+            .append(&self.timestamp)
+            .append(&self.extra_data);
+
+        if with_seal && self.mix_hash.is_some() && self.nonce.is_some() {
+            s.append(&self.mix_hash.unwrap())
+                .append(&self.nonce.unwrap());
+        }
+
+        if self.base_fee_per_gas.is_some() {
+            s.append(&self.base_fee_per_gas.unwrap());
+        }
+    }
+
+    /// Attempt to decode a header from RLP bytes.
+    pub fn decode_rlp(rlp: &Rlp, london_block_number: u64) -> Result<Self, DecoderError> {
+        let mut header = Header {
+            parent_hash: rlp.val_at(0)?,
+            uncles_hash: rlp.val_at(1)?,
+            author: rlp.val_at(2)?,
+            state_root: rlp.val_at(3)?,
+            transactions_root: rlp.val_at(4)?,
+            receipts_root: rlp.val_at(5)?,
+            log_bloom: rlp.val_at(6)?,
+            difficulty: rlp.val_at(7)?,
+            number: rlp.val_at(8)?,
+            gas_limit: rlp.val_at(9)?,
+            gas_used: rlp.val_at(10)?,
+            timestamp: rlp.val_at(11)?,
+            extra_data: rlp.val_at(12)?,
+            mix_hash: Some(rlp.val_at(13)?),
+            nonce: Some(rlp.val_at(14)?),
+            base_fee_per_gas: None,
+        };
+
+        if header.number >= london_block_number {
+            header.base_fee_per_gas = Some(rlp.val_at(15)?);
+        }
+
+        Ok(header)
+    }
+}
+
+impl Eq for Header {}
+
+impl PartialEq for Header {
+    fn eq(&self, other: &Self) -> bool {
+        self.parent_hash == other.parent_hash
+            && self.uncles_hash == other.uncles_hash
+            && self.author == other.author
+            && self.state_root == other.state_root
+            && self.transactions_root == other.transactions_root
+            && self.receipts_root == other.receipts_root
+            && self.log_bloom == other.log_bloom
+            && self.difficulty == other.difficulty
+            && self.number == other.number
+            && self.gas_limit == other.gas_limit
+            && self.gas_used == other.gas_used
+            && self.timestamp == other.timestamp
+            && self.extra_data == other.extra_data
+            && self.mix_hash == other.mix_hash
+            && self.nonce == other.nonce
+            && self.base_fee_per_gas == other.base_fee_per_gas
+    }
+}
+
+impl Encodable for Header {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        self.stream_rlp(s, true);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Header;
+    use hex;
+    use rlp::{self, Rlp};
+
+    // Based on https://github.com/openethereum/openethereum/blob/main/crates/ethcore/types/src/header.rs
+    #[test]
+    fn decode_and_encode_header() {
+        let header_rlp = hex::decode("f901f9a0d405da4e66f1445d455195229624e133f5baafe72b5cf7b3c36c12c8146e98b7a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347948888f1f195afa192cfee860698584c030f4c9db1a05fb2b4bfdef7b314451cb138a534d225c922fc0e5fbe25e451142732c3e25c25a088d2ec6b9860aae1a2c3b299f72b6a5d70d7f7ba4722c78f2c49ba96273c2158a007c6fdfa8eea7e86b81f5b0fc0f78f90cc19f4aa60d323151e0cac660199e9a1b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008302008003832fefba82524d84568e932a80a0a0349d8c3df71f1a48a9df7d03fd5f14aeee7d91332c009ecaff0a71ead405bd88ab4e252a7e8c2a23").unwrap();
+        let rlp = Rlp::new(&header_rlp);
+
+        let header: Header =
+            Header::decode_rlp(&rlp, u64::max_value()).expect("error decoding header");
+        let encoded_header = rlp::encode(&header);
+
+        assert_eq!(header_rlp, encoded_header);
+    }
+
+    // Based on https://github.com/openethereum/openethereum/blob/main/crates/ethcore/types/src/header.rs
+    #[test]
+    fn decode_and_encode_header_after_1559() {
+        let header_rlp = hex::decode("f901faa0d405da4e66f1445d455195229624e133f5baafe72b5cf7b3c36c12c8146e98b7a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347948888f1f195afa192cfee860698584c030f4c9db1a05fb2b4bfdef7b314451cb138a534d225c922fc0e5fbe25e451142732c3e25c25a088d2ec6b9860aae1a2c3b299f72b6a5d70d7f7ba4722c78f2c49ba96273c2158a007c6fdfa8eea7e86b81f5b0fc0f78f90cc19f4aa60d323151e0cac660199e9a1b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008302008011832fefba82524d84568e932a80a0a0349d8c3df71f1a48a9df7d03fd5f14aeee7d91332c009ecaff0a71ead405bd88ab4e252a7e8c2a2364").unwrap();
+        let rlp = Rlp::new(&header_rlp);
+
+        let header: Header =
+            Header::decode_rlp(&rlp, u64::default()).expect("error decoding header");
+        let encoded_header = rlp::encode(&header);
+
+        assert_eq!(header_rlp, encoded_header);
+    }
+}

--- a/trin-history/src/types/header.rs
+++ b/trin-history/src/types/header.rs
@@ -1,6 +1,5 @@
 use bytes::Bytes;
 use ethereum_types::{Bloom, H160, H256, U256};
-use keccak_hash;
 use rlp::{DecoderError, Encodable, Rlp, RlpStream};
 
 /// An Ethereum address.

--- a/trin-history/src/types/mod.rs
+++ b/trin-history/src/types/mod.rs
@@ -1,0 +1,1 @@
+pub mod header;


### PR DESCRIPTION
Add block header structure in a new `types` module in the `trin-history` crate. The implementation includes methods for RLP encoding and decoding. The implementation and unit tests were derived from [OpenEthereum](https://github.com/openethereum/openethereum/blob/main/crates/ethcore/types/src/header.rs).

We port the block header implementation to `trin` because the [OpenEthereum project is being deprecated](https://medium.com/openethereum/gnosis-joins-erigon-formerly-turbo-geth-to-release-next-gen-ethereum-client-c6708dd06dd).