### PR TITLE
Fix failing tests on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,9 @@ jobs:
             - rust/build:
                 release: false
                 with_cache: false
-            - rust/test:
-                with_cache: false
+            - run:
+                name: Test Trin workspace
+                command: cargo test --workspace
             - save_cache:
                 key: cargo-{{ checksum "Cargo.lock" }}-v1
                 paths:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,5 @@ trin-state = { path = "trin-state" }
 members = [
     "trin-history",
     "trin-state",
+    "trin-core"
 ]

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -175,6 +175,10 @@ mod test {
             bootnodes: vec![],
             external_addr: None,
             private_key: None,
+            networks: DEFAULT_SUBNETWORKS
+                .split(",")
+                .map(|n| n.to_string())
+                .collect(),
         };
         let actual_config = TrinConfig::new_from(["trin"].iter()).unwrap();
         assert_eq!(actual_config.web3_transport, expected_config.web3_transport);
@@ -195,6 +199,10 @@ mod test {
             web3_transport: "http".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
             bootnodes: vec![],
+            networks: DEFAULT_SUBNETWORKS
+                .split(",")
+                .map(|n| n.to_string())
+                .collect(),
         };
         let actual_config = TrinConfig::new_from(
             [
@@ -228,6 +236,10 @@ mod test {
             web3_transport: "ipc".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
             bootnodes: vec![],
+            networks: DEFAULT_SUBNETWORKS
+                .split(",")
+                .map(|n| n.to_string())
+                .collect(),
         };
         assert_eq!(actual_config.web3_transport, expected_config.web3_transport);
         assert_eq!(actual_config.web3_http_port, expected_config.web3_http_port);
@@ -257,6 +269,10 @@ mod test {
             web3_transport: "ipc".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
             bootnodes: vec![],
+            networks: DEFAULT_SUBNETWORKS
+                .split(",")
+                .map(|n| n.to_string())
+                .collect(),
         };
         assert_eq!(actual_config.web3_transport, expected_config.web3_transport);
         assert_eq!(actual_config.web3_http_port, expected_config.web3_http_port);
@@ -310,6 +326,10 @@ mod test {
             web3_transport: "ipc".to_string(),
             discovery_port: 999,
             bootnodes: vec![],
+            networks: DEFAULT_SUBNETWORKS
+                .split(",")
+                .map(|n| n.to_string())
+                .collect(),
         };
         let actual_config =
             TrinConfig::new_from(["trin", "--discovery-port", "999"].iter()).unwrap();
@@ -328,6 +348,10 @@ mod test {
             web3_transport: "ipc".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
             bootnodes: vec!["enr:-aoeu".to_string(), "enr:-htns".to_string()],
+            networks: DEFAULT_SUBNETWORKS
+                .split(",")
+                .map(|n| n.to_string())
+                .collect(),
         };
         let actual_config =
             TrinConfig::new_from(["trin", "--bootnodes", "enr:-aoeu,enr:-htns"].iter()).unwrap();
@@ -368,6 +392,10 @@ mod test {
             web3_transport: "ipc".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
             bootnodes: vec![],
+            networks: DEFAULT_SUBNETWORKS
+                .split(",")
+                .map(|n| n.to_string())
+                .collect(),
         };
         let actual_config = TrinConfig::new_from(
             [


### PR DESCRIPTION
By removing `default-members` section from the root Cargo.toml, `cargo test` in CircleCI is not able to detect all the tests in the crates.

This PR adds explicit `cargo test --workspace` command which will run tests on all workspace members in CIrcleCI pipeline. It also fixes some failing tests on master.