### PR TITLE
Overlay network refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3185,6 +3185,7 @@ dependencies = [
  "hex",
  "keccak-hash",
  "log 0.4.14",
+ "parking_lot 0.11.1",
  "rlp 0.5.0",
  "serde_json",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,8 +470,8 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.1.0-beta.9"
-source = "git+https://github.com/sigp/discv5#04e676f05f573c51dc4904a5cabbd88fa5e76267"
+version = "0.1.0-beta.10"
+source = "git+https://github.com/sigp/discv5#10247bbd299227fef20233f2f5a8de9780de09ac"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3159,7 +3159,6 @@ dependencies = [
  "ipconfig",
  "lazy_static 1.4.0",
  "log 0.4.14",
- "parking_lot 0.11.1",
  "rand 0.8.4",
  "reqwest",
  "rlp 0.5.0",
@@ -3181,12 +3180,13 @@ name = "trin-history"
 version = "0.1.0"
 dependencies = [
  "bytes 1.1.0",
+ "discv5",
  "ethereum-types 0.12.0",
  "hex",
  "keccak-hash",
  "log 0.4.14",
- "parking_lot 0.11.1",
  "rlp 0.5.0",
+ "rocksdb",
  "serde_json",
  "tokio",
  "tracing",
@@ -3198,8 +3198,10 @@ dependencies = [
 name = "trin-state"
 version = "0.1.0"
 dependencies = [
+ "discv5",
  "log 0.4.14",
  "num",
+ "rocksdb",
  "serde_json",
  "tokio",
  "tracing",

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,9 @@ use tokio::sync::mpsc;
 use trin_core::cli::TrinConfig;
 use trin_core::jsonrpc::launch_jsonrpc_server;
 use trin_core::portalnet::discovery::Discovery;
+use trin_core::portalnet::overlay::StateProtocol;
 use trin_core::portalnet::protocol::{
-    HistoryNetworkEndpoint, JsonRpcHandler, PortalEndpoint, PortalnetConfig, PortalnetProtocol,
-    StateNetworkEndpoint,
+    HistoryNetworkEndpoint, JsonRpcHandler, PortalEndpoint, PortalnetConfig, StateNetworkEndpoint,
 };
 
 #[tokio::main]
@@ -81,12 +81,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             portalnet_config.bootnode_enrs
         );
 
-        let (mut p2p, events) = PortalnetProtocol::new(discovery, portalnet_config)
+        let (mut p2p, events) = StateProtocol::new(discovery, portalnet_config)
             .await
             .unwrap();
 
         let rpc_handler = JsonRpcHandler {
-            discovery: p2p.discovery.clone(),
+            discovery: p2p.overlay.discovery.clone(),
             jsonrpc_rx,
             state_tx,
             history_tx,

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -15,7 +15,6 @@ futures = "0.3.13"
 hex = "0.4.3"
 lazy_static = "1.4.0"
 log = "0.4.14"
-parking_lot = "0.11.1"
 rand = "0.8.4"
 reqwest = { version = "0.11.0", features = ["blocking"] }
 rlp = "0.5.0"
@@ -38,5 +37,5 @@ uds_windows = "1.0.1"
 interfaces = "0.0.7"
 
 [dependencies.discv5]
-version = "0.1.0-beta.9"
+version = "0.1.0-beta.10"
 git = "https://github.com/sigp/discv5"

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -9,9 +9,11 @@ use structopt::StructOpt;
 const DEFAULT_WEB3_IPC_PATH: &str = "/tmp/trin-jsonrpc.ipc";
 const DEFAULT_WEB3_HTTP_PORT: &str = "8545";
 const DEFAULT_DISCOVERY_PORT: &str = "9000";
+pub const HISTORY_NETWORK: &str = "history";
+pub const STATE_NETWORK: &str = "state";
 const DEFAULT_SUBNETWORKS: &str = "history,state";
 
-#[derive(StructOpt, Debug, PartialEq)]
+#[derive(StructOpt, Debug, PartialEq, Clone)]
 #[structopt(
     name = "trin",
     version = "0.0.1",

--- a/trin-core/src/portalnet/discovery.rs
+++ b/trin-core/src/portalnet/discovery.rs
@@ -32,6 +32,7 @@ impl Default for Config {
 
 pub type ProtocolRequest = Vec<u8>;
 
+/// Base Node Discovery Protocol v5 layer
 pub struct Discovery {
     pub discv5: Discv5,
     /// Indicates if the discv5 service has been started

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -1,19 +1,16 @@
-use crate::utils::{setup_overlay_db, xor_two_values};
-use log::debug;
+use crate::utils::xor_two_values;
 
 use super::{
     discovery::Discovery,
-    protocol::{PortalnetConfig, PortalnetEvents, PROTOCOL},
+    protocol::PROTOCOL,
     types::{FindContent, FindNodes, Message, Ping, Request, SszEnr},
-    utp::UtpListener,
     Enr, U256,
 };
 use discv5::enr::NodeId;
 use discv5::kbucket::{Filter, KBucketsTable};
-use parking_lot::RwLock;
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::RwLock;
 
 /// Maximum number of ENRs in response to FindNodes.
 const FIND_NODES_MAX_NODES: usize = 32;
@@ -47,10 +44,10 @@ impl PartialEq for Node {
 /// Configuration parameters for the overlay network.
 #[derive(Clone)]
 pub struct OverlayConfig {
-    bucket_pending_timeout: Duration,
-    max_incoming_per_bucket: usize,
-    table_filter: Option<Box<dyn Filter<Node>>>,
-    bucket_filter: Option<Box<dyn Filter<Node>>>,
+    pub bucket_pending_timeout: Duration,
+    pub max_incoming_per_bucket: usize,
+    pub table_filter: Option<Box<dyn Filter<Node>>>,
+    pub bucket_filter: Option<Box<dyn Filter<Node>>>,
 }
 
 impl Default for OverlayConfig {
@@ -64,10 +61,13 @@ impl Default for OverlayConfig {
     }
 }
 
-/// The node state for a node in an overlay network on top of Discovery v5.
+/// Overlay protocol is a layer on top of discv5 that handles all requests from the overlay networks
+/// (state, history etc.) and dispatch them to the discv5 protocol TalkReq. Each network should
+/// implement the overlay protocol and the overlay protocol is where we can encapsulate the logic for
+/// handling common network requests/responses.
 #[derive(Clone)]
 pub struct OverlayProtocol {
-    pub discovery: Arc<Discovery>,
+    pub discovery: Arc<RwLock<Discovery>>,
     // The data radius of the local node.
     pub data_radius: Arc<RwLock<U256>>,
     // The overlay routing table of the local node.
@@ -76,17 +76,17 @@ pub struct OverlayProtocol {
 
 impl OverlayProtocol {
     /// Returns the local ENR of the node.
-    pub fn local_enr(&self) -> Enr {
-        self.discovery.discv5.local_enr()
+    pub async fn local_enr(&self) -> Enr {
+        self.discovery.read().await.discv5.local_enr()
     }
 
     // Returns the data radius of the node.
-    pub fn data_radius(&self) -> U256 {
-        self.data_radius.read().clone()
+    pub async fn data_radius(&self) -> U256 {
+        self.data_radius.read().await.clone()
     }
 
     /// Returns a vector of the ENRs of the closest nodes by the given log2 distances.
-    pub fn nodes_by_distance(&self, mut log2_distances: Vec<u64>) -> Vec<Enr> {
+    pub async fn nodes_by_distance(&self, mut log2_distances: Vec<u64>) -> Vec<Enr> {
         let mut nodes_to_send = Vec::new();
         log2_distances.sort_unstable();
         log2_distances.dedup();
@@ -94,12 +94,12 @@ impl OverlayProtocol {
         let mut log2_distances = log2_distances.as_slice();
         if let Some(0) = log2_distances.first() {
             // If the distance is 0 send our local ENR.
-            nodes_to_send.push(self.local_enr());
+            nodes_to_send.push(self.local_enr().await);
             log2_distances = &log2_distances[1..];
         }
 
         if !log2_distances.is_empty() {
-            let mut kbuckets = self.kbuckets.write();
+            let mut kbuckets = self.kbuckets.write().await;
             for node in kbuckets
                 .nodes_by_distances(&log2_distances, FIND_NODES_MAX_NODES)
                 .into_iter()
@@ -112,12 +112,13 @@ impl OverlayProtocol {
     }
 
     /// Returns list of nodes closer to content than self, sorted by distance.
-    pub fn find_nodes_close_to_content(&self, content_key: Vec<u8>) -> Vec<SszEnr> {
-        let self_node_id = self.local_enr().node_id();
+    pub async fn find_nodes_close_to_content(&self, content_key: Vec<u8>) -> Vec<SszEnr> {
+        let self_node_id = self.local_enr().await.node_id();
         let self_distance = xor_two_values(&content_key, &self_node_id.raw().to_vec());
 
         let mut nodes_with_distance: Vec<(Vec<u8>, Enr)> = self
             .table_entries_enr()
+            .await
             .into_iter()
             .map(|enr| {
                 (
@@ -140,30 +141,34 @@ impl OverlayProtocol {
     }
 
     /// Returns a vector of all ENR node IDs of nodes currently contained in the routing table.
-    pub fn table_entries_id(&self) -> Vec<NodeId> {
+    pub async fn table_entries_id(&self) -> Vec<NodeId> {
         self.kbuckets
             .write()
+            .await
             .iter()
             .map(|entry| *entry.node.key.preimage())
             .collect()
     }
 
     /// Returns a vector of all the ENRs of nodes currently contained in the routing table.
-    pub fn table_entries_enr(&self) -> Vec<Enr> {
+    pub async fn table_entries_enr(&self) -> Vec<Enr> {
         self.kbuckets
             .write()
+            .await
             .iter()
             .map(|entry| entry.node.value.enr().clone())
             .collect()
     }
 
     pub async fn send_ping(&self, data_radius: U256, enr: Enr) -> Result<Vec<u8>, String> {
-        let enr_seq = self.discovery.local_enr().seq();
+        let enr_seq = self.discovery.read().await.local_enr().seq();
         let msg = Ping {
             enr_seq,
             data_radius,
         };
         self.discovery
+            .write()
+            .await
             .send_talkreq(
                 enr,
                 PROTOCOL.to_string(),
@@ -175,6 +180,8 @@ impl OverlayProtocol {
     pub async fn send_find_nodes(&self, distances: Vec<u16>, enr: Enr) -> Result<Vec<u8>, String> {
         let msg = FindNodes { distances };
         self.discovery
+            .write()
+            .await
             .send_talkreq(
                 enr,
                 PROTOCOL.to_string(),
@@ -190,155 +197,13 @@ impl OverlayProtocol {
     ) -> Result<Vec<u8>, String> {
         let msg = FindContent { content_key };
         self.discovery
+            .write()
+            .await
             .send_talkreq(
                 enr,
                 PROTOCOL.to_string(),
                 Message::Request(Request::FindContent(msg)).to_bytes(),
             )
             .await
-    }
-}
-
-#[derive(Clone)]
-pub struct HistoryProtocol {
-    pub overlay: Arc<OverlayProtocol>,
-}
-
-#[derive(Clone)]
-pub struct StateProtocol {
-    pub overlay: Arc<OverlayProtocol>,
-}
-
-impl StateProtocol {
-    pub async fn new(
-        mut discovery: Discovery,
-        portal_config: PortalnetConfig,
-    ) -> Result<(Self, PortalnetEvents), String> {
-        let config = OverlayConfig::default();
-        let kbuckets = Arc::new(RwLock::new(KBucketsTable::new(
-            discovery.local_enr().node_id().into(),
-            config.bucket_pending_timeout,
-            config.max_incoming_per_bucket,
-            config.table_filter,
-            config.bucket_filter,
-        )));
-        let data_radius = Arc::new(RwLock::new(portal_config.data_radius));
-
-        let protocol_receiver = discovery
-            .discv5
-            .event_stream()
-            .await
-            .map_err(|e| e.to_string())
-            .unwrap();
-
-        let discovery = Arc::new(discovery);
-
-        let overlay = OverlayProtocol {
-            discovery: discovery.clone(),
-            data_radius,
-            kbuckets,
-        };
-
-        let overlay = Arc::new(overlay);
-        let db = setup_overlay_db(discovery.local_enr());
-
-        let utp_listener = UtpListener {
-            discovery: discovery.clone(),
-            utp_connections: HashMap::new(),
-        };
-
-        let events = PortalnetEvents {
-            discovery: discovery.clone(),
-            overlay: overlay.clone(),
-            protocol_receiver,
-            db,
-            utp_listener,
-        };
-
-        let proto = Self {
-            overlay: overlay.clone(),
-        };
-
-        Ok((proto, events))
-    }
-
-    /// Convenience call for testing, quick way to ping bootnodes
-    pub async fn ping_bootnodes(&mut self) -> Result<(), String> {
-        // Trigger bonding with bootnodes, at both the base layer and portal overlay.
-        // The overlay ping via talkreq will trigger a session at the base layer, then
-        // a session on the (overlay) portal network.
-        for enr in self.overlay.discovery.discv5.table_entries_enr() {
-            debug!("Pinging {} on portal network", enr);
-            let ping_result = self.overlay.send_ping(U256::from(u64::MAX), enr).await?;
-            debug!("Portal network Ping result: {:?}", ping_result);
-        }
-        Ok(())
-    }
-}
-
-impl HistoryProtocol {
-    pub async fn new(
-        mut discovery: Discovery,
-        portal_config: PortalnetConfig,
-    ) -> Result<(Self, PortalnetEvents), String> {
-        let config = OverlayConfig::default();
-        let kbuckets = Arc::new(RwLock::new(KBucketsTable::new(
-            discovery.local_enr().node_id().into(),
-            config.bucket_pending_timeout,
-            config.max_incoming_per_bucket,
-            config.table_filter,
-            config.bucket_filter,
-        )));
-        let data_radius = Arc::new(RwLock::new(portal_config.data_radius));
-
-        let protocol_receiver = discovery
-            .discv5
-            .event_stream()
-            .await
-            .map_err(|e| e.to_string())
-            .unwrap();
-
-        let discovery = Arc::new(discovery);
-
-        let overlay = OverlayProtocol {
-            discovery: discovery.clone(),
-            data_radius,
-            kbuckets,
-        };
-
-        let overlay = Arc::new(overlay);
-        let db = setup_overlay_db(discovery.local_enr());
-
-        let utp_listener = UtpListener {
-            discovery: discovery.clone(),
-            utp_connections: HashMap::new(),
-        };
-
-        let events = PortalnetEvents {
-            discovery: discovery.clone(),
-            overlay: overlay.clone(),
-            protocol_receiver,
-            db,
-            utp_listener,
-        };
-
-        let proto = Self {
-            overlay: overlay.clone(),
-        };
-
-        Ok((proto, events))
-    }
-
-    /// Convenience call for testing, quick way to ping bootnodes
-    pub async fn ping_bootnodes(&mut self) -> Result<(), String> {
-        // Trigger bonding with bootnodes, at both the base layer and portal overlay.
-        // The overlay ping via talkreq will trigger a session at the base layer, then
-        // a session on the (overlay) portal network.
-        for enr in self.overlay.discovery.discv5.table_entries_enr() {
-            debug!("Pinging {} on portal network", enr);
-            let ping_result = self.overlay.send_ping(U256::from(u64::MAX), enr).await?;
-            debug!("Portal network Ping result: {:?}", ping_result);
-        }
-        Ok(())
     }
 }

--- a/trin-core/src/portalnet/protocol.rs
+++ b/trin-core/src/portalnet/protocol.rs
@@ -13,7 +13,6 @@ use crate::{jsonrpc::Params, utils::get_data_dir};
 
 use super::{
     discovery::Discovery,
-    overlay::{Config as OverlayConfig, Overlay},
     types::{
         FindContent, FindNodes, FoundContent, HexData, Nodes, Ping, Pong, Request, Response, SszEnr,
     },
@@ -23,6 +22,8 @@ use super::{
 use super::{types::Message, Enr};
 use std::collections::HashMap;
 use std::convert::TryInto;
+use crate::portalnet::overlay::OverlayProtocol;
+use parking_lot::RwLock;
 
 type Responder<T, E> = mpsc::UnboundedSender<Result<T, E>>;
 
@@ -86,18 +87,12 @@ impl Default for PortalnetConfig {
 
 pub const PROTOCOL: &str = "portal";
 
-#[derive(Clone)]
-pub struct PortalnetProtocol {
-    pub discovery: Arc<Discovery>,
-    pub overlay: Overlay,
-}
-
 pub struct PortalnetEvents {
-    discovery: Arc<Discovery>,
-    overlay: Overlay,
-    protocol_receiver: mpsc::Receiver<Discv5Event>,
-    db: DB,
-    utp_listener: UtpListener,
+    pub discovery: Arc<Discovery>,
+    pub overlay: OverlayProtocol,
+    pub protocol_receiver: mpsc::Receiver<Discv5Event>,
+    pub db: DB,
+    pub utp_listener: UtpListener,
 }
 
 pub struct JsonRpcHandler {
@@ -310,102 +305,102 @@ impl PortalnetEvents {
     }
 }
 
-impl PortalnetProtocol {
-    pub async fn new(
-        mut discovery: Discovery,
-        portal_config: PortalnetConfig,
-    ) -> Result<(Self, PortalnetEvents), String> {
-        let protocol_receiver = discovery
-            .discv5
-            .event_stream()
-            .await
-            .map_err(|e| e.to_string())?;
-
-        let overlay = Overlay::new(
-            discovery.local_enr(),
-            portal_config.data_radius,
-            OverlayConfig::default(),
-        );
-
-        let discovery = Arc::new(discovery);
-        let data_path = get_data_dir(discovery.local_enr());
-
-        let mut db_opts = Options::default();
-        db_opts.create_if_missing(true);
-        let db = DB::open(&db_opts, data_path).unwrap();
-
-        let utp_listener = UtpListener {
-            discovery: discovery.clone(),
-            utp_connections: HashMap::new(),
-        };
-
-        let events = PortalnetEvents {
-            discovery: discovery.clone(),
-            overlay: overlay.clone(),
-            protocol_receiver,
-            db,
-            utp_listener,
-        };
-
-        let proto = Self {
-            discovery: discovery.clone(),
-            overlay: overlay.clone(),
-        };
-
-        Ok((proto, events))
-    }
-
-    pub async fn send_ping(&self, data_radius: U256, enr: Enr) -> Result<Vec<u8>, String> {
-        let enr_seq = self.discovery.local_enr().seq();
-        let msg = Ping {
-            enr_seq,
-            data_radius,
-        };
-        self.discovery
-            .send_talkreq(
-                enr,
-                PROTOCOL.to_string(),
-                Message::Request(Request::Ping(msg)).to_bytes(),
-            )
-            .await
-    }
-
-    pub async fn send_find_nodes(&self, distances: Vec<u16>, enr: Enr) -> Result<Vec<u8>, String> {
-        let msg = FindNodes { distances };
-        self.discovery
-            .send_talkreq(
-                enr,
-                PROTOCOL.to_string(),
-                Message::Request(Request::FindNodes(msg)).to_bytes(),
-            )
-            .await
-    }
-
-    pub async fn send_find_content(
-        &self,
-        content_key: Vec<u8>,
-        enr: Enr,
-    ) -> Result<Vec<u8>, String> {
-        let msg = FindContent { content_key };
-        self.discovery
-            .send_talkreq(
-                enr,
-                PROTOCOL.to_string(),
-                Message::Request(Request::FindContent(msg)).to_bytes(),
-            )
-            .await
-    }
-
-    /// Convenience call for testing, quick way to ping bootnodes
-    pub async fn ping_bootnodes(&mut self) -> Result<(), String> {
-        // Trigger bonding with bootnodes, at both the base layer and portal overlay.
-        // The overlay ping via talkreq will trigger a session at the base layer, then
-        // a session on the (overlay) portal network.
-        for enr in self.discovery.discv5.table_entries_enr() {
-            debug!("Pinging {} on portal network", enr);
-            let ping_result = self.send_ping(U256::from(u64::MAX), enr).await?;
-            debug!("Portal network Ping result: {:?}", ping_result);
-        }
-        Ok(())
-    }
-}
+// impl PortalnetProtocol {
+//     pub async fn new(
+//         mut discovery: Discovery,
+//         portal_config: PortalnetConfig,
+//     ) -> Result<(Self, PortalnetEvents), String> {
+//         let protocol_receiver = discovery
+//             .discv5
+//             .event_stream()
+//             .await
+//             .map_err(|e| e.to_string())?;
+//
+//         let overlay = Overlay::new(
+//             discovery.local_enr(),
+//             portal_config.data_radius,
+//             OverlayConfig::default(),
+//         );
+//
+//         let discovery = Arc::new(discovery);
+//         let data_path = get_data_dir(discovery.local_enr());
+//
+//         let mut db_opts = Options::default();
+//         db_opts.create_if_missing(true);
+//         let db = DB::open(&db_opts, data_path).unwrap();
+//
+//         let utp_listener = UtpListener {
+//             discovery: discovery.clone(),
+//             utp_connections: HashMap::new(),
+//         };
+//
+//         let events = PortalnetEvents {
+//             discovery: discovery.clone(),
+//             overlay: overlay.clone(),
+//             protocol_receiver,
+//             db,
+//             utp_listener,
+//         };
+//
+//         let proto = Self {
+//             discovery: discovery.clone(),
+//             overlay: overlay.clone(),
+//         };
+//
+//         Ok((proto, events))
+//     }
+//
+//     pub async fn send_ping(&self, data_radius: U256, enr: Enr) -> Result<Vec<u8>, String> {
+//         let enr_seq = self.discovery.local_enr().seq();
+//         let msg = Ping {
+//             enr_seq,
+//             data_radius,
+//         };
+//         self.discovery
+//             .send_talkreq(
+//                 enr,
+//                 PROTOCOL.to_string(),
+//                 Message::Request(Request::Ping(msg)).to_bytes(),
+//             )
+//             .await
+//     }
+//
+//     pub async fn send_find_nodes(&self, distances: Vec<u16>, enr: Enr) -> Result<Vec<u8>, String> {
+//         let msg = FindNodes { distances };
+//         self.discovery
+//             .send_talkreq(
+//                 enr,
+//                 PROTOCOL.to_string(),
+//                 Message::Request(Request::FindNodes(msg)).to_bytes(),
+//             )
+//             .await
+//     }
+//
+//     pub async fn send_find_content(
+//         &self,
+//         content_key: Vec<u8>,
+//         enr: Enr,
+//     ) -> Result<Vec<u8>, String> {
+//         let msg = FindContent { content_key };
+//         self.discovery
+//             .send_talkreq(
+//                 enr,
+//                 PROTOCOL.to_string(),
+//                 Message::Request(Request::FindContent(msg)).to_bytes(),
+//             )
+//             .await
+//     }
+//
+//     /// Convenience call for testing, quick way to ping bootnodes
+//     pub async fn ping_bootnodes(&mut self) -> Result<(), String> {
+//         // Trigger bonding with bootnodes, at both the base layer and portal overlay.
+//         // The overlay ping via talkreq will trigger a session at the base layer, then
+//         // a session on the (overlay) portal network.
+//         for enr in self.discovery.discv5.table_entries_enr() {
+//             debug!("Pinging {} on portal network", enr);
+//             let ping_result = self.send_ping(U256::from(u64::MAX), enr).await?;
+//             debug!("Portal network Ping result: {:?}", ping_result);
+//         }
+//         Ok(())
+//     }
+// }

--- a/trin-core/src/portalnet/protocol.rs
+++ b/trin-core/src/portalnet/protocol.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 
 use discv5::{Discv5Event, TalkRequest};
 use log::{debug, error, warn};
-use rocksdb::{Options, DB};
+use rocksdb::{DB};
 use serde_json::Value;
 use tokio::sync::mpsc;
 
-use crate::{jsonrpc::Params, utils::get_data_dir};
+use crate::{jsonrpc::Params};
 
 use super::{
     discovery::Discovery,
@@ -23,7 +23,6 @@ use super::{types::Message, Enr};
 use std::collections::HashMap;
 use std::convert::TryInto;
 use crate::portalnet::overlay::OverlayProtocol;
-use parking_lot::RwLock;
 
 type Responder<T, E> = mpsc::UnboundedSender<Result<T, E>>;
 
@@ -89,7 +88,7 @@ pub const PROTOCOL: &str = "portal";
 
 pub struct PortalnetEvents {
     pub discovery: Arc<Discovery>,
-    pub overlay: OverlayProtocol,
+    pub overlay: Arc<OverlayProtocol>,
     pub protocol_receiver: mpsc::Receiver<Discv5Event>,
     pub db: DB,
     pub utp_listener: UtpListener,

--- a/trin-core/src/portalnet/protocol.rs
+++ b/trin-core/src/portalnet/protocol.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 
 use discv5::{Discv5Event, TalkRequest};
 use log::{debug, error, warn};
-use rocksdb::{DB};
+use rocksdb::DB;
 use serde_json::Value;
 use tokio::sync::mpsc;
 
-use crate::{jsonrpc::Params};
+use crate::jsonrpc::Params;
 
 use super::{
     discovery::Discovery,
@@ -20,9 +20,8 @@ use super::{
     U256,
 };
 use super::{types::Message, Enr};
-use std::collections::HashMap;
-use std::convert::TryInto;
 use crate::portalnet::overlay::OverlayProtocol;
+use std::convert::TryInto;
 
 type Responder<T, E> = mpsc::UnboundedSender<Result<T, E>>;
 
@@ -303,103 +302,3 @@ impl PortalnetEvents {
         }
     }
 }
-
-// impl PortalnetProtocol {
-//     pub async fn new(
-//         mut discovery: Discovery,
-//         portal_config: PortalnetConfig,
-//     ) -> Result<(Self, PortalnetEvents), String> {
-//         let protocol_receiver = discovery
-//             .discv5
-//             .event_stream()
-//             .await
-//             .map_err(|e| e.to_string())?;
-//
-//         let overlay = Overlay::new(
-//             discovery.local_enr(),
-//             portal_config.data_radius,
-//             OverlayConfig::default(),
-//         );
-//
-//         let discovery = Arc::new(discovery);
-//         let data_path = get_data_dir(discovery.local_enr());
-//
-//         let mut db_opts = Options::default();
-//         db_opts.create_if_missing(true);
-//         let db = DB::open(&db_opts, data_path).unwrap();
-//
-//         let utp_listener = UtpListener {
-//             discovery: discovery.clone(),
-//             utp_connections: HashMap::new(),
-//         };
-//
-//         let events = PortalnetEvents {
-//             discovery: discovery.clone(),
-//             overlay: overlay.clone(),
-//             protocol_receiver,
-//             db,
-//             utp_listener,
-//         };
-//
-//         let proto = Self {
-//             discovery: discovery.clone(),
-//             overlay: overlay.clone(),
-//         };
-//
-//         Ok((proto, events))
-//     }
-//
-//     pub async fn send_ping(&self, data_radius: U256, enr: Enr) -> Result<Vec<u8>, String> {
-//         let enr_seq = self.discovery.local_enr().seq();
-//         let msg = Ping {
-//             enr_seq,
-//             data_radius,
-//         };
-//         self.discovery
-//             .send_talkreq(
-//                 enr,
-//                 PROTOCOL.to_string(),
-//                 Message::Request(Request::Ping(msg)).to_bytes(),
-//             )
-//             .await
-//     }
-//
-//     pub async fn send_find_nodes(&self, distances: Vec<u16>, enr: Enr) -> Result<Vec<u8>, String> {
-//         let msg = FindNodes { distances };
-//         self.discovery
-//             .send_talkreq(
-//                 enr,
-//                 PROTOCOL.to_string(),
-//                 Message::Request(Request::FindNodes(msg)).to_bytes(),
-//             )
-//             .await
-//     }
-//
-//     pub async fn send_find_content(
-//         &self,
-//         content_key: Vec<u8>,
-//         enr: Enr,
-//     ) -> Result<Vec<u8>, String> {
-//         let msg = FindContent { content_key };
-//         self.discovery
-//             .send_talkreq(
-//                 enr,
-//                 PROTOCOL.to_string(),
-//                 Message::Request(Request::FindContent(msg)).to_bytes(),
-//             )
-//             .await
-//     }
-//
-//     /// Convenience call for testing, quick way to ping bootnodes
-//     pub async fn ping_bootnodes(&mut self) -> Result<(), String> {
-//         // Trigger bonding with bootnodes, at both the base layer and portal overlay.
-//         // The overlay ping via talkreq will trigger a session at the base layer, then
-//         // a session on the (overlay) portal network.
-//         for enr in self.discovery.discv5.table_entries_enr() {
-//             debug!("Pinging {} on portal network", enr);
-//             let ping_result = self.send_ping(U256::from(u64::MAX), enr).await?;
-//             debug!("Portal network Ping result: {:?}", ping_result);
-//         }
-//         Ok(())
-//     }
-// }

--- a/trin-core/src/portalnet/utp.rs
+++ b/trin-core/src/portalnet/utp.rs
@@ -865,16 +865,9 @@ impl UtpStream {
 
 #[cfg(test)]
 mod tests {
-    use crate::portalnet::discovery::{Config as DiscoveryConfig, Discovery};
-    use crate::portalnet::types::HexData;
-    use crate::portalnet::utp::{ConnectionKey, Packet, PacketHeader, Type, UtpListener, VERSION};
-    use crate::portalnet::Enr;
-    use discv5::{Discv5ConfigBuilder, Discv5Event, TalkRequest};
-    use std::collections::{BTreeMap, HashMap};
+    use crate::portalnet::utp::{Packet, PacketHeader, Type, VERSION};
+    use std::collections::BTreeMap;
     use std::convert::TryFrom;
-    use std::net::SocketAddr;
-    use std::sync::Arc;
-    use tokio::sync::mpsc;
 
     #[test]
     fn test_decode_packet() {

--- a/trin-core/src/portalnet/utp.rs
+++ b/trin-core/src/portalnet/utp.rs
@@ -10,6 +10,7 @@ use std::cmp::{max, min};
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::RwLock;
 
 pub const UTP_PROTOCOL: &str = "utp";
 pub const HEADER_SIZE: usize = 20;
@@ -401,7 +402,7 @@ impl ConnectionKey {
 
 // Basically the same idea as in the official Bit Torrent library we will store all of the active connections data here
 pub struct UtpListener {
-    pub discovery: Arc<Discovery>,
+    pub discovery: Arc<RwLock<Discovery>>,
     pub utp_connections: HashMap<ConnectionKey, UtpStream>,
 }
 
@@ -432,9 +433,9 @@ impl UtpListener {
                         }
                     }
                     Type::StSyn => {
-                        if let Some(enr) = self.discovery.discv5.find_enr(&node_id) {
+                        if let Some(enr) = self.discovery.read().await.discv5.find_enr(&node_id) {
                             // If neither of those cases happened handle this is a new request
-                            let mut conn = UtpStream::init(self.discovery.clone(), enr);
+                            let mut conn = UtpStream::init(Arc::clone(&self.discovery), enr);
                             conn.handle_packet(packet).await;
                             self.utp_connections.insert(
                                 ConnectionKey {
@@ -465,8 +466,8 @@ impl UtpListener {
 
     // I am honestly not sure if I should init this with Enr or NodeId since we could use both
     async fn connect(&mut self, connection_id: u16, node_id: NodeId) {
-        if let Some(enr) = self.discovery.discv5.find_enr(&node_id) {
-            let mut conn = UtpStream::init(self.discovery.clone(), enr);
+        if let Some(enr) = self.discovery.read().await.discv5.find_enr(&node_id) {
+            let mut conn = UtpStream::init(Arc::clone(&self.discovery), enr);
             conn.make_connection(connection_id).await;
             self.utp_connections.insert(
                 ConnectionKey {
@@ -494,7 +495,7 @@ pub struct UtpStream {
     incoming_buffer: BTreeMap<u16, Packet>,
     unsent_queue: VecDeque<Packet>,
     enr: Enr,
-    discovery: Arc<Discovery>,
+    discovery: Arc<RwLock<Discovery>>,
     cur_window: u32,
     remote_wnd_size: u32,
     send_window: HashMap<u16, Packet>,
@@ -514,7 +515,7 @@ pub struct UtpStream {
 }
 
 impl UtpStream {
-    fn init(arc: Arc<Discovery>, enr: Enr) -> Self {
+    fn init(arc: Arc<RwLock<Discovery>>, enr: Enr) -> Self {
         Self {
             state: ConnectionState::Uninitialized,
             seq_nr: 0,
@@ -586,6 +587,8 @@ impl UtpStream {
         }
         let talk_request_result = self
             .discovery
+            .write()
+            .await
             .send_talkreq(self.enr.clone(), UTP_PROTOCOL.to_string(), packet.0.clone())
             .await;
         debug!("uTP TalkRequest result: {:?}", talk_request_result);

--- a/trin-core/src/utils.rs
+++ b/trin-core/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::portalnet::Enr;
 use directories::ProjectDirs;
+use rocksdb::{Options, DB};
 use std::{env, fs};
-use rocksdb::{DB, Options};
 
 const TRIN_DATA_ENV_VAR: &str = "TRIN_DATA_PATH";
 

--- a/trin-core/src/utils.rs
+++ b/trin-core/src/utils.rs
@@ -1,6 +1,7 @@
 use crate::portalnet::Enr;
 use directories::ProjectDirs;
 use std::{env, fs};
+use rocksdb::{DB, Options};
 
 const TRIN_DATA_ENV_VAR: &str = "TRIN_DATA_PATH";
 
@@ -38,6 +39,13 @@ pub fn get_default_data_dir(local_enr: Enr) -> String {
         Some(proj_dirs) => proj_dirs.data_local_dir().to_str().unwrap().to_string(),
         None => panic!("Unable to find data directory"),
     }
+}
+
+pub fn setup_overlay_db(local_enr: Enr) -> DB {
+    let data_path = get_data_dir(local_enr);
+    let mut db_opts = Options::default();
+    db_opts.create_if_missing(true);
+    DB::open(&db_opts, data_path).unwrap()
 }
 
 #[cfg(test)]

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -18,3 +18,4 @@ tracing = "0.1.26"
 tracing-subscriber = "0.2.18"
 tokio = { version = "1.8.0", features = ["full"] }
 trin-core = { path = "../trin-core" }
+parking_lot = "0.11.1"

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -18,4 +18,8 @@ tracing = "0.1.26"
 tracing-subscriber = "0.2.18"
 tokio = { version = "1.8.0", features = ["full"] }
 trin-core = { path = "../trin-core" }
-parking_lot = "0.11.1"
+rocksdb = "0.16.0"
+
+[dependencies.discv5]
+version = "0.1.0-beta.10"
+git = "https://github.com/sigp/discv5"

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -1,0 +1,93 @@
+use discv5::kbucket::KBucketsTable;
+use log::debug;
+use rocksdb::DB;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use trin_core::portalnet::{
+    discovery::Discovery,
+    overlay::{OverlayConfig, OverlayProtocol},
+    protocol::{PortalnetConfig, PortalnetEvents},
+    utp::UtpListener,
+    U256,
+};
+
+/// History network layer on top of the overlay protocol. Encapsulates history network specific data and logic.
+#[derive(Clone)]
+pub struct HistoryNetwork {
+    pub overlay: Arc<OverlayProtocol>,
+}
+
+impl HistoryNetwork {
+    pub async fn new(
+        discovery: Arc<RwLock<Discovery>>,
+        db: Arc<DB>,
+        portal_config: PortalnetConfig,
+    ) -> Result<(Self, PortalnetEvents), String> {
+        let config = OverlayConfig::default();
+        let kbuckets = Arc::new(RwLock::new(KBucketsTable::new(
+            discovery.read().await.local_enr().node_id().into(),
+            config.bucket_pending_timeout,
+            config.max_incoming_per_bucket,
+            config.table_filter,
+            config.bucket_filter,
+        )));
+        let data_radius = Arc::new(RwLock::new(portal_config.data_radius));
+
+        let protocol_receiver = discovery
+            .write()
+            .await
+            .discv5
+            .event_stream()
+            .await
+            .map_err(|e| e.to_string())
+            .unwrap();
+
+        let overlay = OverlayProtocol {
+            discovery: Arc::clone(&discovery),
+            data_radius,
+            kbuckets,
+        };
+
+        let overlay = Arc::new(overlay);
+
+        let utp_listener = UtpListener {
+            discovery: Arc::clone(&discovery),
+            utp_connections: HashMap::new(),
+        };
+
+        let events = PortalnetEvents {
+            discovery: Arc::clone(&discovery),
+            overlay: Arc::clone(&overlay),
+            protocol_receiver,
+            db,
+            utp_listener,
+        };
+
+        let proto = Self {
+            overlay: Arc::clone(&overlay),
+        };
+
+        Ok((proto, events))
+    }
+
+    /// Convenience call for testing, quick way to ping bootnodes
+    pub async fn ping_bootnodes(&mut self) -> Result<(), String> {
+        // Trigger bonding with bootnodes, at both the base layer and portal overlay.
+        // The overlay ping via talkreq will trigger a session at the base layer, then
+        // a session on the (overlay) portal network.
+        for enr in self
+            .overlay
+            .discovery
+            .read()
+            .await
+            .discv5
+            .table_entries_enr()
+        {
+            debug!("Pinging {} on portal history network", enr);
+            let ping_result = self.overlay.send_ping(U256::from(u64::MAX), enr).await?;
+            debug!("Portal history network Ping result: {:?}", ping_result);
+        }
+        Ok(())
+    }
+}

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -14,3 +14,8 @@ tracing = "0.1.26"
 tracing-subscriber = "0.2.18"
 tokio = {version = "1.8.0", features = ["full"]}
 trin-core = { path = "../trin-core" }
+rocksdb = "0.16.0"
+
+[dependencies.discv5]
+version = "0.1.0-beta.10"
+git = "https://github.com/sigp/discv5"

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -2,11 +2,15 @@ use log::info;
 use serde_json::Value;
 use tokio::sync::mpsc;
 
+use network::StateNetwork;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use trin_core::cli::TrinConfig;
 use trin_core::portalnet::discovery::Discovery;
-use trin_core::portalnet::overlay::StateProtocol;
 use trin_core::portalnet::protocol::{PortalnetConfig, StateEndpointKind, StateNetworkEndpoint};
+use trin_core::utils::setup_overlay_db;
 
+pub mod network;
 pub mod utils;
 
 pub struct StateRequestHandler {
@@ -58,6 +62,10 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut discovery = Discovery::new(portalnet_config.clone()).unwrap();
     discovery.start().await.unwrap();
+    let discovery = Arc::new(RwLock::new(discovery));
+
+    // Setup Overlay database
+    let db = Arc::new(setup_overlay_db(discovery.read().await.local_enr()));
 
     info!(
         "About to spawn portal p2p with boot nodes: {:?}",
@@ -65,7 +73,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     tokio::spawn(async move {
-        let (mut p2p, events) = StateProtocol::new(discovery, portalnet_config.clone())
+        let (mut p2p, events) = StateNetwork::new(discovery, db, portalnet_config)
             .await
             .unwrap();
 

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -1,0 +1,93 @@
+use discv5::kbucket::KBucketsTable;
+use log::debug;
+use rocksdb::DB;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use trin_core::portalnet::{
+    discovery::Discovery,
+    overlay::{OverlayConfig, OverlayProtocol},
+    protocol::{PortalnetConfig, PortalnetEvents},
+    utp::UtpListener,
+    U256,
+};
+
+/// State network layer on top of the overlay protocol. Encapsulates state network specific data and logic.
+#[derive(Clone)]
+pub struct StateNetwork {
+    pub overlay: Arc<OverlayProtocol>,
+}
+
+impl StateNetwork {
+    pub async fn new(
+        discovery: Arc<RwLock<Discovery>>,
+        db: Arc<DB>,
+        portal_config: PortalnetConfig,
+    ) -> Result<(Self, PortalnetEvents), String> {
+        let config = OverlayConfig::default();
+        let kbuckets = Arc::new(RwLock::new(KBucketsTable::new(
+            discovery.read().await.local_enr().node_id().into(),
+            config.bucket_pending_timeout,
+            config.max_incoming_per_bucket,
+            config.table_filter,
+            config.bucket_filter,
+        )));
+        let data_radius = Arc::new(RwLock::new(portal_config.data_radius));
+
+        let protocol_receiver = discovery
+            .write()
+            .await
+            .discv5
+            .event_stream()
+            .await
+            .map_err(|e| e.to_string())
+            .unwrap();
+
+        let overlay = OverlayProtocol {
+            discovery: Arc::clone(&discovery),
+            data_radius,
+            kbuckets,
+        };
+
+        let overlay = Arc::new(overlay);
+
+        let utp_listener = UtpListener {
+            discovery: Arc::clone(&discovery),
+            utp_connections: HashMap::new(),
+        };
+
+        let events = PortalnetEvents {
+            discovery: Arc::clone(&discovery),
+            overlay: Arc::clone(&overlay),
+            protocol_receiver,
+            db,
+            utp_listener,
+        };
+
+        let proto = Self {
+            overlay: Arc::clone(&overlay),
+        };
+
+        Ok((proto, events))
+    }
+
+    /// Convenience call for testing, quick way to ping bootnodes
+    pub async fn ping_bootnodes(&mut self) -> Result<(), String> {
+        // Trigger bonding with bootnodes, at both the base layer and portal overlay.
+        // The overlay ping via talkreq will trigger a session at the base layer, then
+        // a session on the (overlay) portal network.
+        for enr in self
+            .overlay
+            .discovery
+            .read()
+            .await
+            .discv5
+            .table_entries_enr()
+        {
+            debug!("Pinging {} on portal state network", enr);
+            let ping_result = self.overlay.send_ping(U256::from(u64::MAX), enr).await?;
+            debug!("Portal state network Ping result: {:?}", ping_result);
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
This introduces some new abstractions for the overlay networks:

```rust
// Base Discovery layer
pub struct Discovery {
    /// discv5 protocol
    pub discv5: Discv5,
    /// Indicates if the discv5 service has been started
    pub started: bool,
   /// listen port for the discovery protocol
    pub listen_socket: SocketAddr,
}

// Overlay layer, should be used by every network
pub struct OverlayProtocol {
    // Contains discovery layer
    pub discovery: Arc<RwLock<Discovery>>,
    // The data radius of the local node
    pub data_radius: Arc<RwLock<U256>>,
    // The overlay routing table of the local node.
    pub kbuckets: Arc<RwLock<KBucketsTable<NodeId, Node>>>,
}

// Network specific layers, currently contain only the overlay protocol
pub struct HistoryProtocol {
    pub overlay: Arc<OverlayProtocol>,
}

pub struct StateProtocol {
    pub overlay: Arc<OverlayProtocol>,
}
```
**Other changes:**

- Creates one Discovery struct as `Arc<RwLock<Discovery>>`: one writer, many readers and passes it as argument to every network.
- Creates one database instance and passes it as argument to every network.
- Spawns separate thread for the JSON-RPC handler

Both networks runs concurrently right now in the main package. I just commented out the event handler for the history network, we need to refactor this to handle the events from both networks concurrently.

**Not included in this PR:**
- Refactor events handlers to work with both networks concurrently.

Fixes #93