### PR TITLE
Handle overlay network events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3132,6 +3132,7 @@ dependencies = [
 name = "trin"
 version = "0.1.0"
 dependencies = [
+ "discv5",
  "log 0.4.14",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ trin-core = { path = "trin-core" }
 trin-history = { path = "trin-history" }
 trin-state = { path = "trin-state" }
 
+[dependencies.discv5]
+version = "0.1.0-beta.10"
+git = "https://github.com/sigp/discv5"
+
 [workspace]
 members = [
     "trin-history",

--- a/trin-core/src/jsonrpc/mod.rs
+++ b/trin-core/src/jsonrpc/mod.rs
@@ -1,0 +1,3 @@
+pub mod handlers;
+pub mod service;
+pub mod types;

--- a/trin-core/src/jsonrpc/types.rs
+++ b/trin-core/src/jsonrpc/types.rs
@@ -1,0 +1,97 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use validator::{Validate, ValidationError};
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(untagged)]
+pub enum Params {
+    /// No parameters
+    None,
+    /// Array of values
+    Array(Vec<Value>),
+    /// Map of values
+    Map(Map<String, Value>),
+}
+
+impl From<Params> for Value {
+    fn from(params: Params) -> Value {
+        match params {
+            Params::Array(vec) => Value::Array(vec),
+            Params::Map(map) => Value::Object(map),
+            Params::None => Value::Null,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Validate)]
+pub struct JsonRequest {
+    #[validate(custom = "validate_jsonrpc_version")]
+    pub jsonrpc: String,
+    #[serde(default = "default_params")]
+    pub params: Params,
+    pub method: String,
+    pub id: u32,
+}
+
+fn default_params() -> Params {
+    Params::None
+}
+
+fn validate_jsonrpc_version(jsonrpc: &str) -> Result<(), ValidationError> {
+    if jsonrpc != "2.0" {
+        return Err(ValidationError::new("Unsupported jsonrpc version"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rstest::rstest;
+    use validator::ValidationErrors;
+
+    #[test]
+    fn test_json_validator_accepts_valid_json() {
+        let request = JsonRequest {
+            jsonrpc: "2.0".to_string(),
+            id: 1,
+            params: Params::None,
+            method: "eth_blockNumber".to_string(),
+        };
+        assert_eq!(request.validate(), Ok(()));
+    }
+
+    #[test]
+    fn test_json_validator_with_invalid_jsonrpc_field() {
+        let request = JsonRequest {
+            jsonrpc: "1.0".to_string(),
+            id: 1,
+            params: Params::None,
+            method: "eth_blockNumber".to_string(),
+        };
+        let errors = request.validate();
+        assert!(ValidationErrors::has_error(&errors, "jsonrpc"));
+    }
+
+    fn expected_map() -> Map<String, Value> {
+        let mut expected_map = serde_json::Map::new();
+        expected_map.insert("key".to_string(), Value::String("value".to_string()));
+        expected_map
+    }
+
+    #[rstest]
+    #[case("[null]", Params::Array(vec![Value::Null]))]
+    #[case("[true]", Params::Array(vec![Value::Bool(true)]))]
+    #[case("[-1]", Params::Array(vec![Value::from(-1)]))]
+    #[case("[4]", Params::Array(vec![Value::from(4)]))]
+    #[case("[2.3]", Params::Array(vec![Value::from(2.3)]))]
+    #[case("[\"hello\"]", Params::Array(vec![Value::String("hello".to_string())]))]
+    #[case("[[0]]", Params::Array(vec![Value::Array(vec![Value::from(0)])]))]
+    #[case("[[]]", Params::Array(vec![Value::Array(vec![])]))]
+    #[case("[{\"key\": \"value\"}]", Params::Array(vec![Value::Object(expected_map())]))]
+    fn request_params_deserialization(#[case] input: &str, #[case] expected: Params) {
+        let deserialized: Params = serde_json::from_str(input).unwrap();
+        assert_eq!(deserialized, expected);
+    }
+}

--- a/trin-core/src/portalnet/discovery.rs
+++ b/trin-core/src/portalnet/discovery.rs
@@ -2,7 +2,7 @@
 
 use super::types::HexData;
 use super::Enr;
-use crate::portalnet::protocol::PortalnetConfig;
+use crate::portalnet::overlay::PortalnetConfig;
 use crate::socket;
 use discv5::enr::{CombinedKey, EnrBuilder, NodeId};
 use discv5::{Discv5, Discv5Config, Discv5ConfigBuilder};

--- a/trin-core/src/portalnet/discovery.rs
+++ b/trin-core/src/portalnet/discovery.rs
@@ -1,8 +1,7 @@
 #![allow(dead_code)]
 
-use super::types::HexData;
+use super::types::{HexData, PortalnetConfig};
 use super::Enr;
-use crate::portalnet::overlay::PortalnetConfig;
 use crate::socket;
 use discv5::enr::{CombinedKey, EnrBuilder, NodeId};
 use discv5::{Discv5, Discv5Config, Discv5ConfigBuilder};

--- a/trin-core/src/portalnet/events.rs
+++ b/trin-core/src/portalnet/events.rs
@@ -13,8 +13,6 @@ use crate::cli::{HISTORY_NETWORK, STATE_NETWORK};
 use std::collections::HashMap;
 use std::convert::TryInto;
 
-pub const PROTOCOL: &str = "portal";
-
 pub struct PortalnetEvents {
     pub discovery: Arc<RwLock<Discovery>>,
     pub protocol_receiver: mpsc::Receiver<Discv5Event>,

--- a/trin-core/src/portalnet/events.rs
+++ b/trin-core/src/portalnet/events.rs
@@ -1,0 +1,163 @@
+use std::sync::Arc;
+
+use discv5::{Discv5Event, TalkRequest};
+use log::{debug, error, warn};
+use rocksdb::DB;
+use tokio::sync::mpsc;
+use tokio::sync::RwLock;
+
+use super::types::Message;
+use super::{
+    discovery::Discovery,
+    types::{FindContent, FindNodes, FoundContent, Nodes, Ping, Pong, Request, Response, SszEnr},
+    utp::{UtpListener, UTP_PROTOCOL},
+};
+use crate::portalnet::overlay::OverlayProtocol;
+use std::collections::HashMap;
+use std::convert::TryInto;
+
+pub const PROTOCOL: &str = "portal";
+
+pub struct PortalnetEvents {
+    pub discovery: Arc<RwLock<Discovery>>,
+    pub overlay: Arc<OverlayProtocol>,
+    pub protocol_receiver: mpsc::Receiver<Discv5Event>,
+    pub db: Arc<DB>,
+    pub utp_listener: UtpListener,
+}
+
+impl PortalnetEvents {
+    pub async fn new(overlay: Arc<OverlayProtocol>, db: Arc<DB>) -> Self {
+        let protocol_receiver = overlay
+            .discovery
+            .write()
+            .await
+            .discv5
+            .event_stream()
+            .await
+            .map_err(|e| e.to_string())
+            .unwrap();
+
+        let utp_listener = UtpListener {
+            discovery: Arc::clone(&overlay.discovery),
+            utp_connections: HashMap::new(),
+        };
+
+        Self {
+            discovery: Arc::clone(&overlay.discovery),
+            overlay,
+            protocol_receiver,
+            db,
+            utp_listener,
+        }
+    }
+
+    /// Receives a request from the talkreq handler and sends a response back
+    pub async fn process_discv5_requests(mut self) {
+        while let Some(event) = self.protocol_receiver.recv().await {
+            debug!("Got discv5 event {:?}", event);
+
+            let request = match event {
+                Discv5Event::TalkRequest(r) => r,
+                _ => continue,
+            };
+
+            match std::str::from_utf8(request.protocol()) {
+                Ok(protocol) => match protocol {
+                    PROTOCOL => {
+                        let reply = match self.process_one_request(&request).await {
+                            Ok(r) => Message::Response(r).to_bytes(),
+                            Err(e) => {
+                                error!("failed to process portal event: {}", e);
+                                e.into_bytes()
+                            }
+                        };
+
+                        if let Err(e) = request.respond(reply) {
+                            warn!("failed to send reply: {}", e);
+                        }
+                    }
+                    UTP_PROTOCOL => {
+                        self.utp_listener
+                            .process_utp_request(request.body(), request.node_id())
+                            .await;
+                        self.process_utp_byte_stream().await;
+                    }
+                    _ => {
+                        warn!("Non supported protocol : {}", protocol);
+                    }
+                },
+                Err(_) => warn!("Invalid utf8 protocol decode"),
+            }
+        }
+    }
+
+    async fn process_one_request(&self, talk_request: &TalkRequest) -> Result<Response, String> {
+        let request = match Message::from_bytes(talk_request.body()) {
+            Ok(Message::Request(r)) => r,
+            Ok(_) => return Err("Invalid message".to_owned()),
+            Err(e) => return Err(format!("Invalid request: {}", e)),
+        };
+
+        let response = match request {
+            Request::Ping(Ping { .. }) => {
+                debug!("Got overlay ping request {:?}", request);
+                let enr_seq = self.discovery.read().await.local_enr().seq();
+                Response::Pong(Pong {
+                    enr_seq: enr_seq,
+                    data_radius: self.overlay.data_radius().await,
+                })
+            }
+            Request::FindNodes(FindNodes { distances }) => {
+                let distances64: Vec<u64> = distances.iter().map(|x| (*x).into()).collect();
+                let enrs = self.overlay.nodes_by_distance(distances64).await;
+                Response::Nodes(Nodes {
+                    // from spec: total = The total number of Nodes response messages being sent.
+                    // TODO: support returning multiple messages
+                    total: 1 as u8,
+                    enrs,
+                })
+            }
+            Request::FindContent(FindContent { content_key }) => match self.db.get(&content_key) {
+                Ok(Some(value)) => {
+                    let empty_enrs: Vec<SszEnr> = vec![];
+                    Response::FoundContent(FoundContent {
+                        enrs: empty_enrs,
+                        payload: value,
+                    })
+                }
+                Ok(None) => {
+                    let enrs = self.overlay.find_nodes_close_to_content(content_key).await;
+                    let empty_payload: Vec<u8> = vec![];
+                    Response::FoundContent(FoundContent {
+                        enrs: enrs,
+                        payload: empty_payload,
+                    })
+                }
+                Err(e) => panic!("Unable to respond to FindContent: {}", e),
+            },
+        };
+
+        Ok(response)
+    }
+
+    // This could be handled in the UtpListener impl, but for consistency with data handling
+    // and clarity it can be put here
+    async fn process_utp_byte_stream(&mut self) {
+        for (_, conn) in self.utp_listener.utp_connections.iter_mut() {
+            let received_stream = conn.recv_data_stream.clone();
+            if received_stream.is_empty() {
+                continue;
+            }
+
+            let message_len = u32::from_be_bytes(received_stream[0..4].try_into().unwrap());
+
+            if message_len + 4 >= received_stream.len() as u32 {
+                // handle data function(&received_stream[4..(message_len + 4)]
+
+                // Removed the handled data from the buffer
+                conn.recv_data_stream = received_stream[((message_len + 4) as usize)..].to_owned();
+            }
+        }
+    }
+}

--- a/trin-core/src/portalnet/mod.rs
+++ b/trin-core/src/portalnet/mod.rs
@@ -7,7 +7,6 @@ use uint::construct_uint;
 pub mod discovery;
 pub mod events;
 pub mod overlay;
-pub mod protocol;
 pub mod types;
 pub mod utp;
 

--- a/trin-core/src/portalnet/mod.rs
+++ b/trin-core/src/portalnet/mod.rs
@@ -5,6 +5,7 @@ use ssz::DecodeError;
 use uint::construct_uint;
 
 pub mod discovery;
+pub mod events;
 pub mod overlay;
 pub mod protocol;
 pub mod types;

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -2,7 +2,7 @@ use crate::utils::xor_two_values;
 
 use super::{
     discovery::Discovery,
-    types::{FindContent, FindNodes, Message, Ping, Request, SszEnr},
+    types::{FindContent, FindNodes, Message, Ping, ProtocolKind, Request, SszEnr},
     Enr, U256,
 };
 use crate::portalnet::types::HexData;
@@ -186,7 +186,7 @@ impl OverlayProtocol {
         &self,
         data_radius: U256,
         enr: Enr,
-        protocol: String,
+        protocol: ProtocolKind,
     ) -> Result<Vec<u8>, String> {
         let enr_seq = self.discovery.read().await.local_enr().seq();
         let msg = Ping {
@@ -198,7 +198,7 @@ impl OverlayProtocol {
             .await
             .send_talkreq(
                 enr,
-                protocol,
+                protocol.to_string(),
                 Message::Request(Request::Ping(msg)).to_bytes(),
             )
             .await
@@ -208,7 +208,7 @@ impl OverlayProtocol {
         &self,
         distances: Vec<u16>,
         enr: Enr,
-        protocol: String,
+        protocol: ProtocolKind,
     ) -> Result<Vec<u8>, String> {
         let msg = FindNodes { distances };
         self.discovery
@@ -216,7 +216,7 @@ impl OverlayProtocol {
             .await
             .send_talkreq(
                 enr,
-                protocol,
+                protocol.to_string(),
                 Message::Request(Request::FindNodes(msg)).to_bytes(),
             )
             .await
@@ -226,7 +226,7 @@ impl OverlayProtocol {
         &self,
         content_key: Vec<u8>,
         enr: Enr,
-        protocol: String,
+        protocol: ProtocolKind,
     ) -> Result<Vec<u8>, String> {
         let msg = FindContent { content_key };
         self.discovery
@@ -234,7 +234,7 @@ impl OverlayProtocol {
             .await
             .send_talkreq(
                 enr,
-                protocol,
+                protocol.to_string(),
                 Message::Request(Request::FindContent(msg)).to_bytes(),
             )
             .await

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -2,7 +2,6 @@ use crate::utils::xor_two_values;
 
 use super::{
     discovery::Discovery,
-    events::PROTOCOL,
     types::{FindContent, FindNodes, Message, Ping, Request, SszEnr},
     Enr, U256,
 };
@@ -160,7 +159,12 @@ impl OverlayProtocol {
             .collect()
     }
 
-    pub async fn send_ping(&self, data_radius: U256, enr: Enr) -> Result<Vec<u8>, String> {
+    pub async fn send_ping(
+        &self,
+        data_radius: U256,
+        enr: Enr,
+        protocol: String,
+    ) -> Result<Vec<u8>, String> {
         let enr_seq = self.discovery.read().await.local_enr().seq();
         let msg = Ping {
             enr_seq,
@@ -171,20 +175,25 @@ impl OverlayProtocol {
             .await
             .send_talkreq(
                 enr,
-                PROTOCOL.to_string(),
+                protocol,
                 Message::Request(Request::Ping(msg)).to_bytes(),
             )
             .await
     }
 
-    pub async fn send_find_nodes(&self, distances: Vec<u16>, enr: Enr) -> Result<Vec<u8>, String> {
+    pub async fn send_find_nodes(
+        &self,
+        distances: Vec<u16>,
+        enr: Enr,
+        protocol: String,
+    ) -> Result<Vec<u8>, String> {
         let msg = FindNodes { distances };
         self.discovery
             .write()
             .await
             .send_talkreq(
                 enr,
-                PROTOCOL.to_string(),
+                protocol,
                 Message::Request(Request::FindNodes(msg)).to_bytes(),
             )
             .await
@@ -194,6 +203,7 @@ impl OverlayProtocol {
         &self,
         content_key: Vec<u8>,
         enr: Enr,
+        protocol: String,
     ) -> Result<Vec<u8>, String> {
         let msg = FindContent { content_key };
         self.discovery
@@ -201,7 +211,7 @@ impl OverlayProtocol {
             .await
             .send_talkreq(
                 enr,
-                PROTOCOL.to_string(),
+                protocol,
                 Message::Request(Request::FindContent(msg)).to_bytes(),
             )
             .await

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -5,8 +5,10 @@ use super::{
     types::{FindContent, FindNodes, Message, Ping, Request, SszEnr},
     Enr, U256,
 };
+use crate::portalnet::types::HexData;
 use discv5::enr::NodeId;
 use discv5::kbucket::{Filter, KBucketsTable};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -37,6 +39,27 @@ impl std::cmp::Eq for Node {}
 impl PartialEq for Node {
     fn eq(&self, other: &Self) -> bool {
         self.enr == other.enr
+    }
+}
+
+#[derive(Clone)]
+pub struct PortalnetConfig {
+    pub external_addr: Option<SocketAddr>,
+    pub private_key: Option<HexData>,
+    pub listen_port: u16,
+    pub bootnode_enrs: Vec<Enr>,
+    pub data_radius: U256,
+}
+
+impl Default for PortalnetConfig {
+    fn default() -> Self {
+        Self {
+            external_addr: None,
+            private_key: None,
+            listen_port: 4242,
+            bootnode_enrs: Vec::<Enr>::new(),
+            data_radius: U256::from(u64::MAX), //TODO better data_radius default?
+        }
     }
 }
 

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -2,7 +2,7 @@ use crate::utils::xor_two_values;
 
 use super::{
     discovery::Discovery,
-    protocol::PROTOCOL,
+    events::PROTOCOL,
     types::{FindContent, FindNodes, Message, Ping, Request, SszEnr},
     Enr, U256,
 };

--- a/trin-core/src/portalnet/protocol.rs
+++ b/trin-core/src/portalnet/protocol.rs
@@ -3,26 +3,14 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use discv5::{Discv5Event, TalkRequest};
-use log::{debug, error, warn};
-use rocksdb::DB;
 use serde_json::Value;
 use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 
 use crate::jsonrpc::Params;
 
-use super::{
-    discovery::Discovery,
-    types::{
-        FindContent, FindNodes, FoundContent, HexData, Nodes, Ping, Pong, Request, Response, SszEnr,
-    },
-    utp::{UtpListener, UTP_PROTOCOL},
-    U256,
-};
-use super::{types::Message, Enr};
-use crate::portalnet::overlay::OverlayProtocol;
-use std::convert::TryInto;
+use super::Enr;
+use super::{discovery::Discovery, types::HexData, U256};
 
 type Responder<T, E> = mpsc::UnboundedSender<Result<T, E>>;
 
@@ -82,16 +70,6 @@ impl Default for PortalnetConfig {
             data_radius: U256::from(u64::MAX), //TODO better data_radius default?
         }
     }
-}
-
-pub const PROTOCOL: &str = "portal";
-
-pub struct PortalnetEvents {
-    pub discovery: Arc<RwLock<Discovery>>,
-    pub overlay: Arc<OverlayProtocol>,
-    pub protocol_receiver: mpsc::Receiver<Discv5Event>,
-    pub db: Arc<DB>,
-    pub utp_listener: UtpListener,
 }
 
 pub struct JsonRpcHandler {
@@ -192,116 +170,5 @@ async fn proxy_query_to_state_subnet(
             )),
         },
         None => Err("No response from state subnetwork".to_string()),
-    }
-}
-
-impl PortalnetEvents {
-    /// Receives a request from the talkreq handler and sends a response back
-    pub async fn process_discv5_requests(mut self) {
-        while let Some(event) = self.protocol_receiver.recv().await {
-            debug!("Got discv5 event {:?}", event);
-
-            let request = match event {
-                Discv5Event::TalkRequest(r) => r,
-                _ => continue,
-            };
-
-            match std::str::from_utf8(request.protocol()) {
-                Ok(protocol) => match protocol {
-                    PROTOCOL => {
-                        let reply = match self.process_one_request(&request).await {
-                            Ok(r) => Message::Response(r).to_bytes(),
-                            Err(e) => {
-                                error!("failed to process portal event: {}", e);
-                                e.into_bytes()
-                            }
-                        };
-
-                        if let Err(e) = request.respond(reply) {
-                            warn!("failed to send reply: {}", e);
-                        }
-                    }
-                    UTP_PROTOCOL => {
-                        self.utp_listener
-                            .process_utp_request(request.body(), request.node_id())
-                            .await;
-                        self.process_utp_byte_stream().await;
-                    }
-                    _ => {
-                        warn!("Non supported protocol : {}", protocol);
-                    }
-                },
-                Err(_) => warn!("Invalid utf8 protocol decode"),
-            }
-        }
-    }
-
-    async fn process_one_request(&self, talk_request: &TalkRequest) -> Result<Response, String> {
-        let request = match Message::from_bytes(talk_request.body()) {
-            Ok(Message::Request(r)) => r,
-            Ok(_) => return Err("Invalid message".to_owned()),
-            Err(e) => return Err(format!("Invalid request: {}", e)),
-        };
-
-        let response = match request {
-            Request::Ping(Ping { .. }) => {
-                debug!("Got overlay ping request {:?}", request);
-                let enr_seq = self.discovery.read().await.local_enr().seq();
-                Response::Pong(Pong {
-                    enr_seq: enr_seq,
-                    data_radius: self.overlay.data_radius().await,
-                })
-            }
-            Request::FindNodes(FindNodes { distances }) => {
-                let distances64: Vec<u64> = distances.iter().map(|x| (*x).into()).collect();
-                let enrs = self.overlay.nodes_by_distance(distances64).await;
-                Response::Nodes(Nodes {
-                    // from spec: total = The total number of Nodes response messages being sent.
-                    // TODO: support returning multiple messages
-                    total: 1 as u8,
-                    enrs,
-                })
-            }
-            Request::FindContent(FindContent { content_key }) => match self.db.get(&content_key) {
-                Ok(Some(value)) => {
-                    let empty_enrs: Vec<SszEnr> = vec![];
-                    Response::FoundContent(FoundContent {
-                        enrs: empty_enrs,
-                        payload: value,
-                    })
-                }
-                Ok(None) => {
-                    let enrs = self.overlay.find_nodes_close_to_content(content_key).await;
-                    let empty_payload: Vec<u8> = vec![];
-                    Response::FoundContent(FoundContent {
-                        enrs: enrs,
-                        payload: empty_payload,
-                    })
-                }
-                Err(e) => panic!("Unable to respond to FindContent: {}", e),
-            },
-        };
-
-        Ok(response)
-    }
-
-    // This could be handled in the UtpListener impl, but for consistency with data handling
-    // and clarity it can be put here
-    async fn process_utp_byte_stream(&mut self) {
-        for (_, conn) in self.utp_listener.utp_connections.iter_mut() {
-            let received_stream = conn.recv_data_stream.clone();
-            if received_stream.is_empty() {
-                continue;
-            }
-
-            let message_len = u32::from_be_bytes(received_stream[0..4].try_into().unwrap());
-
-            if message_len + 4 >= received_stream.len() as u32 {
-                // handle data function(&received_stream[4..(message_len + 4)]
-
-                // Removed the handled data from the buffer
-                conn.recv_data_stream = received_stream[((message_len + 4) as usize)..].to_owned();
-            }
-        }
     }
 }

--- a/trin-core/src/portalnet/types.rs
+++ b/trin-core/src/portalnet/types.rs
@@ -1,4 +1,5 @@
 use std::convert::{TryFrom, TryInto};
+use std::net::SocketAddr;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
@@ -9,6 +10,27 @@ use ssz::{Decode, DecodeError, Encode, SszDecoderBuilder, SszEncoder};
 use ssz_derive::{Decode, Encode};
 
 use super::{Enr, U256};
+
+#[derive(Clone)]
+pub struct PortalnetConfig {
+    pub external_addr: Option<SocketAddr>,
+    pub private_key: Option<HexData>,
+    pub listen_port: u16,
+    pub bootnode_enrs: Vec<Enr>,
+    pub data_radius: U256,
+}
+
+impl Default for PortalnetConfig {
+    fn default() -> Self {
+        Self {
+            external_addr: None,
+            private_key: None,
+            listen_port: 4242,
+            bootnode_enrs: Vec::<Enr>::new(),
+            data_radius: U256::from(u64::MAX), //TODO better data_radius default?
+        }
+    }
+}
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum ProtocolKind {

--- a/trin-core/src/portalnet/types.rs
+++ b/trin-core/src/portalnet/types.rs
@@ -11,6 +11,21 @@ use ssz_derive::{Decode, Encode};
 use super::{Enr, U256};
 
 #[derive(Debug, PartialEq, Clone)]
+pub enum ProtocolKind {
+    History,
+    State,
+}
+
+impl ToString for ProtocolKind {
+    fn to_string(&self) -> String {
+        match self {
+            ProtocolKind::History => "history".to_string(),
+            ProtocolKind::State => "state".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
 pub struct ProtocolMessage {
     message_id: u8,
     encoded_message: Message,

--- a/trin-history/src/events.rs
+++ b/trin-history/src/events.rs
@@ -1,16 +1,11 @@
 use crate::network::HistoryNetwork;
 use discv5::TalkRequest;
 use log::{debug, error, warn};
-use rocksdb::DB;
-use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedReceiver;
-use trin_core::portalnet::types::{
-    FindContent, FindNodes, FoundContent, Message, Nodes, Ping, Pong, Request, Response, SszEnr,
-};
+use trin_core::portalnet::types::Message;
 
 pub struct HistoryEvents {
     pub network: HistoryNetwork,
-    pub db: Arc<DB>,
     pub event_rx: UnboundedReceiver<TalkRequest>,
 }
 
@@ -19,7 +14,12 @@ impl HistoryEvents {
         while let Some(talk_request) = self.event_rx.recv().await {
             debug!("Got history request {:?}", talk_request);
 
-            let reply = match self.process_one_request(&talk_request).await {
+            let reply = match self
+                .network
+                .overlay
+                .process_one_request(&talk_request)
+                .await
+            {
                 Ok(r) => Message::Response(r).to_bytes(),
                 Err(e) => {
                     error!("failed to process portal history event: {}", e);
@@ -31,64 +31,5 @@ impl HistoryEvents {
                 warn!("failed to send reply: {}", e);
             }
         }
-    }
-
-    async fn process_one_request(&self, talk_request: &TalkRequest) -> Result<Response, String> {
-        let request = match Message::from_bytes(talk_request.body()) {
-            Ok(Message::Request(r)) => r,
-            Ok(_) => return Err("Invalid message".to_owned()),
-            Err(e) => return Err(format!("Invalid request: {}", e)),
-        };
-
-        let response = match request {
-            Request::Ping(Ping { .. }) => {
-                debug!("Got history overlay ping request {:?}", request);
-                let enr_seq = self
-                    .network
-                    .overlay
-                    .discovery
-                    .read()
-                    .await
-                    .local_enr()
-                    .seq();
-                Response::Pong(Pong {
-                    enr_seq,
-                    data_radius: self.network.overlay.data_radius().await,
-                })
-            }
-            Request::FindNodes(FindNodes { distances }) => {
-                let distances64: Vec<u64> = distances.iter().map(|x| (*x).into()).collect();
-                let enrs = self.network.overlay.nodes_by_distance(distances64).await;
-                Response::Nodes(Nodes {
-                    // from spec: total = The total number of Nodes response messages being sent.
-                    // TODO: support returning multiple messages
-                    total: 1_u8,
-                    enrs,
-                })
-            }
-            Request::FindContent(FindContent { content_key }) => match self.db.get(&content_key) {
-                Ok(Some(value)) => {
-                    let empty_enrs: Vec<SszEnr> = vec![];
-                    Response::FoundContent(FoundContent {
-                        enrs: empty_enrs,
-                        payload: value,
-                    })
-                }
-                Ok(None) => {
-                    let enrs = self
-                        .network
-                        .overlay
-                        .find_nodes_close_to_content(content_key)
-                        .await;
-                    let empty_payload: Vec<u8> = vec![];
-                    Response::FoundContent(FoundContent {
-                        enrs,
-                        payload: empty_payload,
-                    })
-                }
-                Err(e) => panic!("Unable to respond to FindContent: {}", e),
-            },
-        };
-        Ok(response)
     }
 }

--- a/trin-history/src/events.rs
+++ b/trin-history/src/events.rs
@@ -1,0 +1,94 @@
+use crate::network::HistoryNetwork;
+use discv5::TalkRequest;
+use log::{debug, error, warn};
+use rocksdb::DB;
+use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedReceiver;
+use trin_core::portalnet::types::{
+    FindContent, FindNodes, FoundContent, Message, Nodes, Ping, Pong, Request, Response, SszEnr,
+};
+
+pub struct HistoryEvents {
+    pub network: HistoryNetwork,
+    pub db: Arc<DB>,
+    pub event_rx: UnboundedReceiver<TalkRequest>,
+}
+
+impl HistoryEvents {
+    pub async fn process_requests(mut self) {
+        while let Some(talk_request) = self.event_rx.recv().await {
+            debug!("Got history request {:?}", talk_request);
+
+            let reply = match self.process_one_request(&talk_request).await {
+                Ok(r) => Message::Response(r).to_bytes(),
+                Err(e) => {
+                    error!("failed to process portal history event: {}", e);
+                    e.into_bytes()
+                }
+            };
+
+            if let Err(e) = talk_request.respond(reply) {
+                warn!("failed to send reply: {}", e);
+            }
+        }
+    }
+
+    async fn process_one_request(&self, talk_request: &TalkRequest) -> Result<Response, String> {
+        let request = match Message::from_bytes(talk_request.body()) {
+            Ok(Message::Request(r)) => r,
+            Ok(_) => return Err("Invalid message".to_owned()),
+            Err(e) => return Err(format!("Invalid request: {}", e)),
+        };
+
+        let response = match request {
+            Request::Ping(Ping { .. }) => {
+                debug!("Got history overlay ping request {:?}", request);
+                let enr_seq = self
+                    .network
+                    .overlay
+                    .discovery
+                    .read()
+                    .await
+                    .local_enr()
+                    .seq();
+                Response::Pong(Pong {
+                    enr_seq,
+                    data_radius: self.network.overlay.data_radius().await,
+                })
+            }
+            Request::FindNodes(FindNodes { distances }) => {
+                let distances64: Vec<u64> = distances.iter().map(|x| (*x).into()).collect();
+                let enrs = self.network.overlay.nodes_by_distance(distances64).await;
+                Response::Nodes(Nodes {
+                    // from spec: total = The total number of Nodes response messages being sent.
+                    // TODO: support returning multiple messages
+                    total: 1_u8,
+                    enrs,
+                })
+            }
+            Request::FindContent(FindContent { content_key }) => match self.db.get(&content_key) {
+                Ok(Some(value)) => {
+                    let empty_enrs: Vec<SszEnr> = vec![];
+                    Response::FoundContent(FoundContent {
+                        enrs: empty_enrs,
+                        payload: value,
+                    })
+                }
+                Ok(None) => {
+                    let enrs = self
+                        .network
+                        .overlay
+                        .find_nodes_close_to_content(content_key)
+                        .await;
+                    let empty_payload: Vec<u8> = vec![];
+                    Response::FoundContent(FoundContent {
+                        enrs,
+                        payload: empty_payload,
+                    })
+                }
+                Err(e) => panic!("Unable to respond to FindContent: {}", e),
+            },
+        };
+        Ok(response)
+    }
+}

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -14,7 +14,7 @@ use trin_core::cli::TrinConfig;
 use trin_core::jsonrpc::handlers::{HistoryEndpointKind, HistoryNetworkEndpoint};
 use trin_core::portalnet::discovery::Discovery;
 use trin_core::portalnet::events::PortalnetEvents;
-use trin_core::portalnet::overlay::PortalnetConfig;
+use trin_core::portalnet::types::PortalnetConfig;
 use trin_core::utils::setup_overlay_db;
 
 pub struct HistoryRequestHandler {
@@ -92,13 +92,12 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Spawn History network
     tokio::spawn(async move {
-        let mut p2p = HistoryNetwork::new(discovery.clone(), portalnet_config)
+        let mut p2p = HistoryNetwork::new(discovery.clone(), db, portalnet_config)
             .await
             .unwrap();
 
         let history_events = HistoryEvents {
             network: p2p.clone(),
-            db,
             event_rx: history_receiver,
         };
 

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -11,11 +11,10 @@ use network::HistoryNetwork;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use trin_core::cli::TrinConfig;
+use trin_core::jsonrpc::handlers::{HistoryEndpointKind, HistoryNetworkEndpoint};
 use trin_core::portalnet::discovery::Discovery;
 use trin_core::portalnet::events::PortalnetEvents;
-use trin_core::portalnet::protocol::{
-    HistoryEndpointKind, HistoryNetworkEndpoint, PortalnetConfig,
-};
+use trin_core::portalnet::overlay::PortalnetConfig;
 use trin_core::utils::setup_overlay_db;
 
 pub struct HistoryRequestHandler {

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -5,8 +5,7 @@ use tokio::sync::RwLock;
 use trin_core::cli::STATE_NETWORK;
 use trin_core::portalnet::{
     discovery::Discovery,
-    overlay::{OverlayConfig, OverlayProtocol},
-    protocol::PortalnetConfig,
+    overlay::{OverlayConfig, OverlayProtocol, PortalnetConfig},
     U256,
 };
 

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -2,10 +2,10 @@ use discv5::kbucket::KBucketsTable;
 use log::debug;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use trin_core::cli::STATE_NETWORK;
 use trin_core::portalnet::{
     discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol, PortalnetConfig},
+    types::ProtocolKind,
     U256,
 };
 
@@ -61,7 +61,7 @@ impl HistoryNetwork {
             debug!("Pinging {} on portal history network", enr);
             let ping_result = self
                 .overlay
-                .send_ping(U256::from(u64::MAX), enr, STATE_NETWORK.to_string())
+                .send_ping(U256::from(u64::MAX), enr, ProtocolKind::History)
                 .await?;
             debug!("Portal history network Ping result: {:?}", ping_result);
         }

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -2,6 +2,7 @@ use discv5::kbucket::KBucketsTable;
 use log::debug;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use trin_core::cli::STATE_NETWORK;
 use trin_core::portalnet::{
     discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol},
@@ -59,7 +60,10 @@ impl HistoryNetwork {
             .table_entries_enr()
         {
             debug!("Pinging {} on portal history network", enr);
-            let ping_result = self.overlay.send_ping(U256::from(u64::MAX), enr).await?;
+            let ping_result = self
+                .overlay
+                .send_ping(U256::from(u64::MAX), enr, STATE_NETWORK.to_string())
+                .await?;
             debug!("Portal history network Ping result: {:?}", ping_result);
         }
         Ok(())

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -1,14 +1,13 @@
 use discv5::kbucket::KBucketsTable;
 use log::debug;
 use rocksdb::DB;
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use trin_core::portalnet::{
     discovery::Discovery,
+    events::PortalnetEvents,
     overlay::{OverlayConfig, OverlayProtocol},
-    protocol::{PortalnetConfig, PortalnetEvents},
-    utp::UtpListener,
+    protocol::PortalnetConfig,
     U256,
 };
 
@@ -34,35 +33,15 @@ impl HistoryNetwork {
         )));
         let data_radius = Arc::new(RwLock::new(portal_config.data_radius));
 
-        let protocol_receiver = discovery
-            .write()
-            .await
-            .discv5
-            .event_stream()
-            .await
-            .map_err(|e| e.to_string())
-            .unwrap();
-
         let overlay = OverlayProtocol {
-            discovery: Arc::clone(&discovery),
+            discovery,
             data_radius,
             kbuckets,
         };
 
         let overlay = Arc::new(overlay);
 
-        let utp_listener = UtpListener {
-            discovery: Arc::clone(&discovery),
-            utp_connections: HashMap::new(),
-        };
-
-        let events = PortalnetEvents {
-            discovery: Arc::clone(&discovery),
-            overlay: Arc::clone(&overlay),
-            protocol_receiver,
-            db,
-            utp_listener,
-        };
+        let events = PortalnetEvents::new(Arc::clone(&overlay), db).await;
 
         let proto = Self {
             overlay: Arc::clone(&overlay),

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -1,11 +1,12 @@
 use discv5::kbucket::KBucketsTable;
 use log::debug;
+use rocksdb::DB;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use trin_core::portalnet::{
     discovery::Discovery,
-    overlay::{OverlayConfig, OverlayProtocol, PortalnetConfig},
-    types::ProtocolKind,
+    overlay::{OverlayConfig, OverlayProtocol},
+    types::{PortalnetConfig, ProtocolKind},
     U256,
 };
 
@@ -18,6 +19,7 @@ pub struct HistoryNetwork {
 impl HistoryNetwork {
     pub async fn new(
         discovery: Arc<RwLock<Discovery>>,
+        db: Arc<DB>,
         portal_config: PortalnetConfig,
     ) -> Result<Self, String> {
         let config = OverlayConfig::default();
@@ -34,6 +36,7 @@ impl HistoryNetwork {
             discovery,
             data_radius,
             kbuckets,
+            db,
         };
 
         let overlay = Arc::new(overlay);

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -1,11 +1,9 @@
 use discv5::kbucket::KBucketsTable;
 use log::debug;
-use rocksdb::DB;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use trin_core::portalnet::{
     discovery::Discovery,
-    events::PortalnetEvents,
     overlay::{OverlayConfig, OverlayProtocol},
     protocol::PortalnetConfig,
     U256,
@@ -20,9 +18,8 @@ pub struct HistoryNetwork {
 impl HistoryNetwork {
     pub async fn new(
         discovery: Arc<RwLock<Discovery>>,
-        db: Arc<DB>,
         portal_config: PortalnetConfig,
-    ) -> Result<(Self, PortalnetEvents), String> {
+    ) -> Result<Self, String> {
         let config = OverlayConfig::default();
         let kbuckets = Arc::new(RwLock::new(KBucketsTable::new(
             discovery.read().await.local_enr().node_id().into(),
@@ -41,13 +38,11 @@ impl HistoryNetwork {
 
         let overlay = Arc::new(overlay);
 
-        let events = PortalnetEvents::new(Arc::clone(&overlay), db).await;
-
         let proto = Self {
             overlay: Arc::clone(&overlay),
         };
 
-        Ok((proto, events))
+        Ok(proto)
     }
 
     /// Convenience call for testing, quick way to ping bootnodes

--- a/trin-state/src/events.rs
+++ b/trin-state/src/events.rs
@@ -1,0 +1,94 @@
+use crate::network::StateNetwork;
+use discv5::TalkRequest;
+use log::{debug, error, warn};
+use rocksdb::DB;
+use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedReceiver;
+use trin_core::portalnet::types::{
+    FindContent, FindNodes, FoundContent, Message, Nodes, Ping, Pong, Request, Response, SszEnr,
+};
+
+pub struct StateEvents {
+    pub network: StateNetwork,
+    pub db: Arc<DB>,
+    pub event_rx: UnboundedReceiver<TalkRequest>,
+}
+
+impl StateEvents {
+    pub async fn process_requests(mut self) {
+        while let Some(talk_request) = self.event_rx.recv().await {
+            debug!("Got history request {:?}", talk_request);
+
+            let reply = match self.process_one_request(&talk_request).await {
+                Ok(r) => Message::Response(r).to_bytes(),
+                Err(e) => {
+                    error!("failed to process portal history event: {}", e);
+                    e.into_bytes()
+                }
+            };
+
+            if let Err(e) = talk_request.respond(reply) {
+                warn!("failed to send reply: {}", e);
+            }
+        }
+    }
+
+    async fn process_one_request(&self, talk_request: &TalkRequest) -> Result<Response, String> {
+        let request = match Message::from_bytes(talk_request.body()) {
+            Ok(Message::Request(r)) => r,
+            Ok(_) => return Err("Invalid message".to_owned()),
+            Err(e) => return Err(format!("Invalid request: {}", e)),
+        };
+
+        let response = match request {
+            Request::Ping(Ping { .. }) => {
+                debug!("Got history overlay ping request {:?}", request);
+                let enr_seq = self
+                    .network
+                    .overlay
+                    .discovery
+                    .read()
+                    .await
+                    .local_enr()
+                    .seq();
+                Response::Pong(Pong {
+                    enr_seq,
+                    data_radius: self.network.overlay.data_radius().await,
+                })
+            }
+            Request::FindNodes(FindNodes { distances }) => {
+                let distances64: Vec<u64> = distances.iter().map(|x| (*x).into()).collect();
+                let enrs = self.network.overlay.nodes_by_distance(distances64).await;
+                Response::Nodes(Nodes {
+                    // from spec: total = The total number of Nodes response messages being sent.
+                    // TODO: support returning multiple messages
+                    total: 1_u8,
+                    enrs,
+                })
+            }
+            Request::FindContent(FindContent { content_key }) => match self.db.get(&content_key) {
+                Ok(Some(value)) => {
+                    let empty_enrs: Vec<SszEnr> = vec![];
+                    Response::FoundContent(FoundContent {
+                        enrs: empty_enrs,
+                        payload: value,
+                    })
+                }
+                Ok(None) => {
+                    let enrs = self
+                        .network
+                        .overlay
+                        .find_nodes_close_to_content(content_key)
+                        .await;
+                    let empty_payload: Vec<u8> = vec![];
+                    Response::FoundContent(FoundContent {
+                        enrs,
+                        payload: empty_payload,
+                    })
+                }
+                Err(e) => panic!("Unable to respond to FindContent: {}", e),
+            },
+        };
+        Ok(response)
+    }
+}

--- a/trin-state/src/events.rs
+++ b/trin-state/src/events.rs
@@ -1,16 +1,11 @@
 use crate::network::StateNetwork;
 use discv5::TalkRequest;
 use log::{debug, error, warn};
-use rocksdb::DB;
-use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedReceiver;
-use trin_core::portalnet::types::{
-    FindContent, FindNodes, FoundContent, Message, Nodes, Ping, Pong, Request, Response, SszEnr,
-};
+use trin_core::portalnet::types::Message;
 
 pub struct StateEvents {
     pub network: StateNetwork,
-    pub db: Arc<DB>,
     pub event_rx: UnboundedReceiver<TalkRequest>,
 }
 
@@ -19,7 +14,12 @@ impl StateEvents {
         while let Some(talk_request) = self.event_rx.recv().await {
             debug!("Got state request {:?}", talk_request);
 
-            let reply = match self.process_one_request(&talk_request).await {
+            let reply = match self
+                .network
+                .overlay
+                .process_one_request(&talk_request)
+                .await
+            {
                 Ok(r) => Message::Response(r).to_bytes(),
                 Err(e) => {
                     error!("failed to process portal state event: {}", e);
@@ -31,64 +31,5 @@ impl StateEvents {
                 warn!("failed to send reply: {}", e);
             }
         }
-    }
-
-    async fn process_one_request(&self, talk_request: &TalkRequest) -> Result<Response, String> {
-        let request = match Message::from_bytes(talk_request.body()) {
-            Ok(Message::Request(r)) => r,
-            Ok(_) => return Err("Invalid message".to_owned()),
-            Err(e) => return Err(format!("Invalid request: {}", e)),
-        };
-
-        let response = match request {
-            Request::Ping(Ping { .. }) => {
-                debug!("Got state overlay ping request {:?}", request);
-                let enr_seq = self
-                    .network
-                    .overlay
-                    .discovery
-                    .read()
-                    .await
-                    .local_enr()
-                    .seq();
-                Response::Pong(Pong {
-                    enr_seq,
-                    data_radius: self.network.overlay.data_radius().await,
-                })
-            }
-            Request::FindNodes(FindNodes { distances }) => {
-                let distances64: Vec<u64> = distances.iter().map(|x| (*x).into()).collect();
-                let enrs = self.network.overlay.nodes_by_distance(distances64).await;
-                Response::Nodes(Nodes {
-                    // from spec: total = The total number of Nodes response messages being sent.
-                    // TODO: support returning multiple messages
-                    total: 1_u8,
-                    enrs,
-                })
-            }
-            Request::FindContent(FindContent { content_key }) => match self.db.get(&content_key) {
-                Ok(Some(value)) => {
-                    let empty_enrs: Vec<SszEnr> = vec![];
-                    Response::FoundContent(FoundContent {
-                        enrs: empty_enrs,
-                        payload: value,
-                    })
-                }
-                Ok(None) => {
-                    let enrs = self
-                        .network
-                        .overlay
-                        .find_nodes_close_to_content(content_key)
-                        .await;
-                    let empty_payload: Vec<u8> = vec![];
-                    Response::FoundContent(FoundContent {
-                        enrs,
-                        payload: empty_payload,
-                    })
-                }
-                Err(e) => panic!("Unable to respond to FindContent: {}", e),
-            },
-        };
-        Ok(response)
     }
 }

--- a/trin-state/src/events.rs
+++ b/trin-state/src/events.rs
@@ -17,12 +17,12 @@ pub struct StateEvents {
 impl StateEvents {
     pub async fn process_requests(mut self) {
         while let Some(talk_request) = self.event_rx.recv().await {
-            debug!("Got history request {:?}", talk_request);
+            debug!("Got state request {:?}", talk_request);
 
             let reply = match self.process_one_request(&talk_request).await {
                 Ok(r) => Message::Response(r).to_bytes(),
                 Err(e) => {
-                    error!("failed to process portal history event: {}", e);
+                    error!("failed to process portal state event: {}", e);
                     e.into_bytes()
                 }
             };
@@ -42,7 +42,7 @@ impl StateEvents {
 
         let response = match request {
             Request::Ping(Ping { .. }) => {
-                debug!("Got history overlay ping request {:?}", request);
+                debug!("Got state overlay ping request {:?}", request);
                 let enr_seq = self
                     .network
                     .overlay

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -8,9 +8,10 @@ use network::StateNetwork;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use trin_core::cli::TrinConfig;
+use trin_core::jsonrpc::handlers::{StateEndpointKind, StateNetworkEndpoint};
 use trin_core::portalnet::discovery::Discovery;
 use trin_core::portalnet::events::PortalnetEvents;
-use trin_core::portalnet::protocol::{PortalnetConfig, StateEndpointKind, StateNetworkEndpoint};
+use trin_core::portalnet::overlay::PortalnetConfig;
 use trin_core::utils::setup_overlay_db;
 
 pub mod events;

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -11,7 +11,7 @@ use trin_core::cli::TrinConfig;
 use trin_core::jsonrpc::handlers::{StateEndpointKind, StateNetworkEndpoint};
 use trin_core::portalnet::discovery::Discovery;
 use trin_core::portalnet::events::PortalnetEvents;
-use trin_core::portalnet::overlay::PortalnetConfig;
+use trin_core::portalnet::types::PortalnetConfig;
 use trin_core::utils::setup_overlay_db;
 
 pub mod events;
@@ -87,13 +87,12 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     tokio::spawn(async move {
-        let mut p2p = StateNetwork::new(discovery, portalnet_config)
+        let mut p2p = StateNetwork::new(discovery, db, portalnet_config)
             .await
             .unwrap();
 
         let state_events = StateEvents {
             network: p2p.clone(),
-            db,
             event_rx: state_receiver,
         };
 

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -5,8 +5,7 @@ use tokio::sync::RwLock;
 use trin_core::cli::HISTORY_NETWORK;
 use trin_core::portalnet::{
     discovery::Discovery,
-    overlay::{OverlayConfig, OverlayProtocol},
-    protocol::PortalnetConfig,
+    overlay::{OverlayConfig, OverlayProtocol, PortalnetConfig},
     U256,
 };
 

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -1,11 +1,9 @@
 use discv5::kbucket::KBucketsTable;
 use log::debug;
-use rocksdb::DB;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use trin_core::portalnet::{
     discovery::Discovery,
-    events::PortalnetEvents,
     overlay::{OverlayConfig, OverlayProtocol},
     protocol::PortalnetConfig,
     U256,
@@ -20,9 +18,8 @@ pub struct StateNetwork {
 impl StateNetwork {
     pub async fn new(
         discovery: Arc<RwLock<Discovery>>,
-        db: Arc<DB>,
         portal_config: PortalnetConfig,
-    ) -> Result<(Self, PortalnetEvents), String> {
+    ) -> Result<Self, String> {
         let config = OverlayConfig::default();
         let kbuckets = Arc::new(RwLock::new(KBucketsTable::new(
             discovery.read().await.local_enr().node_id().into(),
@@ -41,13 +38,11 @@ impl StateNetwork {
 
         let overlay = Arc::new(overlay);
 
-        let events = PortalnetEvents::new(Arc::clone(&overlay), db).await;
-
         let proto = Self {
             overlay: Arc::clone(&overlay),
         };
 
-        Ok((proto, events))
+        Ok(proto)
     }
 
     /// Convenience call for testing, quick way to ping bootnodes

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -1,11 +1,12 @@
 use discv5::kbucket::KBucketsTable;
 use log::debug;
+use rocksdb::DB;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use trin_core::portalnet::{
     discovery::Discovery,
-    overlay::{OverlayConfig, OverlayProtocol, PortalnetConfig},
-    types::ProtocolKind,
+    overlay::{OverlayConfig, OverlayProtocol},
+    types::{PortalnetConfig, ProtocolKind},
     U256,
 };
 
@@ -18,6 +19,7 @@ pub struct StateNetwork {
 impl StateNetwork {
     pub async fn new(
         discovery: Arc<RwLock<Discovery>>,
+        db: Arc<DB>,
         portal_config: PortalnetConfig,
     ) -> Result<Self, String> {
         let config = OverlayConfig::default();
@@ -34,6 +36,7 @@ impl StateNetwork {
             discovery,
             data_radius,
             kbuckets,
+            db,
         };
 
         let overlay = Arc::new(overlay);

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -2,10 +2,10 @@ use discv5::kbucket::KBucketsTable;
 use log::debug;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use trin_core::cli::HISTORY_NETWORK;
 use trin_core::portalnet::{
     discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol, PortalnetConfig},
+    types::ProtocolKind,
     U256,
 };
 
@@ -61,7 +61,7 @@ impl StateNetwork {
             debug!("Pinging {} on portal state network", enr);
             let ping_result = self
                 .overlay
-                .send_ping(U256::from(u64::MAX), enr, HISTORY_NETWORK.to_string())
+                .send_ping(U256::from(u64::MAX), enr, ProtocolKind::State)
                 .await?;
             debug!("Portal state network Ping result: {:?}", ping_result);
         }

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -2,6 +2,7 @@ use discv5::kbucket::KBucketsTable;
 use log::debug;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use trin_core::cli::HISTORY_NETWORK;
 use trin_core::portalnet::{
     discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol},
@@ -59,7 +60,10 @@ impl StateNetwork {
             .table_entries_enr()
         {
             debug!("Pinging {} on portal state network", enr);
-            let ping_result = self.overlay.send_ping(U256::from(u64::MAX), enr).await?;
+            let ping_result = self
+                .overlay
+                .send_ping(U256::from(u64::MAX), enr, HISTORY_NETWORK.to_string())
+                .await?;
             debug!("Portal state network Ping result: {:?}", ping_result);
         }
         Ok(())


### PR DESCRIPTION
#### What does this PR do?
This is PR following https://github.com/ethereum/trin/pull/103.
It adds support for running event handlers for state and history network in parallel.

#### Any specific implementation changes that would benefit highlighting?
The general idea is to have one main portal network event handler and a network event handler per network.
The main event handler will dispatch via unbounded channels all events to the specific network handlers by checking the `protocol` header in discv5 `talk_req`.

This implementation was tested with the dummy node from the testing framework branch by sending three ping requests, one for every network(state, history) and one for a network we don't support. Here are the results:

```rust
Sep 20 13:02:16.534  INFO trin_core::cli: Protocol: ipc
IPC path: /tmp/trin-jsonrpc.ipc    
Sep 20 13:02:16.534  INFO trin_core::cli: Pool Size: 2    
Sep 20 13:02:16.534  INFO trin_core::cli: Bootnodes: None    
Sep 20 13:02:26.539 DEBUG trin_core::socket: STUN claims that public network endpoint is: Err("Timed out waiting for STUN server reply")    
Sep 20 13:02:26.547  INFO trin_core::portalnet::discovery: Starting discv5 with local enr encoded=enr:-IS4QEBiJz6RJ6sUlzBMUowcrHJrk9JFzAT32gJktiG6-lTPDzrgEfmhrGSHkprIjUp4bQE_L-bUqxsEANBVGTegCrMBgmlkgnY0gmlwhMCoASGJc2VjcDI1NmsxoQLP5TRJ2p4HSTZL3fa-NxzRANm0OE6VieTw6yfKF2ViyYN1ZHCCIyk decoded=ENR: NodeId: 0x092c..362b, Socket: Some(192.168.1.33:9001)    
Sep 20 13:02:26.551  INFO discv5::service: Discv5 Service started
Sep 20 13:02:26.551 DEBUG discv5::handler: Handler Starting
Sep 20 13:02:26.551 DEBUG discv5::socket::recv: Recv handler starting
Sep 20 13:02:26.551 DEBUG discv5::socket::send: Send handler starting
Sep 20 13:02:26.565 DEBUG trin: Selected networks to spawn: ["history", "state"]    
Sep 20 13:02:26.566  INFO trin: About to spawn State Network with boot nodes: []    
Sep 20 13:02:26.566  INFO trin: About to spawn History Network with boot nodes: []    
Sep 20 13:02:55.816 DEBUG discv5::service: NodeId unknown, requesting ENR. Node: 0x8c16..1720, addr: 192.168.1.33:9876
Sep 20 13:02:55.816 DEBUG discv5::handler: Sending WHOAREYOU to Node: 0x8c16..1720, addr: 192.168.1.33:9876
Sep 20 13:02:55.840 DEBUG discv5::service: Session established with Node: 0x8c16..1720, direction: Incoming
Sep 20 13:02:55.840 DEBUG discv5::service: New connected node added to routing table: 0x8c16..1720
Sep 20 13:02:55.841 DEBUG trin_core::portalnet::events: Got discv5 event NodeInserted { node_id: NodeId { raw: [140, 22, 195, 101, 247, 209, 226, 186, 66, 78, 130, 150, 127, 62, 155, 96, 20, 110, 177, 16, 73, 7, 112, 122, 57, 130, 157, 135, 238, 167, 23, 32] }, replaced: None }    
Sep 20 13:02:55.841 DEBUG trin_core::portalnet::events: Got discv5 event TalkRequest(TalkRequest { id: RequestId([56, 72, 188, 199, 198, 185, 62, 132]), node_address: NodeAddress { socket_addr: 192.168.1.33:9876, node_id: NodeId { raw: [140, 22, 195, 101, 247, 209, 226, 186, 66, 78, 130, 150, 127, 62, 155, 96, 20, 110, 177, 16, 73, 7, 112, 122, 57, 130, 157, 135, 238, 167, 23, 32] } }, protocol: [104, 105, 115, 116, 111, 114, 121], body: [1, 1, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], sender: Some(UnboundedSender { chan: Tx { inner: Chan { tx: Tx { block_tail: 0x555fba6c3390, tail_position: 1 }, semaphore: 0, rx_waker: AtomicWaker, tx_count: 2, rx_fields: "..." } } }) })    
Sep 20 13:02:55.841 DEBUG trin_history::events: Got history request TalkRequest { id: RequestId([56, 72, 188, 199, 198, 185, 62, 132]), node_address: NodeAddress { socket_addr: 192.168.1.33:9876, node_id: NodeId { raw: [140, 22, 195, 101, 247, 209, 226, 186, 66, 78, 130, 150, 127, 62, 155, 96, 20, 110, 177, 16, 73, 7, 112, 122, 57, 130, 157, 135, 238, 167, 23, 32] } }, protocol: [104, 105, 115, 116, 111, 114, 121], body: [1, 1, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], sender: Some(UnboundedSender { chan: Tx { inner: Chan { tx: Tx { block_tail: 0x555fba6c3390, tail_position: 1 }, semaphore: 0, rx_waker: AtomicWaker, tx_count: 2, rx_fields: "..." } } }) }    
Sep 20 13:02:55.841 DEBUG trin_history::events: Got history overlay ping request Ping(Ping { enr_seq: 1, data_radius: 18446744073709551615 })    
Sep 20 13:02:55.841 DEBUG discv5::service: Sending TALK response to Node: 0x8c16..1720, addr: 192.168.1.33:9876
Sep 20 13:02:55.844 DEBUG trin_core::portalnet::events: Got discv5 event TalkRequest(TalkRequest { id: RequestId([108, 84, 236, 165, 144, 113, 72, 111]), node_address: NodeAddress { socket_addr: 192.168.1.33:9876, node_id: NodeId { raw: [140, 22, 195, 101, 247, 209, 226, 186, 66, 78, 130, 150, 127, 62, 155, 96, 20, 110, 177, 16, 73, 7, 112, 122, 57, 130, 157, 135, 238, 167, 23, 32] } }, protocol: [115, 116, 97, 116, 101], body: [1, 1, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], sender: Some(UnboundedSender { chan: Tx { inner: Chan { tx: Tx { block_tail: 0x555fba6c3390, tail_position: 2 }, semaphore: 0, rx_waker: AtomicWaker, tx_count: 2, rx_fields: "..." } } }) })    
Sep 20 13:02:55.844 DEBUG trin_state::events: Got state request TalkRequest { id: RequestId([108, 84, 236, 165, 144, 113, 72, 111]), node_address: NodeAddress { socket_addr: 192.168.1.33:9876, node_id: NodeId { raw: [140, 22, 195, 101, 247, 209, 226, 186, 66, 78, 130, 150, 127, 62, 155, 96, 20, 110, 177, 16, 73, 7, 112, 122, 57, 130, 157, 135, 238, 167, 23, 32] } }, protocol: [115, 116, 97, 116, 101], body: [1, 1, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], sender: Some(UnboundedSender { chan: Tx { inner: Chan { tx: Tx { block_tail: 0x555fba6c3390, tail_position: 2 }, semaphore: 0, rx_waker: AtomicWaker, tx_count: 2, rx_fields: "..." } } }) }    
Sep 20 13:02:55.844 DEBUG trin_state::events: Got state overlay ping request Ping(Ping { enr_seq: 1, data_radius: 18446744073709551615 })    
Sep 20 13:02:55.844 DEBUG discv5::service: Sending TALK response to Node: 0x8c16..1720, addr: 192.168.1.33:9876
Sep 20 13:02:55.846 DEBUG trin_core::portalnet::events: Got discv5 event TalkRequest(TalkRequest { id: RequestId([178, 121, 10, 242, 179, 112, 44, 18]), node_address: NodeAddress { socket_addr: 192.168.1.33:9876, node_id: NodeId { raw: [140, 22, 195, 101, 247, 209, 226, 186, 66, 78, 130, 150, 127, 62, 155, 96, 20, 110, 177, 16, 73, 7, 112, 122, 57, 130, 157, 135, 238, 167, 23, 32] } }, protocol: [98, 97, 114, 102, 111, 111], body: [1, 1, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], sender: Some(UnboundedSender { chan: Tx { inner: Chan { tx: Tx { block_tail: 0x555fba6c3390, tail_position: 3 }, semaphore: 0, rx_waker: AtomicWaker, tx_count: 2, rx_fields: "..." } } }) })    
Sep 20 13:02:55.847  WARN trin_core::portalnet::events: Non supported protocol : barfoo    
Sep 20 13:02:55.847 DEBUG discv5::service: Sending empty TALK response to Node: 0x8c16..1720, addr: 192.168.1.33:9876
```
