### PR TITLE
Modifies get_default_data_dir to take node id instead of enr

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     discovery.write().await.start().await.unwrap();
 
     // Setup Overlay database
-    let db = Arc::new(setup_overlay_db(discovery.read().await.local_enr()));
+    let db = Arc::new(setup_overlay_db(
+        discovery.read().await.local_enr().node_id(),
+    ));
 
     debug!("Selected networks to spawn: {:?}", trin_config.networks);
     // Initialize state sub-network service and event handlers, if selected

--- a/trin-core/src/utils.rs
+++ b/trin-core/src/utils.rs
@@ -1,4 +1,3 @@
-use crate::portalnet::U256;
 use directories::ProjectDirs;
 use discv5::enr::NodeId;
 use rocksdb::{Options, DB};
@@ -32,7 +31,7 @@ pub fn get_default_data_dir(node_id: NodeId) -> String {
 
     // Append first 8 characters of Node ID
     let mut application_string = "Trin_".to_owned();
-    let node_id_string = U256::from(node_id.raw()).to_string();
+    let node_id_string = hex::encode(node_id.raw());
     let suffix = &node_id_string[..8];
     application_string.push_str(suffix);
 

--- a/trin-core/src/utils.rs
+++ b/trin-core/src/utils.rs
@@ -74,5 +74,4 @@ mod test {
         let two = vec![0, 0, 1];
         xor_two_values(&one, &two);
     }
-
 }

--- a/trin-core/src/utils.rs
+++ b/trin-core/src/utils.rs
@@ -75,20 +75,4 @@ mod test {
         xor_two_values(&one, &two);
     }
 
-    #[test]
-    fn test_get_default_data_directory() {
-        // In base 10: 34799626616874909003598320854863980956826645806663081868307102301466166142830
-        let node_id_bytes: [u8; 32] = [
-            76, 239, 228, 2, 227, 174, 123, 117, 195, 237, 200, 80, 219, 0, 188, 225, 18, 196, 162,
-            89, 204, 144, 204, 187, 71, 12, 147, 65, 19, 65, 167, 110,
-        ];
-        let node_id = NodeId::parse(&node_id_bytes).unwrap();
-        let default_data_dir = get_default_data_dir(node_id);
-        let path_leaf = default_data_dir
-            .split("/")
-            .last()
-            .expect("Failed to get leaf of default data path.");
-
-        assert_eq!(path_leaf, "Trin_34799626");
-    }
 }

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -67,7 +67,9 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let discovery = Arc::new(RwLock::new(discovery));
 
     // Setup Overlay database
-    let db = Arc::new(setup_overlay_db(discovery.read().await.local_enr()));
+    let db = Arc::new(setup_overlay_db(
+        discovery.read().await.local_enr().node_id(),
+    ));
 
     let (history_event_tx, history_event_rx) = mpsc::unbounded_channel::<TalkRequest>();
     let portal_events_discovery = Arc::clone(&discovery);

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -64,7 +64,9 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let discovery = Arc::new(RwLock::new(discovery));
 
     // Setup Overlay database
-    let db = Arc::new(setup_overlay_db(discovery.read().await.local_enr()));
+    let db = Arc::new(setup_overlay_db(
+        discovery.read().await.local_enr().node_id(),
+    ));
 
     let (state_event_tx, state_event_rx) = mpsc::unbounded_channel::<TalkRequest>();
     let portal_events_discovery = Arc::clone(&discovery);


### PR DESCRIPTION
Implements @ogenev's initial thoughts from #81.

Uses the first 8 characters of the Node ID's base 10 representation.
Any thoughts on whether we may want hex instead, or less than 8 characters?