### PR TITLE
Add OverlayProtocol constructor

### DIFF
--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -85,6 +85,28 @@ pub struct OverlayProtocol {
 }
 
 impl OverlayProtocol {
+    pub async fn new(
+        config: OverlayConfig,
+        discovery: Arc<RwLock<Discovery>>,
+        db: Arc<DB>,
+        data_radius: U256,
+    ) -> Self {
+        let kbuckets = Arc::new(RwLock::new(KBucketsTable::new(
+            discovery.read().await.local_enr().node_id().into(),
+            config.bucket_pending_timeout,
+            config.max_incoming_per_bucket,
+            config.table_filter,
+            config.bucket_filter,
+        )));
+
+        Self {
+            discovery,
+            data_radius: Arc::new(RwLock::new(data_radius)),
+            kbuckets,
+            db,
+        }
+    }
+
     pub async fn process_one_request(
         &self,
         talk_request: &TalkRequest,

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -1,4 +1,3 @@
-use discv5::kbucket::KBucketsTable;
 use log::debug;
 use rocksdb::DB;
 use std::sync::Arc;
@@ -23,29 +22,11 @@ impl HistoryNetwork {
         portal_config: PortalnetConfig,
     ) -> Result<Self, String> {
         let config = OverlayConfig::default();
-        let kbuckets = Arc::new(RwLock::new(KBucketsTable::new(
-            discovery.read().await.local_enr().node_id().into(),
-            config.bucket_pending_timeout,
-            config.max_incoming_per_bucket,
-            config.table_filter,
-            config.bucket_filter,
-        )));
-        let data_radius = Arc::new(RwLock::new(portal_config.data_radius));
+        let overlay = OverlayProtocol::new(config, discovery, db, portal_config.data_radius).await;
 
-        let overlay = OverlayProtocol {
-            discovery,
-            data_radius,
-            kbuckets,
-            db,
-        };
-
-        let overlay = Arc::new(overlay);
-
-        let proto = Self {
-            overlay: Arc::clone(&overlay),
-        };
-
-        Ok(proto)
+        Ok(Self {
+            overlay: Arc::new(overlay),
+        })
     }
 
     /// Convenience call for testing, quick way to ping bootnodes


### PR DESCRIPTION
Add constructor for `OverlayProtocol` to remove redundant logic and make `OverlayProtocol` responsible for creation of `KBucketsTable`.