### PR TITLE
doc - update --external-address helpstring

### DIFF
--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -65,7 +65,7 @@ pub struct TrinConfig {
 
     #[structopt(
         long = "external-address",
-        help = "The public IP address and port under which this node is accessible"
+        help = "(Only use this if you are behind a NAT) This is the address which will be advertised to peers (in an ENR). Changing it does not change which port or address trin binds to."
     )]
     pub external_addr: Option<SocketAddr>,
 


### PR DESCRIPTION
I wanted to change the port my node was listening to and after skimming
through the output of --help I tried to do so using the
--external-address flag. It turns out this is not the correct flag to
use!

While the previous help string hinted at the behavior of this flag the
new one should help to prevent future confusion.