### PR TITLE
logging - improve legibility of initial log messages

### DIFF
--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -118,27 +118,22 @@ impl TrinConfig {
     }
 
     pub fn display_config(&self) {
+        info!("Launching with config:");
         match self.web3_transport.as_str() {
             "http" => {
-                info!(
-                    "Protocol: {}\nWEB3 HTTP port: {}",
-                    self.web3_transport, self.web3_http_port
-                )
+                info!("- JSON-RPC HTTP port: {}", self.web3_http_port)
             }
             "ipc" => {
-                info!(
-                    "Protocol: {}\nIPC path: {}",
-                    self.web3_transport, self.web3_ipc_path
-                )
+                info!("- JSON-RPC IPC path: {}", self.web3_ipc_path)
             }
-            val => panic!("Unsupported json-rpc protocol: {}", val),
+            val => panic!("Unsupported json-rpc transport: {}", val),
         }
 
-        info!("Pool Size: {}", self.pool_size);
+        info!("- Pool Size: {}", self.pool_size);
 
         match self.bootnodes.is_empty() {
-            true => info!("Bootnodes: None"),
-            _ => info!("Bootnodes: {:?}", self.bootnodes),
+            true => info!("- Bootnodes: None"),
+            _ => info!("- Bootnodes: {:?}", self.bootnodes),
         }
     }
 }

--- a/trin-core/src/jsonrpc/service.rs
+++ b/trin-core/src/jsonrpc/service.rs
@@ -1,7 +1,7 @@
 use super::handlers::{PortalEndpoint, PortalEndpointKind};
 use super::types::JsonRequest;
 use crate::cli::TrinConfig;
-use log::debug;
+use log::{debug, info};
 use reqwest::blocking as reqwest;
 use serde_json::{json, Value};
 use std::fs;
@@ -87,6 +87,8 @@ fn launch_ipc_client(
             panic!("Could not serve from IPC path '{}': {:?}", ipc_path, err);
         }
     };
+
+    info!("listening for commands: {}", ipc_path);
 
     for stream in listener.incoming() {
         let stream = stream.unwrap();


### PR DESCRIPTION
Before

```
Launching trin
Oct 08 11:36:11.864  INFO trin_core::cli: Protocol: ipc
IPC path: /tmp/trin-jsonrpc2.ipc    
Oct 08 11:36:11.865  INFO trin_core::cli: Pool Size: 2    
Oct 08 11:36:11.865  INFO trin_core::cli: Bootnodes: None
(10 sec pause)   
Oct 08 11:36:21.878 DEBUG trin_core::socket: STUN claims that public network endpoint is: Err("Timed out waiting for STUN server reply")    
```

After:

```
Launching trin
Oct 08 11:37:05.744  INFO trin_core::cli: Launching with config:    
Oct 08 11:37:05.744  INFO trin_core::cli: - JSON-RPC IPC path: /tmp/trin-jsonrpc.ipc    
Oct 08 11:37:05.744  INFO trin_core::cli: - Pool Size: 2    
Oct 08 11:37:05.745  INFO trin_core::cli: - Bootnodes: None    
Oct 08 11:37:05.745  INFO trin_core::socket: Blocking: connecting to STUN server to find public network endpoint    
Oct 08 11:37:15.766 DEBUG trin_core::socket: Failed to setup STUN traversal: "Timed out waiting for STUN server reply"    
```