### PR TITLE
Update localhost address for use in docker container

### DIFF
--- a/trin-core/src/jsonrpc/service.rs
+++ b/trin-core/src/jsonrpc/service.rs
@@ -112,7 +112,7 @@ fn launch_http_client(
     trin_config: TrinConfig,
     portal_tx: UnboundedSender<PortalJsonRpcRequest>,
 ) {
-    let uri = format!("127.0.0.1:{}", trin_config.web3_http_port);
+    let uri = format!("0.0.0.0:{}", trin_config.web3_http_port);
     let listener = TcpListener::bind(uri).unwrap();
     for stream in listener.incoming() {
         match stream {


### PR DESCRIPTION
In order to communicate to our http server from outside of a docker container, we need to bind to `0.0.0.0` rather than `127.0.0.1`. Though, I'm not sure if this opens up some security vulnerabilities as the new default? And instead should be controlled via cli flag / env var?