### PR TITLE
ux - do not crash when bootnode bonding times out

### DIFF
--- a/trin-core/src/portalnet/discovery.rs
+++ b/trin-core/src/portalnet/discovery.rs
@@ -4,7 +4,7 @@ use super::types::{HexData, PortalnetConfig};
 use super::Enr;
 use crate::socket;
 use discv5::enr::{CombinedKey, EnrBuilder, NodeId};
-use discv5::{Discv5, Discv5Config, Discv5ConfigBuilder};
+use discv5::{Discv5, Discv5Config, Discv5ConfigBuilder, RequestError};
 use log::info;
 use serde_json::{json, Value};
 use std::net::{IpAddr, SocketAddr};
@@ -171,12 +171,11 @@ impl Discovery {
         enr: Enr,
         protocol: String,
         request: ProtocolRequest,
-    ) -> Result<Vec<u8>, String> {
+    ) -> Result<Vec<u8>, RequestError> {
         let response = self
             .discv5
             .talk_req(enr, protocol.into_bytes(), request)
-            .await
-            .map_err(|e| format!("TalkReq query failed: {:?}", e))?;
+            .await?;
         Ok(response)
     }
 }

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -46,7 +46,8 @@ impl HistoryNetwork {
             let ping_result = self
                 .overlay
                 .send_ping(U256::from(u64::MAX), enr, ProtocolKind::History, None)
-                .await?;
+                .await
+                .map_err(|e| format!("Failed to ping bootnode: {:?}", e))?;
             debug!("Portal history network Ping result: {:?}", ping_result);
         }
         Ok(())


### PR DESCRIPTION
- begin the slow process of replacing Result<_, String> with meaningful
  error types,
- when one bootnode times out don't crash, move on to the next bootnode

---

I'm not convinced that this is the correct way to slice our errors, very open to suggestions! For example it might be better for there to be a `DiscoveryError` which Overlay passes through to its callers. However, I believe this change is a step in the right direction, just about anything is better than using `String` everywhere!

Before:

```
Oct 12 17:27:48.411 DEBUG discv5::service: Sending RPC Request: id: 28fd4d25334fc35a: TALK: protocol: 7374617465, request: 0101000000000000000c00000001000000ffffffffffffffff0000000000000000000000000000000000000000000000002400000000000000 to node: Node: 0x76f9..6f28, addr: Some(71.202.127.37:4567)
Oct 12 17:27:49.413 DEBUG discv5::service: RPC Request timed out. id: 28fd4d25334fc35a
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: "TalkReq query failed: Timeout"', trin-state/src/lib.rs:120:54
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:

```
Oct 12 18:46:12.485 DEBUG discv5::service: Sending RPC Request: id: 8c58437377e21182: TALK: protocol: 7374617465, request: 0101000000000000000c00000001000000ffffffffffffffff0000000000000000000000000000000000000000000000002400000000000000 to node: Node: 0x76f9..6f28, addr: Some(71.202.127.37:4567)
Oct 12 18:46:13.489 DEBUG discv5::service: RPC Request timed out. id: 8c58437377e21182
Oct 12 18:46:13.489 DEBUG trin_state::network:  Timed out while bonding with ENR: NodeId: 0x76f9..6f28, Socket: Some(71.202.127.37:4567)    
```