### PR TITLE
Emit warnings when locks are held for too long

### DIFF
--- a/ethportal-peertest/src/main.rs
+++ b/ethportal-peertest/src/main.rs
@@ -9,6 +9,7 @@ use ethportal_peertest::events::PortalnetEvents;
 use ethportal_peertest::jsonrpc::{
     test_jsonrpc_endpoints_over_http, test_jsonrpc_endpoints_over_ipc,
 };
+use trin_core::locks::RwLoggingExt;
 use trin_core::portalnet::{
     discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol},
@@ -30,10 +31,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
 
         let discovery = Arc::new(RwLock::new(Discovery::new(portal_config).unwrap()));
-        discovery.write().await.start().await.unwrap();
+        discovery.write_with_warn().await.start().await.unwrap();
 
         let db = Arc::new(setup_overlay_db(
-            discovery.read().await.local_enr().node_id(),
+            discovery.read_with_warn().await.local_enr().node_id(),
         ));
 
         let overlay = Arc::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use tokio::sync::RwLock;
 
 use trin_core::jsonrpc::handlers::JsonRpcHandler;
 use trin_core::jsonrpc::types::PortalJsonRpcRequest;
+use trin_core::locks::RwLoggingExt;
 use trin_core::portalnet::events::PortalnetEvents;
 use trin_core::{
     cli::{TrinConfig, HISTORY_NETWORK, STATE_NETWORK},
@@ -52,11 +53,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let discovery = Arc::new(RwLock::new(
         Discovery::new(portalnet_config.clone()).unwrap(),
     ));
-    discovery.write().await.start().await.unwrap();
+    discovery.write_with_warn().await.start().await.unwrap();
 
     // Setup Overlay database
     let db = Arc::new(setup_overlay_db(
-        discovery.read().await.local_enr().node_id(),
+        discovery.read_with_warn().await.local_enr().node_id(),
     ));
 
     debug!("Selected networks to spawn: {:?}", trin_config.networks);

--- a/trin-core/src/jsonrpc/handlers.rs
+++ b/trin-core/src/jsonrpc/handlers.rs
@@ -8,6 +8,7 @@ use tokio::sync::RwLock;
 
 use crate::jsonrpc::endpoints::{Discv5Endpoint, HistoryEndpoint, StateEndpoint, TrinEndpoint};
 use crate::jsonrpc::types::{HistoryJsonRpcRequest, PortalJsonRpcRequest, StateJsonRpcRequest};
+use crate::locks::RwLoggingExt;
 use crate::portalnet::discovery::Discovery;
 
 type Responder<T, E> = mpsc::UnboundedSender<Result<T, E>>;
@@ -25,9 +26,9 @@ impl JsonRpcHandler {
         while let Some(request) = self.portal_jsonrpc_rx.recv().await {
             let response: Value = match request.endpoint {
                 TrinEndpoint::Discv5Endpoint(endpoint) => match endpoint {
-                    Discv5Endpoint::NodeInfo => self.discovery.read().await.node_info(),
+                    Discv5Endpoint::NodeInfo => self.discovery.read_with_warn().await.node_info(),
                     Discv5Endpoint::RoutingTableInfo => {
-                        self.discovery.write().await.routing_table_info()
+                        self.discovery.write_with_warn().await.routing_table_info()
                     }
                 },
                 TrinEndpoint::HistoryEndpoint(endpoint) => {

--- a/trin-core/src/lib.rs
+++ b/trin-core/src/lib.rs
@@ -3,6 +3,7 @@ extern crate lazy_static;
 
 pub mod cli;
 pub mod jsonrpc;
+pub mod locks;
 pub mod portalnet;
 pub mod socket;
 pub mod utils;

--- a/trin-core/src/locks.rs
+++ b/trin-core/src/locks.rs
@@ -1,0 +1,153 @@
+use futures::future::FutureExt;
+use std::future::Future;
+use std::marker::Sync;
+use std::ops::Deref;
+use std::ops::DerefMut;
+use std::panic::Location;
+use std::pin::Pin;
+use std::time::Duration;
+use std::time::Instant;
+use tokio::sync::RwLock;
+use tokio::sync::RwLockReadGuard;
+use tokio::sync::RwLockWriteGuard;
+use tokio::task::JoinHandle;
+
+const ACQUIRE_TIMEOUT_MS: u64 = 100;
+const HOLD_TIMEOUT_MS: u64 = 100;
+
+/// Tries to look exactly like a T, by implementing Deref and DerefMut, but emits
+/// a warning if drop() is not called soon enough.
+pub struct TimedGuard<T> {
+    inner: T,
+    acquisition_line: u32,
+    acquisition_file: &'static str,
+    acquisition_time: Instant,
+    sleep_task: JoinHandle<()>,
+}
+
+impl<T> TimedGuard<T> {
+    fn new(inner: T, acquisition_line: u32, acquisition_file: &'static str) -> TimedGuard<T> {
+        let now = Instant::now();
+        let move_line = acquisition_line;
+        let move_file = acquisition_file;
+        let handle = tokio::spawn(async move {
+            sleep_then_log(move_file, move_line).await;
+        });
+
+        TimedGuard {
+            inner,
+            acquisition_line,
+            acquisition_file,
+            acquisition_time: now,
+            sleep_task: handle,
+        }
+    }
+}
+
+impl<T> Deref for TimedGuard<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for TimedGuard<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<T> Drop for TimedGuard<T> {
+    fn drop(&mut self) {
+        self.sleep_task.abort();
+        let held_for = self.acquisition_time.elapsed().as_millis();
+        if held_for > HOLD_TIMEOUT_MS.into() {
+            log::warn!(
+                "[{}:{}] lock held for too long: {}ms",
+                self.acquisition_file,
+                self.acquisition_line,
+                held_for,
+            )
+        }
+    }
+}
+
+async fn sleep_then_log(file: &'static str, line: u32) {
+    tokio::time::sleep(Duration::from_millis(HOLD_TIMEOUT_MS)).await;
+    log::warn!(
+        "[{}:{}] lock held for over {}ms, not yet released",
+        file,
+        line,
+        HOLD_TIMEOUT_MS.to_string()
+    );
+}
+
+async fn try_lock<T, Fut>(fut: Fut, file: &'static str, line: u32) -> TimedGuard<T>
+where
+    Fut: Future<Output = T>,
+{
+    let acquire_timeout = Duration::from_millis(ACQUIRE_TIMEOUT_MS);
+    let sleep = tokio::time::sleep(acquire_timeout).fuse();
+    let fused = fut.fuse();
+
+    futures::pin_mut!(sleep, fused);
+
+    let now = Instant::now();
+
+    futures::select! {
+        _ = sleep => {
+            log::warn!(
+                "[{}:{}] waiting more than {}ms to acquire lock, still waiting",
+                file, line, ACQUIRE_TIMEOUT_MS,
+            );
+        },
+        guard = fused => {
+            return TimedGuard::new(guard, line, file);
+        }
+    }
+
+    let guard = fused.await;
+    let wait_time = now.elapsed().as_millis();
+    log::warn!("[{}:{}] waited {}ms to acquire lock", file, line, wait_time);
+
+    TimedGuard::new(guard, line, file)
+}
+
+// this is a workaround:
+// - Rust does not support async in traits
+//   https://rust-lang.github.io/async-book/07_workarounds/05_async_in_traits.html
+// - async_trait does not give us enough flexibility to implement #[track_caller]
+//
+// So we manually desugar the async functions and have them return futures
+type Async<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// These methods should be used in favor of the stock read() and write() methods.
+///
+/// These methods emit warnings when the lock takes too long to acquire (meaning it's
+/// likely some other user is holding onto the lock for too long).
+///
+/// They also emit warnings when the returned TimedGuard is kept alive for too long.
+/// (The lock is held until the returned TimedGuard is dropped, so it should be dropped
+/// as soon as possible!)
+pub trait RwLoggingExt<T> {
+    #[track_caller]
+    fn read_with_warn(&self) -> Async<TimedGuard<RwLockReadGuard<T>>>;
+
+    #[track_caller]
+    fn write_with_warn(&self) -> Async<TimedGuard<RwLockWriteGuard<T>>>;
+}
+
+impl<T: Send + Sync> RwLoggingExt<T> for RwLock<T> {
+    #[track_caller]
+    fn read_with_warn(&self) -> Async<TimedGuard<RwLockReadGuard<T>>> {
+        let loc = Location::caller();
+        Box::pin(try_lock(self.read(), loc.file(), loc.line()))
+    }
+
+    #[track_caller]
+    fn write_with_warn(&self) -> Async<TimedGuard<RwLockWriteGuard<T>>> {
+        let loc = Location::caller();
+        Box::pin(try_lock(self.write(), loc.file(), loc.line()))
+    }
+}

--- a/trin-core/src/portalnet/events.rs
+++ b/trin-core/src/portalnet/events.rs
@@ -10,6 +10,7 @@ use super::{
     utp::{UtpListener, UTP_PROTOCOL},
 };
 use crate::cli::{HISTORY_NETWORK, STATE_NETWORK};
+use crate::locks::RwLoggingExt;
 use std::collections::HashMap;
 use std::convert::TryInto;
 
@@ -28,7 +29,7 @@ impl PortalnetEvents {
         state_sender: Option<mpsc::UnboundedSender<TalkRequest>>,
     ) -> Self {
         let protocol_receiver = discovery
-            .write()
+            .write_with_warn()
             .await
             .discv5
             .event_stream()

--- a/trin-state/src/events.rs
+++ b/trin-state/src/events.rs
@@ -3,6 +3,7 @@ use discv5::TalkRequest;
 use log::{debug, error, warn};
 use std::sync::Arc;
 use tokio::sync::{mpsc::UnboundedReceiver, RwLock};
+use trin_core::locks::RwLoggingExt;
 use trin_core::portalnet::types::Message;
 
 pub struct StateEvents {
@@ -17,7 +18,7 @@ impl StateEvents {
 
             let reply = match self
                 .network
-                .write()
+                .write_with_warn()
                 .await
                 .overlay
                 .process_one_request(&talk_request)


### PR DESCRIPTION
Quick note: I'm not sure who to give this to so I gave it to you @njgheorghita, but feel free to pass it off to somebody else if you think that's appropriate!

This PR is not yet finished, there's some cleanup to do (such as removing code duplication, and logging when `rw_write!()` calls hold onto the lock for too long, but opening a PR now to get feedback on the general approach.

---

- Add rw_read and rw_write macros which wrap access to locks
  - They emit warnings if lock acqusition takes over 100ms
  - They emit warnings if locks are held for over 100ms

- Use rw_read and rw_write macros in most places RwLock's are accessed

Using these macros I was able to immediately identify the cause of a
deadlock during boot.

---

Example output:

```
$ RUST_LOG=debug TRIN_INFURA_PROJECT_ID=XXX cargo run -- --networks state --bootnodes $ENR
Launching trin
[more output]
Oct 15 14:25:25.497 DEBUG trin_state::network: Attempting bond with bootnode ENR: NodeId: 0x76f9..6f28, Socket: Some(71.202.127.37:4567)    
Oct 15 14:25:25.598  WARN trin_core::portalnet::events: [trin-core/src/portalnet/events.rs:31] took more than 100 ms to acquire lock    
Oct 15 14:25:25.598  WARN trin_core: [trin-state/src/network.rs:38] lock held for over 100ms, not yet released    
Oct 15 14:25:25.699  WARN trin_core::portalnet::overlay: [trin-core/src/portalnet/overlay.rs:279] waiting more than 100ms to acquire lock, still waiting    
```

This makes it trivial to figure out where the deadlock is!