### PR TITLE
bugfix - remove deadlock when pinging bootnodes

### DIFF
--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -35,8 +35,12 @@ impl StateNetwork {
         // Trigger bonding with bootnodes, at both the base layer and portal overlay.
         // The overlay ping via talkreq will trigger a session at the base layer, then
         // a session on the (overlay) portal network.
-        let guard = self.overlay.discovery.read_with_warn().await;
-        for enr in guard.discv5.table_entries_enr() {
+        let table_entries = {
+            // use a nested scope so that the guard is quickly dropped
+            let guard = self.overlay.discovery.read_with_warn().await;
+            guard.discv5.table_entries_enr()
+        };
+        for enr in table_entries {
             debug!("Attempting bond with bootnode {}", enr);
             let ping_result = self
                 .overlay


### PR DESCRIPTION
Fixes a deadlock which occurs during boot.

---

Before:

```
Oct 15 13:58:05.390  INFO trin_core::jsonrpc::service: listening for commands: /tmp/trin-jsonrpc2.ipc    
Oct 15 13:58:05.491  WARN trin_core::portalnet::events: [trin-core/src/portalnet/events.rs:31] took more than 100 ms to acquire lock    
Oct 15 13:58:05.491  WARN trin_core: [trin-state/src/network.rs:38] lock held for over 100 ms    
Oct 15 13:58:05.491  WARN trin_core::portalnet::overlay: [trin-core/src/portalnet/overlay.rs:272] took more than 100 ms to acquire lock    
[blocks forever]
```

After:

```
Oct 15 15:12:43.300 DEBUG trin_state::network: Attempting bond with bootnode ENR: NodeId: 0x76f9..6f28, Socket: Some(71.202.127.37:4567)    
Oct 15 15:12:43.300 DEBUG discv5::service: Sending RPC Request: id: 41c978172b0c39d3: TALK: protocol: 7374617465, request: 0101000000000000000c00000001000000ffffffffffffffff0000000000000000000000000000000000000000000000002400000000000000 to node: Node: 0x76f9..6f28, addr: Some(71.202.127.37:4567)
Oct 15 15:12:43.402  WARN trin_core: [trin-core/src/portalnet/overlay.rs:279] lock held for over 100ms, not yet released    
Oct 15 15:12:44.303 DEBUG discv5::service: RPC Request timed out. id: 41c978172b0c39d3
Oct 15 15:12:44.304  WARN trin_core: [trin-core/src/portalnet/overlay.rs:279] lock held for too long: 1003ms    
Oct 15 15:12:44.304 DEBUG trin_state::network: Timed out while bonding with ENR: NodeId: 0x76f9..6f28, Socket: Some(71.202.127.37:4567)    
```