### PR TITLE
Process base layer discv5 RPC messages

### DIFF
--- a/trin-core/src/jsonrpc/endpoints.rs
+++ b/trin-core/src/jsonrpc/endpoints.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 pub enum Discv5Endpoint {
     NodeInfo,
     RoutingTableInfo,
+    FindNodes,
 }
 
 /// State network JSON-RPC endpoints. Start with "portalState_" prefix
@@ -51,6 +52,7 @@ impl FromStr for TrinEndpoint {
             "discv5_routingTableInfo" => Ok(TrinEndpoint::Discv5Endpoint(
                 Discv5Endpoint::RoutingTableInfo,
             )),
+            "discv5_findNodes" => Ok(TrinEndpoint::Discv5Endpoint(Discv5Endpoint::FindNodes)),
             "eth_blockNumber" => Ok(TrinEndpoint::InfuraEndpoint(InfuraEndpoint::BlockNumber)),
             "portalHistory_dataRadius" => {
                 Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::DataRadius))

--- a/trin-core/src/jsonrpc/handlers.rs
+++ b/trin-core/src/jsonrpc/handlers.rs
@@ -31,6 +31,10 @@ impl JsonRpcHandler {
                     Discv5Endpoint::RoutingTableInfo => {
                         self.discovery.write().await.routing_table_info()
                     }
+                    Discv5Endpoint::FindNodes => {
+                        // TODO: Add RPC handler for every endpoint and validate parameters
+                        Value::String("Disscv5 FindNodes endpoint not implemented yet!".to_owned())
+                    }
                 },
                 TrinEndpoint::HistoryEndpoint(endpoint) => {
                     let response = match self.history_jsonrpc_tx.as_ref() {

--- a/trin-core/src/jsonrpc/service.rs
+++ b/trin-core/src/jsonrpc/service.rs
@@ -289,6 +289,7 @@ fn dispatch_portal_request(
 ) -> Result<String, String> {
     let (resp_tx, mut resp_rx) = mpsc::unbounded_channel::<Result<Value, String>>();
     let message = PortalJsonRpcRequest {
+        request: obj.clone(),
         endpoint,
         resp: resp_tx,
     };

--- a/trin-core/src/jsonrpc/types.rs
+++ b/trin-core/src/jsonrpc/types.rs
@@ -41,6 +41,7 @@ pub struct JsonRequest {
 // Global portal network JSON-RPC request
 #[derive(Debug, Clone)]
 pub struct PortalJsonRpcRequest {
+    pub request: JsonRequest,
     pub endpoint: TrinEndpoint,
     pub resp: Responder<Value, String>,
 }
@@ -48,6 +49,7 @@ pub struct PortalJsonRpcRequest {
 /// History network JSON-RPC request
 #[derive(Debug)]
 pub struct HistoryJsonRpcRequest {
+    pub request: JsonRequest,
     pub endpoint: HistoryEndpoint,
     pub resp: Responder<Value, String>,
 }
@@ -55,6 +57,7 @@ pub struct HistoryJsonRpcRequest {
 /// State network JSON-RPC request
 #[derive(Debug)]
 pub struct StateJsonRpcRequest {
+    pub request: JsonRequest,
     pub endpoint: StateEndpoint,
     pub resp: Responder<Value, String>,
 }

--- a/trin-core/src/portalnet/events.rs
+++ b/trin-core/src/portalnet/events.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 
 use super::{
-    discovery::Discovery,
+    discovery::{Discovery, DISCV5_PROTOCOL},
     utp::{UtpListener, UTP_PROTOCOL},
 };
 use crate::cli::{HISTORY_NETWORK, STATE_NETWORK};
@@ -79,6 +79,13 @@ impl PortalnetEvents {
                             .process_utp_request(request.body(), request.node_id())
                             .await;
                         self.process_utp_byte_stream().await;
+                    }
+                    DISCV5_PROTOCOL => {
+                        self.discovery
+                            .read()
+                            .await
+                            .process_rpc_request(request)
+                            .await
                     }
                     _ => {
                         warn!("Non supported protocol : {}", protocol);

--- a/trin-core/src/portalnet/types.rs
+++ b/trin-core/src/portalnet/types.rs
@@ -9,10 +9,38 @@ use ssz;
 use ssz::{Decode, DecodeError, Encode, SszDecoderBuilder, SszEncoder};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum, VariableList};
+use thiserror::Error;
 
 use super::{Enr, U256};
 
 type ByteList = VariableList<u8, typenum::U2048>;
+
+#[derive(Error, Debug)]
+pub enum MessageDecodeError {
+    #[error("Failed to decode message from SSZ bytes")]
+    Ssz,
+
+    #[error("Unknown message id")]
+    MessageId,
+
+    #[error("Failed to decode message from empty bytes")]
+    Empty,
+
+    #[error("Invalid message type")]
+    Type,
+}
+
+impl From<DecodeError> for MessageDecodeError {
+    fn from(_err: DecodeError) -> Self {
+        Self::Ssz
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum DiscoveryRequestError {
+    #[error("Invalid discv5 request message")]
+    InvalidMessage,
+}
 
 #[derive(Clone)]
 pub struct PortalnetConfig {
@@ -89,38 +117,35 @@ impl Message {
     }
 
     /// Decode a `Message` type from bytes.
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, MessageDecodeError> {
         if let Some(message_id) = bytes.first() {
             match message_id {
                 // Requests
                 1 => Ok(Message::Request(Request::Ping(
-                    Ping::from_ssz_bytes(&bytes[1..])
-                        .map_err(|e| format!("Failed to decode ssz: {:?}", e))?,
+                    Ping::from_ssz_bytes(&bytes[1..]).map_err(|e| MessageDecodeError::from(e))?,
                 ))),
                 3 => Ok(Message::Request(Request::FindNodes(
                     FindNodes::from_ssz_bytes(&bytes[1..])
-                        .map_err(|e| format!("Failed to decode ssz: {:?}", e))?,
+                        .map_err(|e| MessageDecodeError::from(e))?,
                 ))),
                 5 => Ok(Message::Request(Request::FindContent(
                     FindContent::from_ssz_bytes(&bytes[1..])
-                        .map_err(|e| format!("Failed to decode ssz: {:?}", e))?,
+                        .map_err(|e| MessageDecodeError::from(e))?,
                 ))),
                 2 => Ok(Message::Response(Response::Pong(
-                    Pong::from_ssz_bytes(&bytes[1..])
-                        .map_err(|e| format!("Failed to decode ssz: {:?}", e))?,
+                    Pong::from_ssz_bytes(&bytes[1..]).map_err(|e| MessageDecodeError::from(e))?,
                 ))),
                 4 => Ok(Message::Response(Response::Nodes(
-                    Nodes::from_ssz_bytes(&bytes[1..])
-                        .map_err(|e| format!("Failed to decode ssz: {:?}", e))?,
+                    Nodes::from_ssz_bytes(&bytes[1..]).map_err(|e| MessageDecodeError::from(e))?,
                 ))),
                 6 => Ok(Message::Response(Response::FoundContent(
                     FoundContent::from_ssz_bytes(&bytes[1..])
-                        .map_err(|e| format!("Failed to decode ssz: {:?}", e))?,
+                        .map_err(|e| MessageDecodeError::from(e))?,
                 ))),
-                _ => Err("Unknown message id".to_string()),
+                _ => Err(MessageDecodeError::MessageId),
             }
         } else {
-            Err("Empty bytes".to_string())
+            Err(MessageDecodeError::Empty)
         }
     }
 }


### PR DESCRIPTION
This is the beginning of implementing the json-rpc endpoints with highest priority for the test network.

**What is included in this PR?**

- Better message SSZ decode error handling.
- We are now passing the payload of the json-rpc request to the handlers, so we can extract the params.
- Method to process base layer discv5 RPC messages.
- Expose `discv5_findNodes` endpoint.

**What is next?**

We need to validate the parameters of the json-rpc requests. In a following PR, I'm thinking of implementing rpc handler for every endpoint and add common validation methods for the parameters.