### PR TITLE
Migrate to Rust 2021 edition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  rust: circleci/rust@1.5.0
+  rust: circleci/rust@1.6.0
   win: circleci/windows@2.2.0
 jobs:
   lint-build-test:
@@ -8,7 +8,7 @@ jobs:
             Check linting with Clippy and rustfmt, build the crate, and run tests.
         executor:
             name: rust/default
-            tag: 1.55.0
+            tag: 1.56.0
         steps:
             - checkout
             - restore_cache:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "trin"
 version = "0.1.0"
 authors = ["Jacob Kaufmann <jacobkaufmann18@gmail.com>", "Jason Carver <ut96caarrs@snkmail.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 default-run = "trin"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "ethportal-peertest"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "trin-core"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 base64 = "0.13.0"

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -2,7 +2,8 @@
 name = "trin-history"
 version = "0.1.0"
 authors = ["Jacob Kaufmann <jacobkaufmann18@gmail.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -2,7 +2,8 @@
 name = "trin-state"
 version = "0.1.0"
 authors = ["Jason Carver <ut96caarrs@snkmail.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Upgrade to recently released stable Rust 2021 edition.

Check [here](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html) for more details.