### PR TITLE
Add internal ip cli flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
  "digest",
  "enr",
  "fnv",
- "futures 0.3.16",
+ "futures 0.3.17",
  "hashlink",
  "hex",
  "hkdf",
@@ -797,9 +797,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -822,15 +822,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
+checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -839,15 +839,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
  "autocfg 1.0.1",
  "proc-macro-hack",
@@ -858,21 +858,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
 
 [[package]]
 name = "futures-util"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg 1.0.1",
  "futures-channel",
@@ -2990,7 +2990,7 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
- "futures 0.3.16",
+ "futures 0.3.17",
  "hex",
  "httparse",
  "interfaces",

--- a/ethportal-peertest/README.md
+++ b/ethportal-peertest/README.md
@@ -8,6 +8,10 @@ cd ethportal-peertest
 RUST_LOG=debug cargo run -p ethportal-peertest -- --target-node enr:-IS4QBDHCSMoYoC5UziAwKSyTmMPrhMaEpaE52L8DDAkipqvZQe9fgLy2wVuuEJwO9l1KsYrRoFGCsNjylbd0CDNw60BgmlkgnY0gmlwhMCoXUSJc2VjcDI1NmsxoQJPAZUFErHK1DZYRTLjk3SCNgye9sS-MxoQI-gLiUdwc4N1ZHCCIyk
 ```
 
+# Target Node Config
+
+## IP Address
+To make sure the test harness can communicate with the target node, run the target node with the `--internal-ip` flag to avoid using an external ip address.
+
 ## Transport selection
 Running the test harness will by default test all jsonrpc endpoints over IPC to the target node. To make sure these pass, please make sure that the target node is running with `--web3-transport ipc`. To test jsonrpc over http, use the `--target-transport http` cli argument for the harness, and make sure the target node is running with `--web3-transport http`. Ideally, both transport methods are tested before PRs.
-

--- a/ethportal-peertest/src/main.rs
+++ b/ethportal-peertest/src/main.rs
@@ -27,6 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let peertest_config = PeertestConfig::default();
         let portal_config = PortalnetConfig {
             listen_port: peertest_config.listen_port,
+            internal_ip: true,
             ..Default::default()
         };
 
@@ -67,9 +68,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ProtocolKind::History,
                 None,
             )
-            .await
-            .unwrap();
-        info!("History network Ping result: {:?}", ping_result);
+            .await;
+        match ping_result {
+            Ok(val) => info!("Successful ping to History network: {:?}", val),
+            Err(msg) => panic!("Invalid ping to History network: {:?}", msg),
+        }
 
         info!("Pinging {} on state network", target_node);
         let ping_result = overlay
@@ -79,9 +82,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ProtocolKind::State,
                 None,
             )
-            .await
-            .unwrap();
-        info!("State network Ping result: {:?}", ping_result);
+            .await;
+        match ping_result {
+            Ok(val) => info!("Successful ping to State network: {:?}", val),
+            Err(msg) => panic!("Invalid ping to State network: {:?}", msg),
+        }
 
         match peertest_config.target_transport.as_str() {
             "ipc" => test_jsonrpc_endpoints_over_ipc(peertest_config.target_ipc_path).await,

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         external_addr: trin_config.external_addr,
         private_key: trin_config.private_key.clone(),
         listen_port: trin_config.discovery_port,
+        internal_ip: trin_config.internal_ip,
         bootnode_enrs,
         ..Default::default()
     };

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -70,6 +70,12 @@ pub struct TrinConfig {
     pub external_addr: Option<SocketAddr>,
 
     #[structopt(
+        long = "internal-ip",
+        help = "(For testing purposes) Use local ip address rather than external via STUN."
+    )]
+    pub internal_ip: bool,
+
+    #[structopt(
         validator(check_private_key_length),
         long = "unsafe-private-key",
         help = "Hex encoded 32 byte private key (considered unsafe to pass in pk as cli arg, as it's stored in terminal history - keyfile support coming soon)"
@@ -169,6 +175,7 @@ mod test {
             pool_size: 2,
             web3_transport: "ipc".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
+            internal_ip: false,
             bootnodes: vec![],
             external_addr: None,
             private_key: None,
@@ -195,6 +202,7 @@ mod test {
             pool_size: 3,
             web3_transport: "http".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
+            internal_ip: false,
             bootnodes: vec![],
             networks: DEFAULT_SUBNETWORKS
                 .split(",")
@@ -232,6 +240,7 @@ mod test {
             pool_size: 2,
             web3_transport: "ipc".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
+            internal_ip: false,
             bootnodes: vec![],
             networks: DEFAULT_SUBNETWORKS
                 .split(",")
@@ -265,6 +274,7 @@ mod test {
             pool_size: 2,
             web3_transport: "ipc".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
+            internal_ip: false,
             bootnodes: vec![],
             networks: DEFAULT_SUBNETWORKS
                 .split(",")
@@ -322,6 +332,7 @@ mod test {
             pool_size: 2,
             web3_transport: "ipc".to_string(),
             discovery_port: 999,
+            internal_ip: false,
             bootnodes: vec![],
             networks: DEFAULT_SUBNETWORKS
                 .split(",")
@@ -344,6 +355,7 @@ mod test {
             pool_size: 2,
             web3_transport: "ipc".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
+            internal_ip: false,
             bootnodes: vec!["enr:-aoeu".to_string(), "enr:-htns".to_string()],
             networks: DEFAULT_SUBNETWORKS
                 .split(",")
@@ -388,6 +400,7 @@ mod test {
             pool_size: 2,
             web3_transport: "ipc".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
+            internal_ip: false,
             bootnodes: vec![],
             networks: DEFAULT_SUBNETWORKS
                 .split(",")

--- a/trin-core/src/portalnet/types.rs
+++ b/trin-core/src/portalnet/types.rs
@@ -21,6 +21,7 @@ pub struct PortalnetConfig {
     pub listen_port: u16,
     pub bootnode_enrs: Vec<Enr>,
     pub data_radius: U256,
+    pub internal_ip: bool,
 }
 
 impl Default for PortalnetConfig {
@@ -31,6 +32,7 @@ impl Default for PortalnetConfig {
             listen_port: 4242,
             bootnode_enrs: Vec::<Enr>::new(),
             data_radius: U256::from(u64::MAX), //TODO better data_radius default?
+            internal_ip: false,
         }
     }
 }


### PR DESCRIPTION
Add `--internal-ip` cli flag to skip requesting external ip address from stun server. This allows the testharness to communicate properly with a locally running target node.

I also spent some time trying to clean up the testing structure in the test harness, by catching the panics instead of actually panicking. But, the async nature of the tests made it sufficiently tricky that I'm dropping it for now. https://stackoverflow.com/questions/63159442/how-do-i-use-paniccatch-unwind-with-asynchronous-code

Fixes #147 