### PR TITLE
Update protocol identifiers to match portal wire protocol specs

### DIFF
--- a/ethportal-peertest/src/main.rs
+++ b/ethportal-peertest/src/main.rs
@@ -13,7 +13,7 @@ use trin_core::locks::RwLoggingExt;
 use trin_core::portalnet::{
     discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol},
-    types::{PortalnetConfig, ProtocolKind},
+    types::{PortalnetConfig, ProtocolId},
     utp::UtpListener,
     Enr, U256,
 };
@@ -65,7 +65,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .send_ping(
                 U256::from(u64::MAX),
                 target_node.clone(),
-                ProtocolKind::History,
+                ProtocolId::History,
                 None,
             )
             .await;
@@ -79,7 +79,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .send_ping(
                 U256::from(u64::MAX),
                 target_node.clone(),
-                ProtocolKind::State,
+                ProtocolId::State,
                 None,
             )
             .await;

--- a/trin-core/src/portalnet/discovery.rs
+++ b/trin-core/src/portalnet/discovery.rs
@@ -2,11 +2,13 @@
 
 use super::types::{HexData, PortalnetConfig};
 use super::Enr;
+use crate::portalnet::types::ProtocolId;
 use crate::socket;
 use discv5::enr::{CombinedKey, EnrBuilder, NodeId};
 use discv5::{Discv5, Discv5Config, Discv5ConfigBuilder, RequestError};
 use log::info;
 use serde_json::{json, Value};
+use std::convert::TryFrom;
 use std::net::{IpAddr, SocketAddr};
 
 #[derive(Clone)]
@@ -173,13 +175,13 @@ impl Discovery {
     pub async fn send_talkreq(
         &self,
         enr: Enr,
-        protocol: String,
+        protocol: ProtocolId,
         request: ProtocolRequest,
     ) -> Result<Vec<u8>, RequestError> {
-        let response = self
-            .discv5
-            .talk_req(enr, protocol.into_bytes(), request)
-            .await?;
+        // Send empty protocol id if unable to convert it to bytes
+        let protocol = Vec::try_from(protocol).unwrap_or(vec![]);
+
+        let response = self.discv5.talk_req(enr, protocol, request).await?;
         Ok(response)
     }
 }

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -4,12 +4,11 @@ use crate::utils::distance::xor_two_values;
 use super::{
     discovery::Discovery,
     types::{
-        FindContent, FindNodes, FoundContent, Message, Nodes, Ping, Pong, ProtocolKind, Request,
-        Response, SszEnr,
+        CustomPayload, FindContent, FindNodes, FoundContent, Message, Nodes, Ping, Pong,
+        ProtocolId, Request, Response, SszEnr,
     },
     Enr, U256,
 };
-use crate::portalnet::types::CustomPayload;
 use discv5::{
     enr::NodeId,
     kbucket::{Filter, KBucketsTable},
@@ -278,7 +277,7 @@ impl OverlayProtocol {
         &self,
         data_radius: U256,
         enr: Enr,
-        protocol: ProtocolKind,
+        protocol: ProtocolId,
         payload: Option<Vec<u8>>,
     ) -> Result<Vec<u8>, SendPingError> {
         let enr_seq = self.discovery.read_with_warn().await.local_enr().seq();
@@ -295,7 +294,7 @@ impl OverlayProtocol {
             .await
             .send_talkreq(
                 enr,
-                protocol.to_string(),
+                protocol,
                 Message::Request(Request::Ping(msg)).to_bytes(),
             )
             .await?)
@@ -305,7 +304,7 @@ impl OverlayProtocol {
         &self,
         distances: Vec<u16>,
         enr: Enr,
-        protocol: ProtocolKind,
+        protocol: ProtocolId,
     ) -> Result<Vec<u8>, RequestError> {
         let msg = FindNodes { distances };
         self.discovery
@@ -313,7 +312,7 @@ impl OverlayProtocol {
             .await
             .send_talkreq(
                 enr,
-                protocol.to_string(),
+                protocol,
                 Message::Request(Request::FindNodes(msg)).to_bytes(),
             )
             .await
@@ -323,7 +322,7 @@ impl OverlayProtocol {
         &self,
         content_key: Vec<u8>,
         enr: Enr,
-        protocol: ProtocolKind,
+        protocol: ProtocolId,
     ) -> Result<Vec<u8>, RequestError> {
         let msg = FindContent { content_key };
         self.discovery
@@ -331,7 +330,7 @@ impl OverlayProtocol {
             .await
             .send_talkreq(
                 enr,
-                protocol.to_string(),
+                protocol,
                 Message::Request(Request::FindContent(msg)).to_bytes(),
             )
             .await

--- a/trin-core/src/portalnet/utp.rs
+++ b/trin-core/src/portalnet/utp.rs
@@ -13,8 +13,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
 
 use crate::locks::RwLoggingExt;
+use crate::portalnet::types::ProtocolId;
 
-pub const UTP_PROTOCOL: &str = "utp";
 pub const HEADER_SIZE: usize = 20;
 pub const MAX_DISCV5_PACKET_SIZE: usize = 1280;
 pub const MIN_PACKET_SIZE: usize = 150;
@@ -603,7 +603,7 @@ impl UtpStream {
             .discovery
             .read_with_warn()
             .await
-            .send_talkreq(self.enr.clone(), UTP_PROTOCOL.to_string(), packet.0.clone())
+            .send_talkreq(self.enr.clone(), ProtocolId::Utp, packet.0.clone())
             .await;
         debug!("uTP TalkRequest result: {:?}", talk_request_result);
     }

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -5,7 +5,7 @@ use tokio::sync::RwLock;
 use trin_core::portalnet::{
     discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol},
-    types::{PortalnetConfig, ProtocolKind},
+    types::{PortalnetConfig, ProtocolId},
     U256,
 };
 
@@ -45,7 +45,7 @@ impl HistoryNetwork {
             debug!("Pinging {} on portal history network", enr);
             let ping_result = self
                 .overlay
-                .send_ping(U256::from(u64::MAX), enr, ProtocolKind::History, None)
+                .send_ping(U256::from(u64::MAX), enr, ProtocolId::History, None)
                 .await
                 .map_err(|e| format!("Failed to ping bootnode: {:?}", e))?;
             debug!("Portal history network Ping result: {:?}", ping_result);

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -6,7 +6,7 @@ use trin_core::locks::RwLoggingExt;
 use trin_core::portalnet::{
     discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol, SendPingError},
-    types::{PortalnetConfig, ProtocolKind},
+    types::{PortalnetConfig, ProtocolId},
     U256,
 };
 
@@ -44,7 +44,7 @@ impl StateNetwork {
             debug!("Attempting bond with bootnode {}", enr);
             let ping_result = self
                 .overlay
-                .send_ping(U256::from(u64::MAX), enr.clone(), ProtocolKind::State, None)
+                .send_ping(U256::from(u64::MAX), enr.clone(), ProtocolId::State, None)
                 .await;
 
             match ping_result {


### PR DESCRIPTION
Update protocol id to match the specs [here](https://github.com/ethereum/portal-network-specs/blob/master/portal-wire-protocol.md#protocol-identifiers).

For now, utp protocol id is just a placeholder, so we don't break the existing code. I'm not sure yet if we will need it or not.