### PR TITLE
Prefer slice argument when passing in content key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
                 command: rustup component add clippy
             - run:
                 name: Run Clippy
-                command: cargo clippy --all -- --deny warnings
+                command: cargo clippy --all --all-targets --all-features --no-deps -- --deny warnings
             - run:
                 name: Build Trin workspace
                 command: cargo build --workspace --jobs 2

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -160,10 +160,7 @@ mod test {
     use std::env;
 
     fn env_is_set() -> bool {
-        match env::var("TRIN_INFURA_PROJECT_ID") {
-            Ok(_) => true,
-            _ => false,
-        }
+        matches!(env::var("TRIN_INFURA_PROJECT_ID"), Ok(_))
     }
 
     #[test]
@@ -180,7 +177,7 @@ mod test {
             external_addr: None,
             private_key: None,
             networks: DEFAULT_SUBNETWORKS
-                .split(",")
+                .split(',')
                 .map(|n| n.to_string())
                 .collect(),
         };
@@ -205,7 +202,7 @@ mod test {
             internal_ip: false,
             bootnodes: vec![],
             networks: DEFAULT_SUBNETWORKS
-                .split(",")
+                .split(',')
                 .map(|n| n.to_string())
                 .collect(),
         };
@@ -243,7 +240,7 @@ mod test {
             internal_ip: false,
             bootnodes: vec![],
             networks: DEFAULT_SUBNETWORKS
-                .split(",")
+                .split(',')
                 .map(|n| n.to_string())
                 .collect(),
         };
@@ -277,7 +274,7 @@ mod test {
             internal_ip: false,
             bootnodes: vec![],
             networks: DEFAULT_SUBNETWORKS
-                .split(",")
+                .split(',')
                 .map(|n| n.to_string())
                 .collect(),
         };
@@ -335,7 +332,7 @@ mod test {
             internal_ip: false,
             bootnodes: vec![],
             networks: DEFAULT_SUBNETWORKS
-                .split(",")
+                .split(',')
                 .map(|n| n.to_string())
                 .collect(),
         };
@@ -358,7 +355,7 @@ mod test {
             internal_ip: false,
             bootnodes: vec!["enr:-aoeu".to_string(), "enr:-htns".to_string()],
             networks: DEFAULT_SUBNETWORKS
-                .split(",")
+                .split(',')
                 .map(|n| n.to_string())
                 .collect(),
         };
@@ -403,7 +400,7 @@ mod test {
             internal_ip: false,
             bootnodes: vec![],
             networks: DEFAULT_SUBNETWORKS
-                .split(",")
+                .split(',')
                 .map(|n| n.to_string())
                 .collect(),
         };

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -234,7 +234,11 @@ impl OverlayProtocol {
     }
 
     /// Returns list of nodes closer to content than self, sorted by distance.
-    pub async fn find_nodes_close_to_content(&self, content_key: Vec<u8>) -> Vec<SszEnr> {
+    pub async fn find_nodes_close_to_content<V>(&self, content_key: V) -> Vec<SszEnr>
+    where
+        V: Into<Vec<u8>>,
+    {
+        let content_key = content_key.into();
         let self_node_id = self.local_enr().await.node_id();
         let self_distance = xor_two_values(&content_key, &self_node_id.raw().to_vec());
 
@@ -328,12 +332,16 @@ impl OverlayProtocol {
             .await
     }
 
-    pub async fn send_find_content(
+    pub async fn send_find_content<V>(
         &self,
-        content_key: Vec<u8>,
+        content_key: V,
         enr: Enr,
         protocol: ProtocolId,
-    ) -> Result<Vec<u8>, RequestError> {
+    ) -> Result<Vec<u8>, RequestError>
+    where
+        V: Into<Vec<u8>>,
+    {
+        let content_key = content_key.into();
         let msg = FindContent { content_key };
         self.discovery
             .read_with_warn()

--- a/trin-state/src/utils.rs
+++ b/trin-state/src/utils.rs
@@ -102,7 +102,7 @@ mod test {
         let content_id = U256::from_dec_str("5").unwrap();
         let node_id = U256::from_dec_str("1").unwrap();
         let expected = U256::from_dec_str("4").unwrap();
-        let calculated_distance = distance(content_id.clone(), node_id.clone()).unwrap();
+        let calculated_distance = distance(content_id, node_id).unwrap();
         assert_eq!(calculated_distance, expected);
         let reversed = distance(node_id, content_id).unwrap();
         assert_eq!(reversed, expected);
@@ -129,8 +129,8 @@ mod test {
     #[test]
     fn test_distance_four() {
         let content_id = U256::from_dec_str("0").unwrap();
-        let node_id = U256::from_dec_str(&MID_DEC_STR).unwrap();
-        let expected = U256::from_dec_str(&MID_DEC_STR).unwrap();
+        let node_id = U256::from_dec_str(MID_DEC_STR).unwrap();
+        let expected = U256::from_dec_str(MID_DEC_STR).unwrap();
         let calculated_distance = distance(content_id, node_id).unwrap();
         assert_eq!(calculated_distance, expected);
     }


### PR DESCRIPTION
This change probably looks a little surprising in isolation. Right now it causes an extra clone (because we were previously able to move in a vector that now has to be cloned inside the method).

Here is a super draft-y PR to help show the context of where I think it makes more sense:
https://github.com/ethereum/trin/pull/166/files#diff-fd7cee899607b5a0b4e30853e7bb9f8a191ed26926c7724f6b66d3070f62cf56R67-R72

Also, at some point, it should be possible to build the request from a slice without copying it first. It just doesn't seem like a priority now. But we might as well prepare the API to head that direction IMO. As always, open to discussion.