### PR TITLE
[Conceptual] Looking up an account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3212,6 +3212,7 @@ version = "0.1.0"
 dependencies = [
  "discv5",
  "eth_trie",
+ "keccak-hash",
  "log 0.4.14",
  "num",
  "rocksdb",

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -337,13 +337,13 @@ impl OverlayProtocol {
         content_key: V,
         enr: Enr,
         protocol: ProtocolId,
-    ) -> Result<Vec<u8>, RequestError>
+    ) -> Result<FoundContent, OverlayRequestError>
     where
         V: Into<Vec<u8>>,
     {
         let content_key = content_key.into();
         let msg = FindContent { content_key };
-        self.discovery
+        let result_bytes = self.discovery
             .read_with_warn()
             .await
             .send_talkreq(
@@ -351,6 +351,8 @@ impl OverlayProtocol {
                 protocol,
                 Message::Request(Request::FindContent(msg)).to_bytes(),
             )
-            .await
+            .await?;
+
+        FoundContent::try_from(&result_bytes)
     }
 }

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = "1.56"
 
 [dependencies]
 eth_trie = "0.1.0"
+keccak-hash = "0.8.0"
 log = "0.4.14"
 num = "0.4.0"
 serde_json = "1.0.59"


### PR DESCRIPTION
Just starting to feel out what it might look like to get the encoded account from the state trie.

So far, this totally ignores the question of state root. That will be addressed by v0.1.1 of eth-trie: https://github.com/carver/eth-trie.rs/issues/20