### PR TITLE
WIP - Add little command for easy access to JSON-RPC interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,9 +2490,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.22"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
 dependencies = [
  "clap",
  "lazy_static 1.4.0",
@@ -2501,9 +2501,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2972,9 +2972,18 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "trin-cli",
  "trin-core",
  "trin-history",
  "trin-state",
+]
+
+[[package]]
+name = "trin-cli"
+version = "0.1.0"
+dependencies = [
+ "structopt",
+ "trin-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64-compat"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a8d4d2746f89841e49230dd26917df1876050f95abafafbe34f47cb534b88d7"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,6 +1271,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad24d69a8a0698db8ffb9048e937e8ae3ee3bc45772a5d7b6979b1d2d5b6a9f7"
+dependencies = [
+ "base64-compat",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "k256"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2345,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
@@ -2982,6 +3003,9 @@ dependencies = [
 name = "trin-cli"
 version = "0.1.0"
 dependencies = [
+ "jsonrpc",
+ "serde",
+ "serde_json",
  "structopt",
  "trin-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tracing-subscriber = "0.2.18"
 trin-core = { path = "trin-core" }
 trin-history = { path = "trin-history" }
 trin-state = { path = "trin-state" }
+trin-cli = { path = "trin-cli" }
 
 [dependencies.discv5]
 version = "0.1.0-beta.10"
@@ -26,5 +27,6 @@ members = [
     "trin-history",
     "trin-state",
     "trin-core",
+    "trin-cli",
     "ethportal-peertest"
 ]

--- a/trin-cli/Cargo.toml
+++ b/trin-cli/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
 name = "trin-cli"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 structopt="0.3.25"
 trin-core = { path = "../trin-core" }
+jsonrpc = "0.12.0"
+serde_json = "1.0.68"
+serde = "1.0.117"
 
 [[bin]]
 name="trin-cli"

--- a/trin-cli/Cargo.toml
+++ b/trin-cli/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "trin-cli"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+structopt="0.3.25"
+trin-core = { path = "../trin-core" }
+
+[[bin]]
+name="trin-cli"
+path="src/main.rs"

--- a/trin-cli/src/main.rs
+++ b/trin-cli/src/main.rs
@@ -1,0 +1,57 @@
+use structopt::StructOpt;
+use std::path::PathBuf;
+
+use trin_core::cli::DEFAULT_WEB3_IPC_PATH;
+
+#[derive(StructOpt, Debug)]
+#[structopt(
+    name = "trin-cli",
+    version = "0.0.1",
+    author = "Ethereum Foundation",
+    about = "Utilities for interacting with trin nodes",
+)]
+enum Config {
+    #[structopt(
+        about = "run JSON-RPC commands",
+    )]
+    RPC {
+        #[structopt(
+            default_value(DEFAULT_WEB3_IPC_PATH),
+            long,
+            help = "path to JSON-RPC endpoint",
+        )]
+        ipc: PathBuf,
+
+        #[structopt(
+            help = "e.g. discv5_routingTableInfo",
+            required = true,
+        )]
+        endpoint: String,
+    },
+
+    #[structopt(
+        about = "show list of available JSON-RPC methods",
+    )]
+    ListEndpoints,
+}
+
+/*
+ * I have a large mapping from strings to structs describing each endpoint.
+ * RPC attempts to trigger the endpoint
+ * ListEndpoints operates directly on that map
+ *
+ * Alt: just pass the endpoint along and see if it works
+ */
+
+fn main() {
+    let config = Config::from_args();
+
+    match config {
+        Config::RPC {ipc, endpoint} => {
+            println!("RPC {:?} {}", ipc, endpoint);
+        }
+        Config::ListEndpoints => {
+            println!("List Endpoints");
+        }
+    };
+}

--- a/trin-cli/src/main.rs
+++ b/trin-cli/src/main.rs
@@ -1,5 +1,6 @@
 use structopt::StructOpt;
 use std::path::PathBuf;
+use std::os::unix::net::UnixStream;
 
 use trin_core::cli::DEFAULT_WEB3_IPC_PATH;
 
@@ -49,9 +50,168 @@ fn main() {
     match config {
         Config::RPC {ipc, endpoint} => {
             println!("RPC {:?} {}", ipc, endpoint);
+
+            let mut client = TrinClient::from_ipc(&ipc).unwrap();
+            let resp = client.routing_table_info();
+            println!("resp: {:?}", resp);
+
+            let resp = client.state_data_radius();
+            println!("resp: {:?}", resp);
         }
         Config::ListEndpoints => {
             println!("List Endpoints");
         }
     };
+}
+
+fn build_request<'a>(method: &'a str, request_id: u64) -> jsonrpc::Request<'a> {
+    jsonrpc::Request {
+        method: method,
+        params: &[],
+        id: serde_json::json!(request_id),
+        jsonrpc: Some("2.0"),
+    }
+}
+
+// TODO: these belong in trin_core::jsonrpc::types
+#[derive(Debug, serde::Deserialize)]
+pub struct RoutingTableNodeInfo {
+    pub node_id: String,
+    pub enr: String,
+    pub status: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct RoutingTableInfoResponse {
+    pub buckets: Vec<RoutingTableNodeInfo>,
+
+    #[serde(rename="localKey")]
+    pub local_node_id: String,
+}
+
+pub trait ParseResponse<'a>
+{
+    fn parse(value: &'a jsonrpc::Response) -> Result<Self, &'static str> where Self: Sized;
+}
+
+// this looks exactly like TryFrom, but we cannot provide a blanket implementation of
+// TryFrom for two reasons:
+// - a conflicting blanket implementation already exists in core (TryInto)
+// - we cannot write blanket implementations for traits which are not defined in our crate
+impl<'a, T> ParseResponse<'a> for T
+where T: serde::Deserialize<'a> {
+    fn parse(value: &'a jsonrpc::Response) -> Result<Self, &'static str> where Self: Sized{
+        if let Some(ref raw_value) = value.result {
+            Ok(serde_json::from_str(raw_value.get()).unwrap())
+        } else {
+            // TODO: handle the error case!
+            Err("no value")
+        }
+    }
+
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(transparent)]
+pub struct DataRadiusResponse {
+    pub data_radius: String,
+}
+
+pub trait TryClone {
+    fn try_clone(&self) -> std::io::Result<Self> where Self: Sized;
+}
+
+impl TryClone for UnixStream {
+    fn try_clone(&self) -> std::io::Result<Self> {
+        UnixStream::try_clone(self)
+    }
+}
+
+pub struct TrinClient<S>
+where S: std::io::Read + std::io::Write + TryClone
+{
+    stream: S,
+    request_id: u64,
+}
+
+impl TrinClient<UnixStream>
+{
+    fn from_ipc(path: &PathBuf) -> std::io::Result<Self> {
+        // TODO: a nice error if this file does not exist
+        Ok(Self {
+            stream: UnixStream::connect(path)?,
+            request_id: 0
+        })
+    }
+}
+
+impl<'a, S> TrinClient<S>
+where S: std::io::Read + std::io::Write + TryClone
+{
+    fn build_request(&mut self, method: &'a str) -> jsonrpc::Request<'a> {
+        let result = build_request(method, self.request_id);
+        self.request_id += 1;
+        
+        result
+    }
+
+    fn make_request<T: serde::Deserialize<'a>>(&mut self, req: jsonrpc::Request) -> T {
+        let data = serde_json::to_vec(&req).unwrap();
+
+        self.stream.write_all(&data).unwrap();
+        self.stream.flush().unwrap();
+
+        let clone = self.stream.try_clone().unwrap();
+        let deser = serde_json::Deserializer::from_reader(clone);
+        for obj in deser.into_iter::<jsonrpc::Response>() {
+            let response_obj = obj.unwrap();
+            println!("response: {:?}", response_obj);
+            let resp = T::parse(&response_obj);
+            return resp.unwrap();
+        }
+
+        unreachable!()
+    }
+
+    fn routing_table_info(&mut self) -> RoutingTableInfoResponse {
+        let req = self.build_request("discv5_routingTableInfo");
+        self.make_request(req)
+
+        /*
+        let data = serde_json::to_vec(&req).unwrap();
+
+        self.stream.write_all(&data).unwrap();
+        self.stream.flush().unwrap();
+
+        let clone = self.stream.try_clone().unwrap();
+        let deser = serde_json::Deserializer::from_reader(clone);
+        for obj in deser.into_iter::<jsonrpc::Response>() {
+            let response_obj = obj.unwrap();
+            println!("response: {:?}", response_obj);
+            let routing = RoutingTableInfoResponse::parse(&response_obj);
+            return routing.unwrap();
+        }
+
+        unreachable!()
+        */
+    }
+
+    fn state_data_radius(&mut self) -> DataRadiusResponse {
+        let req = self.build_request("portalState_dataRadius");
+        let data = serde_json::to_vec(&req).unwrap();
+
+        self.stream.write_all(&data).unwrap();
+        self.stream.flush().unwrap();
+
+        let clone = self.stream.try_clone().unwrap();
+        let deser = serde_json::Deserializer::from_reader(clone);
+        for obj in deser.into_iter::<jsonrpc::Response>() {
+            let response_obj = obj.unwrap();
+            println!("response: {:?}", response_obj);
+            let routing = DataRadiusResponse::parse(&response_obj);
+            return routing.unwrap();
+        }
+
+        unreachable!()
+    }
 }


### PR DESCRIPTION
Very WIP, current interface:

```
brian@beat:~/ef/trin$ cargo run -p trin-cli -- rpc discv5_routingTableInfo
RoutingTableInfoResponse { buckets: [RoutingTableNodeInfo { node_id: "0xd40a..2cb0", enr: "enr:-IS4QGAwk1EybH8deeq9xrlH6HF_ZnWAu4vMODJbgZ0i78_IUnN0vdQgBpJ0p4ZXWD6FNq_k-kP1-9ZpHCqvIQphtoMBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQL0kZO-svDs-h0vbTo-QsWhJ7XeRmaQH0g8jqej35K0t4N1ZHCCEdg", status: "Connected" }], local_node_id: "0x302c..1cd1" }
```

Would appreciate suggestions:
- `trin-cli rpc discv5_routingTableInfo` is honest but... still not a very good interface. How could it be improved?
  - what should this command be called?
  - should commands be given short names like `routingTable`?

There's still work to do:
- [ ] Refactor, move a lot of this logic into `trin_core::jsonrpc`
- [ ] Refactor `peertest` (clientside) to use these structs
  - [ ] This might require adding support for connecting over HTTP
- [ ] Refactor the handlers (serverside) to use these nice serializable structs instead of manually generating responses
- [ ] Come up with a clean way to map the user-supplied and dynamically typed argv into method calls
- [ ] Add support for the rest of the JSON-RPC endpoints (I'll probably defer that work for future PRs)
- [ ] Implement a `trin-cli endpoints` which lists available endpoints (maybe this is just `trin-cli help` and I let structopt do most of the work)