### PR TITLE
Update stun server

### DIFF
--- a/trin-core/src/socket.rs
+++ b/trin-core/src/socket.rs
@@ -7,7 +7,9 @@ use interfaces::{self, Interface};
 #[cfg(windows)]
 use ipconfig;
 
-const STUN_SERVER: &str = "143.198.142.185:3478";
+// This stun server is part of the testnet infrastructure.
+// If you are unable to connect, please create an issue.
+const STUN_SERVER: &str = "159.223.0.83:3478";
 
 /// Ping a STUN server on the public network. This does two things:
 /// - Creates an externally-addressable UDP port, if you are behind a NAT


### PR DESCRIPTION
Devops helped set up a stun server as part of the testnet infrastructure which is a more stable solution than the stun server we've been using. Everything appears to functional for me, but another confirmation that the new stun server is functional would be great. @carver you can go ahead and tear down the stun server you setup locally if you'd like.

fixes #25 