### PR TITLE
Update web3-http-port to web3-http-address

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ OPTIONS:
         --pool-size <pool_size>               max size of threadpool [default: 2]
         --unsafe-private-key <private_key>    Hex encoded 32 byte private key (considered unsafe to pass in pk as cli
                                               arg, as it's stored in terminal history - keyfile support coming soon)
-        --web3-http-port <web3_http_port>     port to accept json-rpc http connections [default: 8545]
+        --web3-http-address <web3-http-address>    address to accept json-rpc http connections [default: 127.0.0.1:8545]
         --web3-ipc-path <web3_ipc_path>       path to json-rpc endpoint over IPC [default: /tmp/trin-jsonrpc.ipc]
         --web3-transport <web3_transport>     select transport protocol to serve json-rpc endpoint [default: ipc]
                                               [possible values: http, ipc]

--- a/ethportal-peertest/src/cli.rs
+++ b/ethportal-peertest/src/cli.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::ffi::OsString;
 use structopt::StructOpt;
-use trin_core::cli::DEFAULT_WEB3_HTTP_PORT as DEFAULT_TARGET_HTTP_PORT;
+use trin_core::cli::DEFAULT_WEB3_HTTP_ADDRESS as DEFAULT_TARGET_HTTP_ADDRESS;
 use trin_core::cli::DEFAULT_WEB3_IPC_PATH as DEFAULT_TARGET_IPC_PATH;
 
 const DEFAULT_LISTEN_PORT: &str = "9876";
@@ -52,11 +52,11 @@ pub struct PeertestConfig {
     pub target_ipc_path: String,
 
     #[structopt(
-        default_value = DEFAULT_TARGET_HTTP_PORT,
-        long = "target-http-port",
-        help = "HTTP port of target node under test"
+        default_value = DEFAULT_TARGET_HTTP_ADDRESS,
+        long = "target-http-address",
+        help = "HTTP address of target node under test"
     )]
-    pub target_http_port: String,
+    pub target_http_address: String,
 }
 
 impl PeertestConfig {

--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -136,14 +136,14 @@ fn get_response_result(response: Value) -> Result<Value, JsonRpcResponseError> {
     }
 }
 
-pub async fn test_jsonrpc_endpoints_over_http(target_http_port: String) {
+pub async fn test_jsonrpc_endpoints_over_http(target_http_address: String) {
     let client = Client::new();
     for endpoint in JsonRpcEndpoint::all_endpoints() {
         info!("Testing over HTTP: {:?}", endpoint.method);
         let json_string = endpoint.to_jsonrpc();
         let req = Request::builder()
             .method(Method::POST)
-            .uri(format!("http://127.0.0.1:{}", target_http_port))
+            .uri(format!("http://{}", target_http_address))
             .header("content-type", "application/json")
             .body(Body::from(json_string))
             .unwrap();

--- a/ethportal-peertest/src/main.rs
+++ b/ethportal-peertest/src/main.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         match peertest_config.target_transport.as_str() {
             "ipc" => test_jsonrpc_endpoints_over_ipc(peertest_config.target_ipc_path).await,
-            "http" => test_jsonrpc_endpoints_over_http(peertest_config.target_http_port).await,
+            "http" => test_jsonrpc_endpoints_over_http(peertest_config.target_http_address).await,
             _ => panic!(
                 "Invalid target-transport provided: {:?}",
                 peertest_config.target_transport

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -7,7 +7,7 @@ use std::net::SocketAddr;
 use structopt::StructOpt;
 
 pub const DEFAULT_WEB3_IPC_PATH: &str = "/tmp/trin-jsonrpc.ipc";
-pub const DEFAULT_WEB3_HTTP_PORT: &str = "8545";
+pub const DEFAULT_WEB3_HTTP_ADDRESS: &str = "127.0.0.1:8545";
 const DEFAULT_DISCOVERY_PORT: &str = "9000";
 pub const HISTORY_NETWORK: &str = "history";
 pub const STATE_NETWORK: &str = "state";
@@ -29,11 +29,11 @@ pub struct TrinConfig {
     pub web3_transport: String,
 
     #[structopt(
-        default_value(DEFAULT_WEB3_HTTP_PORT),
-        long = "web3-http-port",
-        help = "port to accept json-rpc http connections"
+        default_value(DEFAULT_WEB3_HTTP_ADDRESS),
+        long = "web3-http-address",
+        help = "address to accept json-rpc http connections"
     )]
-    pub web3_http_port: u16,
+    pub web3_http_address: String,
 
     #[structopt(
         default_value(DEFAULT_WEB3_IPC_PATH),
@@ -113,9 +113,9 @@ impl TrinConfig {
                 DEFAULT_WEB3_IPC_PATH => {}
                 _ => panic!("Must not supply an ipc path when using http protocol for json-rpc"),
             },
-            "ipc" => match &config.web3_http_port.to_string()[..] {
-                DEFAULT_WEB3_HTTP_PORT => {}
-                _ => panic!("Must not supply an http port when using ipc protocol for json-rpc"),
+            "ipc" => match &config.web3_http_address[..] {
+                DEFAULT_WEB3_HTTP_ADDRESS => {}
+                _ => panic!("Must not supply an http address when using ipc protocol for json-rpc"),
             },
             val => panic!("Unsupported json-rpc protocol: {}", val),
         }
@@ -127,7 +127,7 @@ impl TrinConfig {
         info!("Launching with config:");
         match self.web3_transport.as_str() {
             "http" => {
-                info!("- JSON-RPC HTTP port: {}", self.web3_http_port)
+                info!("- JSON-RPC HTTP address: {}", self.web3_http_address)
             }
             "ipc" => {
                 info!("- JSON-RPC IPC path: {}", self.web3_ipc_path)
@@ -170,7 +170,7 @@ mod test {
     fn test_default_args() {
         assert!(env_is_set());
         let expected_config = TrinConfig {
-            web3_http_port: DEFAULT_WEB3_HTTP_PORT.parse::<u16>().unwrap(),
+            web3_http_address: DEFAULT_WEB3_HTTP_ADDRESS.to_string(),
             web3_ipc_path: DEFAULT_WEB3_IPC_PATH.to_string(),
             pool_size: 2,
             web3_transport: "ipc".to_string(),
@@ -186,7 +186,10 @@ mod test {
         };
         let actual_config = TrinConfig::new_from(["trin"].iter()).unwrap();
         assert_eq!(actual_config.web3_transport, expected_config.web3_transport);
-        assert_eq!(actual_config.web3_http_port, expected_config.web3_http_port);
+        assert_eq!(
+            actual_config.web3_http_address,
+            expected_config.web3_http_address
+        );
         assert_eq!(actual_config.pool_size, expected_config.pool_size);
         assert_eq!(actual_config.external_addr, expected_config.external_addr);
     }
@@ -197,7 +200,7 @@ mod test {
         let expected_config = TrinConfig {
             external_addr: None,
             private_key: None,
-            web3_http_port: 8080,
+            web3_http_address: "0.0.0.0:8080".to_string(),
             web3_ipc_path: DEFAULT_WEB3_IPC_PATH.to_string(),
             pool_size: 3,
             web3_transport: "http".to_string(),
@@ -214,8 +217,8 @@ mod test {
                 "trin",
                 "--web3-transport",
                 "http",
-                "--web3-http-port",
-                "8080",
+                "--web3-http-address",
+                "0.0.0.0:8080",
                 "--pool-size",
                 "3",
             ]
@@ -223,7 +226,10 @@ mod test {
         )
         .unwrap();
         assert_eq!(actual_config.web3_transport, expected_config.web3_transport);
-        assert_eq!(actual_config.web3_http_port, expected_config.web3_http_port);
+        assert_eq!(
+            actual_config.web3_http_address,
+            expected_config.web3_http_address
+        );
         assert_eq!(actual_config.pool_size, expected_config.pool_size);
     }
 
@@ -235,7 +241,7 @@ mod test {
         let expected_config = TrinConfig {
             external_addr: None,
             private_key: None,
-            web3_http_port: DEFAULT_WEB3_HTTP_PORT.parse::<u16>().unwrap(),
+            web3_http_address: DEFAULT_WEB3_HTTP_ADDRESS.to_string(),
             web3_ipc_path: DEFAULT_WEB3_IPC_PATH.to_string(),
             pool_size: 2,
             web3_transport: "ipc".to_string(),
@@ -248,7 +254,10 @@ mod test {
                 .collect(),
         };
         assert_eq!(actual_config.web3_transport, expected_config.web3_transport);
-        assert_eq!(actual_config.web3_http_port, expected_config.web3_http_port);
+        assert_eq!(
+            actual_config.web3_http_address,
+            expected_config.web3_http_address
+        );
         assert_eq!(actual_config.pool_size, expected_config.pool_size);
     }
 
@@ -269,7 +278,7 @@ mod test {
         let expected_config = TrinConfig {
             private_key: None,
             external_addr: None,
-            web3_http_port: DEFAULT_WEB3_HTTP_PORT.parse::<u16>().unwrap(),
+            web3_http_address: DEFAULT_WEB3_HTTP_ADDRESS.to_string(),
             web3_ipc_path: "/path/test.ipc".to_string(),
             pool_size: 2,
             web3_transport: "ipc".to_string(),
@@ -282,7 +291,10 @@ mod test {
                 .collect(),
         };
         assert_eq!(actual_config.web3_transport, expected_config.web3_transport);
-        assert_eq!(actual_config.web3_http_port, expected_config.web3_http_port);
+        assert_eq!(
+            actual_config.web3_http_address,
+            expected_config.web3_http_address
+        );
         assert_eq!(actual_config.pool_size, expected_config.pool_size);
         assert_eq!(actual_config.web3_ipc_path, expected_config.web3_ipc_path);
     }
@@ -305,15 +317,15 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "Must not supply an http port when using ipc")]
-    fn test_ipc_protocol_rejects_custom_web3_http_port() {
+    #[should_panic(expected = "Must not supply an http address when using ipc")]
+    fn test_ipc_protocol_rejects_custom_web3_http_address() {
         assert!(env_is_set());
         TrinConfig::new_from(
             [
                 "trin",
                 "--web3-transport",
                 "ipc",
-                "--web3-http-port",
+                "--web3-http-address",
                 "7879",
             ]
             .iter(),
@@ -327,7 +339,7 @@ mod test {
         let expected_config = TrinConfig {
             external_addr: None,
             private_key: None,
-            web3_http_port: DEFAULT_WEB3_HTTP_PORT.parse::<u16>().unwrap(),
+            web3_http_address: DEFAULT_WEB3_HTTP_ADDRESS.to_string(),
             web3_ipc_path: DEFAULT_WEB3_IPC_PATH.to_string(),
             pool_size: 2,
             web3_transport: "ipc".to_string(),
@@ -350,7 +362,7 @@ mod test {
         let expected_config = TrinConfig {
             external_addr: None,
             private_key: None,
-            web3_http_port: DEFAULT_WEB3_HTTP_PORT.parse::<u16>().unwrap(),
+            web3_http_address: DEFAULT_WEB3_HTTP_ADDRESS.to_string(),
             web3_ipc_path: DEFAULT_WEB3_IPC_PATH.to_string(),
             pool_size: 2,
             web3_transport: "ipc".to_string(),
@@ -395,7 +407,7 @@ mod test {
         let expected_config = TrinConfig {
             external_addr: None,
             private_key: Some(HexData(vec![1; 32])),
-            web3_http_port: DEFAULT_WEB3_HTTP_PORT.parse::<u16>().unwrap(),
+            web3_http_address: DEFAULT_WEB3_HTTP_ADDRESS.to_string(),
             web3_ipc_path: DEFAULT_WEB3_IPC_PATH.to_string(),
             pool_size: 2,
             web3_transport: "ipc".to_string(),

--- a/trin-core/src/jsonrpc/service.rs
+++ b/trin-core/src/jsonrpc/service.rs
@@ -119,8 +119,7 @@ fn launch_http_client(
     })
     .expect("Error setting Ctrl-C handler.");
 
-    let uri = format!("0.0.0.0:{}", trin_config.web3_http_port);
-    let listener = TcpListener::bind(uri).unwrap();
+    let listener = TcpListener::bind(trin_config.web3_http_address).unwrap();
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {


### PR DESCRIPTION
Updates cli arg `web3-http-port` to `web3-http-address` - useful for use with docker container to allow using `0.0.0.0` as the ip address. 

Fixes #129 