### PR TITLE
Use rust v1.56.1 to mitigate "Trojan Source"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
             Check linting with Clippy and rustfmt, build the crate, and run tests.
         executor:
             name: rust/default
-            tag: 1.56.0
+            tag: 1.56.1
         environment:
             RUSTFLAGS: '-D warnings'
         steps:


### PR DESCRIPTION
See https://blog.rust-lang.org/2021/11/01/cve-2021-42574.html