### PR TITLE
Update protocol id match in test harness handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "discv5",
+ "hex",
  "hyper",
  "log 0.4.14",
  "rocksdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "trin"
 version = "0.1.0"
 authors = ["Jacob Kaufmann <jacobkaufmann18@gmail.com>", "Jason Carver <ut96caarrs@snkmail.com>"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.56.1"
 default-run = "trin"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ethportal-peertest"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.56.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = "1.56.1"
 [dependencies]
 clap = "2.33.3"
 hyper = { version = "0.14", features = ["full"] }
+hex = "0.4.3"
 log = "0.4.14"
 rocksdb = "0.16.0"
 serde_json = "1.0.59"

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trin-core"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.56.1"
 
 [dependencies]
 base64 = "0.13.0"

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -3,7 +3,7 @@ name = "trin-history"
 version = "0.1.0"
 authors = ["Jacob Kaufmann <jacobkaufmann18@gmail.com>"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.56.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -3,7 +3,7 @@ name = "trin-state"
 version = "0.1.0"
 authors = ["Jason Carver <ut96caarrs@snkmail.com>"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.56.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Update test harness handler with protocolid introduced in https://github.com/ethereum/trin/pull/162 and bump all crates rust version to 1.56.1 (related to https://github.com/ethereum/trin/pull/173).