### PR TITLE
Run Discovery and StateNetwork without locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.1.0-beta.10"
-source = "git+https://github.com/sigp/discv5#10247bbd299227fef20233f2f5a8de9780de09ac"
+source = "git+https://github.com/carver/discv5?branch=fewer-mutable-borrows#7cd3f424f1b9e2e30e84c019ba8f3a2469df3ead"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ trin-state = { path = "trin-state" }
 trin-cli = { path = "trin-cli" }
 
 [dependencies.discv5]
-version = "0.1.0-beta.10"
-git = "https://github.com/sigp/discv5"
+branch = "fewer-mutable-borrows"
+git = "https://github.com/carver/discv5"
 
 [workspace]
 members = [

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -21,5 +21,5 @@ tracing-subscriber = "0.2.18"
 trin-core = { path = "../trin-core" }
 
 [dependencies.discv5]
-version = "0.1.0-beta.5"
-git = "https://github.com/sigp/discv5"
+branch = "fewer-mutable-borrows"
+git = "https://github.com/carver/discv5"

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -46,8 +46,8 @@ uds_windows = "1.0.1"
 interfaces = "0.0.7"
 
 [dependencies.discv5]
-version = "0.1.0-beta.10"
-git = "https://github.com/sigp/discv5"
+branch = "fewer-mutable-borrows"
+git = "https://github.com/carver/discv5"
 
 [dependencies.rusqlite]
 version = "0.25.3"

--- a/trin-core/src/portalnet/discovery.rs
+++ b/trin-core/src/portalnet/discovery.rs
@@ -82,7 +82,7 @@ impl Discovery {
             enr, enr
         );
 
-        let mut discv5 = Discv5::new(enr, enr_key, config.discv5_config)
+        let discv5 = Discv5::new(enr, enr_key, config.discv5_config)
             .map_err(|e| format!("Failed to create discv5 instance: {}", e))?;
 
         for enr in config.bootnode_enrs {
@@ -123,7 +123,7 @@ impl Discovery {
     }
 
     /// Returns vector of all ENR node IDs of nodes currently contained in the routing table mapped to JSON Value.
-    pub fn routing_table_info(&mut self) -> Value {
+    pub fn routing_table_info(&self) -> Value {
         let buckets: Vec<(String, String, String)> = self
             .discv5
             .table_entries()

--- a/trin-core/src/portalnet/events.rs
+++ b/trin-core/src/portalnet/events.rs
@@ -3,18 +3,16 @@ use std::sync::Arc;
 use discv5::{Discv5Event, TalkRequest};
 use log::{debug, warn};
 use tokio::sync::mpsc;
-use tokio::sync::RwLock;
 
 use super::types::ProtocolId;
 use super::{discovery::Discovery, utp::UtpListener};
-use crate::locks::RwLoggingExt;
 use hex;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::str::FromStr;
 
 pub struct PortalnetEvents {
-    pub discovery: Arc<RwLock<Discovery>>,
+    pub discovery: Arc<Discovery>,
     pub protocol_receiver: mpsc::Receiver<Discv5Event>,
     pub utp_listener: UtpListener,
     pub history_sender: Option<mpsc::UnboundedSender<TalkRequest>>,
@@ -23,13 +21,11 @@ pub struct PortalnetEvents {
 
 impl PortalnetEvents {
     pub async fn new(
-        discovery: Arc<RwLock<Discovery>>,
+        discovery: Arc<Discovery>,
         history_sender: Option<mpsc::UnboundedSender<TalkRequest>>,
         state_sender: Option<mpsc::UnboundedSender<TalkRequest>>,
     ) -> Self {
         let protocol_receiver = discovery
-            .write_with_warn()
-            .await
             .discv5
             .event_stream()
             .await

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -143,13 +143,13 @@ impl PartialEq for Node {
 /// The overlay service.
 pub struct OverlayService {
     /// The underlying Discovery v5 protocol.
-    discovery: Arc<RwLock<Discovery>>,
+    discovery: Arc<Discovery>,
     /// The content database of the local node.
     db: Arc<DB>,
     /// The routing table of the local node.
     kbuckets: Arc<RwLock<KBucketsTable<NodeId, Node>>>,
     /// The data radius of the local node.
-    data_radius: Arc<RwLock<U256>>,
+    data_radius: Arc<U256>,
     /// The protocol identifier.
     protocol: ProtocolId,
     // TODO: This should probably be a bounded channel.
@@ -164,10 +164,10 @@ impl OverlayService {
     /// is updated according to incoming requests and responses as well as autonomous maintenance
     /// processes.
     pub async fn spawn(
-        discovery: Arc<RwLock<Discovery>>,
+        discovery: Arc<Discovery>,
         db: Arc<DB>,
         kbuckets: Arc<RwLock<KBucketsTable<NodeId, Node>>>,
-        data_radius: Arc<RwLock<U256>>,
+        data_radius: Arc<U256>,
         protocol: ProtocolId,
     ) -> Result<UnboundedSender<OverlayRequest>, String> {
         let (request_tx, request_rx) = mpsc::unbounded_channel();
@@ -198,12 +198,12 @@ impl OverlayService {
 
     /// Returns the local ENR of the node.
     async fn local_enr(&self) -> Enr {
-        self.discovery.read_with_warn().await.discv5.local_enr()
+        self.discovery.discv5.local_enr()
     }
 
     /// Returns the data radius of the node.
     async fn data_radius(&self) -> U256 {
-        self.data_radius.read_with_warn().await.clone()
+        *self.data_radius
     }
 
     /// Processes an overlay request.
@@ -299,8 +299,6 @@ impl OverlayService {
     ) -> Result<Response, OverlayRequestError> {
         match self
             .discovery
-            .read_with_warn()
-            .await
             .send_talk_req(
                 destination,
                 self.protocol.clone(),

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -22,5 +22,5 @@ trin-core = { path = "../trin-core" }
 rocksdb = "0.16.0"
 
 [dependencies.discv5]
-version = "0.1.0-beta.10"
-git = "https://github.com/sigp/discv5"
+branch = "fewer-mutable-borrows"
+git = "https://github.com/carver/discv5"

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -16,13 +16,7 @@ impl HistoryRequestHandler {
             match request.endpoint {
                 HistoryEndpoint::DataRadius => {
                     let _ = request.resp.send(Ok(Value::String(
-                        self.network
-                            .read()
-                            .await
-                            .overlay
-                            .data_radius()
-                            .await
-                            .to_string(),
+                        self.network.read().await.overlay.data_radius.to_string(),
                     )));
                 }
             }

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -45,12 +45,10 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut discovery = Discovery::new(portalnet_config.clone()).unwrap();
     discovery.start().await.unwrap();
-    let discovery = Arc::new(RwLock::new(discovery));
+    let discovery = Arc::new(discovery);
 
     // Setup Overlay database
-    let db = Arc::new(setup_overlay_db(
-        discovery.read().await.local_enr().node_id(),
-    ));
+    let db = Arc::new(setup_overlay_db(discovery.local_enr().node_id()));
 
     let (history_event_tx, history_event_rx) = mpsc::unbounded_channel::<TalkRequest>();
     let portal_events_discovery = Arc::clone(&discovery);
@@ -78,7 +76,7 @@ type HistoryEventTx = Option<mpsc::UnboundedSender<TalkRequest>>;
 type HistoryJsonRpcTx = Option<mpsc::UnboundedSender<HistoryJsonRpcRequest>>;
 
 pub async fn initialize_history_network(
-    discovery: &Arc<RwLock<Discovery>>,
+    discovery: &Arc<Discovery>,
     portalnet_config: PortalnetConfig,
     db: Arc<DB>,
 ) -> (

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -1,7 +1,6 @@
 use log::debug;
 use rocksdb::DB;
 use std::sync::Arc;
-use tokio::sync::RwLock;
 use trin_core::portalnet::{
     discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol, OverlayRequestError},
@@ -16,7 +15,7 @@ pub struct HistoryNetwork {
 
 impl HistoryNetwork {
     pub async fn new(
-        discovery: Arc<RwLock<Discovery>>,
+        discovery: Arc<Discovery>,
         db: Arc<DB>,
         portal_config: PortalnetConfig,
     ) -> Self {
@@ -40,14 +39,7 @@ impl HistoryNetwork {
         // Trigger bonding with bootnodes, at both the base layer and portal overlay.
         // The overlay ping via talkreq will trigger a session at the base layer, then
         // a session on the (overlay) portal network.
-        for enr in self
-            .overlay
-            .discovery
-            .read()
-            .await
-            .discv5
-            .table_entries_enr()
-        {
+        for enr in self.overlay.discovery.discv5.table_entries_enr() {
             debug!("Pinging {} on portal history network", enr);
             let ping_result = self.overlay.send_ping(enr.clone(), None).await;
 

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -20,5 +20,5 @@ trin-core = { path = "../trin-core" }
 rocksdb = "0.16.0"
 
 [dependencies.discv5]
-version = "0.1.0-beta.10"
-git = "https://github.com/sigp/discv5"
+branch = "fewer-mutable-borrows"
+git = "https://github.com/carver/discv5"

--- a/trin-state/src/events.rs
+++ b/trin-state/src/events.rs
@@ -1,14 +1,13 @@
 use crate::network::StateNetwork;
 use discv5::TalkRequest;
 use std::sync::Arc;
-use tokio::sync::{mpsc::UnboundedReceiver, RwLock};
+use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::Instrument;
 use tracing::{debug, error, warn};
-use trin_core::locks::RwLoggingExt;
 use trin_core::portalnet::types::Message;
 
 pub struct StateEvents {
-    pub network: Arc<RwLock<StateNetwork>>,
+    pub network: Arc<StateNetwork>,
     pub event_rx: UnboundedReceiver<TalkRequest>,
 }
 
@@ -17,8 +16,6 @@ impl StateEvents {
         while let Some(talk_request) = self.event_rx.recv().await {
             let reply = match self
                 .network
-                .write_with_warn()
-                .await
                 .overlay
                 .process_one_request(&talk_request)
                 .instrument(tracing::info_span!("state_network"))

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -1,13 +1,12 @@
 use crate::network::StateNetwork;
 use serde_json::Value;
 use std::sync::Arc;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::mpsc;
 use trin_core::jsonrpc::{endpoints::StateEndpoint, types::StateJsonRpcRequest};
-use trin_core::locks::RwLoggingExt;
 
 /// Handles State network JSON-RPC requests
 pub struct StateRequestHandler {
-    pub network: Arc<RwLock<StateNetwork>>,
+    pub network: Arc<StateNetwork>,
     pub state_rx: mpsc::UnboundedReceiver<StateJsonRpcRequest>,
 }
 
@@ -16,8 +15,7 @@ impl StateRequestHandler {
         while let Some(request) = self.state_rx.recv().await {
             match request.endpoint {
                 StateEndpoint::DataRadius => {
-                    let net = self.network.read_with_warn().await;
-                    let radius = &net.overlay.data_radius;
+                    let radius = &self.network.overlay.data_radius;
                     let _ = request.resp.send(Ok(Value::String(radius.to_string())));
                 }
             }

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -17,7 +17,7 @@ impl StateRequestHandler {
             match request.endpoint {
                 StateEndpoint::DataRadius => {
                     let net = self.network.read_with_warn().await;
-                    let radius = net.overlay.data_radius().await;
+                    let radius = &net.overlay.data_radius;
                     let _ = request.resp.send(Ok(Value::String(radius.to_string())));
                 }
             }

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -44,12 +44,10 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut discovery = Discovery::new(portalnet_config.clone()).unwrap();
     discovery.start().await.unwrap();
-    let discovery = Arc::new(RwLock::new(discovery));
+    let discovery = Arc::new(discovery);
 
     // Setup Overlay database
-    let db = Arc::new(setup_overlay_db(
-        discovery.read_with_warn().await.local_enr().node_id(),
-    ));
+    let db = Arc::new(setup_overlay_db(discovery.local_enr().node_id()));
 
     let (state_event_tx, state_event_rx) = mpsc::unbounded_channel::<TalkRequest>();
     let portal_events_discovery = Arc::clone(&discovery);
@@ -76,7 +74,7 @@ type StateEventTx = Option<mpsc::UnboundedSender<TalkRequest>>;
 type StateJsonRpcTx = Option<mpsc::UnboundedSender<StateJsonRpcRequest>>;
 
 pub async fn initialize_state_network(
-    discovery: &Arc<RwLock<Discovery>>,
+    discovery: &Arc<Discovery>,
     portalnet_config: PortalnetConfig,
     db: Arc<DB>,
 ) -> (StateHandler, StateNetworkTask, StateEventTx, StateJsonRpcTx) {

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -44,7 +44,7 @@ impl StateNetwork {
     }
 
     /// Convenience call for testing, quick way to ping bootnodes
-    pub async fn ping_bootnodes(&mut self) -> Result<(), String> {
+    pub async fn ping_bootnodes(&self) -> Result<(), String> {
         // Trigger bonding with bootnodes, at both the base layer and portal overlay.
         // The overlay ping via talkreq will trigger a session at the base layer, then
         // a session on the (overlay) portal network.


### PR DESCRIPTION
So I've been trying to get trin to talk to itself. I was running into something that looks like a deadlock. Locks, especially spread across a codebase, are a huge PITA to debug. Rather than do the first of many painful lock debug sessions, I wanted to see what it would look like to get rid of them.

It may be doable, but let's chat about it!

---

This requires some API updates to sigp/discv5. The good news is that the change is just to re-frame a bunch of methods as borrow instead of mutable-borrow. Then sharing the discovery instance will be trivial.

This seems to be a trivial change to discv5, because most of the internal variables are in a `RwLock` anyway.