### PR TITLE
Add parameter to cli tool

### DIFF
--- a/trin-cli/Cargo.toml
+++ b/trin-cli/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 structopt="0.3.25"
 trin-core = { path = "../trin-core" }
 jsonrpc = "0.12.0"
-serde_json = "1.0.68"
+serde_json = { version = "1.0.68", features = ["raw_value"] }
 serde = "1.0.117"
 thiserror = "1.0.29"
 

--- a/trin-cli/README.md
+++ b/trin-cli/README.md
@@ -15,7 +15,12 @@ Attempting RPC. endpoint=discv5_routingTableInfo file=/tmp/trin-jsonrpc.ipc
 }
 ```
 
-If you have multiple nodes running you can manually select which one you communicate with:
+### To send a parameter, use the `--params` flag. Currently, the cli tool only supports a single param.
+```sh
+$ cargo run -p trin-cli -- portal_pingState --params "enr:...."
+```
+
+### If you have multiple nodes running you can manually select which one you communicate with:
 
 ```sh
 $ cargo run -p trin-cli -- discv5_routingTableInfo --ipc /tmp/trin-jsonrpc-2.ipc


### PR DESCRIPTION
Adds capability for a single parameter to cli tool. It's been tested against `portal_statePing` in #188 .  Obviously, a more robust scheme with multiple parameters is ideal, but I held off on that for now since we don't have any jsonrpc endpoints with multiple params to test against. 