### PR TITLE
Remove unnecessary rwlock from history network

### DIFF
--- a/trin-history/src/events.rs
+++ b/trin-history/src/events.rs
@@ -1,14 +1,13 @@
 use crate::network::HistoryNetwork;
 use discv5::TalkRequest;
 use std::sync::Arc;
-use tokio::sync::{mpsc::UnboundedReceiver, RwLock};
+use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::Instrument;
 use tracing::{debug, error, warn};
-use trin_core::locks::RwLoggingExt;
 use trin_core::portalnet::types::Message;
 
 pub struct HistoryEvents {
-    pub network: Arc<RwLock<HistoryNetwork>>,
+    pub network: Arc<HistoryNetwork>,
     pub event_rx: UnboundedReceiver<TalkRequest>,
 }
 
@@ -17,8 +16,6 @@ impl HistoryEvents {
         while let Some(talk_request) = self.event_rx.recv().await {
             let reply = match self
                 .network
-                .write_with_warn()
-                .await
                 .overlay
                 .process_one_request(&talk_request)
                 .instrument(tracing::info_span!("history_network"))

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -1,12 +1,12 @@
 use crate::network::HistoryNetwork;
 use serde_json::Value;
 use std::sync::Arc;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::mpsc;
 use trin_core::jsonrpc::{endpoints::HistoryEndpoint, types::HistoryJsonRpcRequest};
 
 /// Handles History network JSON-RPC requests
 pub struct HistoryRequestHandler {
-    pub network: Arc<RwLock<HistoryNetwork>>,
+    pub network: Arc<HistoryNetwork>,
     pub history_rx: mpsc::UnboundedReceiver<HistoryJsonRpcRequest>,
 }
 
@@ -15,9 +15,8 @@ impl HistoryRequestHandler {
         while let Some(request) = self.history_rx.recv().await {
             match request.endpoint {
                 HistoryEndpoint::DataRadius => {
-                    let _ = request.resp.send(Ok(Value::String(
-                        self.network.read().await.overlay.data_radius.to_string(),
-                    )));
+                    let radius = &self.network.overlay.data_radius;
+                    let _ = request.resp.send(Ok(Value::String(radius.to_string())));
                 }
             }
         }

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -35,7 +35,7 @@ impl HistoryNetwork {
     }
 
     /// Convenience call for testing, quick way to ping bootnodes
-    pub async fn ping_bootnodes(&mut self) -> Result<(), String> {
+    pub async fn ping_bootnodes(&self) -> Result<(), String> {
         // Trigger bonding with bootnodes, at both the base layer and portal overlay.
         // The overlay ping via talkreq will trigger a session at the base layer, then
         // a session on the (overlay) portal network.


### PR DESCRIPTION
With the latest `discv5` library, we no longer need to use locks on overlay networks. fixes #190 