### PR TITLE
Add trin cli binary to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,14 @@ COPY ./trin-state ./trin-state
 COPY ./ethportal-peertest ./ethportal-peertest 
 
 # build for release
-RUN cargo build --release
+RUN cargo build --all --release
 
 # final base
 FROM rust:1.56.1
 
 # copy build artifact from build stage
 COPY --from=builder /trin/target/release/trin .
+COPY --from=builder /trin/target/release/trin-cli .
 
 ENV RUST_LOG=debug
 

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -22,10 +22,11 @@ const DEFAULT_SUBNETWORKS: &str = "history,state";
 )]
 pub struct TrinConfig {
     #[structopt(
-    default_value = "ipc",
-    possible_values(&["http", "ipc"]),
-    long = "web3-transport",
-    help = "select transport protocol to serve json-rpc endpoint")]
+        default_value = "ipc",
+        possible_values(&["http", "ipc"]),
+        long = "web3-transport",
+        help = "select transport protocol to serve json-rpc endpoint"
+    )]
     pub web3_transport: String,
 
     #[structopt(


### PR DESCRIPTION
A couple minor bugfixes for using `trin-cli` inside a docker container
- Make `--params` arg optional 
- Add copy `trin-cli` binary to dockerfile