### PR TITLE
Re-enable ping peertests

### DIFF
--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -45,13 +45,11 @@ fn validate_endpoint_response(method: &str, result: &Value) {
         }
         "portal_historyPing" => {
             assert!(result.is_string());
-            assert!(result.as_str().unwrap().contains("data_radius"));
-            assert!(result.as_str().unwrap().contains("payload"));
+            // TODO test for enrSeq, recipient{IP,Port}
         }
         "portal_statePing" => {
             assert!(result.is_string());
-            assert!(result.as_str().unwrap().contains("data_radius"));
-            assert!(result.as_str().unwrap().contains("payload"));
+            // TODO test for enrSeq, recipient{IP,Port}
         }
         _ => panic!("Unsupported endpoint"),
     };

--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -59,7 +59,7 @@ fn validate_endpoint_response(method: &str, result: &Value) {
 }
 
 impl JsonRpcEndpoint {
-    pub fn all_endpoints(_target_node: String) -> Vec<JsonRpcEndpoint> {
+    pub fn all_endpoints(target_node: String) -> Vec<JsonRpcEndpoint> {
         vec![
             JsonRpcEndpoint {
                 method: "web3_clientVersion".to_string(),
@@ -86,7 +86,6 @@ impl JsonRpcEndpoint {
                 id: 5,
                 params: Params::None,
             },
-            /*
             JsonRpcEndpoint {
                 method: "portal_statePing".to_string(),
                 id: 6,
@@ -97,7 +96,6 @@ impl JsonRpcEndpoint {
                 id: 7,
                 params: Params::Array(vec![Value::String(target_node)]),
             },
-            */
         ]
     }
 

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -7,22 +7,46 @@ mod test {
     async fn test_launches() {
         tracing_subscriber::fmt::init();
 
-        let peertest_config = peertest::PeertestConfig::new_from([".", "--target-node", "enr:-IS4QFuwD0Zgt_R_yRbIMHHQq_iAmewBewahQgIjIiSTRnzZWp_y8atv0jSN0oeE3KJ8qnNHI-AEgfJfqWYVEqvjWqYBgmlkgnY0gmlwhMCoAcCJc2VjcDI1NmsxoQI19BFyTJb6NhSYOi3nJQJdXL3WESUI4ouxYzBr423MdIN1ZHCCIyg"].iter()).unwrap();
+        // Run a client, as a buddy peer for ping tests, etc.
+        let (buddy_enode, buddy_client_exiter) = {
+            let trin_config = TrinConfig::new_from(
+                [
+                    "trin",
+                    "--internal-ip",
+                    "--unsafe-private-key",
+                    "7261696e626f7773756e69636f726e737261696e626f7773756e69636f726e73",
+                ]
+                .iter(),
+            )
+            .unwrap();
+            let web3_ipc_path = trin_config.web3_ipc_path.clone();
+            let exiter = trin::run_trin(trin_config, String::new()).await.unwrap();
+            let enode = peertest::jsonrpc::get_enode(&web3_ipc_path).unwrap();
+            (enode, exiter)
+        };
 
+        let peertest_config =
+            peertest::PeertestConfig::new_from([".", "--target-node", &buddy_enode].iter())
+                .unwrap();
+
+        // Run a client, to be tested
         let trin_config = TrinConfig::new_from(
             [
                 "trin",
                 "--internal-ip",
                 "--web3-ipc-path",
                 &peertest_config.web3_ipc_path,
+                "--discovery-port",
+                "9001",
             ]
             .iter(),
         )
         .unwrap();
-        let exiter = trin::run_trin(trin_config, String::new()).await.unwrap();
+        let test_client_exiter = trin::run_trin(trin_config, String::new()).await.unwrap();
 
         peertest::test_jsonrpc_endpoints_over_ipc(peertest_config).await;
 
-        exiter.exit();
+        buddy_client_exiter.exit();
+        test_client_exiter.exit();
     }
 }

--- a/trin-core/src/jsonrpc/service.rs
+++ b/trin-core/src/jsonrpc/service.rs
@@ -84,13 +84,17 @@ pub fn launch_jsonrpc_server(
 fn set_ipc_cleanup_handlers(ipc_path: &str) {
     {
         let ipc_path = ipc_path.to_string();
-        ctrlc::set_handler(move || {
+        if let Err(err) = ctrlc::set_handler(move || {
             if let Err(err) = fs::remove_file(&ipc_path) {
                 debug!("Ctrl-C: Skipped removing {} because: {}", ipc_path, err);
             };
             std::process::exit(1);
-        })
-        .expect("Error setting Ctrl-C handler.");
+        }) {
+            warn!(
+                "Could not set the Ctrl-C handler for removing the IPC socket: {}",
+                err
+            );
+        }
     }
 
     {


### PR DESCRIPTION
Fix #196 

Includes a refactor to reduce duplicate code when making IPC requests from peertest. Also, was crashing when ctrl-c was registering twice (on the 2nd trin run).

Note that we're not actually returning the correct values for portal_*Ping json requests, but that belongs in a separate issue (#198). This PR is just about building the structure necessary to run two copies of trin and trigger messages between them.