### PR TITLE
Overlay nodes

### DIFF
--- a/trin-core/src/jsonrpc/endpoints.rs
+++ b/trin-core/src/jsonrpc/endpoints.rs
@@ -61,7 +61,9 @@ impl FromStr for TrinEndpoint {
             "portal_historyFindContent" => {
                 Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::FindContent))
             }
-            "portal_historyFindNodes" => Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::FindNodes)),
+            "portal_historyFindNodes" => {
+                Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::FindNodes))
+            }
             "portal_historyPing" => Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::Ping)),
             "portal_historyRadius" => {
                 Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::DataRadius))

--- a/trin-core/src/jsonrpc/endpoints.rs
+++ b/trin-core/src/jsonrpc/endpoints.rs
@@ -11,16 +11,18 @@ pub enum Discv5Endpoint {
 #[derive(Debug, PartialEq, Clone)]
 pub enum StateEndpoint {
     DataRadius,
-    Ping,
     FindContent,
+    FindNodes,
+    Ping,
 }
 
 /// History network JSON-RPC endpoints. Start with "portalHistory_" prefix
 #[derive(Debug, PartialEq, Clone)]
 pub enum HistoryEndpoint {
     DataRadius,
-    Ping,
     FindContent,
+    FindNodes,
+    Ping,
 }
 
 /// Ethereum JSON-RPC endpoints not currently supported by portal network requests, proxied to Infura
@@ -59,6 +61,7 @@ impl FromStr for TrinEndpoint {
             "portal_historyFindContent" => {
                 Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::FindContent))
             }
+            "portal_historyFindNodes" => Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::FindNodes)),
             "portal_historyPing" => Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::Ping)),
             "portal_historyRadius" => {
                 Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::DataRadius))
@@ -66,6 +69,7 @@ impl FromStr for TrinEndpoint {
             "portal_stateFindContent" => {
                 Ok(TrinEndpoint::StateEndpoint(StateEndpoint::FindContent))
             }
+            "portal_stateFindNodes" => Ok(TrinEndpoint::StateEndpoint(StateEndpoint::FindNodes)),
             "portal_statePing" => Ok(TrinEndpoint::StateEndpoint(StateEndpoint::Ping)),
             "portal_stateRadius" => Ok(TrinEndpoint::StateEndpoint(StateEndpoint::DataRadius)),
             _ => Err(()),

--- a/trin-core/src/jsonrpc/types.rs
+++ b/trin-core/src/jsonrpc/types.rs
@@ -152,11 +152,11 @@ impl TryFrom<[&Value; 2]> for FindNodesParams {
             Err(_) => return Err(ValidationError::new("Unable to decode distances")),
         };
         if distances.len() == 0 {
-            return Err(ValidationError::new("Invalid distances param: Empty list."))
+            return Err(ValidationError::new("Invalid distances param: Empty list."));
         } else if distances.len() > 256 {
             return Err(ValidationError::new(
-                "Invalid distances param: More than 256 max allowed # of elements."
-            ))
+                "Invalid distances param: More than 256 max allowed # of elements.",
+            ));
         }
         Ok(Self { enr, distances })
     }

--- a/trin-core/src/jsonrpc/types.rs
+++ b/trin-core/src/jsonrpc/types.rs
@@ -98,10 +98,7 @@ impl TryFrom<&Value> for PingParams {
     type Error = ValidationError;
 
     fn try_from(param: &Value) -> Result<Self, Self::Error> {
-        let enr: SszEnr = match param.try_into() {
-            Ok(val) => val,
-            Err(msg) => return Err(msg),
-        };
+        let enr: SszEnr = param.try_into()?;
         Ok(Self { enr })
     }
 }
@@ -129,10 +126,7 @@ impl TryFrom<[&Value; 2]> for FindNodesParams {
     type Error = ValidationError;
 
     fn try_from(params: [&Value; 2]) -> Result<Self, Self::Error> {
-        let enr: SszEnr = match params[0].try_into() {
-            Ok(val) => val,
-            Err(msg) => return Err(msg),
-        };
+        let enr: SszEnr = params[0].try_into()?;
 
         let distances = params[1]
             .as_str()
@@ -168,11 +162,7 @@ impl TryFrom<[&Value; 2]> for FindContentParams {
     type Error = ValidationError;
 
     fn try_from(params: [&Value; 2]) -> Result<Self, Self::Error> {
-        let enr: SszEnr = match params[0].try_into() {
-            Ok(val) => val,
-            Err(msg) => return Err(msg),
-        };
-
+        let enr: SszEnr = params[0].try_into()?;
         let content_key = params[1]
             .as_str()
             .ok_or_else(|| ValidationError::new("Empty content key param"))?;

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -194,6 +195,10 @@ impl OverlayProtocol {
         distances: Vec<u16>,
     ) -> Result<Nodes, OverlayRequestError> {
         // Construct the request.
+        match validate_find_nodes_distances(&distances) {
+            Ok(_) => (),
+            Err(msg) => return Err(msg),
+        }
         let request = FindNodes { distances };
         let direction = RequestDirection::Outgoing { destination: enr };
 
@@ -253,6 +258,64 @@ impl OverlayProtocol {
         match rx.await {
             Ok(result) => result,
             Err(error) => Err(OverlayRequestError::ChannelFailure(error.to_string())),
+        }
+    }
+}
+
+fn validate_find_nodes_distances(distances: &Vec<u16>) -> Result<(), OverlayRequestError> {
+    if distances.len() == 0 {
+        return Err(OverlayRequestError::InvalidRequest(
+            "Invalid distances: Empty list".to_string(),
+        ));
+    }
+    if distances.len() > 256 {
+        return Err(OverlayRequestError::InvalidRequest(
+            "Invalid distances: More than 256 elements".to_string(),
+        ));
+    }
+    let invalid_distances: Vec<&u16> = distances.iter().filter(|val| val > &&256u16).collect();
+    if invalid_distances.len() > 0 {
+        return Err(OverlayRequestError::InvalidRequest(format!(
+            "Invalid distances: Distances greater than 256 are not allowed. Found: {:?}",
+            invalid_distances
+        )));
+    }
+    let unique: HashSet<u16> = HashSet::from_iter(distances.iter().cloned());
+    if unique.len() != distances.len() {
+        return Err(OverlayRequestError::InvalidRequest(
+            "Invalid distances: Duplicate elements detected".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(vec![0u16])]
+    #[case(vec![256u16])]
+    #[case((0u16..256u16).collect())]
+    fn test_nodes_validator_accepts_valid_input(#[case] input: Vec<u16>) {
+        let result = validate_find_nodes_distances(&input);
+        match result {
+            Ok(val) => assert_eq!(val, ()),
+            Err(_) => panic!("Valid test case fails"),
+        }
+    }
+
+    #[rstest]
+    #[case(vec![], "Empty list")]
+    #[case(vec![0u16; 257], "More than 256")]
+    #[case(vec![257u16], "Distances greater than")]
+    #[case(vec![0u16, 0u16, 1u16], "Duplicate elements detected")]
+    fn test_nodes_validator_rejects_invalid_input(#[case] input: Vec<u16>, #[case] msg: String) {
+        let result = validate_find_nodes_distances(&input);
+        match result {
+            Ok(_) => panic!("Invalid test case passed"),
+            Err(err) => assert!(err.to_string().contains(&msg)),
         }
     }
 }

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -195,10 +195,7 @@ impl OverlayProtocol {
         distances: Vec<u16>,
     ) -> Result<Nodes, OverlayRequestError> {
         // Construct the request.
-        match validate_find_nodes_distances(&distances) {
-            Ok(_) => (),
-            Err(msg) => return Err(msg),
-        }
+        validate_find_nodes_distances(&distances)?;
         let request = FindNodes { distances };
         let direction = RequestDirection::Outgoing { destination: enr };
 
@@ -308,7 +305,7 @@ mod test {
 
     #[rstest]
     #[case(vec![], "Empty list")]
-    #[case(vec![0u16; 257], "More than 256")]
+    #[case((0u16..257u16).collect(), "More than 256")]
     #[case(vec![257u16], "Distances greater than")]
     #[case(vec![0u16, 0u16, 1u16], "Duplicate elements detected")]
     fn test_nodes_validator_rejects_invalid_input(#[case] input: Vec<u16>, #[case] msg: String) {

--- a/trin-core/src/portalnet/types/messages.rs
+++ b/trin-core/src/portalnet/types/messages.rs
@@ -12,6 +12,7 @@ use ssz::{Decode, DecodeError, Encode};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum, VariableList};
 use thiserror::Error;
+use validator::ValidationError;
 
 use crate::portalnet::overlay_service::OverlayRequestError;
 use crate::portalnet::{types::uint::U256, Enr};
@@ -445,6 +446,26 @@ pub struct SszEnr(Enr);
 impl SszEnr {
     pub fn new(enr: Enr) -> SszEnr {
         SszEnr(enr)
+    }
+}
+
+impl Into<Enr> for SszEnr {
+    fn into(self) -> Enr {
+        Enr::from(self.0.clone())
+    }
+}
+
+impl TryFrom<&Value> for SszEnr {
+    type Error = ValidationError;
+
+    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+        let enr = value
+            .as_str()
+            .ok_or_else(|| ValidationError::new("Empty enr value"))?;
+        match Enr::from_str(enr) {
+            Ok(enr) => Ok(Self(enr)),
+            Err(_) => Err(ValidationError::new("Invalid enr value")),
+        }
     }
 }
 

--- a/trin-core/src/portalnet/types/messages.rs
+++ b/trin-core/src/portalnet/types/messages.rs
@@ -377,6 +377,13 @@ impl ssz::Decode for Nodes {
     }
 }
 
+impl Into<Value> for Nodes {
+    fn into(self) -> Value {
+        serde_json::json!({ "enrs": format!("{:?}", self.enrs) , "total": self.total})
+    }
+}
+
+
 #[derive(Debug, PartialEq, Clone, Encode, Decode)]
 pub struct FindContent {
     // TODO: Use some version of H256

--- a/trin-core/src/portalnet/types/messages.rs
+++ b/trin-core/src/portalnet/types/messages.rs
@@ -451,7 +451,7 @@ impl SszEnr {
 
 impl Into<Enr> for SszEnr {
     fn into(self) -> Enr {
-        Enr::from(self.0.clone())
+        Enr::from(self.0)
     }
 }
 

--- a/trin-core/src/portalnet/types/messages.rs
+++ b/trin-core/src/portalnet/types/messages.rs
@@ -383,7 +383,6 @@ impl Into<Value> for Nodes {
     }
 }
 
-
 #[derive(Debug, PartialEq, Clone, Encode, Decode)]
 pub struct FindContent {
     // TODO: Use some version of H256

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -28,7 +28,7 @@ impl HistoryRequestHandler {
                         Ok(val) => match self
                             .network
                             .overlay
-                            .send_find_content(val.enr, val.content_key.into())
+                            .send_find_content(val.enr.into(), val.content_key.into())
                             .await
                         {
                             Ok(content) => match content.try_into() {
@@ -46,7 +46,7 @@ impl HistoryRequestHandler {
                         Ok(val) => match self
                             .network
                             .overlay
-                            .send_find_nodes(val.enr, val.distances)
+                            .send_find_nodes(val.enr.into(), val.distances)
                             .await
                         {
                             Ok(nodes) => Ok(nodes.into()),
@@ -58,7 +58,7 @@ impl HistoryRequestHandler {
                 }
                 HistoryEndpoint::Ping => {
                     let response = match PingParams::try_from(request.params) {
-                        Ok(val) => match self.network.overlay.send_ping(val.enr).await {
+                        Ok(val) => match self.network.overlay.send_ping(val.enr.into()).await {
                             Ok(pong) => Ok(pong.into()),
                             Err(msg) => Err(format!("Ping request timeout: {:?}", msg)),
                         },

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -41,6 +41,9 @@ impl HistoryRequestHandler {
                     };
                     let _ = request.resp.send(response);
                 }
+                HistoryEndpoint::FindNodes => {
+                    let _ = request.resp.send(Ok(Value::String("".to_string())));
+                }
                 HistoryEndpoint::Ping => {
                     let response = match PingParams::try_from(request.params) {
                         Ok(val) => match self.network.overlay.send_ping(val.enr).await {

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc;
 use crate::network::StateNetwork;
 use trin_core::jsonrpc::{
     endpoints::StateEndpoint,
-    types::{FindContentParams, PingParams, StateJsonRpcRequest},
+    types::{FindContentParams, FindNodesParams, PingParams, StateJsonRpcRequest},
 };
 
 /// Handles State network JSON-RPC requests
@@ -38,6 +38,17 @@ impl StateRequestHandler {
                             Err(msg) => Err(format!("FindContent request timeout: {:?}", msg)),
                         },
                         Err(msg) => Err(format!("Invalid FindContent params: {:?}", msg)),
+                    };
+                    let _ = request.resp.send(response);
+                }
+                StateEndpoint::FindNodes => {
+                    let response = match FindNodesParams::try_from(request.params) {
+                        Ok(val) => match self.network.overlay.send_find_nodes(val.enr, val.distances).await
+                        {
+                            Ok(nodes) => Ok(nodes.into()),
+                            Err(msg) => Err(format!("FindNodes request timeout: {:?}", msg)),
+                        }
+                        Err(msg) => Err(format!("Invalid FindNodes params: {:?}", msg)),
                     };
                     let _ = request.resp.send(response);
                 }

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -28,7 +28,7 @@ impl StateRequestHandler {
                         Ok(val) => match self
                             .network
                             .overlay
-                            .send_find_content(val.enr, val.content_key.into())
+                            .send_find_content(val.enr.into(), val.content_key.into())
                             .await
                         {
                             Ok(content) => match content.try_into() {
@@ -46,7 +46,7 @@ impl StateRequestHandler {
                         Ok(val) => match self
                             .network
                             .overlay
-                            .send_find_nodes(val.enr, val.distances)
+                            .send_find_nodes(val.enr.into(), val.distances)
                             .await
                         {
                             Ok(nodes) => Ok(nodes.into()),
@@ -58,7 +58,7 @@ impl StateRequestHandler {
                 }
                 StateEndpoint::Ping => {
                     let response = match PingParams::try_from(request.params) {
-                        Ok(val) => match self.network.overlay.send_ping(val.enr).await {
+                        Ok(val) => match self.network.overlay.send_ping(val.enr.into()).await {
                             Ok(pong) => Ok(pong.into()),
                             Err(msg) => Err(format!("Ping request timeout: {:?}", msg)),
                         },

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -43,11 +43,15 @@ impl StateRequestHandler {
                 }
                 StateEndpoint::FindNodes => {
                     let response = match FindNodesParams::try_from(request.params) {
-                        Ok(val) => match self.network.overlay.send_find_nodes(val.enr, val.distances).await
+                        Ok(val) => match self
+                            .network
+                            .overlay
+                            .send_find_nodes(val.enr, val.distances)
+                            .await
                         {
                             Ok(nodes) => Ok(nodes.into()),
                             Err(msg) => Err(format!("FindNodes request timeout: {:?}", msg)),
-                        }
+                        },
                         Err(msg) => Err(format!("Invalid FindNodes params: {:?}", msg)),
                     };
                     let _ = request.resp.send(response);


### PR DESCRIPTION
- Add support for `portal_stateFindNodes(enr, distances)`/`portal_historyFindNodes(enr, distances)` jsonrpc endpoint
- Implement some helper traits on `SszEnr` for cleaner param conversion
- Add validation methods to `send_find_nodes()` according to the [spec](https://github.com/ethereum/portal-network-specs/blob/master/portal-wire-protocol.md#find-nodes-0x02)