### PR TITLE
Implement `custom_payload` element of overlay Ping/Pong JSON-RPC params

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
                 command: cargo build --workspace --jobs 2
             - run:
                 name: Test Trin workspace
-                command: cargo test --workspace
+                command: cargo test --workspace --jobs 2
             - save_cache:
                 key: cargo-{{ checksum "Cargo.lock" }}-v1
                 paths:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,7 +3211,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber 0.2.19",
- "trin-cli",
  "trin-core",
  "trin-history",
  "trin-state",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ tracing-subscriber = "0.2.18"
 trin-core = { path = "trin-core" }
 trin-history = { path = "trin-history" }
 trin-state = { path = "trin-state" }
-trin-cli = { path = "trin-cli" }
 
 [dev-dependencies]
 ethportal-peertest = { path = "ethportal-peertest" }

--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -87,12 +87,18 @@ impl JsonRpcEndpoint {
             JsonRpcEndpoint {
                 method: "portal_statePing".to_string(),
                 id: 6,
-                params: Params::Array(vec![Value::String(buddy_node.clone())]),
+                params: Params::Array(vec![
+                    Value::String(buddy_node.clone()),
+                    Value::String("010100".to_string()),
+                ]),
             },
             JsonRpcEndpoint {
                 method: "portal_historyPing".to_string(),
                 id: 7,
-                params: Params::Array(vec![Value::String(buddy_node)]),
+                params: Params::Array(vec![
+                    Value::String(buddy_node),
+                    Value::String("010100".to_string()),
+                ]),
             },
         ]
     }

--- a/trin-core/src/jsonrpc/types.rs
+++ b/trin-core/src/jsonrpc/types.rs
@@ -5,7 +5,7 @@ use tokio::sync::mpsc;
 use validator::{Validate, ValidationError};
 
 use crate::jsonrpc::endpoints::{HistoryEndpoint, StateEndpoint, TrinEndpoint};
-use crate::portalnet::types::messages::{ByteList, SszEnr};
+use crate::portalnet::types::messages::{ByteList, CustomPayload, SszEnr};
 
 type Responder<T, E> = mpsc::UnboundedSender<Result<T, E>>;
 
@@ -78,6 +78,7 @@ fn validate_jsonrpc_version(jsonrpc: &str) -> Result<(), ValidationError> {
 
 pub struct PingParams {
     pub enr: SszEnr,
+    pub custom_payload: Option<CustomPayload>,
 }
 
 impl TryFrom<Params> for PingParams {
@@ -87,7 +88,8 @@ impl TryFrom<Params> for PingParams {
         match params {
             Params::Array(val) => match val.len() {
                 1 => PingParams::try_from(&val[0]),
-                _ => Err(ValidationError::new("Expected only a single param")),
+                2 => PingParams::try_from([&val[0], &val[1]]),
+                _ => Err(ValidationError::new("Expected 1 or 2 params")),
             },
             _ => Err(ValidationError::new("Expected array of params")),
         }
@@ -99,7 +101,24 @@ impl TryFrom<&Value> for PingParams {
 
     fn try_from(param: &Value) -> Result<Self, Self::Error> {
         let enr: SszEnr = param.try_into()?;
-        Ok(Self { enr })
+        Ok(Self {
+            enr,
+            custom_payload: None,
+        })
+    }
+}
+
+impl TryFrom<[&Value; 2]> for PingParams {
+    type Error = ValidationError;
+
+    fn try_from(param: [&Value; 2]) -> Result<Self, Self::Error> {
+        let enr: SszEnr = param[0].try_into()?;
+        // let custom_payload: ByteList = param[1].try_into()?;
+        let custom_payload: CustomPayload = param[1].try_into()?;
+        Ok(Self {
+            enr,
+            custom_payload: Some(custom_payload),
+        })
     }
 }
 

--- a/trin-core/src/jsonrpc/types.rs
+++ b/trin-core/src/jsonrpc/types.rs
@@ -113,7 +113,6 @@ impl TryFrom<[&Value; 2]> for PingParams {
 
     fn try_from(param: [&Value; 2]) -> Result<Self, Self::Error> {
         let enr: SszEnr = param[0].try_into()?;
-        // let custom_payload: ByteList = param[1].try_into()?;
         let custom_payload: CustomPayload = param[1].try_into()?;
         Ok(Self {
             enr,

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -9,8 +9,8 @@ use super::{
     Enr,
 };
 use crate::portalnet::types::messages::{
-    ByteList, Content, FindContent, FindNodes, Message, Nodes, Ping, Pong, ProtocolId, Request,
-    Response,
+    Content, CustomPayload, FindContent, FindNodes, Message, Nodes, Ping, Pong, ProtocolId,
+    Request, Response,
 };
 
 use discv5::{
@@ -172,7 +172,7 @@ impl OverlayProtocol {
         // Construct the request.
         let enr_seq = self.discovery.local_enr().seq();
         let data_radius = self.data_radius();
-        let custom_payload = ByteList::from(data_radius.as_ssz_bytes());
+        let custom_payload = CustomPayload::from(data_radius.as_ssz_bytes());
         let request = Ping {
             enr_seq,
             custom_payload,

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -9,8 +9,8 @@ use crate::{
         discovery::Discovery,
         types::{
             messages::{
-                ByteList, Content, FindContent, FindNodes, Message, Nodes, Ping, Pong, ProtocolId,
-                Request, Response, SszEnr,
+                ByteList, Content, CustomPayload, FindContent, FindNodes, Message, Nodes, Ping,
+                Pong, ProtocolId, Request, Response, SszEnr,
             },
             uint::U256,
         },
@@ -463,7 +463,7 @@ impl OverlayService {
         );
         let enr_seq = self.local_enr().seq();
         let data_radius = self.data_radius();
-        let custom_payload = ByteList::from(data_radius.as_ssz_bytes());
+        let custom_payload = CustomPayload::from(data_radius.as_ssz_bytes());
         Pong {
             enr_seq,
             custom_payload,
@@ -728,7 +728,7 @@ impl OverlayService {
 
         let enr_seq = self.local_enr().seq();
         let data_radius = self.data_radius();
-        let custom_payload = ByteList::from(data_radius.as_ssz_bytes());
+        let custom_payload = CustomPayload::from(data_radius.as_ssz_bytes());
         let ping = Request::Ping(Ping {
             enr_seq,
             custom_payload,
@@ -1016,7 +1016,7 @@ mod tests {
 
         let ping = Ping {
             enr_seq: source.seq() + 1,
-            custom_payload: ByteList::from(data_radius.as_ssz_bytes()),
+            custom_payload: CustomPayload::from(data_radius.as_ssz_bytes()),
         };
 
         service.process_ping(ping, node_id);
@@ -1054,7 +1054,7 @@ mod tests {
 
         let ping = Ping {
             enr_seq: source.seq(),
-            custom_payload: ByteList::from(data_radius.as_ssz_bytes()),
+            custom_payload: CustomPayload::from(data_radius.as_ssz_bytes()),
         };
 
         service.process_ping(ping, node_id);
@@ -1137,7 +1137,7 @@ mod tests {
 
         let pong = Pong {
             enr_seq: source.seq() + 1,
-            custom_payload: ByteList::from(data_radius.as_ssz_bytes()),
+            custom_payload: CustomPayload::from(data_radius.as_ssz_bytes()),
         };
 
         service.process_pong(pong, source.clone());
@@ -1174,7 +1174,7 @@ mod tests {
 
         let pong = Pong {
             enr_seq: source.seq(),
-            custom_payload: ByteList::from(data_radius.as_ssz_bytes()),
+            custom_payload: CustomPayload::from(data_radius.as_ssz_bytes()),
         };
 
         service.process_pong(pong, source);

--- a/trin-core/src/portalnet/types/messages.rs
+++ b/trin-core/src/portalnet/types/messages.rs
@@ -19,6 +19,28 @@ use crate::portalnet::{types::uint::U256, Enr};
 
 pub type ByteList = VariableList<u8, typenum::U2048>;
 
+pub struct CustomPayload(ByteList);
+
+impl TryFrom<&Value> for CustomPayload {
+    type Error = ValidationError;
+
+    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+        let value = value
+            .as_str()
+            .ok_or_else(|| ValidationError::new("Empty custom payload value"))?;
+        let custom_payload = match hex::decode(value) {
+            Ok(custom_payload) => custom_payload,
+            Err(_) => Err(ValidationError::new(
+                "Unable to decode hex payload into bytes",
+            ))?,
+        };
+        match ByteList::try_from(custom_payload) {
+            Ok(custom_payload) => Ok(Self(custom_payload)),
+            Err(_) => Err(ValidationError::new("Invalid custom payload value")),
+        }
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum MessageDecodeError {
     #[error("Failed to decode message from SSZ bytes")]


### PR DESCRIPTION
What does this PR do:

- Add new `CustomPayload` struct
- Add support for custom payload param of `historyPing` and `statePing` JSON-RPC
- Implement `CustomPayload` struct in overlay Ping/Pong messages. This required some custom SSZ decode/encode implementation, so we can match the test vectors.

Fixes https://github.com/ethereum/trin/issues/203