### PR TITLE
Discv5 bucket refresh lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,9 +229,9 @@ checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1095,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f072413d126e57991455e0a922b31e4c8ba7c2ffbebf6b78b4f8521397d65cd"
+checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -1340,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg 1.0.1",
  "hashbrown 0.11.2",
@@ -2613,9 +2613,9 @@ checksum = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -2805,9 +2805,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@ pub async fn run_trin(
     let mut discovery = Discovery::new(portalnet_config.clone()).unwrap();
     discovery.start().await.unwrap();
     let discovery = Arc::new(discovery);
+    // Search for discv5 peers (bucket refresh lookup)
+    tokio::spawn(Arc::clone(&discovery).bucket_refresh_lookup());
 
     // Setup Overlay database
     let db = Arc::new(setup_overlay_db(discovery.local_enr().node_id()));

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -17,7 +17,7 @@ use crate::{
         },
         Enr,
     },
-    utils::{bytes, distance::xor, hash_delay_queue::HashDelayQueue},
+    utils::{distance::xor, hash_delay_queue::HashDelayQueue, node_id},
 };
 
 use discv5::{
@@ -44,7 +44,7 @@ pub const FIND_NODES_MAX_NODES: usize = 32;
 pub const FIND_CONTENT_MAX_NODES: usize = 32;
 /// With even distribution assumptions, 2**17 is enough to put each node (estimating 100k nodes,
 /// which is more than 10x the ethereum mainnet node count) into a unique bucket by the 17th bucket index.
-pub const EXPECTED_NON_EMPTY_BUCKETS: usize = 17;
+const EXPECTED_NON_EMPTY_BUCKETS: usize = 17;
 
 /// An overlay request error.
 #[derive(Clone, Error, Debug)]
@@ -380,7 +380,7 @@ impl OverlayService {
                 }
                 _ = OverlayService::bucket_maintenance_poll(self.protocol.clone(), &self.kbuckets) => {}
                 _ = bucket_refresh_interval.tick() => {
-                    debug!("Overlay bucket refresh lookup");
+                    debug!("[{:?}] Overlay bucket refresh lookup", self.protocol);
                     self.bucket_refresh_lookup();
                 }
             }
@@ -987,17 +987,8 @@ impl OverlayService {
         // TODO: Implement Recursive(iterative) FINDNODE. This is a stub.
     }
 
-    /// Generate random NodeId based on bucket index target.
-    /// First we generate a random distance metric with leading zeroes based on the target bucket.
-    /// Then we XOR the result distance with the local NodeId to get the random target NodeId
     fn generate_random_node_id(&self, target_bucket_idx: u8) -> anyhow::Result<NodeId> {
-        let distance_leading_zeroes = 255 - target_bucket_idx;
-        let random_distance = bytes::random_32byte_array(distance_leading_zeroes);
-        let raw_node_id = xor(&self.local_enr().node_id().raw(), &random_distance);
-        match NodeId::parse(Into::<[u8; 32]>::into(raw_node_id).as_slice()) {
-            Ok(node_id) => Ok(node_id),
-            Err(msg) => Err(anyhow::Error::msg(msg)),
-        }
+        node_id::generate_random_node_id(target_bucket_idx, self.local_enr().node_id())
     }
 }
 

--- a/trin-core/src/portalnet/types/uint.rs
+++ b/trin-core/src/portalnet/types/uint.rs
@@ -52,6 +52,15 @@ construct_uint! {
     pub struct U256(4);
 }
 
+/// Convert u256 to 32 byte array
+impl U256 {
+    pub fn to_32_byte_array(self) -> [u8; 32] {
+        let mut byte_array = [0; 32];
+        self.to_big_endian(byte_array.as_mut_slice());
+        byte_array
+    }
+}
+
 // Taken from https://github.com/sigp/lighthouse/blob/stable/consensus/ssz/src/encode/impls.rs
 impl ssz::Encode for U256 {
     fn is_ssz_fixed_len() -> bool {

--- a/trin-core/src/utils/mod.rs
+++ b/trin-core/src/utils/mod.rs
@@ -3,3 +3,4 @@ pub mod content_key;
 pub mod db;
 pub mod distance;
 pub mod hash_delay_queue;
+pub mod node_id;

--- a/trin-core/src/utils/node_id.rs
+++ b/trin-core/src/utils/node_id.rs
@@ -1,0 +1,59 @@
+use crate::utils::bytes;
+use crate::utils::distance::xor;
+use discv5::enr::NodeId;
+
+/// Generate random NodeId based on bucket index target and a local node id.
+/// First we generate a random distance metric with leading zeroes based on the target bucket.
+/// Then we XOR the result distance with the local NodeId to get the random target NodeId
+pub fn generate_random_node_id(
+    target_bucket_idx: u8,
+    local_node_id: NodeId,
+) -> anyhow::Result<NodeId> {
+    let distance_leading_zeroes = 255 - target_bucket_idx;
+    let random_distance = bytes::random_32byte_array(distance_leading_zeroes);
+    let raw_node_id = xor(&local_node_id.raw(), &random_distance);
+    match NodeId::parse(raw_node_id.to_32_byte_array().as_slice()) {
+        Ok(node_id) => Ok(node_id),
+        Err(msg) => Err(anyhow::Error::msg(msg)),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_generate_random_node_id_1() {
+        let target_bucket_idx: u8 = 5;
+        let local_node_id = NodeId::random();
+        let random_node_id = generate_random_node_id(target_bucket_idx, local_node_id).unwrap();
+        let distance = xor(&random_node_id.raw(), &local_node_id.raw());
+        let distance = distance.to_32_byte_array();
+
+        assert_eq!(distance[0..31], vec![0; 31]);
+        assert!(distance[31] < 64 && distance[31] >= 32)
+    }
+
+    #[test]
+    fn test_generate_random_node_id_2() {
+        let target_bucket_idx: u8 = 0;
+        let local_node_id = NodeId::random();
+        let random_node_id = generate_random_node_id(target_bucket_idx, local_node_id).unwrap();
+        let distance = xor(&random_node_id.raw(), &local_node_id.raw());
+        let distance = distance.to_32_byte_array();
+
+        assert_eq!(distance[0..31], vec![0; 31]);
+        assert_eq!(distance[31], 1);
+    }
+
+    #[test]
+    fn test_generate_random_node_id_3() {
+        let target_bucket_idx: u8 = 255;
+        let local_node_id = NodeId::random();
+        let random_node_id = generate_random_node_id(target_bucket_idx, local_node_id).unwrap();
+        let distance = xor(&random_node_id.raw(), &local_node_id.raw());
+        let distance = distance.to_32_byte_array();
+
+        assert!(distance[0] > 127);
+    }
+}

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -47,6 +47,9 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     discovery.start().await.unwrap();
     let discovery = Arc::new(discovery);
 
+    // Search for discv5 peers (bucket refresh lookup)
+    tokio::spawn(Arc::clone(&discovery).bucket_refresh_lookup());
+
     // Setup Overlay database
     let db = Arc::new(setup_overlay_db(discovery.local_enr().node_id()));
 

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -45,6 +45,9 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     discovery.start().await.unwrap();
     let discovery = Arc::new(discovery);
 
+    // Search for discv5 peers (bucket refresh lookup)
+    tokio::spawn(Arc::clone(&discovery).bucket_refresh_lookup());
+
     // Setup Overlay database
     let db = Arc::new(setup_overlay_db(discovery.local_enr().node_id()));
 


### PR DESCRIPTION
Implements bucket refresh lookup algorithm for base discv5 layer. It is using the same logic as described in https://github.com/ethereum/trin/pull/213.

#### Implementation details

- `generate_random_node_id` method has been extracted in the `utils` module, so it can be used in both discv5's `discovery` and `overlay_service`.

Fixes https://github.com/ethereum/trin/issues/223