### PR TITLE
Modify XOR distance function to operate on length 32 byte arrays

### DIFF
--- a/trin-core/src/utils/bytes.rs
+++ b/trin-core/src/utils/bytes.rs
@@ -1,16 +1,18 @@
-use rand::Rng;
+use rand::{Rng, RngCore};
 
 /// Generate 32 byte array with N leading bit zeros
-pub fn random_32byte_array(leading_bit_zeros: u8) -> Vec<u8> {
-    let first_zero_bytes = leading_bit_zeros / 8u8;
+pub fn random_32byte_array(leading_bit_zeros: u8) -> [u8; 32] {
+    let first_zero_bytes: usize = leading_bit_zeros as usize / 8;
     let first_nonzero_byte_leading_zeros = leading_bit_zeros % 8u8;
 
-    let mut bytes = vec![0; first_zero_bytes.into()];
-    let mut random_bytes: Vec<u8> = (0..32 - first_zero_bytes)
-        .map(|_| rand::random::<u8>())
-        .collect();
+    let mut bytes = [0; 32];
+    rand::thread_rng().fill_bytes(&mut bytes[first_zero_bytes..]);
 
-    random_bytes[0] = if first_nonzero_byte_leading_zeros == 0 {
+    if first_zero_bytes == 32 {
+        return bytes;
+    }
+
+    bytes[first_zero_bytes] = if first_nonzero_byte_leading_zeros == 0 {
         // We want the byte after first zero bytes to start with 1 bit, i.e value > 128
         rand::thread_rng().gen_range(128..=255)
     } else {
@@ -21,8 +23,6 @@ pub fn random_32byte_array(leading_bit_zeros: u8) -> Vec<u8> {
         rand::thread_rng()
             .gen_range(min_nonzero_byte_value..min_nonzero_byte_value.saturating_mul(2))
     };
-
-    bytes.append(&mut random_bytes);
 
     bytes
 }


### PR DESCRIPTION
Modify XOR distance function to operate on length 32 byte arrays.

All distance computations should operate on 32-byte (256-bit) values. With this modification, we can remove unnecessary error handling and type conversions. I went with big-endian in this implementation, but if desired, I could add an additional parameter to specify endian-ness.

I think this is the general form that a `Distance` trait should take. I chose not to define that trait here, and defer it to a later PR.