### PR TITLE
Modify content-key tests to conform to content keys test vectors spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac-sha256"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf358bbbbf03cbe18c2bc53c34b9f1dc212d2ce5cc56bf95ce34cec4359613b"
+
+[[package]]
 name = "http"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3298,6 +3304,7 @@ dependencies = [
  "eth2_ssz_types",
  "futures 0.3.19",
  "hex",
+ "hmac-sha256",
  "httparse",
  "interfaces",
  "ipconfig",

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0.59"
 stunclient = "0.1.2"
 structopt = "0.3"
 sha3 = "0.9.1"
+hmac-sha256 = "1.1.1"
 thiserror = "1.0.29"
 threadpool = "1.8.1"
 tokio = {version = "1.8.0", features = ["full"]}


### PR DESCRIPTION
This modifies the tests to conform to the test vectors here: https://github.com/ethereum/portal-network-specs/blob/master/content-keys-test-vectors.md.

Minor changes were made to the hash functions to conform to the updated spec as well.

Also it combines the test for encoding/decoding of key x and converting key x to the respective id into a single test. This reduces lines of code by a lot and also possibility for error.