### PR TITLE
Rename refactoring and add comments to uTP

### DIFF
--- a/trin-core/src/portalnet/events.rs
+++ b/trin-core/src/portalnet/events.rs
@@ -7,7 +7,7 @@ use tokio::sync::{mpsc, RwLock};
 use super::discovery::Discovery;
 use super::types::messages::ProtocolId;
 use crate::locks::RwLoggingExt;
-use crate::utp::stream::{ConnectionState, UtpListener};
+use crate::utp::stream::{SocketState, UtpListener};
 use crate::utp::trin_helpers::{UtpAccept, UtpMessageId};
 use hex;
 use ssz::Decode;
@@ -119,7 +119,7 @@ impl PortalnetEvents {
             .utp_connections
             .iter_mut()
         {
-            if conn.state == ConnectionState::Disconnected {
+            if conn.state == SocketState::Disconnected {
                 let received_stream = conn.recv_data_stream.clone();
 
                 match self
@@ -127,7 +127,7 @@ impl PortalnetEvents {
                     .read_with_warn()
                     .await
                     .listening
-                    .get(&conn.conn_id_recv)
+                    .get(&conn.receiver_connection_id)
                 {
                     Some(message_type) => match message_type {
                         UtpMessageId::OfferAcceptStream => {

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -333,7 +333,7 @@ impl OverlayProtocol {
                             })
                     {
                         // send the content to the acceptor over a uTP stream
-                        conn.write(&UtpMessage::new(content_message.as_ssz_bytes()).encode()[..]);
+                        conn.send_to(&UtpMessage::new(content_message.as_ssz_bytes()).encode()[..]);
                     }
                 } else if state == UtpStreamState::Finished {
                     if let Some(conn) =

--- a/trin-core/src/utp/stream.rs
+++ b/trin-core/src/utp/stream.rs
@@ -16,6 +16,9 @@ use crate::portalnet::types::messages::ProtocolId;
 use crate::utp::packets::{Packet, PacketHeader, PacketType, HEADER_SIZE};
 use crate::utp::trin_helpers::{UtpMessageId, UtpStreamState};
 
+// Maximum time (in microseconds) to wait for incoming packets when the send window is full
+const PRE_SEND_TIMEOUT: u32 = 500_000;
+
 pub const MAX_DISCV5_PACKET_SIZE: usize = 1280;
 pub const MIN_PACKET_SIZE: usize = 150;
 const MIN_DISCV5_PACKET_SIZE: usize = 63;
@@ -24,7 +27,8 @@ const CCONTROL_TARGET: usize = 100 * 1000;
 const MAX_CWND_INCREASE_BYTES_PER_RTT: usize = 3000;
 const MIN_WINDOW_SIZE: usize = 10;
 
-fn get_time() -> u32 {
+/// Return current time in microseconds since the UNIX epoch.
+fn now_microseconds() -> u32 {
     (SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
@@ -33,7 +37,7 @@ fn get_time() -> u32 {
 }
 
 fn get_time_diff(response_time: u32) -> u32 {
-    let current_time = get_time();
+    let current_time = now_microseconds();
 
     if current_time > response_time {
         current_time - response_time
@@ -46,8 +50,8 @@ pub fn rand() -> u16 {
     rand::thread_rng().gen()
 }
 
-#[derive(PartialEq, Clone)]
-pub enum ConnectionState {
+#[derive(PartialEq, Clone, Debug)]
+pub enum SocketState {
     Uninitialized,
     SynSent,
     SynRecv,
@@ -73,7 +77,7 @@ impl ConnectionKey {
 // Basically the same idea as in the official Bit Torrent library we will store all of the active connections data here
 pub struct UtpListener {
     pub discovery: Arc<Discovery>,
-    pub utp_connections: HashMap<ConnectionKey, UtpStream>,
+    pub utp_connections: HashMap<ConnectionKey, UtpSocket>,
     // We only want to listen/handle packets of connections that were negotiated with
     pub listening: HashMap<u16, UtpMessageId>,
 }
@@ -84,35 +88,36 @@ impl UtpListener {
             Ok(packet) => {
                 let connection_id = packet.connection_id();
 
-                match packet.type_() {
+                match packet.get_type() {
                     PacketType::Reset => {
                         let key_fn =
                             |offset| ConnectionKey::new(*node_id, connection_id - 1 + offset);
-                        let f =
-                            |conn: &&mut UtpStream| -> bool { conn.conn_id_send == connection_id };
+                        let f = |conn: &&mut UtpSocket| -> bool {
+                            conn.sender_connection_id == connection_id
+                        };
 
                         if let Some(conn) = self.utp_connections.get_mut(&key_fn(1)) {
-                            conn.state = ConnectionState::Disconnected;
+                            conn.state = SocketState::Disconnected;
                         } else if let Some(conn) =
                             self.utp_connections.get_mut(&key_fn(2)).filter(f)
                         {
-                            conn.state = ConnectionState::Disconnected;
+                            conn.state = SocketState::Disconnected;
                         } else if let Some(conn) =
                             self.utp_connections.get_mut(&key_fn(0)).filter(f)
                         {
-                            conn.state = ConnectionState::Disconnected;
+                            conn.state = SocketState::Disconnected;
                         }
                     }
                     PacketType::Syn => {
                         if let Some(enr) = self.discovery.discv5.find_enr(node_id) {
                             // If neither of those cases happened handle this is a new request
                             let (tx, _) = mpsc::unbounded_channel::<UtpStreamState>();
-                            let mut conn = UtpStream::init(Arc::clone(&self.discovery), enr, tx);
+                            let mut conn = UtpSocket::new(Arc::clone(&self.discovery), enr, tx);
                             conn.handle_packet(packet);
                             self.utp_connections.insert(
                                 ConnectionKey {
                                     node_id: *node_id,
-                                    conn_id_recv: conn.conn_id_recv,
+                                    conn_id_recv: conn.receiver_connection_id,
                                 },
                                 conn,
                             );
@@ -144,7 +149,7 @@ impl UtpListener {
         tx: mpsc::UnboundedSender<UtpStreamState>,
     ) {
         if let Some(enr) = self.discovery.discv5.find_enr(&node_id) {
-            let mut conn = UtpStream::init(Arc::clone(&self.discovery), enr, tx);
+            let mut conn = UtpSocket::new(Arc::clone(&self.discovery), enr, tx);
             conn.make_connection(connection_id);
             self.utp_connections.insert(
                 ConnectionKey {
@@ -159,62 +164,103 @@ impl UtpListener {
 
 // Used to be MicroTransportProtocol impl but it is basically just called UtpStream compared to the
 // Rust Tcp Lib so I changed it
-pub struct UtpStream {
-    pub state: ConnectionState,
+pub struct UtpSocket {
+    /// The wrapped discv5 protocol
+    socket: Arc<Discovery>,
+
+    /// Socket state
+    pub state: SocketState,
+
+    // Remote peer
+    connected_to: Enr,
+
+    /// Sequence number for the next packet
     seq_nr: u16,
+
+    /// Sequence number of the latest acknowledged packet sent by the remote peer
     ack_nr: u16,
-    pub conn_id_recv: u16,
-    conn_id_send: u16,
+
+    /// Sender connection identifier
+    sender_connection_id: u16,
+
+    /// Receiver connection identifier
+    pub receiver_connection_id: u16,
+
     // maximum window size, in bytes
     max_window: u32,
-    // <seq_nr, packet>
+
+    /// Received but not acknowledged packets
     incoming_buffer: BTreeMap<u16, Packet>,
+
+    /// Packets not yet sent
     unsent_queue: VecDeque<Packet>,
-    enr: Enr,
-    discovery: Arc<Discovery>,
+
+    /// Bytes in flight
     cur_window: u32,
+
+    /// Window size of the remote peer
     remote_wnd_size: u32,
+
+    /// Sent but not yet acknowledged packets
     send_window: HashMap<u16, Packet>,
-    // counts the amount of acks
-    duplicate_acks: u8,
-    // stores the last ack we seen
-    last_ack: u16,
-    // round trip time
+
+    /// How many ACKs did the socket receive for packet with sequence number equal to `ack_nr`
+    duplicate_ack_count: u8,
+
+    /// Sequence number of the latest packet the remote peer acknowledged
+    last_acked: u16,
+
+    /// Round-trip time to remote peer
     rtt: i32,
-    // rtt variance
-    rtt_var: i32,
-    base_delay: Vec<u32>,
-    timeout: u64,
+
+    /// Variance of the round-trip time to the remote peer
+    rtt_variance: i32,
+
+    /// Rolling window of packet delay to remote peer
+    base_delays: Vec<u32>,
+
+    /// Rolling window of the difference between sending a packet and receiving its acknowledgement
+    current_delays: Vec<u32>,
+
+    /// Current congestion timeout in milliseconds
+    congestion_timeout: u64,
+
+    /// Start of the current minute for sampling purposes
+    // TODO: Add Timestamp struct here
     last_rollover: u32,
-    current_delay: Vec<u32>,
+
     pub recv_data_stream: Vec<u8>,
     tx: mpsc::UnboundedSender<UtpStreamState>,
 }
 
-impl UtpStream {
-    fn init(arc: Arc<Discovery>, enr: Enr, tx: mpsc::UnboundedSender<UtpStreamState>) -> Self {
+impl UtpSocket {
+    fn new(
+        socket: Arc<Discovery>,
+        connected_to: Enr,
+        tx: mpsc::UnboundedSender<UtpStreamState>,
+    ) -> Self {
         Self {
-            state: ConnectionState::Uninitialized,
+            state: SocketState::Uninitialized,
             seq_nr: 0,
             ack_nr: 0,
-            conn_id_recv: 0,
-            conn_id_send: 0,
+            receiver_connection_id: 0,
+            sender_connection_id: 0,
             max_window: 0,
             incoming_buffer: Default::default(),
             unsent_queue: Default::default(),
-            enr,
-            discovery: arc,
+            connected_to,
+            socket,
             cur_window: 0,
             remote_wnd_size: 0,
             send_window: Default::default(),
-            duplicate_acks: 0,
-            last_ack: 0,
+            duplicate_ack_count: 0,
+            last_acked: 0,
             rtt: 0,
-            rtt_var: 0,
-            base_delay: vec![],
-            timeout: 1000,
+            rtt_variance: 0,
+            base_delays: vec![],
+            congestion_timeout: 1000,
             last_rollover: 0,
-            current_delay: Vec::with_capacity(8),
+            current_delays: Vec::with_capacity(8),
             recv_data_stream: vec![],
 
             // signal when node is connected to write payload
@@ -222,82 +268,123 @@ impl UtpStream {
         }
     }
 
-    /// Writes a message to the uTP stream
-    pub fn write(&mut self, message: &[u8]) {
-        for chunk in message.chunks(MAX_DISCV5_PACKET_SIZE - MIN_DISCV5_PACKET_SIZE - HEADER_SIZE) {
-            let mut response = PacketHeader::new();
-            response.set_type(PacketType::Data);
-            response.set_connection_id(self.conn_id_send);
-            response.set_timestamp(get_time());
-            response.set_timestamp_difference(0);
-            response.set_seq_nr(self.seq_nr);
-            response.set_ack_nr(self.ack_nr);
+    /// Sends data on the socket to the remote peer. On success, returns the number of bytes
+    /// written.
+    //
+    // # Implementation details
+    //
+    // This method inserts packets into the send buffer and keeps trying to
+    // advance the send window until an ACK corresponding to the last packet is
+    // received.
+    //
+    // Note that the buffer passed to `send_to` might exceed the maximum packet
+    // size, which will result in the data being split over several packets.
+    pub fn send_to(&mut self, buf: &[u8]) -> usize {
+        //TODO: CHeck if we need this
+        //
+        // if self.state == SocketState::Closed {
+        //     return Err(SocketError::ConnectionClosed.into());
+        // }
 
-            self.seq_nr += 1;
-            let packet = Packet::with_payload(response, chunk);
-            self.unsent_queue.push_back(packet)
+        let total_length = buf.len();
+
+        for chunk in buf.chunks(MAX_DISCV5_PACKET_SIZE - MIN_DISCV5_PACKET_SIZE - HEADER_SIZE) {
+            let mut header = PacketHeader::new();
+            header.set_type(PacketType::Data);
+            header.set_connection_id(self.sender_connection_id);
+            header.set_timestamp(now_microseconds());
+            header.set_seq_nr(self.seq_nr);
+            header.set_ack_nr(self.ack_nr);
+
+            let packet = Packet::with_payload(header, chunk);
+            self.unsent_queue.push_back(packet);
+
+            // Intentionally wrap around sequence number
+            self.seq_nr = self.seq_nr.wrapping_add(1);
         }
 
+        // Send every packet in the queue
         self.send_packets_in_queue();
+
+        total_length
     }
 
     fn send_packets_in_queue(&mut self) {
         while let Some(packet) = self.unsent_queue.pop_front() {
-            self.send(packet.clone());
-            self.cur_window += packet.0.len() as u32;
+            self.send_packet(packet.clone());
+            self.cur_window += packet.as_ref().len() as u32;
             self.send_window.insert(packet.get_header().seq_nr, packet);
         }
     }
 
     fn resend_packet(&self, seq_nr: u16) {
         if let Some(packet) = self.send_window.get(&seq_nr) {
-            self.send(packet.clone());
+            self.send_packet(packet.clone());
         }
     }
 
-    fn send(&self, packet: Packet) {
-        let max_send = max(
+    /// Send one packet.
+    fn send_packet(&self, packet: Packet) {
+        debug!("current window: {}", self.send_window.len());
+        let max_inflight = max(
             MAX_DISCV5_PACKET_SIZE,
             min(self.max_window as usize, self.remote_wnd_size as usize),
         );
-        let now = get_time();
+        let now = now_microseconds();
 
-        // Wait for rate control, but don't wait forever
-        while self.cur_window + packet.0.len() as u32 > max_send as u32 && get_time() - now < 500000
+        // Wait until enough in-flight packets are acknowledged for rate control purposes, but don't
+        // wait more than 500 ms (PRE_SEND_TIMEOUT) before sending the packet
+        while self.cur_window + packet.as_ref().len() as u32 > max_inflight as u32
+            && now_microseconds() - now < PRE_SEND_TIMEOUT
         {
-            debug!("max_send {}", max_send);
+            debug!("self.curr_window: {}", self.cur_window);
+            debug!("max_inflight: {}", max_inflight);
+            debug!("self.duplicate_ack_count: {}", self.duplicate_ack_count);
+            debug!("now_microseconds() - now = {}", now_microseconds() - now)
+            // TODO: Why here we dont do for example:
+            // let mut buf = [0; BUF_SIZE];
+            // self.recv(&mut buf)?;
         }
 
-        let enr = self.enr.clone();
-        let discovery = self.discovery.clone();
+        debug!(
+            "out: now_microseconds() - now = {}",
+            now_microseconds() - now
+        );
+
+        let enr = self.connected_to.clone();
+        let discovery = self.socket.clone();
+        let packet_to_send = packet.clone();
 
         // Handle talkreq/talkresp in the background
         tokio::spawn(async move {
-            let talk_request_result = discovery
-                .send_talk_req(enr, ProtocolId::Utp, packet.0.clone())
-                .await;
-            debug!("uTP TalkRequest result: {:?}", talk_request_result);
+            if let Err(response) = discovery
+                .send_talk_req(enr, ProtocolId::Utp, Vec::from(packet_to_send.as_ref()))
+                .await
+            {
+                debug!("Unable to send utp talk req: {response}")
+            }
         });
+        debug!("sent {:?}", packet);
     }
 
     fn update_base_delay(&mut self, delay: u32, now: u32) {
         if now - self.last_rollover > 60 * 1000 {
             self.last_rollover = now;
-            if self.base_delay.len() == 10 {
-                self.base_delay.remove(0);
+            if self.base_delays.len() == 10 {
+                self.base_delays.remove(0);
             }
-            self.base_delay.push(delay);
+            self.base_delays.push(delay);
         } else {
-            let index = self.base_delay.len() - 1;
-            self.base_delay[index] = min(self.base_delay[index], delay);
+            let index = self.base_delays.len() - 1;
+            self.base_delays[index] = min(self.base_delays[index], delay);
         }
     }
 
     fn update_current_delay(&mut self, delay: u32) {
-        if !self.current_delay.len() < 8 {
-            self.current_delay = self.current_delay[1..].to_owned();
+        if !self.current_delays.len() < 8 {
+            self.current_delays = self.current_delays[1..].to_owned();
         }
-        self.current_delay.push(delay);
+        self.current_delays.push(delay);
     }
 
     fn filter(current_delay: &[u32]) -> u32 {
@@ -309,39 +396,22 @@ impl UtpStream {
     }
 
     fn make_connection(&mut self, connection_id: u16) {
-        if self.state == ConnectionState::Uninitialized {
-            self.state = ConnectionState::SynSent;
+        if self.state == SocketState::Uninitialized {
+            self.state = SocketState::SynSent;
             self.seq_nr = 1;
-            self.conn_id_recv = connection_id;
-            self.conn_id_send = self.conn_id_recv + 1;
+            self.receiver_connection_id = connection_id;
+            self.sender_connection_id = self.receiver_connection_id + 1;
 
-            let mut response = PacketHeader::new();
-            response.set_type(PacketType::Syn);
-            response.set_connection_id(self.conn_id_recv);
-            response.set_timestamp(get_time());
-            response.set_timestamp_difference(0);
-            response.set_seq_nr(self.seq_nr + 1);
-            response.set_ack_nr(0);
+            let mut header = PacketHeader::new();
+            header.set_type(PacketType::Syn);
+            header.set_connection_id(self.receiver_connection_id);
+            header.set_timestamp(now_microseconds());
+            header.set_timestamp_difference(0);
+            header.set_seq_nr(self.seq_nr + 1);
+            header.set_ack_nr(0);
 
-            self.send(Packet::new(response));
+            self.send_packet(Packet::new(header));
         }
-    }
-
-    fn make_connection_rand_id(&mut self) {
-        self.state = ConnectionState::SynSent;
-        self.seq_nr = 1;
-        self.conn_id_recv = rand();
-        self.conn_id_send = self.conn_id_recv + 1;
-
-        let mut response = PacketHeader::new();
-        response.set_type(PacketType::Syn);
-        response.set_connection_id(self.conn_id_recv);
-        response.set_timestamp(get_time());
-        response.set_timestamp_difference(0);
-        response.set_seq_nr(self.seq_nr + 1);
-        response.set_ack_nr(0);
-
-        self.send(Packet::new(response));
     }
 
     fn build_selective_ack(&self) -> Vec<u8> {
@@ -365,18 +435,23 @@ impl UtpStream {
     }
 
     pub fn send_finalize(&self) {
-        let mut response = PacketHeader::new();
-        response.set_type(PacketType::Fin);
-        response.set_connection_id(self.conn_id_send);
-        response.set_timestamp(get_time());
-        response.set_timestamp_difference(0);
-        response.set_seq_nr(self.seq_nr + 1);
-        response.set_ack_nr(0);
+        let mut header = PacketHeader::new();
+        header.set_type(PacketType::Fin);
+        header.set_connection_id(self.sender_connection_id);
+        header.set_timestamp(now_microseconds());
+        header.set_timestamp_difference(0);
+        header.set_seq_nr(self.seq_nr + 1);
+        header.set_ack_nr(0);
 
-        self.send(Packet::new(response));
+        self.send_packet(Packet::new(header));
     }
 
     fn handle_packet(&mut self, packet: Packet) {
+        debug!(
+            "Handle packet: {:?}. Conn state: {:?}",
+            packet.get_type(),
+            self.state
+        );
         self.remote_wnd_size = packet.wnd_size();
 
         // Only acknowledge this if this follows the last one, else do it when we advance the send
@@ -385,7 +460,7 @@ impl UtpStream {
             self.ack_nr = packet.seq_nr();
         }
 
-        match packet.type_() {
+        match packet.get_type() {
             PacketType::Data => self.handle_data_packet(packet),
             PacketType::Fin => self.handle_finalize_packet(packet),
             PacketType::State => self.handle_state_packet(packet),
@@ -395,25 +470,25 @@ impl UtpStream {
     }
 
     fn handle_data_packet(&mut self, packet: Packet) {
-        if self.state == ConnectionState::SynRecv {
-            self.state = ConnectionState::Connected;
+        if self.state == SocketState::SynRecv {
+            self.state = SocketState::Connected;
         }
 
-        let mut response = PacketHeader::new();
-        response.set_type(PacketType::State);
-        response.set_connection_id(self.conn_id_send);
-        response.set_timestamp(get_time());
-        response.set_timestamp_difference(get_time_diff(packet.timestamp()));
-        response.set_seq_nr(self.seq_nr);
-        response.set_ack_nr(self.ack_nr);
+        let mut header = PacketHeader::new();
+        header.set_type(PacketType::State);
+        header.set_connection_id(self.sender_connection_id);
+        header.set_timestamp(now_microseconds());
+        header.set_timestamp_difference(get_time_diff(packet.timestamp()));
+        header.set_seq_nr(self.seq_nr);
+        header.set_ack_nr(self.ack_nr);
 
-        let mut reply = Packet::new(response);
+        let mut reply = Packet::new(header);
         if packet.seq_nr().wrapping_sub(self.ack_nr) > 1 {
             let sack_bitfield = self.build_selective_ack();
             reply.set_selective_ack(sack_bitfield);
         }
 
-        self.send(reply);
+        self.send_packet(reply);
 
         // Add packet to BTreeMap
         self.incoming_buffer.insert(packet.seq_nr(), packet);
@@ -434,27 +509,32 @@ impl UtpStream {
     }
 
     fn handle_state_packet(&mut self, packet: Packet) {
-        if self.state == ConnectionState::SynSent {
-            self.state = ConnectionState::Connected;
+        if self.state == SocketState::SynSent {
+            self.state = SocketState::Connected;
             self.ack_nr = packet.seq_nr() - 1;
 
             self.tx.send(UtpStreamState::Connected).unwrap();
         } else {
-            if self.last_ack == packet.ack_nr() {
-                self.duplicate_acks += 1;
+            if self.last_acked == packet.ack_nr() {
+                self.duplicate_ack_count += 1;
             } else {
-                self.last_ack = packet.ack_nr();
-                self.duplicate_acks = 1;
+                self.last_acked = packet.ack_nr();
+                self.duplicate_ack_count = 1;
             }
+            debug!(
+                "Send window first {:?}, Packet ack_nr: {}",
+                self.send_window,
+                packet.ack_nr()
+            );
 
             // handle timeouts and congestion window
             if let Some(stored_packet) = self.send_window.get(&packet.ack_nr()) {
-                let now = get_time();
+                let now = now_microseconds();
                 let our_delay = now - stored_packet.timestamp();
                 self.update_base_delay(our_delay, now);
                 self.update_current_delay(our_delay);
-                let queuing_delay =
-                    UtpStream::filter(&self.current_delay) - self.base_delay.iter().min().unwrap();
+                let queuing_delay = UtpSocket::filter(&self.current_delays)
+                    - self.base_delays.iter().min().unwrap();
 
                 self.update_congestion_window(&packet, queuing_delay);
                 self.update_timeout(our_delay, queuing_delay);
@@ -488,7 +568,7 @@ impl UtpStream {
                 }
             }
 
-            if self.duplicate_acks == 3 && !already_resent_ack_1 {
+            if self.duplicate_ack_count == 3 && !already_resent_ack_1 {
                 self.resend_packet(packet.ack_nr() + 1);
                 packet_loss_detected = true;
             }
@@ -500,11 +580,12 @@ impl UtpStream {
             // acknowledge received packet
             if let Some(stored_packet) = self.send_window.get(&packet.ack_nr()) {
                 let seq_nr = stored_packet.seq_nr();
-                let len = stored_packet.0.len() as u32;
+                let len = stored_packet.as_ref().len() as u32;
                 self.send_window.remove(&seq_nr);
 
                 // Since we want to close the stream when they have recv all of the packets
                 // use a channel
+                debug!("Send_window: {:?}", self.send_window);
                 if self.send_window.is_empty() {
                     self.tx.send(UtpStreamState::Finished).unwrap();
                 }
@@ -520,7 +601,7 @@ impl UtpStream {
         let mut bytes_acked = 0;
         for (i, stored_packet) in self.send_window.iter() {
             if &packet.ack_nr() <= i {
-                bytes_acked += stored_packet.0.len();
+                bytes_acked += stored_packet.as_ref().len();
             }
         }
 
@@ -536,43 +617,43 @@ impl UtpStream {
     fn update_timeout(&mut self, our_delay: u32, queuing_delay: u32) {
         let packet_rtt = (our_delay - queuing_delay) as i32;
         let delta = self.rtt - packet_rtt;
-        self.rtt_var += (delta - self.rtt_var) / 4;
+        self.rtt_variance += (delta - self.rtt_variance) / 4;
         self.rtt += (packet_rtt - self.rtt) / 8;
-        self.timeout = max((self.rtt + self.rtt_var * 4) as u64, 500);
+        self.congestion_timeout = max((self.rtt + self.rtt_variance * 4) as u64, 500);
     }
 
     fn handle_finalize_packet(&mut self, packet: Packet) {
-        if self.state == ConnectionState::Connected {
-            self.state = ConnectionState::Disconnected;
+        if self.state == SocketState::Connected {
+            self.state = SocketState::Disconnected;
 
-            let mut response = PacketHeader::new();
-            response.set_type(PacketType::State);
-            response.set_connection_id(self.conn_id_send);
-            response.set_timestamp(get_time());
-            response.set_timestamp_difference(get_time_diff(packet.timestamp()));
-            response.set_seq_nr(self.seq_nr);
-            response.set_ack_nr(self.ack_nr);
+            let mut header = PacketHeader::new();
+            header.set_type(PacketType::State);
+            header.set_connection_id(self.sender_connection_id);
+            header.set_timestamp(now_microseconds());
+            header.set_timestamp_difference(get_time_diff(packet.timestamp()));
+            header.set_seq_nr(self.seq_nr);
+            header.set_ack_nr(self.ack_nr);
 
-            self.send(Packet::new(response));
+            self.send_packet(Packet::new(header));
         }
     }
 
     fn handle_syn_packet(&mut self, packet: Packet) {
-        self.conn_id_recv = packet.connection_id() + 1;
-        self.conn_id_send = packet.connection_id();
+        self.receiver_connection_id = packet.connection_id() + 1;
+        self.sender_connection_id = packet.connection_id();
         self.seq_nr = rand();
         self.ack_nr = packet.seq_nr();
-        self.state = ConnectionState::SynRecv;
+        self.state = SocketState::SynRecv;
 
-        let mut response = PacketHeader::new();
-        response.set_type(PacketType::State);
-        response.set_connection_id(self.conn_id_send);
-        response.set_timestamp(get_time());
-        response.set_timestamp_difference(get_time_diff(packet.timestamp()));
-        response.set_seq_nr(self.seq_nr);
-        response.set_ack_nr(self.ack_nr);
+        let mut header = PacketHeader::new();
+        header.set_type(PacketType::State);
+        header.set_connection_id(self.sender_connection_id);
+        header.set_timestamp(now_microseconds());
+        header.set_timestamp_difference(get_time_diff(packet.timestamp()));
+        header.set_seq_nr(self.seq_nr);
+        header.set_ack_nr(self.ack_nr);
 
-        self.send(Packet::new(response));
+        self.send_packet(Packet::new(header));
     }
 }
 
@@ -592,8 +673,8 @@ mod tests {
         let packet = Packet::try_from(&buf[..]);
         assert!(packet.is_ok());
         let packet = packet.unwrap();
-        assert_eq!(packet.type_(), PacketType::State);
-        assert_eq!(packet.version(), VERSION);
+        assert_eq!(packet.get_type(), PacketType::State);
+        assert_eq!(packet.get_version(), VERSION);
         assert_eq!(packet.extension(), 0);
         assert_eq!(packet.connection_id(), 42054);
         assert_eq!(packet.timestamp(), 2805920832);
@@ -614,8 +695,8 @@ mod tests {
         let packet = Packet::try_from(&buf[..]);
         assert!(packet.is_ok());
         let packet = packet.unwrap();
-        assert_eq!(packet.type_(), PacketType::State);
-        assert_eq!(packet.version(), VERSION);
+        assert_eq!(packet.get_type(), PacketType::State);
+        assert_eq!(packet.get_version(), VERSION);
         assert_eq!(packet.extension(), 1);
         assert_eq!(packet.connection_id(), 42054);
         assert_eq!(packet.timestamp(), 2805920832);
@@ -639,18 +720,18 @@ mod tests {
 
     #[test]
     fn test_encode_packet() {
-        let mut response = PacketHeader::new();
-        response.set_type(PacketType::Data);
-        response.set_connection_id(49300);
-        response.set_timestamp(2805920832);
-        response.set_timestamp_difference(1805367832);
-        response.set_wnd_size(61440);
-        response.set_seq_nr(12044);
-        response.set_ack_nr(12024);
+        let mut header = PacketHeader::new();
+        header.set_type(PacketType::Data);
+        header.set_connection_id(49300);
+        header.set_timestamp(2805920832);
+        header.set_timestamp_difference(1805367832);
+        header.set_wnd_size(61440);
+        header.set_seq_nr(12044);
+        header.set_ack_nr(12024);
 
-        let packet = Packet::new(response);
-        assert_eq!(packet.type_(), PacketType::Data);
-        assert_eq!(packet.version(), VERSION);
+        let packet = Packet::new(header);
+        assert_eq!(packet.get_type(), PacketType::Data);
+        assert_eq!(packet.get_version(), VERSION);
         assert_eq!(packet.extension(), 0);
         assert_eq!(packet.connection_id(), 49300);
         assert_eq!(packet.timestamp(), 2805920832);
@@ -663,19 +744,19 @@ mod tests {
 
     #[test]
     fn test_encode_packet_with_payload() {
-        let mut response = PacketHeader::new();
-        response.set_type(PacketType::Data);
-        response.set_connection_id(49300);
-        response.set_timestamp(2805920832);
-        response.set_timestamp_difference(1805367832);
-        response.set_wnd_size(61440);
-        response.set_seq_nr(12044);
-        response.set_ack_nr(12024);
+        let mut header = PacketHeader::new();
+        header.set_type(PacketType::Data);
+        header.set_connection_id(49300);
+        header.set_timestamp(2805920832);
+        header.set_timestamp_difference(1805367832);
+        header.set_wnd_size(61440);
+        header.set_seq_nr(12044);
+        header.set_ack_nr(12024);
         let payload = b"Hello world".to_vec();
 
-        let packet = Packet::with_payload(response, &payload[..]);
-        assert_eq!(packet.type_(), PacketType::Data);
-        assert_eq!(packet.version(), VERSION);
+        let packet = Packet::with_payload(header, &payload[..]);
+        assert_eq!(packet.get_type(), PacketType::Data);
+        assert_eq!(packet.get_version(), VERSION);
         assert_eq!(packet.extension(), 0);
         assert_eq!(packet.connection_id(), 49300);
         assert_eq!(packet.timestamp(), 2805920832);
@@ -694,16 +775,16 @@ mod tests {
 
     #[test]
     fn test_selective_ack() {
-        let mut response = PacketHeader::new();
-        response.set_type(PacketType::State);
-        response.set_connection_id(49300);
-        response.set_timestamp(2805920832);
-        response.set_timestamp_difference(1805367832);
-        response.set_wnd_size(61440);
-        response.set_seq_nr(12044);
-        response.set_ack_nr(12024);
+        let mut header = PacketHeader::new();
+        header.set_type(PacketType::State);
+        header.set_connection_id(49300);
+        header.set_timestamp(2805920832);
+        header.set_timestamp_difference(1805367832);
+        header.set_wnd_size(61440);
+        header.set_seq_nr(12044);
+        header.set_ack_nr(12024);
 
-        let mut reply = Packet::new(response);
+        let mut reply = Packet::new(header);
         reply.set_selective_ack(vec![0b1001_1101, 0b0000_0000, 0b0101_1010, 0b0000_0001]);
 
         assert_eq!(reply.get_extensions()[0].bitmask[0], 0b1001_1101);
@@ -717,110 +798,110 @@ mod tests {
 
     #[test]
     fn test_syn_packet() {
-        let mut response = PacketHeader::new();
-        response.set_type(PacketType::Syn);
-        response.set_connection_id(10049);
-        response.set_timestamp(3384187322);
-        response.set_timestamp_difference(0);
-        response.set_wnd_size(1048576);
-        response.set_seq_nr(11884);
-        response.set_ack_nr(0);
+        let mut header = PacketHeader::new();
+        header.set_type(PacketType::Syn);
+        header.set_connection_id(10049);
+        header.set_timestamp(3384187322);
+        header.set_timestamp_difference(0);
+        header.set_wnd_size(1048576);
+        header.set_seq_nr(11884);
+        header.set_ack_nr(0);
 
-        let packet = Packet::new(response);
+        let packet = Packet::new(header);
         assert_eq!(
-            hex::encode(packet.0),
+            hex::encode(packet.as_ref()),
             "41002741c9b699ba00000000001000002e6c0000"
         );
     }
 
     #[test]
     fn test_act_packet_no_extension() {
-        let mut response = PacketHeader::new();
-        response.set_type(PacketType::State);
-        response.set_connection_id(10049);
-        response.set_timestamp(6195294);
-        response.set_timestamp_difference(916973699);
-        response.set_wnd_size(1048576);
-        response.set_seq_nr(16807);
-        response.set_ack_nr(11885);
+        let mut header = PacketHeader::new();
+        header.set_type(PacketType::State);
+        header.set_connection_id(10049);
+        header.set_timestamp(6195294);
+        header.set_timestamp_difference(916973699);
+        header.set_wnd_size(1048576);
+        header.set_seq_nr(16807);
+        header.set_ack_nr(11885);
 
-        let packet = Packet::new(response);
+        let packet = Packet::new(header);
         assert_eq!(
-            hex::encode(packet.0),
+            hex::encode(packet.as_ref()),
             "21002741005e885e36a7e8830010000041a72e6d"
         );
     }
 
     #[test]
     fn test_act_packet_with_selective_ack_extension() {
-        let mut response = PacketHeader::new();
-        response.set_type(PacketType::State);
-        response.set_connection_id(10049);
-        response.set_timestamp(6195294);
-        response.set_timestamp_difference(916973699);
-        response.set_wnd_size(1048576);
-        response.set_seq_nr(16807);
-        response.set_ack_nr(11885);
+        let mut header = PacketHeader::new();
+        header.set_type(PacketType::State);
+        header.set_connection_id(10049);
+        header.set_timestamp(6195294);
+        header.set_timestamp_difference(916973699);
+        header.set_wnd_size(1048576);
+        header.set_seq_nr(16807);
+        header.set_ack_nr(11885);
 
-        let mut reply = Packet::new(response);
+        let mut reply = Packet::new(header);
         reply.set_selective_ack(vec![1, 0, 0, 128]);
 
         assert_eq!(
-            hex::encode(reply.0),
+            hex::encode(reply.as_ref()),
             "21012741005e885e36a7e8830010000041a72e6d000401000080"
         );
     }
 
     #[test]
     fn test_data_packet() {
-        let mut response = PacketHeader::new();
-        response.set_type(PacketType::Data);
-        response.set_connection_id(26237);
-        response.set_timestamp(252492495);
-        response.set_timestamp_difference(242289855);
-        response.set_wnd_size(1048576);
-        response.set_seq_nr(8334);
-        response.set_ack_nr(16806);
+        let mut header = PacketHeader::new();
+        header.set_type(PacketType::Data);
+        header.set_connection_id(26237);
+        header.set_timestamp(252492495);
+        header.set_timestamp_difference(242289855);
+        header.set_wnd_size(1048576);
+        header.set_seq_nr(8334);
+        header.set_ack_nr(16806);
 
-        let packet = Packet::with_payload(response, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        let packet = Packet::with_payload(header, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
         assert_eq!(
-            hex::encode(packet.0),
+            hex::encode(packet.as_ref()),
             "0100667d0f0cbacf0e710cbf00100000208e41a600010203040506070809"
         );
     }
 
     #[test]
     fn test_fin_packet() {
-        let mut response = PacketHeader::new();
-        response.set_type(PacketType::Fin);
-        response.set_connection_id(19003);
-        response.set_timestamp(515227279);
-        response.set_timestamp_difference(511481041);
-        response.set_wnd_size(1048576);
-        response.set_seq_nr(41050);
-        response.set_ack_nr(16806);
+        let mut header = PacketHeader::new();
+        header.set_type(PacketType::Fin);
+        header.set_connection_id(19003);
+        header.set_timestamp(515227279);
+        header.set_timestamp_difference(511481041);
+        header.set_wnd_size(1048576);
+        header.set_seq_nr(41050);
+        header.set_ack_nr(16806);
 
-        let packet = Packet::new(response);
+        let packet = Packet::new(header);
         assert_eq!(
-            hex::encode(packet.0),
+            hex::encode(packet.as_ref()),
             "11004a3b1eb5be8f1e7c94d100100000a05a41a6"
         );
     }
 
     #[test]
     fn test_reset_packet() {
-        let mut response = PacketHeader::new();
-        response.set_type(PacketType::Reset);
-        response.set_connection_id(62285);
-        response.set_timestamp(751226811);
-        response.set_timestamp_difference(0);
-        response.set_wnd_size(0);
-        response.set_seq_nr(55413);
-        response.set_ack_nr(16807);
+        let mut header = PacketHeader::new();
+        header.set_type(PacketType::Reset);
+        header.set_connection_id(62285);
+        header.set_timestamp(751226811);
+        header.set_timestamp_difference(0);
+        header.set_wnd_size(0);
+        header.set_seq_nr(55413);
+        header.set_ack_nr(16807);
 
-        let packet = Packet::new(response);
+        let packet = Packet::new(header);
         assert_eq!(
-            hex::encode(packet.0),
+            hex::encode(packet.as_ref()),
             "3100f34d2cc6cfbb0000000000000000d87541a7"
         );
     }


### PR DESCRIPTION
This is the first PR of a series of PRs to refactor the uTP implementation and fix some of the uTP bugs.

This PR includes a simple renaming of some of the variables, methods and adding comments to improve code readability and debugging. This PR doesn't change any functionality.

It is using the uTP [library](https://github.com/meqif/rust-utp) implemented in Rust for reference.