### PR TITLE
Refactor uTP packet extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2116,6 +2116,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger",
+ "log 0.4.14",
+ "rand 0.8.4",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3311,6 +3322,7 @@ dependencies = [
  "log 0.4.14",
  "num",
  "parking_lot 0.11.2",
+ "quickcheck",
  "rand 0.8.4",
  "rlp 0.5.1",
  "rocksdb",

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -52,3 +52,6 @@ interfaces = "0.0.7"
 [dependencies.rusqlite]
 version = "0.25.3"
 features = ["bundled"]
+
+[dev-dependencies]
+quickcheck = "1.0.3"

--- a/trin-core/src/utp/bit_iterator.rs
+++ b/trin-core/src/utp/bit_iterator.rs
@@ -1,0 +1,58 @@
+// How many bits in a `u8`
+const U8BITS: usize = 8;
+
+/// Lazy iterator over bits of a vector of bytes, starting with the LSB
+/// (least-significat bit) of the first element of the vector.
+pub struct BitIterator<'a> {
+    object: &'a [u8],
+    next_index: usize,
+    end_index: usize,
+}
+
+impl<'a> BitIterator<'a> {
+    /// Creates an iterator from a vector of bytes. Each byte becomes eight bits, with the least
+    /// significant bits coming first.
+    pub fn from_bytes(obj: &'a [u8]) -> BitIterator<'_> {
+        BitIterator {
+            object: obj,
+            next_index: 0,
+            end_index: obj.len() * U8BITS,
+        }
+    }
+
+    /// Returns the number of ones in the binary representation of the underlying object.
+    pub fn count_ones(&self) -> u32 {
+        self.object.iter().fold(0, |acc, bv| acc + bv.count_ones())
+    }
+}
+
+impl<'a> Iterator for BitIterator<'a> {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<bool> {
+        if self.next_index != self.end_index {
+            let (byte_index, bit_index) = (self.next_index / U8BITS, self.next_index % U8BITS);
+            let bit = self.object[byte_index] >> bit_index & 0x1;
+            self.next_index += 1;
+            Some(bit == 0x1)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.end_index, Some(self.end_index))
+    }
+}
+
+impl<'a> ExactSizeIterator for BitIterator<'a> {}
+
+#[test]
+fn test_iterator() {
+    let bytes = vec![0xCA, 0xFE];
+    let expected_bits = vec![0, 1, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1];
+
+    for (i, bit) in BitIterator::from_bytes(&bytes).enumerate() {
+        assert_eq!(bit, expected_bits[i] == 1);
+    }
+}

--- a/trin-core/src/utp/mod.rs
+++ b/trin-core/src/utp/mod.rs
@@ -1,3 +1,4 @@
+mod bit_iterator;
 pub mod packets;
 pub mod stream;
 mod time;


### PR DESCRIPTION
This PR is part of phase 1 defined in https://github.com/ethereum/trin/issues/232#issuecomment-1033862510.

It tries to accomplish the following:

- refactor uTP packet extension by creating `ExtensionType` object and iterator.
- update `set_selective_ack` method to match the new extension type
- change `send_window` from HashMap to Vec;
- add `advance_send_window` method to improve and encapsulate current advance window logic
- add more unit tests

Those changes bring us one step closer to having 1:1 core uTP implementation with rust-utp.