### PR TITLE
Implement uTP socket recv() method and init uTP testing framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4218,6 +4218,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 
 [[package]]
+name = "utp-testing"
+version = "0.1.0"
+dependencies = [
+ "discv5",
+ "hex",
+ "log 0.4.14",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.2.25",
+ "trin-core",
+]
+
+[[package]]
 name = "validator"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbf56136a5198c7b01a49e3afcbef6cf84597273d298f54432926024107b0109"
 
 [[package]]
+name = "async-recursion"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3951,6 +3962,7 @@ name = "trin-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-recursion",
  "base64",
  "bytes 1.1.0",
  "clap 2.34.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "trin-core",
     "trin-cli",
     "ethportal-peertest",
+    "utp-testing",
 ]
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ members = [
     "trin-state",
     "trin-core",
     "trin-cli",
-    "ethportal-peertest"
+    "ethportal-peertest",
 ]
 
 [patch.crates-io]

--- a/newsfragments/248.added.md
+++ b/newsfragments/248.added.md
@@ -1,0 +1,3 @@
+Add uTP socket `recv()` method.
+
+Init uTP testing framework.

--- a/newsfragments/248.changed.md
+++ b/newsfragments/248.changed.md
@@ -1,0 +1,1 @@
+Refactor ACCEPT rpc and handling uTP events with recv()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use log::debug;
@@ -49,11 +48,7 @@ pub async fn run_trin(
     };
 
     // Initialize UTP listener
-    let utp_listener = Arc::new(RwLock::new(UtpListener {
-        discovery: Arc::clone(&discovery),
-        utp_connections: HashMap::new(),
-        listening: HashMap::new(),
-    }));
+    let utp_listener = Arc::new(RwLock::new(UtpListener::new(Arc::clone(&discovery))));
 
     // Initialize Storage config
     let storage_config =

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = "1.58.0"
 
 [dependencies]
 anyhow = "1.0.52"
+async-recursion = "1.0.0"
 base64 = "0.13.0"
 bytes = "1.1.0"
 clap = "2.33.3"

--- a/trin-core/src/portalnet/events.rs
+++ b/trin-core/src/portalnet/events.rs
@@ -7,10 +7,8 @@ use tokio::sync::{mpsc, RwLock};
 use super::discovery::Discovery;
 use super::types::messages::ProtocolId;
 use crate::locks::RwLoggingExt;
-use crate::utp::stream::{SocketState, UtpListener};
-use crate::utp::trin_helpers::{UtpAccept, UtpMessageId};
+use crate::utp::stream::UtpListener;
 use hex;
-use ssz::Decode;
 use std::str::FromStr;
 
 pub struct PortalnetEvents {
@@ -93,7 +91,11 @@ impl PortalnetEvents {
                             .process_utp_request(request)
                             .await;
                         // handles actual data sent over utp. eg, stores data in db
-                        self.process_utp_byte_stream().await;
+                        self.utp_listener
+                            .write_with_warn()
+                            .await
+                            .process_utp_byte_stream()
+                            .await;
                     }
                     _ => {
                         warn!(
@@ -108,54 +110,4 @@ impl PortalnetEvents {
             }
         }
     }
-
-    // https://github.com/ethereum/portal-network-specs/pull/98\
-    // Currently the way to handle data over uTP isn't finalized yet, so we are going to use the
-    // handle data on connection closed method, as that seems to be the accepted method for now.
-    async fn process_utp_byte_stream(&mut self) {
-        for (conn_key, conn) in self
-            .utp_listener
-            .write_with_warn()
-            .await
-            .utp_connections
-            .iter_mut()
-        {
-            if conn.state == SocketState::Closed {
-                let received_stream = conn.recv_data_stream.clone();
-
-                match self
-                    .utp_listener
-                    .read_with_warn()
-                    .await
-                    .listening
-                    .get(&conn.receiver_connection_id)
-                {
-                    Some(message_type) => match message_type {
-                        UtpMessageId::OfferAcceptStream => {
-                            match UtpAccept::from_ssz_bytes(&received_stream[..]) {
-                                Ok(payload) => {
-                                    for (key, content) in payload.message {
-                                        store(key, content).unwrap();
-                                    }
-                                }
-                                Err(_) => debug!("Recv malformed data on handing UtpAccept"),
-                            }
-                        }
-                    },
-                    _ => warn!("uTP listening HashMap doesn't have uTP stream message type"),
-                }
-
-                self.utp_listener
-                    .write_with_warn()
-                    .await
-                    .utp_connections
-                    .remove(conn_key);
-            }
-        }
-    }
-}
-
-// stub function for overlay store
-fn store(_key: Vec<u8>, _content: Vec<u8>) -> Result<(), String> {
-    Ok(())
 }

--- a/trin-core/src/portalnet/events.rs
+++ b/trin-core/src/portalnet/events.rs
@@ -90,7 +90,8 @@ impl PortalnetEvents {
                         self.utp_listener
                             .write_with_warn()
                             .await
-                            .process_utp_request(request.body(), request.node_id());
+                            .process_utp_request(request)
+                            .await;
                         // handles actual data sent over utp. eg, stores data in db
                         self.process_utp_byte_stream().await;
                     }

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -91,6 +91,10 @@ pub enum OverlayRequestError {
     /// Error types resulting from building ACCEPT message
     #[error("Error while building accept message")]
     AcceptError(ssz_types::Error),
+
+    /// Error types resulting from building ACCEPT message
+    #[error("Error while sending offer message")]
+    OfferError(String),
 }
 
 impl From<discv5::RequestError> for OverlayRequestError {

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -1183,11 +1183,7 @@ mod tests {
         };
         let discovery = Arc::new(Discovery::new(portal_config).unwrap());
 
-        let utp_listener = Arc::new(RwLockT::new(UtpListener {
-            discovery: Arc::clone(&discovery),
-            utp_connections: HashMap::new(),
-            listening: HashMap::new(),
-        }));
+        let utp_listener = Arc::new(RwLockT::new(UtpListener::new(Arc::clone(&discovery))));
 
         // Initialize DB config
         let storage_capacity: u32 = DEFAULT_STORAGE_CAPACITY.parse().unwrap();

--- a/trin-core/src/utp/trin_helpers.rs
+++ b/trin-core/src/utp/trin_helpers.rs
@@ -50,15 +50,6 @@ pub struct UtpAccept {
     pub message: Vec<(Vec<u8>, Vec<u8>)>,
 }
 
-// This is used in Channels. It is just used here so we know when to send the data, but also when that
-// data is fully sent. We need this because uTP streams aren't long lived, also how uTP is implemented
-// on top of Discv5
-#[derive(PartialEq, Debug)]
-pub enum UtpStreamState {
-    Connected,
-    Finished,
-}
-
 // This is not in a spec, this is just for internally tracking for what portal message
 // negotiated the uTP stream
 pub enum UtpMessageId {

--- a/trin-core/src/utp/util.rs
+++ b/trin-core/src/utp/util.rs
@@ -1,4 +1,5 @@
 use num::ToPrimitive;
+use rand::Rng;
 use std::ops::Sub;
 
 /// Calculate the exponential weighted moving average for a vector of numbers, with a smoothing
@@ -20,6 +21,21 @@ pub fn abs_diff<T: PartialOrd + Sub<Output = U>, U>(a: T, b: T) -> U {
         a - b
     } else {
         b - a
+    }
+}
+
+/// Safely generates two sequential connection identifiers.
+///
+/// This avoids an overflow when the generated receiver identifier is the largest
+/// representable value in u16 and it is incremented to yield the corresponding sender
+/// identifier.
+pub fn generate_sequential_identifiers() -> (u16, u16) {
+    let mut rng = rand::thread_rng();
+    let id = rng.gen::<u16>();
+    if id.checked_add(1).is_some() {
+        (id, id + 1)
+    } else {
+        (id - 1, id)
     }
 }
 
@@ -66,5 +82,11 @@ mod test {
         let b = 5;
         assert_eq!(abs_diff(a, b), 5);
         assert_eq!(abs_diff(b, a), 5);
+    }
+
+    #[test]
+    fn test_generate_sequential_identifiers() {
+        let (id_1, id_2) = generate_sequential_identifiers();
+        assert!(id_2 == id_1 + 1 || id_2 == id_1 - 1);
     }
 }

--- a/trin-core/tests/overlay.rs
+++ b/trin-core/tests/overlay.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -33,11 +32,7 @@ async fn init_overlay(
     .unwrap();
     let db = Arc::new(PortalStorage::new(storage_config).unwrap());
     let overlay_config = OverlayConfig::default();
-    let utp_listener = Arc::new(RwLock::new(UtpListener {
-        discovery: Arc::clone(&discovery),
-        utp_connections: HashMap::new(),
-        listening: HashMap::new(),
-    }));
+    let utp_listener = Arc::new(RwLock::new(UtpListener::new(Arc::clone(&discovery))));
 
     OverlayProtocol::new(
         overlay_config,

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -11,7 +11,6 @@ use crate::events::HistoryEvents;
 use crate::jsonrpc::HistoryRequestHandler;
 use discv5::TalkRequest;
 use network::HistoryNetwork;
-use std::collections::HashMap;
 use std::sync::Arc;
 use trin_core::cli::TrinConfig;
 use trin_core::jsonrpc::types::HistoryJsonRpcRequest;
@@ -49,11 +48,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Search for discv5 peers (bucket refresh lookup)
     tokio::spawn(Arc::clone(&discovery).bucket_refresh_lookup());
 
-    let utp_listener = Arc::new(RwLock::new(UtpListener {
-        discovery: Arc::clone(&discovery),
-        utp_connections: HashMap::new(),
-        listening: HashMap::new(),
-    }));
+    let utp_listener = Arc::new(RwLock::new(UtpListener::new(Arc::clone(&discovery))));
 
     let (history_event_tx, history_event_rx) = mpsc::unbounded_channel::<TalkRequest>();
     let portal_events_discovery = Arc::clone(&discovery);

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -97,6 +97,11 @@ impl HistoryNetwork {
                     debug!("Unexpected error while bonding with {} => {:?}", enr, error);
                     return Err(anyhow!(error.to_string()));
                 }
+                _ => {
+                    let msg = format!("Unexpected error while bonding with {enr}");
+                    debug!("{msg}");
+                    return Err(anyhow!(msg));
+                }
             }
         }
         Ok(())

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -7,7 +7,6 @@ use crate::events::StateEvents;
 use crate::jsonrpc::StateRequestHandler;
 use discv5::TalkRequest;
 use network::StateNetwork;
-use std::collections::HashMap;
 use trin_core::cli::TrinConfig;
 use trin_core::jsonrpc::types::StateJsonRpcRequest;
 use trin_core::portalnet::discovery::Discovery;
@@ -47,11 +46,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Search for discv5 peers (bucket refresh lookup)
     tokio::spawn(Arc::clone(&discovery).bucket_refresh_lookup());
 
-    let utp_listener = Arc::new(RwLock::new(UtpListener {
-        discovery: Arc::clone(&discovery),
-        utp_connections: HashMap::new(),
-        listening: HashMap::new(),
-    }));
+    let utp_listener = Arc::new(RwLock::new(UtpListener::new(Arc::clone(&discovery))));
 
     let (state_event_tx, state_event_rx) = mpsc::unbounded_channel::<TalkRequest>();
     let portal_events_discovery = Arc::clone(&discovery);

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -106,6 +106,11 @@ impl StateNetwork {
                     debug!("Unexpected error while bonding with {} => {:?}", enr, error);
                     return Err(anyhow!(error.to_string()));
                 }
+                _ => {
+                    let msg = format!("Unexpected error while bonding with {enr}");
+                    debug!("{msg}");
+                    return Err(anyhow!(msg));
+                }
             }
         }
         Ok(())

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "utp-testing"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tracing = "0.1.26"
+tracing-subscriber = "0.2.18"
+trin-core = { path = "../trin-core" }
+tokio = {version = "1.8.0", features = ["full"]}
+discv5 = "0.1.0-beta.13"
+hex = "0.4.3"
+log = "0.4.14"

--- a/utp-testing/README.md
+++ b/utp-testing/README.md
@@ -1,0 +1,7 @@
+# utp-testing
+
+Utp testing framework (WIP)
+
+```sh
+$ RUST_LOG=debug cargo run -p utp-testing
+```

--- a/utp-testing/src/main.rs
+++ b/utp-testing/src/main.rs
@@ -1,0 +1,147 @@
+use discv5::Discv5Event;
+use log::debug;
+use std::str::FromStr;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use trin_core::portalnet::discovery::Discovery;
+use trin_core::portalnet::types::messages::{PortalnetConfig, ProtocolId};
+use trin_core::portalnet::Enr;
+use trin_core::utp::stream::UtpListener;
+use trin_core::utp::trin_helpers::{UtpMessage, UtpMessageId};
+
+pub struct TestApp {
+    utp_listener: Arc<RwLock<UtpListener>>,
+}
+
+impl TestApp {
+    async fn send_utp_request(&mut self, connection_id: u16, payload: Vec<u8>, enr: Enr) {
+        self.utp_listener
+            .write()
+            .await
+            .listening
+            .insert(connection_id, UtpMessageId::OfferAcceptStream);
+
+        let mut conn = self
+            .utp_listener
+            .write()
+            .await
+            .connect(connection_id, enr.node_id())
+            .await
+            .unwrap();
+
+        let mut buf = [0; 1500];
+        conn.recv(&mut buf).await.unwrap();
+
+        conn.send_to(&UtpMessage::new(payload.clone()).encode()[..])
+            .await
+            .unwrap();
+
+        tokio::spawn(async move {
+            conn.close().await.unwrap();
+            debug!("connecton state: {:?}", conn.state)
+        });
+    }
+
+    async fn process_utp_request(&self) {
+        let mut event_stream = self
+            .utp_listener
+            .read()
+            .await
+            .discovery
+            .discv5
+            .event_stream()
+            .await
+            .unwrap();
+
+        let listener = Arc::clone(&self.utp_listener);
+
+        tokio::spawn(async move {
+            while let Some(event) = event_stream.recv().await {
+                let request = match event {
+                    Discv5Event::TalkRequest(r) => r,
+                    _ => continue,
+                };
+
+                let protocol_id =
+                    ProtocolId::from_str(&hex::encode_upper(request.protocol())).unwrap();
+
+                if let ProtocolId::Utp = protocol_id {
+                    listener.write().await.process_utp_request(request).await;
+                    listener.write().await.process_utp_byte_stream().await;
+                };
+            }
+        });
+    }
+
+    async fn prepare_to_receive(&self, connection_id: u16) {
+        // listen for incoming connection request on conn_id, as part of utp handshake
+        self.utp_listener
+            .write()
+            .await
+            .listening
+            .insert(connection_id, UtpMessageId::OfferAcceptStream);
+
+        // also listen on conn_id + 1 because this is the actual receive path for acceptor
+        self.utp_listener
+            .write()
+            .await
+            .listening
+            .insert(connection_id + 1, UtpMessageId::OfferAcceptStream);
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let client_port = 9002;
+    let mut client = run_test_app(client_port).await;
+
+    let server_port = 9003;
+    let server = run_test_app(server_port).await;
+
+    let server_enr = server.utp_listener.write().await.discovery.local_enr();
+
+    let connection_id = 66;
+    let payload = vec![6; 2000];
+
+    client
+        .utp_listener
+        .write()
+        .await
+        .discovery
+        .send_talk_req(server_enr.clone(), ProtocolId::History, vec![])
+        .await
+        .unwrap();
+
+    server.prepare_to_receive(connection_id).await;
+
+    client
+        .send_utp_request(connection_id, payload, server_enr)
+        .await;
+
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to pause until ctrl-c");
+}
+
+async fn run_test_app(discv5_port: u16) -> TestApp {
+    let config = PortalnetConfig {
+        listen_port: discv5_port,
+        internal_ip: true,
+        ..Default::default()
+    };
+
+    let mut discovery = Discovery::new(config).unwrap();
+    discovery.start().await.unwrap();
+
+    let utp_listener = UtpListener::new(Arc::new(discovery));
+
+    let test_app = TestApp {
+        utp_listener: Arc::new(RwLock::new(utp_listener)),
+    };
+
+    test_app.process_utp_request().await;
+
+    test_app
+}


### PR DESCRIPTION
### What was wrong?

To be able to write meaningful unit tests and build the uTP testing framework, we want to encapsulate the uTP module and consume the uTP socket packets.

### How was it fixed?

- Implemented uTP socket `recv()` and `close()` methods that allows us to handle a uTP packet from the discv5 socket, consume the result and gracefully close the uTP connection, so it  works now as a standard socket call, for example, we can say:

```rust
client.send_to(..);
server.recv(..);
client.close()
```

- added a simple uTP testing code just to make sure we can transfer data between two uTP implementations without any known issues.

- added test for triple ack response

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history

This PR is completing Phase 2 in https://github.com/ethereum/trin/issues/232#issuecomment-1033862510.
