### PR TITLE
Remove empty OverlayService unit tests

### DIFF
--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -1343,14 +1343,6 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn process_response_source_in_table_disconnected() {}
-
-    #[tokio::test]
-    #[serial]
-    async fn process_response_source_not_in_table() {}
-
-    #[tokio::test]
-    #[serial]
     async fn process_pong_source_in_table_higher_enr_seq() {
         let mut service = task::spawn(build_service());
 


### PR DESCRIPTION
### What was wrong?

There were leftover empty (unimplemented) unit tests for `OverlayService`.

### How was it fixed?

Remove empty unit tests.

If the tests are deemed necessary, then those tests can be added back later. We should not have dead code.

### To-Do

N/A
