### PR TITLE
Misc improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ notes:
 		git commit -m "Compile release notes"
 
 release:
+		# First run `make notes version=<version>` before this
 		./newsfragments/validate_files.py is-empty
-		cargo release $(version) --all
+		cargo release $(version) --all --execute
 
 create-docker-image:
 		docker build -t ethpm/trin:latest -t ethpm/trin:$(version) -f ./Dockerfile .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.towncrier]
 # Read https://github.com/ethereum/trin/newsfragments/README.md for instructions
-package = "trin"
 filename = "docs/release_notes.md"
 directory = "newsfragments"
 underlines = ["", ""]

--- a/trin-core/src/portalnet/storage.rs
+++ b/trin-core/src/portalnet/storage.rs
@@ -433,6 +433,7 @@ impl PortalStorage {
         let data_path_root: String = get_data_dir(node_id).to_owned();
         let data_suffix: &str = "/rocksdb";
         let data_path = data_path_root + data_suffix;
+        debug!("Setting up RocksDB at path: {:?}", data_path);
 
         let mut db_opts = Options::default();
         db_opts.create_if_missing(true);
@@ -445,6 +446,7 @@ impl PortalStorage {
         let data_path_root: String = get_data_dir(node_id).to_owned();
         let data_suffix: &str = "/trin.sqlite";
         let data_path = data_path_root + data_suffix;
+        debug!("Setting up SqliteDB at path: {:?}", data_path);
 
         let manager = SqliteConnectionManager::file(data_path);
         let pool = Pool::new(manager)?;


### PR DESCRIPTION
### What was wrong?
These are just a couple of bugfixes/improvements I'd like to get into `master`. They popped up while trying to cut a first release. First release status is potentially on hold for now. There's something about patching in @ogenev 's `discv5` branch that `cargo-release` doesn't pick up on when packaging each crate individually - which results in a compile error since it reverts to `discv5 = 0.13.0-beta`. There definitely might be a workaround, but I wasn't able to find one. Ultimately, it seems to me like patches are intended for quick-fixes, and not a sustainable dependency. It also seems like fairly clean code habit to not cut any releases that rely on a patch. Tbh, a technical first release is not immediately urgent, but it does seem worthwhile to get those patched fixes in to `discv5`.

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
