### PR TITLE
Replace MockContentKey with IdentityContentKey

### DIFF
--- a/trin-core/src/bin/generate-data.rs
+++ b/trin-core/src/bin/generate-data.rs
@@ -3,7 +3,7 @@ use rand::{distributions::Alphanumeric, Rng};
 use std::process::Command;
 use structopt::StructOpt;
 use trin_core::portalnet::storage::PortalStorage;
-use trin_core::portalnet::types::content_key::MockContentKey;
+use trin_core::portalnet::types::content_key::IdentityContentKey;
 use trin_core::utils::db::get_data_dir;
 
 // For every 1 kb of data we store (key + value), RocksDB tends to grow by this many kb on disk...
@@ -39,7 +39,9 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let value = generate_random_value(size_of_values);
         let key = generate_random_value(SIZE_OF_KEYS);
 
-        let content_key = MockContentKey::try_from(key).unwrap();
+        // Conversion should not fail because Vec is length 32.
+        let content_key = IdentityContentKey::try_from(key).unwrap();
+
         let display: Vec<u8> = content_key.clone().into();
         println!("{:?} -> {:?}", display, &value);
         storage.store(&content_key, &value)?;

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -1161,7 +1161,7 @@ mod tests {
         cli::DEFAULT_STORAGE_CAPACITY,
         portalnet::{
             discovery::Discovery, overlay::OverlayConfig, storage::PortalStorage,
-            types::content_key::MockContentKey, types::messages::PortalnetConfig,
+            types::content_key::IdentityContentKey, types::messages::PortalnetConfig,
         },
         utils::node_id::generate_random_remote_enr,
     };
@@ -1176,7 +1176,7 @@ mod tests {
         };
     }
 
-    fn build_service() -> OverlayService<MockContentKey> {
+    fn build_service() -> OverlayService<IdentityContentKey> {
         let portal_config = PortalnetConfig {
             internal_ip: true,
             ..Default::default()

--- a/trin-core/src/portalnet/storage.rs
+++ b/trin-core/src/portalnet/storage.rs
@@ -646,16 +646,21 @@ pub mod test {
 
         let value: Vec<u8> = "value".into();
 
-        let content_key_a = IdentityContentKey::new([0; 32]);
+        let content_key_a = IdentityContentKey::new([1; 32]);
         storage.store(&content_key_a, &value)?;
 
-        let content_key_b = IdentityContentKey::new([1; 32]);
+        let content_key_b = IdentityContentKey::new([5; 32]);
         storage.store(&content_key_b, &value)?;
 
         let expected_content_id = content_key_b.content_id();
-
         let result = storage.find_farthest_content_id()?;
+        assert_eq!(result.unwrap(), expected_content_id);
 
+        let content_key_c = IdentityContentKey::new([10; 32]);
+        storage.store(&content_key_c, &value)?;
+
+        let expected_content_id = content_key_c.content_id();
+        let result = storage.find_farthest_content_id()?;
         assert_eq!(result.unwrap(), expected_content_id);
 
         temp_dir.close()?;

--- a/trin-core/src/portalnet/types/content_key.rs
+++ b/trin-core/src/portalnet/types/content_key.rs
@@ -6,28 +6,45 @@ pub trait OverlayContentKey: Into<Vec<u8>> + TryFrom<Vec<u8>> + Clone {
     fn content_id(&self) -> [u8; 32];
 }
 
-// Mock type for testing
+/// A content key type whose content id is the inner value. Allows for the construction
+/// of a content key with an arbitary content ID.
 #[derive(Clone)]
-pub struct MockContentKey {
-    value: Vec<u8>,
+pub struct IdentityContentKey {
+    value: [u8; 32],
 }
 
-impl TryFrom<Vec<u8>> for MockContentKey {
+impl IdentityContentKey {
+    /// Constructs a new `IdentityContentKey` with the specified value.
+    pub fn new(value: [u8; 32]) -> Self {
+        Self { value }
+    }
+}
+
+impl TryFrom<Vec<u8>> for IdentityContentKey {
     type Error = String;
 
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        Ok(MockContentKey { value })
+        // Require that length of input is equal to 32.
+        if value.len() != 32 {
+            return Err(String::from("Input Vec has invalid length"));
+        }
+
+        // The following will not panic because of the length check above.
+        let mut key_value: [u8; 32] = [0; 32];
+        key_value.copy_from_slice(&value[..32]);
+
+        Ok(Self { value: key_value })
     }
 }
 
-impl Into<Vec<u8>> for MockContentKey {
+impl Into<Vec<u8>> for IdentityContentKey {
     fn into(self) -> Vec<u8> {
-        self.value
+        self.value.into()
     }
 }
 
-impl OverlayContentKey for MockContentKey {
+impl OverlayContentKey for IdentityContentKey {
     fn content_id(&self) -> [u8; 32] {
-        [0; 32]
+        self.value
     }
 }

--- a/trin-core/tests/overlay.rs
+++ b/trin-core/tests/overlay.rs
@@ -9,7 +9,7 @@ use trin_core::{
         overlay::{OverlayConfig, OverlayProtocol},
         storage::PortalStorage,
         types::{
-            content_key::MockContentKey,
+            content_key::IdentityContentKey,
             messages::{Content, Message, PortalnetConfig, ProtocolId, SszEnr},
             uint::U256,
         },
@@ -25,7 +25,7 @@ use tokio::time::{self, Duration};
 async fn init_overlay(
     discovery: Arc<Discovery>,
     protocol: ProtocolId,
-) -> OverlayProtocol<MockContentKey> {
+) -> OverlayProtocol<IdentityContentKey> {
     let storage_config = PortalStorage::setup_config(
         discovery.local_enr().node_id(),
         DEFAULT_STORAGE_CAPACITY.parse().unwrap(),
@@ -50,7 +50,10 @@ async fn init_overlay(
     .await
 }
 
-async fn spawn_overlay(discovery: Arc<Discovery>, overlay: Arc<OverlayProtocol<MockContentKey>>) {
+async fn spawn_overlay(
+    discovery: Arc<Discovery>,
+    overlay: Arc<OverlayProtocol<IdentityContentKey>>,
+) {
     let (overlay_tx, mut overlay_rx) = mpsc::unbounded_channel();
     let mut discovery_rx = discovery
         .discv5
@@ -206,7 +209,7 @@ async fn overlay() {
     // Node one should be added to the routing table because it is the destination of the request.
     // All ENRs in the content response should be added to the routing table, except for node two,
     // because node two is the local node.
-    let content_key = MockContentKey::try_from(vec![0u8; 32]).unwrap();
+    let content_key = IdentityContentKey::new([0u8; 32]);
     let content_enrs = match overlay_two
         .send_find_content(overlay_one.local_enr(), content_key.into())
         .await


### PR DESCRIPTION
### What was wrong?

The `content_id` method for `MockContentKey` always returns a zeroed byte array. In other words, the `content_id` method is the zero function. This is not so useful for testing.

### How was it fixed?

Replace `MockContentKey` with `IdentityContentKey`, where the `content_id` method is the identity function with respect to the value within the content key. This allows us to create content keys with arbitrary content IDs.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
