### PR TITLE
Adds modified versions of QueryPool, Query types from sigp discv5

### DIFF
--- a/trin-core/src/portalnet/find/iterators/findnodes.rs
+++ b/trin-core/src/portalnet/find/iterators/findnodes.rs
@@ -40,6 +40,7 @@ pub struct FindNodeQuery<TNodeId> {
     progress: QueryProgress,
 
     /// The closest peers to the target, ordered by increasing distance.
+    /// Assumes that no two peers are equidistant.
     closest_peers: BTreeMap<Distance, QueryPeer<TNodeId>>,
 
     /// The number of peers for which the query is currently waiting for results.
@@ -152,19 +153,17 @@ where
             Entry::Occupied(mut entry) => match entry.get().state {
                 QueryPeerState::Waiting(..) => {
                     if self.num_waiting < 0 {
-                       error!("In findenodes.rs on_success num_waiting is negative. Aborting.")
+                       error!("In findenodes.rs on_success num_waiting is negative.")
                        return
                     }
                     self.num_waiting -= 1;
                     let peer = e.get_mut();
                     peer.peers_returned += closer_peers.len();
-                    // mark the peer as succeeded
                     peer.state = QueryPeerState::Succeeded;
                 }
                 QueryPeerState::Unresponsive => {
                     let peer = e.get_mut();
                     peer.peers_returned += closer_peers.len();
-                    // mark the peer as succeeded
                     peer.state = QueryPeerState::Succeeded;
                 }
                 QueryPeerState::NotContacted

--- a/trin-core/src/portalnet/find/iterators/findnodes.rs
+++ b/trin-core/src/portalnet/find/iterators/findnodes.rs
@@ -1,0 +1,701 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+// This basis of this file has been taken from the rust-libp2p codebase:
+// https://github.com/libp2p/rust-libp2p
+//
+use super::super::query_pool::{QueryState};
+use discv5::{
+    kbucket::{Distance, Key},
+};
+use std::{
+    collections::btree_map::{BTreeMap, Entry},
+    time::{Duration, Instant},
+};
+
+
+#[derive(Debug, Clone)]
+pub struct FindNodeQuery<TNodeId> {
+    /// The target key we are looking for
+    target_key: Key<TNodeId>,
+
+    /// The current state of progress of the query.
+    progress: QueryProgress,
+
+    /// The closest peers to the target, ordered by increasing distance.
+    closest_peers: BTreeMap<Distance, QueryPeer<TNodeId>>,
+
+    /// The number of peers for which the query is currently waiting for results.
+    num_waiting: usize,
+
+    /// The configuration of the query.
+    config: FindNodeQueryConfig,
+}
+
+/// Configuration for a `Query`.
+#[derive(Debug, Clone)]
+pub struct FindNodeQueryConfig {
+    /// Allowed level of parallelism.
+    ///
+    /// The `α` parameter in the Kademlia paper. The maximum number of peers that a query
+    /// is allowed to wait for in parallel while iterating towards the closest
+    /// nodes to a target. Defaults to `3`.
+    pub parallelism: usize,
+
+    /// Number of results to produce.
+    ///
+    /// The number of closest peers that a query must obtain successful results
+    /// for before it terminates. Defaults to the maximum number of entries in a
+    /// single k-bucket, i.e. the `k` parameter in the Kademlia paper.
+    pub num_results: usize,
+
+    /// The timeout for a single peer.
+    ///
+    /// If a successful result is not reported for a peer within this timeout
+    /// window, the iterator considers the peer unresponsive and will not wait for
+    /// the peer when evaluating the termination conditions, until and unless a
+    /// result is delivered. Defaults to `10` seconds.
+    pub peer_timeout: Duration,
+}
+
+impl<TNodeId> FindNodeQuery<TNodeId>
+where
+    TNodeId: Into<Key<TNodeId>> + Eq + Clone,
+{
+    /// Creates a new query with the given configuration.
+    pub fn with_config<I>(
+        config: FindNodeQueryConfig,
+        target_key: Key<TNodeId>,
+        known_closest_peers: I,
+    ) -> Self
+    where
+        I: IntoIterator<Item = Key<TNodeId>>,
+    {
+        // Initialise the closest peers to begin the query with.
+        let closest_peers = known_closest_peers
+            .into_iter()
+            .map(|key| {
+                let key: Key<TNodeId> = key;
+                let distance = key.distance(&target_key);
+                let state = QueryPeerState::NotContacted;
+                (distance, QueryPeer::new(key, state))
+            })
+            .take(config.num_results)
+            .collect();
+
+        // The query initially makes progress by iterating towards the target.
+        let progress = QueryProgress::Iterating { no_progress: 0 };
+
+        FindNodeQuery {
+            config,
+            target_key,
+            progress,
+            closest_peers,
+            num_waiting: 0,
+        }
+    }
+
+    /// Callback for delivering the result of a successful request to a peer
+    /// that the query is waiting on.
+    ///
+    /// Delivering results of requests back to the query allows the query to make
+    /// progress. The query is said to make progress either when the given
+    /// `closer_peers` contain a peer closer to the target than any peer seen so far,
+    /// or when the query did not yet accumulate `num_results` closest peers and
+    /// `closer_peers` contains a new peer, regardless of its distance to the target.
+    ///
+    /// After calling this function, `next` should eventually be called again
+    /// to advance the state of the query.
+    ///
+    /// If the query is finished, the query is not currently waiting for a
+    /// result from `peer`, or a result for `peer` has already been reported,
+    /// calling this function has no effect.
+    pub fn on_success(&mut self, node_id: &TNodeId, closer_peers: Vec<TNodeId>) {
+        if let QueryProgress::Finished = self.progress {
+            return;
+        }
+
+        let key: Key<TNodeId> = node_id.clone().into();
+        let distance = key.distance(&self.target_key);
+
+        // Mark the peer's progress, the total nodes it has returned and it's current iteration.
+        // If the node returned peers, mark it as succeeded.
+        match self.closest_peers.entry(distance) {
+            Entry::Vacant(..) => return,
+            Entry::Occupied(mut e) => match e.get().state {
+                QueryPeerState::Waiting(..) => {
+                    debug_assert!(self.num_waiting > 0);
+                    self.num_waiting -= 1;
+                    let peer = e.get_mut();
+                    peer.peers_returned += closer_peers.len();
+                    // mark the peer as succeeded
+                    peer.state = QueryPeerState::Succeeded;
+                }
+                QueryPeerState::Unresponsive => {
+                    let peer = e.get_mut();
+                    peer.peers_returned += closer_peers.len();
+                    // mark the peer as succeeded
+                    peer.state = QueryPeerState::Succeeded;
+                }
+                QueryPeerState::NotContacted
+                | QueryPeerState::Failed
+                | QueryPeerState::Succeeded => return,
+            },
+        }
+
+        let mut progress = false;
+        let num_closest = self.closest_peers.len();
+
+        // Incorporate the reported closer peers into the query.
+        for peer in closer_peers {
+            let key: Key<TNodeId> = peer.into();
+            let distance = self.target_key.distance(&key);
+            let peer = QueryPeer::new(key, QueryPeerState::NotContacted);
+            self.closest_peers.entry(distance).or_insert(peer);
+            // The query makes progress if the new peer is either closer to the target
+            // than any peer seen so far (i.e. is the first entry), or the query did
+            // not yet accumulate enough closest peers.
+            progress = self.closest_peers.keys().next() == Some(&distance)
+                || num_closest < self.config.num_results;
+        }
+
+        // Update the query progress.
+        self.progress = match self.progress {
+            QueryProgress::Iterating { no_progress } => {
+                let no_progress = if progress { 0 } else { no_progress + 1 };
+                if no_progress >= self.config.parallelism {
+                    QueryProgress::Stalled
+                } else {
+                    QueryProgress::Iterating { no_progress }
+                }
+            }
+            QueryProgress::Stalled => {
+                if progress {
+                    QueryProgress::Iterating { no_progress: 0 }
+                } else {
+                    QueryProgress::Stalled
+                }
+            }
+            QueryProgress::Finished => QueryProgress::Finished,
+        }
+    }
+
+    /// Callback for informing the query about a failed request to a peer
+    /// that the query is waiting on.
+    ///
+    /// After calling this function, `next` should eventually be called again
+    /// to advance the state of the query.
+    ///
+    /// If the query is finished, the query is not currently waiting for a
+    /// result from `peer`, or a result for `peer` has already been reported,
+    /// calling this function has no effect.
+    pub fn on_failure(&mut self, peer: &TNodeId) {
+        if let QueryProgress::Finished = self.progress {
+            return;
+        }
+
+        let key: Key<TNodeId> = peer.clone().into();
+        let distance = key.distance(&self.target_key);
+
+        match self.closest_peers.entry(distance) {
+            Entry::Vacant(_) => {}
+            Entry::Occupied(mut e) => match e.get().state {
+                QueryPeerState::Waiting(..) => {
+                    debug_assert!(self.num_waiting > 0);
+                    self.num_waiting -= 1;
+                    e.get_mut().state = QueryPeerState::Failed
+                }
+                QueryPeerState::Unresponsive => e.get_mut().state = QueryPeerState::Failed,
+                _ => {}
+            },
+        }
+    }
+
+    /// Advances the state of the query, potentially getting a new peer to contact.
+    ///
+    /// See [`QueryState`].
+    pub fn next(&mut self, now: Instant) -> QueryState<TNodeId> {
+        if let QueryProgress::Finished = self.progress {
+            return QueryState::Finished;
+        }
+
+        // Count the number of peers that returned a result. If there is a
+        // request in progress to one of the `num_results` closest peers, the
+        // counter is set to `None` as the query can only finish once
+        // `num_results` closest peers have responded (or there are no more
+        // peers to contact, see `active_counter`).
+        let mut result_counter = Some(0);
+
+        // Check if the query is at capacity w.r.t. the allowed parallelism.
+        let at_capacity = self.at_capacity();
+
+        for peer in self.closest_peers.values_mut() {
+            match peer.state {
+                QueryPeerState::NotContacted => {
+                    // This peer is waiting to be reiterated.
+                    if !at_capacity {
+                        let timeout = now + self.config.peer_timeout;
+                        peer.state = QueryPeerState::Waiting(timeout);
+                        self.num_waiting += 1;
+                        let peer = peer.key.preimage().clone();
+                        return QueryState::Waiting(Some(peer));
+                    } else {
+                        return QueryState::WaitingAtCapacity;
+                    }
+                }
+
+                QueryPeerState::Waiting(timeout) => {
+                    if now >= timeout {
+                        // Peers that don't respond within timeout are set to `Failed`.
+                        debug_assert!(self.num_waiting > 0);
+                        self.num_waiting -= 1;
+                        peer.state = QueryPeerState::Unresponsive;
+                    } else if at_capacity {
+                        // The query is still waiting for a result from a peer and is
+                        // at capacity w.r.t. the maximum number of peers being waited on.
+                        return QueryState::WaitingAtCapacity;
+                    } else {
+                        // The query is still waiting for a result from a peer and the
+                        // `result_counter` did not yet reach `num_results`. Therefore
+                        // the query is not yet done, regardless of already successful
+                        // queries to peers farther from the target.
+                        result_counter = None;
+                    }
+                }
+
+                QueryPeerState::Succeeded => {
+                    if let Some(ref mut cnt) = result_counter {
+                        *cnt += 1;
+                        // If `num_results` successful results have been delivered for the
+                        // closest peers, the query is done.
+                        if *cnt >= self.config.num_results {
+                            self.progress = QueryProgress::Finished;
+                            return QueryState::Finished;
+                        }
+                    }
+                }
+
+                QueryPeerState::Failed | QueryPeerState::Unresponsive => {
+                    // Skip over unresponsive or failed peers.
+                }
+            }
+        }
+
+        if self.num_waiting > 0 {
+            // The query is still waiting for results and not at capacity w.r.t.
+            // the allowed parallelism, but there are no new peers to contact
+            // at the moment.
+            QueryState::Waiting(None)
+        } else {
+            // The query is finished because all available peers have been contacted
+            // and the query is not waiting for any more results.
+            self.progress = QueryProgress::Finished;
+            QueryState::Finished
+        }
+    }
+
+    /// Consumes the query, returning the target and the closest peers.
+    pub fn into_result(self) -> Vec<TNodeId> {
+        self.closest_peers
+            .into_iter()
+            .filter_map(|(_, peer)| {
+                if let QueryPeerState::Succeeded = peer.state {
+                    Some(peer.key.into_preimage())
+                } else {
+                    None
+                }
+            })
+            .take(self.config.num_results)
+            .collect()
+    }
+
+    /// Checks if the query is at capacity w.r.t. the permitted parallelism.
+    ///
+    /// While the query is stalled, up to `num_results` parallel requests
+    /// are allowed. This is a slightly more permissive variant of the
+    /// requirement that the initiator "resends the FIND_NODE to all of the
+    /// k closest nodes it has not already queried".
+    fn at_capacity(&self) -> bool {
+        match self.progress {
+            QueryProgress::Stalled => self.num_waiting >= self.config.num_results,
+            QueryProgress::Iterating { .. } => self.num_waiting >= self.config.parallelism,
+            QueryProgress::Finished => true,
+        }
+    }
+}
+
+/// Stage of the query.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+enum QueryProgress {
+    /// The query is making progress by iterating towards `num_results` closest
+    /// peers to the target with a maximum of `parallelism` peers for which the
+    /// query is waiting for results at a time.
+    ///
+    /// > **Note**: When the query switches back to `Iterating` after being
+    /// > `Stalled`, it may temporarily be waiting for more than `parallelism`
+    /// > results from peers, with new peers only being considered once
+    /// > the number pending results drops below `parallelism`.
+    Iterating {
+        /// The number of consecutive results that did not yield a peer closer
+        /// to the target. When this number reaches `parallelism` and no new
+        /// peer was discovered or at least `num_results` peers are known to
+        /// the query, it is considered `Stalled`.
+        no_progress: usize,
+    },
+
+    /// A query is stalled when it did not make progress after `parallelism`
+    /// consecutive successful results (see `on_success`).
+    ///
+    /// While the query is stalled, the maximum allowed parallelism for pending
+    /// results is increased to `num_results` in an attempt to finish the query.
+    /// If the query can make progress again upon receiving the remaining
+    /// results, it switches back to `Iterating`. Otherwise it will be finished.
+    Stalled,
+
+    /// The query is finished.
+    ///
+    /// A query finishes either when it has collected `num_results` results
+    /// from the closest peers (not counting those that failed or are unresponsive)
+    /// or because the query ran out of peers that have not yet delivered
+    /// results (or failed).
+    Finished,
+}
+
+/// Representation of a peer in the context of a query.
+#[derive(Debug, Clone)]
+struct QueryPeer<TNodeId> {
+    /// The `KBucket` key used to identify the peer.
+    key: Key<TNodeId>,
+
+    /// The current rpc request iteration that has been made on this peer.
+    iteration: usize,
+
+    /// The number of peers that have been returned by this peer.
+    peers_returned: usize,
+
+    /// The current query state of this peer.
+    state: QueryPeerState,
+}
+
+impl<TNodeId> QueryPeer<TNodeId> {
+    pub fn new(key: Key<TNodeId>, state: QueryPeerState) -> Self {
+        QueryPeer {
+            key,
+            iteration: 1,
+            peers_returned: 0,
+            state,
+        }
+    }
+}
+
+/// The state of `QueryPeer` in the context of a query.
+#[derive(Debug, Copy, Clone)]
+enum QueryPeerState {
+    /// The peer has not yet been contacted.
+    ///
+    /// This is the starting state for every peer known to, or discovered by, a query.
+    NotContacted,
+
+    /// The query is waiting for a result from the peer.
+    Waiting(Instant),
+
+    /// A result was not delivered for the peer within the configured timeout.
+    ///
+    /// The peer is not taken into account for the termination conditions
+    /// of the iterator until and unless it responds.
+    Unresponsive,
+
+    /// Obtaining a result from the peer has failed.
+    ///
+    /// This is a final state, reached as a result of a call to `on_failure`.
+    Failed,
+
+    /// A successful result from the peer has been delivered.
+    ///
+    /// This is a final state, reached as a result of a call to `on_success`.
+    Succeeded,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use discv5::enr::NodeId;
+    use quickcheck::*;
+    use rand_07::{thread_rng, Rng};
+    use std::time::Duration;
+
+    type TestQuery = FindNodeQuery<NodeId>;
+
+    fn random_nodes(n: usize) -> impl Iterator<Item = NodeId> + Clone {
+        (0..n).map(|_| NodeId::random())
+    }
+
+    fn random_query<G: Rng>(g: &mut G) -> TestQuery {
+        let known_closest_peers = random_nodes(g.gen_range(1, 60)).map(Key::from);
+        let target = NodeId::random();
+        let config = FindNodeQueryConfig {
+            parallelism: g.gen_range(1, 10),
+            num_results: g.gen_range(1, 25),
+            peer_timeout: Duration::from_secs(g.gen_range(10, 30)),
+        };
+        FindNodeQuery::with_config(config, target.into(), known_closest_peers)
+    }
+
+    fn sorted(target: &Key<NodeId>, peers: &[Key<NodeId>]) -> bool {
+        peers
+            .windows(2)
+            .all(|w| w[0].distance(&target) < w[1].distance(&target))
+    }
+
+    impl Arbitrary for TestQuery {
+        fn arbitrary<G: Gen>(g: &mut G) -> TestQuery {
+            random_query(g)
+        }
+    }
+
+    #[test]
+    fn new_query() {
+        let query = random_query(&mut thread_rng());
+        let target = query.target_key.clone();
+
+        let (keys, states): (Vec<_>, Vec<_>) = query
+            .closest_peers
+            .values()
+            .map(|e| (e.key.clone(), &e.state))
+            .unzip();
+
+        let none_contacted = states
+            .iter()
+            .all(|s| matches!(s, QueryPeerState::NotContacted));
+
+        assert!(none_contacted, "Unexpected peer state in new query.");
+        assert!(
+            sorted(&target, &keys),
+            "Closest peers in new query not sorted by distance to target."
+        );
+        assert_eq!(
+            query.num_waiting, 0,
+            "Unexpected peers in progress in new query."
+        );
+        assert!(
+            query.into_result().is_empty(),
+            "Unexpected closest peers in new query"
+        );
+    }
+
+    #[test]
+    fn termination_and_parallelism() {
+        fn prop(mut query: TestQuery) {
+            let now = Instant::now();
+            let mut rng = thread_rng();
+
+            let mut expected = query
+                .closest_peers
+                .values()
+                .map(|e| e.key.clone())
+                .collect::<Vec<_>>();
+            let num_known = expected.len();
+            let max_parallelism = usize::min(query.config.parallelism, num_known);
+
+            let target = query.target_key.clone();
+            let mut remaining;
+            let mut num_failures = 0;
+
+            'finished: loop {
+                if expected.is_empty() {
+                    break;
+                }
+                // Split off the next up to `parallelism` expected peers.
+                else if expected.len() < max_parallelism {
+                    remaining = Vec::new();
+                } else {
+                    remaining = expected.split_off(max_parallelism);
+                }
+
+                // Advance the query for maximum parallelism.
+                for k in expected.iter() {
+                    match query.next(now) {
+                        QueryState::Finished => break 'finished,
+                        QueryState::Waiting(Some(p)) => assert_eq!(&p, k.preimage()),
+                        QueryState::Waiting(None) => panic!("Expected another peer."),
+                        QueryState::WaitingAtCapacity => panic!("Unexpectedly reached capacity."),
+                    }
+                }
+                let num_waiting = query.num_waiting;
+                assert_eq!(num_waiting, expected.len());
+
+                // Check the bounded parallelism.
+                if query.at_capacity() {
+                    assert_eq!(query.next(now), QueryState::WaitingAtCapacity)
+                }
+
+                // Report results back to the query with a random number of "closer"
+                // peers or an error, thus finishing the "in-flight requests".
+                for (i, k) in expected.iter().enumerate() {
+                    if rng.gen_bool(0.75) {
+                        let num_closer = rng.gen_range(0, query.config.num_results + 1);
+                        let closer_peers = random_nodes(num_closer).collect::<Vec<_>>();
+                        // let _: () = remaining;
+                        remaining.extend(closer_peers.iter().map(|x| Key::from(*x)));
+                        query.on_success(k.preimage(), closer_peers);
+                    } else {
+                        num_failures += 1;
+                        query.on_failure(k.preimage());
+                    }
+                    assert_eq!(query.num_waiting, num_waiting - (i + 1));
+                }
+
+                // Re-sort the remaining expected peers for the next "round".
+                remaining.sort_by_key(|k| target.distance(&k));
+
+                expected = remaining
+            }
+
+            // The query must be finished.
+            assert_eq!(query.next(now), QueryState::Finished);
+            assert_eq!(query.progress, QueryProgress::Finished);
+
+            // Determine if all peers have been contacted by the query. This _must_ be
+            // the case if the query finished with fewer than the requested number
+            // of results.
+            let all_contacted = query.closest_peers.values().all(|e| {
+                !matches!(
+                    e.state,
+                    QueryPeerState::NotContacted | QueryPeerState::Waiting { .. }
+                )
+            });
+
+            let target_key = query.target_key.clone();
+            let num_results = query.config.num_results;
+            let result = query.into_result();
+            let closest = result.into_iter().map(Key::from).collect::<Vec<_>>();
+
+            // assert_eq!(result.target, target);
+            assert!(sorted(&target_key, &closest));
+
+            if closest.len() < num_results {
+                // The query returned fewer results than requested. Therefore
+                // either the initial number of known peers must have been
+                // less than the desired number of results, or there must
+                // have been failures.
+                assert!(num_known < num_results || num_failures > 0);
+                // All peers must have been contacted.
+                assert!(all_contacted, "Not all peers have been contacted.");
+            } else {
+                assert_eq!(num_results, closest.len(), "Too  many results.");
+            }
+        }
+
+        QuickCheck::new().tests(10).quickcheck(prop as fn(_) -> _)
+    }
+
+    #[test]
+    fn no_duplicates() {
+        fn prop(mut query: TestQuery) -> bool {
+            let now = Instant::now();
+            let closer: Vec<NodeId> = random_nodes(1).collect();
+
+            // A first peer reports a "closer" peer.
+            let peer1 = if let QueryState::Waiting(Some(p)) = query.next(now) {
+                p
+            } else {
+                panic!("No peer.");
+            };
+            query.on_success(&peer1, closer.clone());
+            // Duplicate result from the same peer.
+            query.on_success(&peer1, closer.clone());
+
+            // If there is a second peer, let it also report the same "closer" peer.
+            match query.next(now) {
+                QueryState::Waiting(Some(p)) => {
+                    let peer2 = p;
+                    query.on_success(&peer2, closer.clone())
+                }
+                QueryState::Finished => {}
+                _ => panic!("Unexpectedly query state."),
+            };
+
+            // The "closer" peer must only be in the query once.
+            let n = query
+                .closest_peers
+                .values()
+                .filter(|e| e.key.preimage() == &closer[0])
+                .count();
+            assert_eq!(n, 1);
+
+            true
+        }
+
+        QuickCheck::new().tests(10).quickcheck(prop as fn(_) -> _)
+    }
+
+    #[test]
+    fn timeout() {
+        fn prop(mut query: TestQuery) -> bool {
+            let mut now = Instant::now();
+            let peer = query
+                .closest_peers
+                .values()
+                .next()
+                .unwrap()
+                .key
+                .clone()
+                .into_preimage();
+            // Poll the query for the first peer to be in progress.
+            match query.next(now) {
+                QueryState::Waiting(Some(id)) => assert_eq!(id, peer),
+                _ => panic!(),
+            }
+
+            // Artificially advance the clock.
+            now += query.config.peer_timeout;
+
+            // Advancing the query again should mark the first peer as unresponsive.
+            let _ = query.next(now);
+            match &query.closest_peers.values().next().unwrap() {
+                QueryPeer {
+                    key,
+                    state: QueryPeerState::Unresponsive,
+                    ..
+                } => {
+                    assert_eq!(key.preimage(), &peer);
+                }
+                QueryPeer { state, .. } => panic!("Unexpected peer state: {:?}", state),
+            }
+
+            let finished = query.progress == QueryProgress::Finished;
+            query.on_success(&peer, Vec::<NodeId>::new());
+            let closest = query.into_result();
+
+            if finished {
+                // Delivering results when the query already finished must have
+                // no effect.
+                assert_eq!(Vec::<NodeId>::new(), closest);
+            } else {
+                // Unresponsive peers can still deliver results while the iterator
+                // is not finished.
+                assert_eq!(vec![peer], closest)
+            }
+            true
+        }
+
+        QuickCheck::new().tests(10).quickcheck(prop as fn(_) -> _)
+    }
+}

--- a/trin-core/src/portalnet/find/iterators/findnodes.rs
+++ b/trin-core/src/portalnet/find/iterators/findnodes.rs
@@ -62,8 +62,8 @@ pub struct FindNodeQueryConfig {
     /// Number of results to produce.
     ///
     /// The number of closest peers that a query must obtain successful results
-    /// for before it terminates. Defaults to the maximum number of entries in a
-    /// single k-bucket, i.e. the `k` parameter in the Kademlia paper.
+    /// for before it terminates. Kademlia paper specifices that this should be equal
+    /// to k, the max number of entries in a k-bucket. Currently defaults to `20`. 
     pub num_results: usize,
 
     /// The timeout for a single peer.
@@ -73,6 +73,16 @@ pub struct FindNodeQueryConfig {
     /// the peer when evaluating the termination conditions, until and unless a
     /// result is delivered. Defaults to `10` seconds.
     pub peer_timeout: Duration,
+}
+
+impl FindNodeQueryConfig {
+    pub fn default() -> Self {
+        Self {
+            parallelism: 3,
+            num_results: 20,
+            peer_timeout: Duration::from_secs(10),
+        }
+    }
 }
 
 impl<TNodeId> FindNodeQuery<TNodeId>

--- a/trin-core/src/portalnet/find/iterators/findnodes.rs
+++ b/trin-core/src/portalnet/find/iterators/findnodes.rs
@@ -30,7 +30,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-
 #[derive(Debug, Clone)]
 pub struct FindNodeQuery<TNodeId> {
     /// The target key we are looking for
@@ -383,9 +382,6 @@ enum QueryProgress {
 struct QueryPeer<TNodeId> {
     /// The `KBucket` key used to identify the peer.
     key: Key<TNodeId>,
-
-    /// The current rpc request iteration that has been made on this peer.
-    iteration: usize,
 
     /// The number of peers that have been returned by this peer.
     peers_returned: usize,

--- a/trin-core/src/portalnet/find/iterators/mod.rs
+++ b/trin-core/src/portalnet/find/iterators/mod.rs
@@ -1,0 +1,1 @@
+pub mod findnodes;

--- a/trin-core/src/portalnet/find/mod.rs
+++ b/trin-core/src/portalnet/find/mod.rs
@@ -1,0 +1,3 @@
+pub mod iterators;
+pub mod query_info;
+pub mod query_pool;

--- a/trin-core/src/portalnet/find/query_info.rs
+++ b/trin-core/src/portalnet/find/query_info.rs
@@ -41,8 +41,8 @@ impl QueryInfo {
     }
 }
 
-impl TargetKey<NodeId> for QueryInfo {
-    fn key(&self) -> Key<NodeId> {
+impl TargetKey<TNodeId> for QueryInfo {
+    fn key(&self) -> Key<TNodeId> {
         match self.query_type {
             QueryType::FindNode(ref node_id) => {
                 Key::new_raw(*node_id, *GenericArray::from_slice(&node_id.raw()))

--- a/trin-core/src/portalnet/find/query_info.rs
+++ b/trin-core/src/portalnet/find/query_info.rs
@@ -1,0 +1,135 @@
+use discv5::{kbucket::Key, Enr};
+use crate::portalnet::types::messages::{Request, FindNodes};
+use discv5::enr::NodeId;
+use sha3::digest::generic_array::GenericArray;
+use smallvec::SmallVec;
+use tokio::sync::oneshot;
+use crate::portalnet::find::query_pool::TargetKey;
+
+/// Information about a query.
+#[derive(Debug)]
+pub struct QueryInfo {
+    /// What we are querying and why.
+    pub query_type: QueryType,
+
+    /// Temporary ENRs used when trying to reach nodes.
+    pub untrusted_enrs: SmallVec<[Enr; 16]>,
+
+    /// The number of distances we request for each peer.
+    pub distances_to_request: usize,
+}
+
+/// Additional information about the query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryType {
+    /// The user requested a `FIND_NODE` query to be performed. It should be reported when finished.
+    FindNode(NodeId),
+}
+
+impl QueryInfo {
+    /// Builds an RPC Request, given the QueryInfo
+    pub(crate) fn rpc_request(&self, peer: NodeId) -> Result<Request, &'static str> {
+        let request = match self.query_type {
+            QueryType::FindNode(node_id) => {
+                let distances = findnode_log2distance(node_id, peer, self.distances_to_request)
+                    .ok_or("Requested a node find itself")?;
+                Request::FindNodes(FindNodes { distances })
+            }
+        };
+
+        Ok(request)
+    }
+}
+
+impl TargetKey<NodeId> for QueryInfo {
+    fn key(&self) -> Key<NodeId> {
+        match self.query_type {
+            QueryType::FindNode(ref node_id) => {
+                Key::new_raw(*node_id, *GenericArray::from_slice(&node_id.raw()))
+            }
+        }
+    }
+}
+
+/// Calculates the log2 distance for a destination peer given a target and the size (number of
+/// distances to request).
+///
+/// As the iteration increases, FINDNODE requests adjacent distances from the exact peer distance.
+///
+/// As an example, if the target has a distance of 12 from the remote peer, the sequence of distances that are sent for increasing iterations would be [12, 13, 11, 14, 10, .. ].
+fn findnode_log2distance(target: NodeId, peer: NodeId, size: usize) -> Option<Vec<u16>> {
+    if size > 127 {
+        // invoke and endless loop - coding error
+        panic!("Iterations cannot be greater than 127");
+    }
+
+    let dst_key: Key<NodeId> = peer.into();
+    let distance_u64 = dst_key.log2_distance(&target.into())?;
+    let distance: u16 = distance_u64 as u16;
+    
+    let mut result_list = vec![distance];
+    let mut difference = 1;
+    while result_list.len() < size {
+        if distance + difference <= 256 {
+            result_list.push(distance + difference);
+        }
+        if result_list.len() < size {
+            if let Some(d) = distance.checked_sub(difference) {
+
+                result_list.push(d);
+            }
+        }
+        difference += 1;
+    }
+    Some(result_list[..size].to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_log2distance() {
+        let target = NodeId::new(&[0u8; 32]);
+        let mut destination = [0u8; 32];
+        destination[10] = 1; // gives a log2 distance of 169
+        let destination = NodeId::new(&destination);
+
+        let expected_distances = vec![169, 170, 168, 171, 167, 172, 166, 173, 165];
+
+        assert_eq!(
+            findnode_log2distance(target, destination, expected_distances.len()).unwrap(),
+            expected_distances
+        );
+    }
+
+    #[test]
+    fn test_log2distance_lower() {
+        let target = NodeId::new(&[0u8; 32]);
+        let mut destination = [0u8; 32];
+        destination[31] = 8; // gives a log2 distance of 5
+        let destination = NodeId::new(&destination);
+
+        let expected_distances = vec![4, 5, 3, 6, 2, 7, 1, 8, 0, 9, 10];
+
+        assert_eq!(
+            findnode_log2distance(target, destination, expected_distances.len()).unwrap(),
+            expected_distances
+        );
+    }
+
+    #[test]
+    fn test_log2distance_upper() {
+        let target = NodeId::new(&[0u8; 32]);
+        let mut destination = [0u8; 32];
+        destination[0] = 8; // gives a log2 distance of 252
+        let destination = NodeId::new(&destination);
+
+        let expected_distances = vec![252, 253, 251, 254, 250, 255, 249, 256, 248, 247, 246];
+
+        assert_eq!(
+            findnode_log2distance(target, destination, expected_distances.len()).unwrap(),
+            expected_distances
+        );
+    }
+}

--- a/trin-core/src/portalnet/find/query_pool.rs
+++ b/trin-core/src/portalnet/find/query_pool.rs
@@ -38,7 +38,7 @@ pub trait TargetKey<TNodeId> {
 /// that determines the peer selection strategy, i.e. the order in which the
 /// peers involved in the query should be contacted.
 pub struct QueryPool<TTarget, TNodeId, TResult> {
-    next_id: usize,
+    next_id: QueryId,
     query_timeout: Duration,
     queries: FnvHashMap<QueryId, Query<TTarget, TNodeId, TResult>>,
     result_type: PhantomData<TResult>

--- a/trin-core/src/portalnet/find/query_pool.rs
+++ b/trin-core/src/portalnet/find/query_pool.rs
@@ -1,0 +1,295 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+// This basis of this file has been taken from the rust-libp2p codebase:
+// https://github.com/libp2p/rust-libp2p
+
+use super::iterators::findnodes::{FindNodeQuery, FindNodeQueryConfig};
+
+use discv5::kbucket::{Key};
+use fnv::FnvHashMap;
+use std::time::{Duration, Instant};
+use std::marker::PhantomData;
+
+pub trait TargetKey<TNodeId> {
+    fn key(&self) -> Key<TNodeId>;
+}
+
+/// A `QueryPool` provides an aggregate state machine for driving `Query`s to completion.
+///
+/// Internally, a `Query` is in turn driven by an underlying `QueryPeerIter`
+/// that determines the peer selection strategy, i.e. the order in which the
+/// peers involved in the query should be contacted.
+pub struct QueryPool<TTarget, TNodeId, TResult> {
+    next_id: usize,
+    query_timeout: Duration,
+    queries: FnvHashMap<QueryId, Query<TTarget, TNodeId, TResult>>,
+    result_type: PhantomData<TResult>
+}
+
+/// The observable states emitted by [`QueryPool::poll`].
+#[allow(clippy::type_complexity)]
+pub enum QueryPoolState<'a, TTarget, TNodeId, TResult> {
+    /// The pool is idle, i.e. there are no queries to process.
+    Idle,
+    /// At least one query is waiting for results. `Some(request)` indicates
+    /// that a new request is now being waited on.
+    Waiting(Option<(&'a mut Query<TTarget, TNodeId, TResult>, TNodeId)>),
+    /// A query has finished.
+    Finished(Query<TTarget, TNodeId, TResult>),
+    /// A query has timed out.
+    Timeout(Query<TTarget, TNodeId, TResult>),
+}
+
+impl<TTarget, TNodeId, TResult> QueryPool<TTarget, TNodeId, TResult>
+where
+    TTarget: TargetKey<TNodeId>,
+    TNodeId: Into<Key<TNodeId>> + Eq + Clone,
+    TResult: Into<TNodeId> + Clone,
+{
+    /// Creates a new `QueryPool` with the given configuration.
+    pub fn new(query_timeout: Duration) -> Self {
+        QueryPool {
+            next_id: 0,
+            query_timeout,
+            queries: Default::default(),
+            result_type: PhantomData
+        }
+    }
+
+    /// Returns an iterator over the queries in the pool.
+    pub fn iter(&self) -> impl Iterator<Item = &Query<TTarget, TNodeId, TResult>> {
+        self.queries.values()
+    }
+
+    /// Adds a query to the pool that iterates towards the closest peers to the target.
+    pub fn add_findnode_query<I>(
+        &mut self,
+        config: FindNodeQueryConfig,
+        target: TTarget,
+        peers: I,
+    ) -> QueryId
+    where
+        I: IntoIterator<Item = Key<TNodeId>>,
+    {
+        let target_key = target.key();
+        let findnode_query = FindNodeQuery::with_config(config, target_key, peers);
+        let peer_iter = QueryPeerIter::FindNode(findnode_query);
+        self.add(peer_iter, target)
+    }
+
+    fn add(&mut self, peer_iter: QueryPeerIter<TNodeId>, target: TTarget) -> QueryId {
+        let id = QueryId(self.next_id);
+        self.next_id = self.next_id.wrapping_add(1);
+        let query = Query::new(id, peer_iter, target);
+        self.queries.insert(id, query);
+        id
+    }
+
+    /// Returns a mutable reference to a query with the given ID, if it is in the pool.
+    pub fn get_mut(&mut self, id: QueryId) -> Option<&mut Query<TTarget, TNodeId, TResult>> {
+        self.queries.get_mut(&id)
+    }
+
+    /// Polls the pool to advance the queries.
+    pub fn poll(&mut self) -> QueryPoolState<'_, TTarget, TNodeId, TResult> {
+        let now = Instant::now();
+        let mut finished = None;
+        let mut waiting = None;
+        let mut timeout = None;
+
+        for (&query_id, query) in self.queries.iter_mut() {
+            query.started = query.started.or(Some(now));
+            match query.next(now) {
+                QueryState::Finished => {
+                    finished = Some(query_id);
+                    break;
+                }
+                QueryState::Waiting(Some(return_peer)) => {
+                    waiting = Some((query_id, return_peer));
+                    break;
+                }
+                QueryState::Waiting(None) | QueryState::WaitingAtCapacity => {
+                    let elapsed = now - query.started.unwrap_or(now);
+                    if elapsed >= self.query_timeout {
+                        timeout = Some(query_id);
+                        break;
+                    }
+                }
+            }
+        }
+
+        if let Some((query_id, return_peer)) = waiting {
+            let query = self.queries.get_mut(&query_id).expect("s.a.");
+            return QueryPoolState::Waiting(Some((query, return_peer)));
+        }
+
+        if let Some(query_id) = finished {
+            let query = self.queries.remove(&query_id).expect("s.a.");
+            return QueryPoolState::Finished(query);
+        }
+
+        if let Some(query_id) = timeout {
+            let query = self.queries.remove(&query_id).expect("s.a.");
+            return QueryPoolState::Timeout(query);
+        }
+
+        if self.queries.is_empty() {
+            QueryPoolState::Idle
+        } else {
+            QueryPoolState::Waiting(None)
+        }
+    }
+}
+
+/// Unique identifier for an active query.
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct QueryId(pub usize);
+
+impl std::ops::Deref for QueryId {
+    type Target = usize;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// A query in a `QueryPool`.
+pub struct Query<TTarget, TNodeId, TResult> {
+    /// The unique ID of the query.
+    id: QueryId,
+    /// The peer iterator that drives the query state.
+    peer_iter: QueryPeerIter<TNodeId>,
+    /// The instant when the query started (i.e. began waiting for the first
+    /// result from a peer).
+    started: Option<Instant>,
+    /// Target we are looking for.
+    target: TTarget,
+    /// Phantom use of TResult generic type, which is used in implementation.
+    unused_result: PhantomData<TResult>,
+    
+}
+
+/// The peer selection strategies that can be used by queries.
+enum QueryPeerIter<TNodeId> {
+    FindNode(FindNodeQuery<TNodeId>)
+}
+
+impl<TTarget, TNodeId, TResult> Query<TTarget, TNodeId, TResult>
+where
+    TTarget: TargetKey<TNodeId>,
+    TNodeId: Into<Key<TNodeId>> + Eq + Clone,
+    TResult: Into<TNodeId> + Clone,
+{
+    /// Creates a new query without starting it.
+    fn new(id: QueryId, peer_iter: QueryPeerIter<TNodeId>, target: TTarget) -> Self {
+        Query {
+            id,
+            peer_iter,
+            target,
+            started: None,
+            unused_result: PhantomData,
+        }
+    }
+
+    /// Gets the unique ID of the query.
+    pub fn id(&self) -> QueryId {
+        self.id
+    }
+
+    /// Informs the query that the attempt to contact `peer` failed.
+    pub fn on_failure(&mut self, peer: &TNodeId) {
+        match &mut self.peer_iter {
+            QueryPeerIter::FindNode(iter) => iter.on_failure(&peer),
+        }
+    }
+
+    /// Informs the query that the attempt to contact `peer` succeeded,
+    /// possibly resulting in new peers that should be incorporated into
+    /// the query, if applicable.
+    pub fn on_success<'a>(&mut self, peer: &TNodeId, new_peers: &'a [TResult])
+    where
+        &'a TResult: Into<TNodeId>,
+    {
+        match &mut self.peer_iter {
+            QueryPeerIter::FindNode(iter) => {
+                iter.on_success(peer, new_peers.iter().map(|result| result.into()).collect())
+            }
+        }
+    }
+
+    /// Advances the state of the underlying peer iterator.
+    fn next(&mut self, now: Instant) -> QueryState<TNodeId> {
+        match &mut self.peer_iter {
+            QueryPeerIter::FindNode(iter) => iter.next(now),
+        }
+    }
+
+    /// Consumes the query, producing the final `QueryResult`.
+    pub fn into_result(self) -> QueryResult<TTarget, impl Iterator<Item = TNodeId>> {
+        let peers = match self.peer_iter {
+            QueryPeerIter::FindNode(iter) => iter.into_result(),
+        };
+        QueryResult {
+            target: self.target,
+            closest_peers: peers.into_iter(),
+        }
+    }
+
+    /// Returns a reference to the query `target`.
+    pub fn target(&self) -> &TTarget {
+        &self.target
+    }
+
+    /// Returns a mutable reference to the query `target`.
+    pub fn target_mut(&mut self) -> &mut TTarget {
+        &mut self.target
+    }
+}
+
+/// The result of a `Query`.
+pub struct QueryResult<TTarget, TClosest> {
+    /// The target of the query.
+    pub target: TTarget,
+    /// The closest peers to the target found by the query.
+    pub closest_peers: TClosest,
+}
+
+/// The state of the query reported by [`closest::FindNodeQuery::next`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryState<TNodeId> {
+    /// The query is waiting for results.
+    ///
+    /// `Some(peer)` indicates that the query is now waiting for a result
+    /// from `peer`, in addition to any other peers for which the query is already
+    /// waiting for results.
+    ///
+    /// `None` indicates that the query is waiting for results and there is no
+    /// new peer to contact, despite the query not being at capacity w.r.t.
+    /// the permitted parallelism.
+    Waiting(Option<TNodeId>),
+
+    /// The query is waiting for results and is at capacity w.r.t. the
+    /// permitted parallelism.
+    WaitingAtCapacity,
+
+    /// The query finished.
+    Finished,
+}
+


### PR DESCRIPTION
### What does this add?

This PR adds relatively generic utility types used for iterative FindNodes/FindContent implementations, mostly taken from https://github.com/sigp/discv5/blob/master/src/query_pool.rs with some customizations/re-organization done. 

Customizations include:

- Stripping out of `PredicateQuery` types. These allowed one to specify an arbitrary filter to run over ENRs discovered. Removing this type is the reason for the compiler currently requiring `PhantomData` fields in `query_pool.rs`, because the `PredicateQuery` definition used the `TResult` field while the `FindNodeQuery` definition does not.
- Modify `QueryInfo` to use `Trin` types when generating requests instead of `sigp/discv5' types.

The main types defined are the `QueryPool` type, the `Query` type (both defined in `find/query_pool.rs`), and the `FindNodeQuery`  type (defined in `find/iterators/findnodes.rs`). 

The `QueryPool` type holds a set of `Query` entries, each of which has an instance of the `QueryPeerIter` enum, which points to a `FindNodeQuery` (or a `FindContentQuery` once implemented), whose `on_success`/`on_failure` methods define the rules by which the query is advanced each time a response is received from a peer. 

### How will it be used?

The subsequent PR that uses these types:

-  adds a `QueryPool` member to the `OverlayService` struct.
-  adds a function that polls the `QueryPool` for `QueryPoolState` objects, based off of which the query will either finish or a`FINDNODES` message will be sent to the next peer (whose info is contained in the `QueryPoolState` object) via a `TALK_REQ`.
- adds a function that calls `on_success`/`on_failure` when a `NODES` message is received from a node that is part of a query.
- calls the `QueryPool`'s `add_findnode_query` method in the OverlayService to begin a FindNodes query.

Another subsequent PR will need to define `FindContentQuery` and its respective `on_success`/`on_failure` methods, at which point this approach will work for `FindContent` as well. I envision the `OverlayService` having two `QueryPool` members, one for each type of query. Each `QueryPool` will be instantiated with different types corresponding to the types of data that will be returned (content or ENRs).