### PR TITLE
Implement FindContent <-> Content uTP stream

### DIFF
--- a/newsfragments/270.added.md
+++ b/newsfragments/270.added.md
@@ -1,0 +1,1 @@
+Implement FindContent/Content uTP stream

--- a/trin-core/src/utp/trin_helpers.rs
+++ b/trin-core/src/utp/trin_helpers.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 // These are just some Trin helper functions
 
+use crate::portalnet::types::messages::Content;
 use ssz_derive::{Decode, Encode};
 
 // These Utp impl are related to sending messages over uTP not the implementation itself or stream
@@ -52,7 +53,10 @@ pub struct UtpAccept {
 
 // This is not in a spec, this is just for internally tracking for what portal message
 // negotiated the uTP stream
+#[derive(Debug, Clone)]
 pub enum UtpMessageId {
+    FindContentStream,
+    FindContentData(Content),
     OfferAcceptStream,
 }
 


### PR DESCRIPTION
### What was wrong?
FindContent/Content uTP scenario was not implemented.

### How was it fixed?
- Implemented uTP stream for FindContent/Content.
- Some unnecessary uTP logs where deleted.

The current implementation is manually tested with Fluffy in both directions.

### To-Do
Those should be added in later PRs, as I would like to test Offer/Accept uTP next:

- write uTP bi-directional test (when we want to send DATA packet right after SYN-ACK).
- Return content data instead of connection-id  to json-rpc client when we send FIndContent request and uTP stream is initialized.

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
