### PR TITLE
Refactor OFFER/ACCEPT uTP stream and add `portal_*Offer` json-rpc endpoint

### DIFF
--- a/newsfragments/275.added.md
+++ b/newsfragments/275.added.md
@@ -1,0 +1,1 @@
+Add `portal_*Offer` JSON-RPC andpoint

--- a/trin-core/src/jsonrpc/endpoints.rs
+++ b/trin-core/src/jsonrpc/endpoints.rs
@@ -14,6 +14,7 @@ pub enum StateEndpoint {
     FindContent,
     FindNodes,
     LocalContent,
+    Offer,
     Ping,
 }
 
@@ -24,6 +25,7 @@ pub enum HistoryEndpoint {
     FindContent,
     FindNodes,
     LocalContent,
+    Offer,
     Ping,
     RecursiveFindContent,
 }
@@ -77,6 +79,7 @@ impl FromStr for TrinEndpoint {
             "portal_historyLocalContent" => {
                 Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::LocalContent))
             }
+            "portal_historyOffer" => Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::Offer)),
             "portal_historyPing" => Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::Ping)),
             "portal_historyRadius" => {
                 Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::DataRadius))
@@ -88,6 +91,7 @@ impl FromStr for TrinEndpoint {
             "portal_stateLocalContent" => {
                 Ok(TrinEndpoint::StateEndpoint(StateEndpoint::LocalContent))
             }
+            "portal_stateOffer" => Ok(TrinEndpoint::StateEndpoint(StateEndpoint::Offer)),
             "portal_statePing" => Ok(TrinEndpoint::StateEndpoint(StateEndpoint::Ping)),
             "portal_stateRadius" => Ok(TrinEndpoint::StateEndpoint(StateEndpoint::DataRadius)),
             _ => Err(()),

--- a/trin-core/src/portalnet/types/messages.rs
+++ b/trin-core/src/portalnet/types/messages.rs
@@ -491,6 +491,12 @@ pub struct Accept {
     pub content_keys: BitList<typenum::U8>,
 }
 
+impl Into<Value> for Accept {
+    fn into(self) -> Value {
+        serde_json::json!({ "connection_id": format!("{:?}", self.connection_id.to_be()) , "content_keys": self.content_keys})
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct SszEnr(Enr);
 

--- a/trin-core/src/utp/trin_helpers.rs
+++ b/trin-core/src/utp/trin_helpers.rs
@@ -57,7 +57,8 @@ pub struct UtpAccept {
 pub enum UtpMessageId {
     FindContentStream,
     FindContentData(Content),
-    OfferAcceptStream,
+    OfferStream,
+    AcceptStream(Vec<Vec<u8>>),
 }
 
 #[cfg(test)]

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use tokio::sync::mpsc;
 
 use crate::network::StateNetwork;
+use trin_core::jsonrpc::types::OfferParams;
 use trin_core::jsonrpc::{
     endpoints::StateEndpoint,
     types::{
@@ -78,6 +79,26 @@ impl StateRequestHandler {
                             Err(msg) => Err(format!("FindNodes request timeout: {:?}", msg)),
                         },
                         Err(msg) => Err(format!("Invalid FindNodes params: {:?}", msg)),
+                    };
+                    let _ = request.resp.send(response);
+                }
+                StateEndpoint::Offer => {
+                    let response = match OfferParams::try_from(request.params) {
+                        Ok(val) => {
+                            let content_keys =
+                                val.content_keys.iter().map(|key| key.to_vec()).collect();
+
+                            match self
+                                .network
+                                .overlay
+                                .send_offer(content_keys, val.enr.into())
+                                .await
+                            {
+                                Ok(accept) => Ok(accept.into()),
+                                Err(msg) => Err(format!("Offer request timeout: {:?}", msg)),
+                            }
+                        }
+                        Err(msg) => Err(format!("Invalid Offer params: {:?}", msg)),
                     };
                     let _ = request.resp.send(response);
                 }

--- a/utp-testing/src/main.rs
+++ b/utp-testing/src/main.rs
@@ -19,7 +19,7 @@ impl TestApp {
             .write()
             .await
             .listening
-            .insert(connection_id, UtpMessageId::OfferAcceptStream);
+            .insert(connection_id, UtpMessageId::OfferStream);
 
         let mut conn = self
             .utp_listener
@@ -79,14 +79,14 @@ impl TestApp {
             .write()
             .await
             .listening
-            .insert(connection_id, UtpMessageId::OfferAcceptStream);
+            .insert(connection_id, UtpMessageId::OfferStream);
 
         // also listen on conn_id + 1 because this is the actual receive path for acceptor
         self.utp_listener
             .write()
             .await
             .listening
-            .insert(connection_id + 1, UtpMessageId::OfferAcceptStream);
+            .insert(connection_id + 1, UtpMessageId::OfferStream);
     }
 }
 


### PR DESCRIPTION
### What was wrong?
-  Offer/Accept implementation was not tested.
- `portal_*Offer` json-rpc endpoint was not implemented.

### How was it fixed?
- Manually tested Offer/Accept uTP stream in both directions with Fluffy and fixed all known issues.
- Implemented `portal_*Offer` json-rpc endpoint.

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
