### PR TITLE
Implement `--ephemeral` CLI flag

### DIFF
--- a/newsfragments/277.added.md
+++ b/newsfragments/277.added.md
@@ -1,0 +1,1 @@
+This implements the `--ephemeral/e` CLI boolean flag that deletes Trin's data on exit.

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -110,6 +110,13 @@ pub struct TrinConfig {
 
     #[structopt(long = "metrics-url", help = "URL for prometheus server")]
     pub metrics_url: Option<String>,
+
+    #[structopt(
+        short = "e",
+        long = "ephemeral",
+        help = "Enable temporary trin data storage that is deleted on exit."
+    )]
+    pub ephemeral: bool,
 }
 
 impl TrinConfig {
@@ -198,6 +205,7 @@ mod test {
                 .split(',')
                 .map(|n| n.to_string())
                 .collect(),
+            ephemeral: false,
         };
         let actual_config = TrinConfig::new_from(["trin"].iter()).unwrap();
         assert_eq!(actual_config.web3_transport, expected_config.web3_transport);
@@ -229,6 +237,7 @@ mod test {
                 .split(',')
                 .map(|n| n.to_string())
                 .collect(),
+            ephemeral: false,
         };
         let actual_config = TrinConfig::new_from(
             [
@@ -273,6 +282,7 @@ mod test {
                 .split(',')
                 .map(|n| n.to_string())
                 .collect(),
+            ephemeral: false,
         };
         assert_eq!(actual_config.web3_transport, expected_config.web3_transport);
         assert_eq!(
@@ -313,6 +323,7 @@ mod test {
                 .split(',')
                 .map(|n| n.to_string())
                 .collect(),
+            ephemeral: false,
         };
         assert_eq!(actual_config.web3_transport, expected_config.web3_transport);
         assert_eq!(
@@ -377,6 +388,7 @@ mod test {
                 .split(',')
                 .map(|n| n.to_string())
                 .collect(),
+            ephemeral: false,
         };
         let actual_config =
             TrinConfig::new_from(["trin", "--discovery-port", "999"].iter()).unwrap();
@@ -403,6 +415,7 @@ mod test {
                 .split(',')
                 .map(|n| n.to_string())
                 .collect(),
+            ephemeral: false,
         };
         let actual_config =
             TrinConfig::new_from(["trin", "--bootnodes", "enr:-aoeu,enr:-htns"].iter()).unwrap();
@@ -451,6 +464,7 @@ mod test {
                 .split(',')
                 .map(|n| n.to_string())
                 .collect(),
+            ephemeral: false,
         };
         let actual_config = TrinConfig::new_from(
             [

--- a/trin-core/src/jsonrpc/service.rs
+++ b/trin-core/src/jsonrpc/service.rs
@@ -21,6 +21,7 @@ use validator::Validate;
 use crate::cli::TrinConfig;
 use crate::jsonrpc::endpoints::TrinEndpoint;
 use crate::jsonrpc::types::{JsonRequest, PortalJsonRpcRequest};
+use crate::utils::db::cleanup_data_dir;
 
 pub struct JsonRpcExiter {
     should_exit: Arc<RwLock<bool>>,
@@ -86,6 +87,7 @@ fn set_ipc_cleanup_handlers(ipc_path: &str) {
             if let Err(err) = fs::remove_file(&ipc_path) {
                 debug!("Ctrl-C: Skipped removing {} because: {}", ipc_path, err);
             };
+            cleanup_data_dir();
             std::process::exit(1);
         }) {
             warn!(

--- a/trin-core/src/utils/db.rs
+++ b/trin-core/src/utils/db.rs
@@ -1,9 +1,15 @@
 use std::path::Path;
 use std::{env, fs};
 
+use crate::cli::TrinConfig;
 use directories::ProjectDirs;
 use discv5::enr::NodeId;
+use log::debug;
+use std::sync::Mutex;
 
+lazy_static! {
+    static ref TRIN_NODE_ID_DATA_DIRS: Mutex<Vec<String>> = Mutex::new(vec![]);
+}
 const TRIN_DATA_ENV_VAR: &str = "TRIN_DATA_PATH";
 
 pub fn get_data_dir(node_id: NodeId) -> String {
@@ -21,6 +27,10 @@ pub fn get_data_dir(node_id: NodeId) -> String {
         .to_str()
         .unwrap()
         .to_string();
+    TRIN_NODE_ID_DATA_DIRS
+        .lock()
+        .unwrap()
+        .push(node_id_data_dir.to_owned());
     fs::create_dir_all(&node_id_data_dir).expect("Unable to create data directory folder");
     node_id_data_dir
 }
@@ -32,5 +42,19 @@ pub fn get_default_data_dir() -> String {
     match ProjectDirs::from("", "", "trin") {
         Some(proj_dirs) => proj_dirs.data_local_dir().to_str().unwrap().to_string(),
         None => panic!("Unable to find data directory"),
+    }
+}
+
+pub fn cleanup_data_dir() {
+    // TODO: Once TrieDB and PortalStorage are merged, and Trin uses a single
+    // data directory, we should update TRIN_NODE_IDE_DATA_DIRS to a string.
+    let trin_config = TrinConfig::from_cli();
+    if trin_config.ephemeral {
+        let paths = TRIN_NODE_ID_DATA_DIRS.lock().unwrap();
+        for path in &*paths {
+            if let Err(err) = fs::remove_dir_all(path) {
+                debug!("Ctrl-C: Skipped removing {} because: {}", path, err);
+            };
+        }
     }
 }


### PR DESCRIPTION
### What was wrong?

This Fixes #81, implementing the `--ephemeral` CLI flag.
### How was it fixed?

This was fixed by creating a mutable singleton vector that stores the session's data path on startup and utilizes it in `utils::db::cleanup_data_dir`, which deletes the ephemeral directories on signal interruption (if the `--ephemeral` CLI flag is enabled).

Trin's signal interruption is already being handled in the `service.rs` via `setup_ipc_cleanup_handlers()`, and can only be called once. In order to minimize the amount of changes, a call to `cleanup_data_dir()` has been added here.  

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Review thread safety and `lock()` usage with mutable global variables