### PR TITLE
Bugfix data dir setup

### DIFF
--- a/newsfragments/278.fixed.md
+++ b/newsfragments/278.fixed.md
@@ -1,0 +1,1 @@
+Bugfix invalidly namespaced data directory setup.

--- a/trin-core/src/portalnet/storage.rs
+++ b/trin-core/src/portalnet/storage.rs
@@ -435,7 +435,9 @@ impl PortalStorage {
     /// Helper function for opening a SQLite connection.
     /// Used for testing.
     pub fn setup_rocksdb(node_id: NodeId) -> Result<rocksdb::DB, PortalStorageError> {
-        let data_path: String = get_data_dir(node_id).to_owned();
+        let data_path_root: String = get_data_dir(node_id).to_owned();
+        let data_suffix: &str = "/rocksdb";
+        let data_path = data_path_root + data_suffix;
         debug!("Setting up RocksDB at path: {:?}", data_path);
 
         let mut db_opts = Options::default();

--- a/trin-core/src/utils/db.rs
+++ b/trin-core/src/utils/db.rs
@@ -23,7 +23,6 @@ pub fn get_default_data_dir(node_id: NodeId) -> String {
     let node_id_string = hex::encode(node_id.raw());
     let suffix = &node_id_string[..8];
     application_string.push_str(suffix);
-    application_string.push_str("/rocksdb");
 
     match ProjectDirs::from("", "", &application_string) {
         Some(proj_dirs) => proj_dirs.data_local_dir().to_str().unwrap().to_string(),
@@ -31,8 +30,11 @@ pub fn get_default_data_dir(node_id: NodeId) -> String {
     }
 }
 
+/// Used to setup a database for TrieDB in State Network
 pub fn setup_overlay_db(node_id: NodeId) -> DB {
-    let data_path = get_data_dir(node_id);
+    let data_path_root = get_data_dir(node_id);
+    let data_suffix: &str = "/rocksdb";
+    let data_path = data_path_root + data_suffix;
     let mut db_opts = Options::default();
     db_opts.create_if_missing(true);
     DB::open(&db_opts, data_path).unwrap()

--- a/trin-core/src/utils/db.rs
+++ b/trin-core/src/utils/db.rs
@@ -2,7 +2,6 @@ use std::{env, fs};
 
 use directories::ProjectDirs;
 use discv5::enr::NodeId;
-use rocksdb::{Options, DB};
 
 const TRIN_DATA_ENV_VAR: &str = "TRIN_DATA_PATH";
 
@@ -28,14 +27,4 @@ pub fn get_default_data_dir(node_id: NodeId) -> String {
         Some(proj_dirs) => proj_dirs.data_local_dir().to_str().unwrap().to_string(),
         None => panic!("Unable to find data directory"),
     }
-}
-
-/// Used to setup a database for TrieDB in State Network
-pub fn setup_overlay_db(node_id: NodeId) -> DB {
-    let data_path_root = get_data_dir(node_id);
-    let data_suffix: &str = "/rocksdb";
-    let data_path = data_path_root + data_suffix;
-    let mut db_opts = Options::default();
-    db_opts.create_if_missing(true);
-    DB::open(&db_opts, data_path).unwrap()
 }

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -15,7 +15,6 @@ use trin_core::portalnet::{
         metric::XorMetric,
     },
 };
-use trin_core::utils::db::setup_overlay_db;
 use trin_core::utp::stream::UtpListener;
 
 use crate::trie::TrieDB;
@@ -35,7 +34,7 @@ impl StateNetwork {
         portal_config: PortalnetConfig,
     ) -> Self {
         // todo: revisit triedb location
-        let db = setup_overlay_db(NodeId::random());
+        let db = PortalStorage::setup_rocksdb(NodeId::random()).unwrap();
         let triedb = TrieDB::new(Arc::new(db));
         let trie = EthTrie::new(Arc::new(triedb));
 


### PR DESCRIPTION
### What was wrong?
@hmrtn pointed out that  `get_data_dir` was incorrectly namespaced under `/rocksdb` - when it should be returning simply the `/trin_xxxxx` directory.

### How was it fixed?
Moved the `/rocksdb` namespacing to its appropriate location.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
