### PR TITLE
Add uTP `recv_from` method and more uTP tests

### DIFF
--- a/newsfragments/283.added.md
+++ b/newsfragments/283.added.md
@@ -1,0 +1,1 @@
+Add uTP socket `recv_from` method and more uTP tests

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -275,7 +275,6 @@ impl<TContentKey: OverlayContentKey + Send, TMetric: Metric + Send>
 
                         match conn {
                             Ok(mut conn) => {
-                                // TODO: Implement this with recv_from
                                 // Handle STATE packet for SYN
                                 let mut buf = [0; BUF_SIZE];
                                 match conn.recv(&mut buf).await {
@@ -373,7 +372,6 @@ impl<TContentKey: OverlayContentKey + Send, TMetric: Metric + Send>
             .connect(connection_id, enr.node_id())
             .await?;
 
-        // TODO: Replace this with recv_from
         // Handle STATE packet for SYN
         let mut buf = [0; BUF_SIZE];
         conn.recv(&mut buf).await?;


### PR DESCRIPTION
### What was wrong?
- uTP socket `recv_from` method was missing

### How was it fixed?
- Adding `recv_from` method allow us to receive all streamed uTP data to a write buffer:

```rust
        let mut buf = [0; BUF_SIZE];
        socket.recv_from(&mut buf).await
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
