### PR TITLE
Remove Result wrap of return type in random NodeId gen

### DIFF
--- a/trin-core/src/portalnet/discovery.rs
+++ b/trin-core/src/portalnet/discovery.rs
@@ -212,21 +212,15 @@ impl Discovery {
                          Some(bucket) => {
                              let target_bucket_idx = u8::try_from(bucket.0);
                              if let Ok(idx) = target_bucket_idx {
-                                 // Randomly generate a NodeID that falls within the target bucket.
+                                 // Randomly generate a node ID that falls within the target bucket.
                                  let target_node_id = generate_random_node_id(idx, self.local_enr().node_id());
-                                 // Do the random lookup on this node-id.
-                                 match target_node_id {
-                                     Ok(node_id) => {
-                                        // get metrics
-                                        let metrics = self.discv5.metrics();
-                                        let connected_peers = self.discv5.connected_peers();
-                                        debug!("Connected peers: {}, Active sessions: {}, Unsolicited requests/s: {:.2}", connected_peers, metrics.active_sessions, metrics.unsolicited_requests_per_second);
-                                        debug!("Searching for discv5 peers...");
-                                        // execute a FINDNODE query
-                                        self.recursive_find_node(node_id).await;
-                            },
-                                     Err(msg) => warn!("{:?}", msg),
-                                 }
+                                 // Do the random lookup on this node ID.
+                                 let metrics = self.discv5.metrics();
+                                 let connected_peers = self.discv5.connected_peers();
+                                 debug!("Connected peers: {}, Active sessions: {}, Unsolicited requests/s: {:.2}", connected_peers, metrics.active_sessions, metrics.unsolicited_requests_per_second);
+                                 debug!("Searching for discv5 peers...");
+                                 // execute a FINDNODE query
+                                 self.recursive_find_node(target_node_id).await;
                              } else {
                                  error!("Unable to downcast bucket index.")
                              }

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -440,13 +440,10 @@ impl<TContentKey: OverlayContentKey + Send, TMetric: Metric + Send>
             Some(bucket) => {
                 let target_bucket_idx = u8::try_from(bucket.0);
                 if let Ok(idx) = target_bucket_idx {
-                    // Randomly generate a NodeID that falls within the target bucket.
+                    // Randomly generate a node ID that falls within the target bucket.
                     let target_node_id = self.generate_random_node_id(idx);
-                    // Do the random lookup on this node-id.
-                    match target_node_id {
-                        Ok(node_id) => self.send_recursive_findnode(&node_id),
-                        Err(msg) => warn!("{:?}", msg),
-                    }
+                    // Do the random lookup on this node ID.
+                    self.send_recursive_findnode(&target_node_id);
                 } else {
                     error!("Unable to downcast bucket index.")
                 }
@@ -1211,7 +1208,7 @@ impl<TContentKey: OverlayContentKey + Send, TMetric: Metric + Send>
         // TODO: Implement Recursive(iterative) FINDNODE. This is a stub.
     }
 
-    fn generate_random_node_id(&self, target_bucket_idx: u8) -> anyhow::Result<NodeId> {
+    fn generate_random_node_id(&self, target_bucket_idx: u8) -> NodeId {
         node_id::generate_random_node_id(target_bucket_idx, self.local_enr().node_id())
     }
 }
@@ -1809,7 +1806,7 @@ mod tests {
     #[serial]
     fn test_generate_random_node_id(#[case] target_bucket_idx: u8) {
         let service = task::spawn(build_service());
-        let random_node_id = service.generate_random_node_id(target_bucket_idx).unwrap();
+        let random_node_id = service.generate_random_node_id(target_bucket_idx);
         let key = kbucket::Key::from(random_node_id);
         let bucket = service.kbuckets.read();
         let expected_index = bucket.get_index(&key).unwrap();

--- a/trin-core/src/utils/node_id.rs
+++ b/trin-core/src/utils/node_id.rs
@@ -18,17 +18,15 @@ use std::net::Ipv4Addr;
 /// Generate random NodeId based on bucket index target and a local node id.
 /// First we generate a random distance metric with leading zeroes based on the target bucket.
 /// Then we XOR the result distance with the local NodeId to get the random target NodeId
-pub fn generate_random_node_id(
-    target_bucket_idx: u8,
-    local_node_id: NodeId,
-) -> anyhow::Result<NodeId> {
+// TODO: We should be able to make this generic over a `Metric`.
+pub fn generate_random_node_id(target_bucket_idx: u8, local_node_id: NodeId) -> NodeId {
     let distance_leading_zeroes = 255 - target_bucket_idx;
     let random_distance = bytes::random_32byte_array(distance_leading_zeroes);
 
     let raw_node_id = XorMetric::distance(&local_node_id.raw(), &random_distance);
     let raw_node_id_be = u256_to_be_bytes(raw_node_id);
 
-    Ok(NodeId::new(&raw_node_id_be))
+    NodeId::new(&raw_node_id_be)
 }
 
 /// Returns the big-endian byte representation of a given `U256`.
@@ -62,7 +60,7 @@ mod test {
     fn test_generate_random_node_id_1() {
         let target_bucket_idx: u8 = 5;
         let local_node_id = NodeId::random();
-        let random_node_id = generate_random_node_id(target_bucket_idx, local_node_id).unwrap();
+        let random_node_id = generate_random_node_id(target_bucket_idx, local_node_id);
         let distance = XorMetric::distance(&random_node_id.raw(), &local_node_id.raw());
         let distance = u256_to_be_bytes(distance);
 
@@ -74,7 +72,7 @@ mod test {
     fn test_generate_random_node_id_2() {
         let target_bucket_idx: u8 = 0;
         let local_node_id = NodeId::random();
-        let random_node_id = generate_random_node_id(target_bucket_idx, local_node_id).unwrap();
+        let random_node_id = generate_random_node_id(target_bucket_idx, local_node_id);
         let distance = XorMetric::distance(&random_node_id.raw(), &local_node_id.raw());
         let distance = u256_to_be_bytes(distance);
 
@@ -86,7 +84,7 @@ mod test {
     fn test_generate_random_node_id_3() {
         let target_bucket_idx: u8 = 255;
         let local_node_id = NodeId::random();
-        let random_node_id = generate_random_node_id(target_bucket_idx, local_node_id).unwrap();
+        let random_node_id = generate_random_node_id(target_bucket_idx, local_node_id);
         let distance = XorMetric::distance(&random_node_id.raw(), &local_node_id.raw());
         let distance = u256_to_be_bytes(distance);
 


### PR DESCRIPTION
### What was wrong?

We unnecessarily wrap return type for random `NodeId` generation function in `Result`.

### How was it fixed?

Remove `Result` wrap from return type.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
