### PR TITLE
Consolidate metrics flags

### DIFF
--- a/newsfragments/292.added.md
+++ b/newsfragments/292.added.md
@@ -1,0 +1,1 @@
+Consolidates the `--enable_metrics`, `--metrics_url` CLI flags into a single flag, `--enable-metrics-with-url`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub async fn run_trin(
         private_key: trin_config.private_key.clone(),
         listen_port: trin_config.discovery_port,
         no_stun: trin_config.no_stun,
-        enable_metrics: trin_config.enable_metrics,
+        enable_metrics: trin_config.enable_metrics_with_url.is_some(),
         bootnode_enrs,
         ..Default::default()
     };
@@ -46,11 +46,10 @@ pub async fn run_trin(
     // Search for discv5 peers (bucket refresh lookup)
     tokio::spawn(Arc::clone(&discovery).bucket_refresh_lookup());
 
-    // Initialize metrics
-    if trin_config.enable_metrics {
-        let binding = trin_config.metrics_url.as_ref().unwrap().parse().unwrap();
-        prometheus_exporter::start(binding).unwrap();
-    };
+    // Initialize prometheus metrics
+    if let Some(addr) = trin_config.enable_metrics_with_url {
+        prometheus_exporter::start(addr).unwrap();
+    }
 
     // Initialize and spawn UTP listener
     let (utp_events_tx, utp_listener_tx, utp_listener_rx, mut utp_listener) =


### PR DESCRIPTION
### What was wrong?
This consolidates the metrics flags into a single flag, `--enable-metrics-with-url`, as described in issue #262.

### How was it fixed?
Fixes #262 
Removed the the `-enable-metrics` bool and `-metrics-url` string in favor of a single flag, `--enable-metrics-with-url`.  
`PortalnetConfig` and its downstream dependencies are left untouched because we can use a `is_some()` boolean to check if the flag is set (and use it if true).
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
