### PR TITLE
Properly serialize extra data bytes in header

### DIFF
--- a/newsfragments/293.fixed.md
+++ b/newsfragments/293.fixed.md
@@ -1,0 +1,1 @@
+Properly serialize 'extra_data' bytes field in Header type.

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -35,7 +35,7 @@ rocksdb = "0.16.0"
 rstest = "0.11.0"
 r2d2 = "0.8.9"
 r2d2_sqlite = "0.19.0"
-serde = {version = "1.0.125", features = ["derive"] }
+serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.59"
 serial_test = "0.5.1"
 sha2 = "0.10.1"
@@ -45,13 +45,13 @@ sha3 = "0.9.1"
 tempdir = "0.3.7"
 thiserror = "1.0.29"
 threadpool = "1.8.1"
-tokio = {version = "1.8.0", features = ["full"]}
+tokio = { version = "1.8.0", features = ["full"] }
 tokio-test = "0.4.2"
 tokio-util = "0.6.8"
 tracing = "0.1.26"
 tracing-futures = "0.2.5"
 uint = { version = "0.8.5", default-features = false }
-ureq = {version = "2.2.0", features = ["json"]}
+ureq = { version = "2.2.0", features = ["json"] }
 validator = { version = "0.13.0", features = ["derive"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/trin-core/src/types/header.rs
+++ b/trin-core/src/types/header.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use ethereum_types::{Bloom, H160, H256, U256};
 use rlp::{DecoderError, Encodable, Rlp, RlpStream};
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 /// An Ethereum address.
 type Address = H160;
@@ -36,6 +36,7 @@ pub struct Header {
     /// Block timestamp.
     pub timestamp: u64,
     /// Block extra data.
+    #[serde(serialize_with = "as_hex")]
     pub extra_data: Vec<u8>,
     /// Block PoW mix hash.
     pub mix_hash: Option<H256>,
@@ -43,6 +44,13 @@ pub struct Header {
     pub nonce: Option<u64>,
     /// Block base fee per gas. Introduced by EIP-1559.
     pub base_fee_per_gas: Option<U256>,
+}
+
+fn as_hex<S>(value: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(format!("0x{}", hex::encode(value)).as_str())
 }
 
 // Based on https://github.com/openethereum/openethereum/blob/main/crates/ethcore/types/src/header.rs


### PR DESCRIPTION
### What was wrong?
the old web3's decoded response to `eth_getBlockByHash`...
```
AttributeDict({'author': '0x2a65aca4d5fc5b5c859090a6c34d164135398226',
 'base_fee_per_gas': None,
 'difficulty': 7767604946080,
 'extra_data': [215,
  131,
  1,
  3,
  2,
  132,
  71,
  101,
  116,
  104,
  135,
  103,
  111,
  49,
  46,
  53,
  46,
  49,
  133,
  108,
  105,
  110,
  117,
  120],
 'gas_limit': '0x2fefd8',
 'gas_used': '0x5208',
 'log_bloom': '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
 'mix_hash': '0xc5e99c6e90fbdee5650ff9b6dd41198655872ba32f810de58acb193a954e1589',
 'nonce': HexBytes('0x40f1ce50d18d7fdc'),
 'number': 633130,
 'parent_hash': '0x6add1c183f1194eb132ca8079197c7f2bc43f644f96bf5ab00a93aa4be499360',
 'receipts_root': '0x59cf53b2f956a914b8360ea6fe271ebe7b10461c736eb16eb1a4121ba3abbb85',
 'state_root': '0x5ae233f6377f0671c612ec2a8bd15c20e428094f2fafc79bead9c55a989294dd',
 'timestamp': 1449116606,
 'transactions_root': '0x64183d9f805f4aecbf532de75e6ad276dc281ba90947ff706beeaecc14eec6f5',
 'uncles_hash': '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347'})
```
### How was it fixed?
the new response ....
```
AttributeDict({'author': '0x2a65aca4d5fc5b5c859090a6c34d164135398226',
 'base_fee_per_gas': None,
 'difficulty': 7767604946080,
 'extra_data': '0xd783010302844765746887676f312e352e31856c696e7578',
 'gas_limit': '0x2fefd8',
 'gas_used': '0x5208',
 'log_bloom': '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
 'mix_hash': '0xc5e99c6e90fbdee5650ff9b6dd41198655872ba32f810de58acb193a954e1589',
 'nonce': HexBytes('0x40f1ce50d18d7fdc'),
 'number': 633130,
 'parent_hash': '0x6add1c183f1194eb132ca8079197c7f2bc43f644f96bf5ab00a93aa4be499360',
 'receipts_root': '0x59cf53b2f956a914b8360ea6fe271ebe7b10461c736eb16eb1a4121ba3abbb85',
 'state_root': '0x5ae233f6377f0671c612ec2a8bd15c20e428094f2fafc79bead9c55a989294dd',
 'timestamp': 1449116606,
 'transactions_root': '0x64183d9f805f4aecbf532de75e6ad276dc281ba90947ff706beeaecc14eec6f5',
 'uncles_hash': '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347'})
```
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
