### PR TITLE
Fix data dir setup

### DIFF
--- a/newsfragments/294.fixed.md
+++ b/newsfragments/294.fixed.md
@@ -1,0 +1,1 @@
+Update data dir setup that was broken when using an environment variable to set the path.

--- a/trin-core/src/utils/db.rs
+++ b/trin-core/src/utils/db.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::{env, fs};
 
 use directories::ProjectDirs;
@@ -6,16 +7,8 @@ use discv5::enr::NodeId;
 const TRIN_DATA_ENV_VAR: &str = "TRIN_DATA_PATH";
 
 pub fn get_data_dir(node_id: NodeId) -> String {
-    let path = env::var(TRIN_DATA_ENV_VAR).unwrap_or_else(|_| get_default_data_dir(node_id));
-
-    fs::create_dir_all(&path).expect("Unable to create data directory folder");
-    path
-}
-
-pub fn get_default_data_dir(node_id: NodeId) -> String {
-    // Windows: C:\Users\Username\AppData\Roaming\Trin\data
-    // macOS: ~/Library/Application Support/Trin
-    // Unix-like: $HOME/.local/share/trin
+    let trin_data_dir = env::var(TRIN_DATA_ENV_VAR).unwrap_or_else(|_| get_default_data_dir());
+    let trin_data_dir = Path::new(&trin_data_dir);
 
     // Append first 8 characters of Node ID
     let mut application_string = "Trin_".to_owned();
@@ -23,7 +16,20 @@ pub fn get_default_data_dir(node_id: NodeId) -> String {
     let suffix = &node_id_string[..8];
     application_string.push_str(suffix);
 
-    match ProjectDirs::from("", "", &application_string) {
+    let node_id_data_dir = trin_data_dir
+        .join(application_string)
+        .to_str()
+        .unwrap()
+        .to_string();
+    fs::create_dir_all(&node_id_data_dir).expect("Unable to create data directory folder");
+    node_id_data_dir
+}
+
+pub fn get_default_data_dir() -> String {
+    // Windows: C:\Users\Username\AppData\Roaming\trin
+    // macOS: ~/Library/Application Support/trin
+    // Unix-like: $HOME/.local/share/trin
+    match ProjectDirs::from("", "", "trin") {
         Some(proj_dirs) => proj_dirs.data_local_dir().to_str().unwrap().to_string(),
         None => panic!("Unable to find data directory"),
     }


### PR DESCRIPTION
### What was wrong?
@hmrtn pointed out that using `TRIN_DATA_PATH` environment variable was broken.

### How was it fixed?
- Use `Path` to handle env var paths with & without a trailing slash (`./path/to/db` & `./path/to/db/`)
- Updates default data dir to namespace under `/trin`. Previously, all of the `trin_xxxxx` directories were just stored under the default data dir.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
