### PR TITLE
Reconfigure ethportal test structure

### DIFF
--- a/ethportal-peertest/src/lib.rs
+++ b/ethportal-peertest/src/lib.rs
@@ -18,6 +18,18 @@ pub struct PeertestNode {
     pub exiter: Arc<JsonRpcExiter>,
 }
 
+pub struct Peertest {
+    pub bootnode: PeertestNode,
+    pub nodes: Vec<PeertestNode>,
+}
+
+impl Peertest {
+    pub fn exit_all_nodes(&self) {
+        self.bootnode.exiter.exit();
+        self.nodes.iter().for_each(|node| node.exiter.exit());
+    }
+}
+
 pub async fn launch_node(id: u16, bootnode_enr: Option<&String>) -> anyhow::Result<PeertestNode> {
     let discovery_port: u16 = 9000 + id;
     let discovery_port: String = discovery_port.to_string();
@@ -52,7 +64,7 @@ pub async fn launch_node(id: u16, bootnode_enr: Option<&String>) -> anyhow::Resu
     Ok(PeertestNode { enr, exiter })
 }
 
-pub async fn launch_peertest_nodes(count: u16) -> (PeertestNode, Vec<PeertestNode>) {
+pub async fn launch_peertest_nodes(count: u16) -> Peertest {
     // Bootnode uses a peertest id of 1
     let bootnode = launch_node(1, None).await.unwrap();
     let bootnode_enr = bootnode.enr.to_base64();
@@ -64,5 +76,5 @@ pub async fn launch_peertest_nodes(count: u16) -> (PeertestNode, Vec<PeertestNod
     )
     .await
     .unwrap();
-    (bootnode, nodes)
+    Peertest { bootnode, nodes }
 }

--- a/ethportal-peertest/src/main.rs
+++ b/ethportal-peertest/src/main.rs
@@ -11,19 +11,15 @@ use ethportal_peertest::launch_peertest_nodes;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let (bootnode, peertest_nodes) = launch_peertest_nodes(2).await;
+    let peertest = launch_peertest_nodes(2).await;
     // Short sleep to make sure all peertest nodes can connect
     thread::sleep(time::Duration::from_secs(1));
 
     tokio::spawn(async move {
         let peertest_config = PeertestConfig::from_cli();
         match peertest_config.target_transport.as_str() {
-            "ipc" => {
-                test_jsonrpc_endpoints_over_ipc(peertest_config, bootnode.enr.to_base64()).await
-            }
-            "http" => {
-                test_jsonrpc_endpoints_over_http(peertest_config, bootnode.enr.to_base64()).await
-            }
+            "ipc" => test_jsonrpc_endpoints_over_ipc(peertest_config, &peertest).await,
+            "http" => test_jsonrpc_endpoints_over_http(peertest_config, &peertest).await,
             _ => panic!(
                 "Invalid target-transport provided: {:?}",
                 peertest_config.target_transport
@@ -32,8 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         info!("All tests passed successfully!");
 
-        bootnode.exiter.exit();
-        peertest_nodes.iter().for_each(|node| node.exiter.exit());
+        peertest.exit_all_nodes();
     })
     .await
     .unwrap();

--- a/newsfragments/295.fixed.md
+++ b/newsfragments/295.fixed.md
@@ -1,0 +1,1 @@
+Reconfigure ethportal-peertest testing structure to allow for multiple tests for a single jsonrpc endpoint.

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -9,7 +9,7 @@ mod test {
         tracing_subscriber::fmt::init();
 
         // Run a client, as a buddy peer for ping tests, etc.
-        let (bootnode, peertest_nodes) = peertest::launch_peertest_nodes(2).await;
+        let peertest = peertest::launch_peertest_nodes(2).await;
         // Short sleep to make sure all peertest nodes can connect
         thread::sleep(time::Duration::from_secs(1));
 
@@ -28,14 +28,9 @@ mod test {
         .unwrap();
         let test_client_exiter = trin::run_trin(trin_config, String::new()).await.unwrap();
 
-        peertest::jsonrpc::test_jsonrpc_endpoints_over_ipc(
-            peertest_config,
-            bootnode.enr.to_base64(),
-        )
-        .await;
+        peertest::jsonrpc::test_jsonrpc_endpoints_over_ipc(peertest_config, &peertest).await;
 
-        bootnode.exiter.exit();
-        peertest_nodes.iter().for_each(|node| node.exiter.exit());
+        peertest.exit_all_nodes();
         test_client_exiter.exit();
     }
 }


### PR DESCRIPTION
### What was wrong?
`ethportal-peertest` had a big flaw, you could only run one test per jsonrpc endpoint. This is not ideal, since we'll want to run multiple tests for various functionality against a single endpoint.

### How was it fixed?
Reconfigured the test architecture to allow for multiple tests against a single endpoint. Furthermore, included some refactoring that will later allow us to introduce more complex tests (eg, a single test composed of multiple jsonrpc requests - which will be useful in testing content, iterative find nodes, and iterative find content...). It's not fully implemented here, but all the "validation functions" will need to perform these tests is whether to use `make_ipc_request` or `make_http_request` (aka, access to the `portalnet_config`) and then they can encapsulate any logic needed to perform and validate subsequent jsonrpc requests for the test.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
