### PR TITLE
Update README and getting started docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Trin is a Rust implementation of a [Portal Network](https://github.com/ethereum/portal-network-specs) client.
 
-The Portal Network is still in the research phase, so understand that this client is experimental.
+The Portal Network is still in the research phase, and this client is experimental.
+
+**Do not rely on Trin in a production setting.**
 
 ## How to use Trin
 
@@ -14,11 +16,12 @@ Trin is a prototype Portal Network client. This implementation and the Portal Ne
 
 In this stage of development, Trin relies on Infura to respond to some requests that it cannot fulfill itself. Additionally, Trin lacks comprehensive data validation.
 
-Do not rely on Trin in a production setting.
-
 ## Want to help?
 
 Want to file a bug, contribute some code, or improve documentation? Excellent! Read up on our
 guidelines for [contributing](/docs/contributing.md),
 then check out issues that are labeled
 [Good First Issue](https://github.com/ethereum/trin/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
+
+Join our [Discord](https://discord.gg/pWVEESXB) to participate in the conversation!
+

--- a/README.md
+++ b/README.md
@@ -1,72 +1,20 @@
 # Trin
-Trin is an Ethereum "portal": a json-rpc server with nearly instant sync, and
-low CPU & storage usage.
 
-Trin does this by making these tradeoffs:
-- Trusts miners to include valid state transitions, to skip sync
-- Shards state across a (new) p2p network, to reduce local storage needs
+Trin is a Rust implementation of a [Portal Network](https://github.com/ethereum/portal-network-specs) client.
 
-This should sound similar to a light client. It is, but with a peer-to-peer
-philosophy rather than the LES client/server model, which has introduced
-challenges in an altruistic environment.
-
-## Repository Structure
-
-The portal protocol is a collection of networks. Trin needs to connect to all of them.
-
-The repository is structured as follows:
-
-- `trin/`: The main entry point to run a holistic Ethereum portal client
-- `trin-history/`: The chain history network
-- `trin-state/`: The state network
-
-## Ready for production?
-
-LOL, not even a little bit. At the last readme update, this was simply a proxy
-to Infura for all inbound requests, and doesn't validate any answers against
-state roots.
-
-Trin will proxy at least *some* requests to Infura for quite a while, but the
-plan is to incrementally reduce the reliance on Infura, as more trin
-functionality becomes available.
+The Portal Network is still in the research phase, so understand that this client is experimental.
 
 ## How to use Trin
 
-Checkout out the [Getting Started](/docs/getting_started.md) guide to quickly get up and running with Trin.
+Check out the [Getting Started](/docs/getting_started.md) guide to quickly get up and running with Trin.
 
-## CLI Options
-```sh
-trin 0.0.1
-carver
-Run an eth portal client
+## Experimental Status
 
-USAGE:
-    trin [OPTIONS]
+Trin is a prototype Portal Network client. This implementation and the Portal Network specificiation will continue to co-evolve.
 
-FLAGS:
-        --enable-metrics    Enable prometheus metrics reporting (requires --metrics-url)
-    -h, --help              Prints help information
-        --internal-ip       (For testing purposes) Use local ip address rather than external via STUN.
-    -V, --version           Prints version information
+In this stage of development, Trin relies on Infura to respond to some requests that it cannot fulfill itself. Additionally, Trin lacks comprehensive data validation.
 
-OPTIONS:
-        --bootnodes <bootnodes>               One or more comma-delimited base64-encoded ENR's or multiaddr strings of
-                                              peers to initially add to the local routing table [default: ]
-        --discovery-port <discovery_port>     The UDP port to listen on. [default: 9000]
-        --external-address <external_addr>    The public IP address and port under which this node is accessible
-        --kb <kb>                             Maximum number of kilobytes of total data to store in the DB
-                                              [default: 100000]
-        --metrics-url <metrics-url>           URL for prometheus server
-        --networks <networks>...              Comma-separated list of which portal subnetworks to activate
-                                              [default: history,state]
-        --pool-size <pool_size>               max size of threadpool [default: 2]
-        --unsafe-private-key <private_key>    Hex encoded 32 byte private key (considered unsafe to pass in pk as cli
-                                              arg, as it's stored in terminal history - keyfile support coming soon)
-        --web3-http-address <web3-http-address>    address to accept json-rpc http connections [default: 127.0.0.1:8545]
-        --web3-ipc-path <web3_ipc_path>       path to json-rpc endpoint over IPC [default: /tmp/trin-jsonrpc.ipc]
-        --web3-transport <web3_transport>     select transport protocol to serve json-rpc endpoint [default: ipc]
-                                              [possible values: http, ipc]
-```
+Do not rely on Trin in a production setting.
 
 ## Want to help?
 
@@ -74,9 +22,3 @@ Want to file a bug, contribute some code, or improve documentation? Excellent! R
 guidelines for [contributing](/docs/contributing.md),
 then check out issues that are labeled
 [Good First Issue](https://github.com/ethereum/trin/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
-
-## Gotchas
-
-- There is a limit on concurrent connections given by the threadpool. At last
-  doc update, that number was 2, but will surely change. If you leave
-  connections open, then new connections will block.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,7 +12,7 @@
 
 Note: If you use a VPN, you should disable it before running Trin.
 
-Install dependencies:
+Install dependencies (Ubuntu/Debian):
 
 ```sh
 apt install libssl-dev librocksdb-dev libclang-dev 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -46,7 +46,7 @@ cargo build -p trin-core
 cargo test -p trin-core
 
 # Run
-cargo run -p trin
+cargo run
 ```
 
 Note: You may also pass environment variable values in the same command as the run command. This is especially useful for setting log levels.
@@ -75,10 +75,12 @@ cargo run -p trin -- --bootnodes <bootnode-enr>
 ## Default data directories
 
 - Linux/Unix: `$HOME/.local/share/trin`
-- MacOS: `~/Library/Application Support/Trin`
-- Windows: `C:\Users\Username\AppData\Roaming\Trin\data`
+- MacOS: `~/Library/Application Support/trin`
+- Windows: `C:\Users\Username\AppData\Roaming\trin`
 
 ## Using Trin
+
+In some of the following sections, we make use of the [web3.py](https://github.com/ethereum/web3.py/) library.
 
 ### Connect over IPC
 
@@ -127,6 +129,8 @@ nc -U /tmp/trin-jsonrpc.ipc
 {"jsonrpc":"2.0","id":86,"params":[],"method":"discv5_nodeInfo"}
 {"id":86,"jsonrpc":"2.0","result":"enr:-IS4QHK_CnCsQKT-mFTilJ5msHacIJtU91aYe8FhAd_K7G-ACO-FO2GPFOyM7kiphjXMwrNh8Y4mSbN3ufSdBQFzjikBgmlkgnY0gmlwhMCoAMKJc2VjcDI1NmsxoQNa58x56RRRcUeOegry5S4yQvLa6LKlDcbBPHL4H5Oy4oN1ZHCCIyg"}
 ```
+
+For something in between, you may use `curl` to send requests to the HTTP JSON-RPC endpoint.
 
 ## Using Trin-CLI
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,51 +1,89 @@
 # Getting Started
 
-#### Trin is currently in unstable alpha, and should not be used in production. If you run into any bugs while using Trin, please file an Issue!
-#### Check out the [Release Notes](/docs/release_notes.md) to see the latest supported features.
+**Trin is currently in unstable alpha, and should not be used in production. If you run into any bugs while using Trin, please file an Issue!**
 
-# Pre-requisites
-- You will need an [Infura](https://infura.io/) ID to use Trin.
-- You will need [Rust](https://www.rust-lang.org/) installed on your machine.
+**Check out the [Release Notes](/docs/release_notes.md) to see the latest supported features.**
 
-# Via Source
+## Prerequisites
+- [Infura](https://infura.io/) project ID
+- [Rust](https://www.rust-lang.org/) installation
 
-### Install dependencies (on Ubuntu/Debian)
+## Building, Testing, and Running
+
+Note: If you use a VPN, you should disable it before running Trin.
+
+Install dependencies:
 
 ```sh
 apt install libssl-dev librocksdb-dev libclang-dev 
 ```
 
+Environment variables:
+
+```sh
+# Required 
+export TRIN_INFURA_PROJECT_ID=<infura-project-id>
+
+# Optional 
+export RUST_LOG=<error/warn/info/debug/trace>
+export TRIN_DATA_PATH=<path-to-data-directory>
+```
+
+Build, test, and run:
+
 ```sh
 git clone https://github.com/ethereum/trin.git
 cd trin
-export TRIN_INFURA_PROJECT_ID=yourinfurakey
+
+# Build
+cargo build --workspace
+
+# Run test suite
+cargo test --workspace
+
+# Build and run test suite for an individual crate
+cargo build -p trin-core
+cargo test -p trin-core
+
+# Run
+cargo run -p trin
+```
+
+Note: You may also pass environment variable values in the same command as the run command. This is especially useful for setting log levels.
+
+```sh
 RUST_LOG=debug cargo run -p trin
 ```
 
-(Trin might take a couple of minutes to compile the first time you launch it.)
+View CLI options:
 
-If you use a VPN, you should turn it off before starting a Trin process.
-
-You should now see logs from Trin as it boots up and connects to the Portal Network
-
-To run individual networks:
 ```sh
-cargo run -p trin-state|trin-history
+cargo run -p trin -- --help
 ```
 
-**Optional:** Custom data directory
-```shell
-TRIN_DATA_PATH="/your_path"
-```
-*Note, default data paths are:*\
-Linux/Unix - `$HOME/.local/share/trin`\
-MacOS - `~/Library/Application Support/Trin`\
-Windows - `C:\Users\Username\AppData\Roaming\Trin\data`
+### Connect to the Portal Network testnet
 
-# Using Trin
+To establish a connection with a peer, pass in one or more bootnode ENRs.
+
+Here, we connect to one of the designated Portal Network testnet bootnodes. Find a [testnet bootnode ENR](https://github.com/ethereum/portal-network-specs/blob/master/testnet.md). 
+Pass the ENR as the value for the `--bootnodes` CLI flag.
+
+```sh
+cargo run -p trin -- --bootnodes <bootnode-enr> 
+```
+
+## Default data directories
+
+- Linux/Unix: `$HOME/.local/share/trin`
+- MacOS: `~/Library/Application Support/Trin`
+- Windows: `C:\Users\Username\AppData\Roaming\Trin\data`
+
+## Using Trin
 
 ### Connect over IPC
+
 In a python shell:
+
 ```py
 >>> from web3 import Web3
 >>> w3 = Web3(Web3.IPCProvider("/tmp/trin-jsonrpc.ipc"))
@@ -58,12 +96,15 @@ In a python shell:
 See the [wiki](https://eth.wiki/json-rpc/API#json-rpc-methods) for other standard methods that are implemented. You can use the [web3.py](https://web3py.readthedocs.io/en/stable/web3.eth.html#module-web3.eth) API to access these. Note that currently most of them proxy to Infura rather than requesting the data from the Portal Network.
 
 ### Connect over HTTP
+
 First launch trin using HTTP as the json-rpc transport protocol:
+
 ```sh
-TRIN_INFURA_PROJECT_ID="YoUr-Id-HeRe" cargo run -- --web3-transport http
+cargo run -- --web3-transport http
 ```
 
 Then, in a python shell:
+
 ```py
 >>> from web3 import Web3
 >>> w3 = Web3(Web3.HTTPProvider("http://127.0.0.1:8545"))
@@ -76,6 +117,7 @@ Then, in a python shell:
 The client version responds immediately, from the trin client. The block number is retrieved more slowly, by proxying to Infura.
 
 To interact with trin at the lowest possible level, try netcat:
+
 ```sh
 nc -U /tmp/trin-jsonrpc.ipc
 {"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":83}
@@ -86,63 +128,68 @@ nc -U /tmp/trin-jsonrpc.ipc
 {"id":86,"jsonrpc":"2.0","result":"enr:-IS4QHK_CnCsQKT-mFTilJ5msHacIJtU91aYe8FhAd_K7G-ACO-FO2GPFOyM7kiphjXMwrNh8Y4mSbN3ufSdBQFzjikBgmlkgnY0gmlwhMCoAMKJc2VjcDI1NmsxoQNa58x56RRRcUeOegry5S4yQvLa6LKlDcbBPHL4H5Oy4oN1ZHCCIyg"}
 ```
 
-# Using Trin-CLI
-Trin needs to connect to a bootnode to join the Portal network. There are a couple of ways to do this. You can use the `--bootnodes` CLI flag to pass in bootnode ENR's, or you can send a message to a bootnode using JSON-RPC, automatically adding the bootnode to your routing table.
+## Using Trin-CLI
 
-We can use Trin-CLI to initiate sending a message from our Trin client to another.
+A more detailed description of `trin-cli` is available [here](../trin-cli/README.md).
+
+We can use Trin-CLI to initiate sending a message from one Trin client to another.
 
 ### Trin-CLI Environment
+
 - Open a new terminal window and make sure you're in the same directory where Trin is installed.
-- Don't forget to set the Infura environment variable: `export TRIN_INFURA_PROJECT_ID=yourinfurakey`
+- Make sure that you've set the required environment variables.
 
 ### View routing table
+
 Each Trin client uses a routing table to maintain a record of members in the Portal network with whom it can communicate. At startup, your routing table should be empty (unless you've passed in the bootnode ENR's via the `--bootnodes` CLI param).
 
-To view your routing table...
-```sh
-$ cargo run -p trin-cli -- discv5_routingTableInfo
-```
-
-To view ENR information about your own Trin client.
-```sh
-$ cargo run -p trin-cli -- discv5_nodeInfo
-```
-
-### Interacting with the Portal Network
-
-##### Bootnode ENRs & Available Content Keys
-```
-- ENR: `enr:-IS4QB8hN50UDNFqwqF-9vzvqW0cYf2UuvIBAR1j47szLEnBE7L3TM85iVB3gppDTWPY8waLgvwko3wsl-P7lKaXsloBgmlkgnY0gmlwhKEjVaWJc2VjcDI1NmsxoQOSGugH1jSdiE_fRK1FIBe9oLxaWH8D_7xXSnaOVBe-SYN1ZHCCIyg`
-	- Content Key: `0001007a7d6975af1290a5110dc660872c23d4894d44f21a37ec92c1973b2127da47ed`
-- ENR: `enr:-IS4QOQ-e1fLwD31xh3hcYYdc7mvsFKwgD6KSjuvr2lO2gSmE1fYp109TwjepDY55y7basyVMDM8ZyIyyoBg-Tfe790BgmlkgnY0gmlwhM69ZOyJc2VjcDI1NmsxoQLaI-m2CDIjpwcnUf1ESspvOctJLpIrLA8AZ4zbo_1bFIN1ZHCCIyg`
-	- Content Key: `000100e2f81ab2f7a0aaa6c5cee61a82d176a2344603f8cf8569e135e1ee98667f0bc3`
-- ENR: `enr:-IS4QGqW_aBPPvEyyrw9E1XpqHmBp3If6D2GkQIokd01OuVPcyWAjKfEY7DP4y3ZAU7exCEgtJNp8TCj9ZLAtA4K1MsBgmlkgnY0gmlwhJ_fCDaJc2VjcDI1NmsxoQN9rahqamBOJfj4u6yssJQJ1-EZoyAw-7HIgp1FwNUdnoN1ZHCCIyg`
-	- Content Key: `000100373ea34c8e7b3c43aece207f3ece4ef6b0749e2ab3e62a38b746609f9e3b11dd`
-```
-
-### Ping a bootnode
-Send a `PING` to another node on any of the Portal Networks (currently, only history and state are supported in Trin).
+View your routing table:
 
 ```sh
-$ cargo run -p trin-cli -- portal_historyPing --params enr:....
+cargo run -p trin-cli -- discv5_routingTableInfo
 ```
 
-After pinging a bootnode, you should be able to see the messages being sent and received in your node's logs. Now you can check your routing table again, where you should see the pinged bootnode (along with other nodes the bootnode shared with you). Congrats! You're now connected to the Portal network.
+View ENR information about your own Trin client:
+
+```sh
+cargo run -p trin-cli -- discv5_nodeInfo
+```
+
+### Connect to the Portal Network testnet
+
+You can send a message from the local node to a bootnode using JSON-RPC, automatically adding the bootnode to your routing table.
+
+Find a [testnet bootnode ENR](https://github.com/ethereum/portal-network-specs/blob/master/testnet.md). 
+
+Send a `PING` to the node on any of the Portal sub-networks (currently, only history and state are supported in Trin).
+
+```sh
+cargo run -p trin-cli -- portal_historyPing --params <bootnode-enr> 
+```
+
+After pinging a bootnode, you should be able to see the messages being sent and received in your node's logs. Now you can check your routing table again, where you should see the pinged bootnode (along with other nodes the bootnode shared with you). Congrats! You're now connected to the Portal Network testnet.
 
 ### Request Content
+
 Send a `FindContent` message to a Portal Network bootnode.
 
 ```sh
-$ cargo run -p trin-cli -- portal_historyFindContent --params enr:....,0001...
+cargo run -p trin-cli -- portal_historyFindContent --params <bootnode-enr>,<content-key>
 ```
 
 ### Setting up local metrics reporting
 
-1 - Install [Grafana & Prometheus](https://grafana.com/docs/grafana/latest/getting-started/getting-started-prometheus/)
-2 - Configure your Prometheus server to target an open port to where `prometheus_exporter` will export Trin metrics.
-3 - Start your Trin process with `--enable-metrics --metrics-url 127.0.0.1:9100` as flags
+1. Install [Grafana & Prometheus](https://grafana.com/docs/grafana/latest/getting-started/getting-started-prometheus/)
+2. Configure your Prometheus server to target an open port to where `prometheus_exporter` will export Trin metrics.
+3. Start your Trin process with `--enable-metrics --metrics-url 127.0.0.1:9100` as flags
 	- The `--metrics-url` parameter is the address for `prometheus_exporter` to export metrics to, and should be equal to the port to which your Prometheus server is targeting.
-4 - Navigate to the URL on which Grafana is running in your browser (probably `localhost:3000`) and login.
-5 - Add your Prometheus server as a Data Source, using the URL on which your Prometheus server is running.
-6 - Use the "Import" dashboard feature in Grafana to create your Trin dashboard, and copy and paste `metrics_dashboard.json` as the template.
-7 - You should now be able to see live metrics reporting for your Trin node.
+4. Navigate to the URL on which Grafana is running in your browser (probably `localhost:3000`) and login.
+5. Add your Prometheus server as a Data Source, using the URL on which your Prometheus server is running.
+6. Use the "Import" dashboard feature in Grafana to create your Trin dashboard, and copy and paste `metrics_dashboard.json` as the template.
+7. You should now be able to see live metrics reporting for your Trin node.
+
+## Gotchas
+
+- There is a limit on concurrent connections given by the threadpool. At last
+  doc update, that number was 2, but will surely change. If you leave
+  connections open, then new connections will block.


### PR DESCRIPTION
### What was wrong?

The README and getting started docs could use some revisions.

### How was it fixed?

- Trim down the README.
- Clean up formatting.
- Add more comments on commands.
- Remove CLI option section in favor of command to display CLI options.
- Remove boot node list in favor of link to portal network specs boot node list.
- Move "gotchas" from README to getting started.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
