### PR TITLE
Add utp-testing crate to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY ./trin-history ./trin-history
 COPY ./trin-state ./trin-state 
 COPY ./ethportal-peertest ./ethportal-peertest 
 COPY ./mainnetMM ./mainnetMM 
+COPY ./utp-testing ./utp-testing 
 
 # build for release
 RUN cargo build --all --release


### PR DESCRIPTION
### What was wrong?
`utp-testing` crate wasn't added to Dockerfile, so compilation failed.

### How was it fixed?
Added `utp-testing` crate to Dockerfile

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
