### PR TITLE
Handle received uTP data stream in FindContent/Content

### DIFF
--- a/newsfragments/288.fixed.md
+++ b/newsfragments/288.fixed.md
@@ -1,0 +1,1 @@
+Wait for the uTP socket to receive the data stream to end and return it.

--- a/trin-core/src/utp/stream.rs
+++ b/trin-core/src/utp/stream.rs
@@ -273,16 +273,12 @@ impl UtpListener {
                 debug!("Received data: with len: {}", received_stream.len());
 
                 match self.listening.get(&conn.receiver_connection_id) {
-                    Some(message_type) => match message_type {
-                        UtpMessageId::AcceptStream(content_keys) => {
+                    Some(message_type) => {
+                        if let UtpMessageId::AcceptStream(content_keys) = message_type {
                             // TODO: Implement this with overlay store and decode receiver stream if multiple content values are send
                             debug!("Store {content_keys:?}, {received_stream:?}");
                         }
-                        UtpMessageId::FindContentData(_content) => {
-                            // TODO: Process Content data received via uTP stream
-                        }
-                        _ => {}
-                    },
+                    }
                     _ => warn!("uTP listening HashMap doesn't have uTP stream message type"),
                 }
                 utp_connections.remove(conn_key);


### PR DESCRIPTION
### What was wrong?
Fixes https://github.com/ethereum/trin/issues/288
### How was it fixed?
Wait for the uTP socket to receive the data stream to end and return it.

Before:
```j
{"jsonrpc":"2.0","id":86,"params":["enr:-IS4QDhGlinG83cF82q_1xr-QFwovgP_xOrMsOLCxagon4dJCCk3uixRepA-V_tehSb2ys5qaHKD2Vj4CkuMtUK-LQYBgmlkgnY0gmlwhMCoZD2Jc2VjcDI1NmsxoQIUBbeSac7_fnelMhiV6Bs22eRlEwPCuQn67TyEEhVV74N1ZHCCIzE", "000f00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"],"method":"portal_historyFindContent"}

{"id":86,"jsonrpc":"2.0","result":{"connection_id":50305}}
```

Now:

``` j
{"jsonrpc":"2.0","id":86,"params":["enr:-IS4QDhGlinG83cF82q_1xr-QFwovgP_xOrMsOLCxagon4dJCCk3uixRepA-V_tehSb2ys5qaHKD2Vj4CkuMtUK-LQYBgmlkgnY0gmlwhMCoZD2Jc2VjcDI1NmsxoQIUBbeSac7_fnelMhiV6Bs22eRlEwPCuQn67TyEEhVV74N1ZHCCIzE", "000f00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"],"method":"portal_historyFindContent"}

{"id":86,"jsonrpc":"2.0","result":{"content":"0000021df9021af90215a05b4d24387325216ea951874a80a5659b152a02513fd5806ba6f98b0ea631e918a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942a65aca4d5fc5b5c859090a6c34d164135398226a09a0dfdb71c2688e5c1e822e69914abfd83e51c352dab5359ec70cfccb6b1d93aa056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000860a9c1834b95f830f2b3f832fefd8808456be2eb398d783010303844765746887676f312e352e31856c696e7578a098977429260804c1f1efa4817a55afc8b2ed9f9a8bf62058b173e8993372ea2688fc33fb995aa6994ac0c00000021df9021af90215a05b4d24387325216ea951874a80a5659b152a02513fd5806ba6f98b0ea631e918a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942a65aca4d5fc5b5c859090a6c34d164135398226a09a0dfdb71c2688e5c1e822e69914abfd83e51c352dab5359ec70cfccb6b1d93aa056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000860a9c1834b95f830f2b3f832fefd8808456be2eb398d783010303844765746887676f312e352e31856c696e7578a098977429260804c1f1efa4817a55afc8b2ed9f9a8bf62058b173e8993372ea2688fc33fb995aa6994ac0c00000021df9021af90215a05b4d24387325216ea951874a80a5659b152a02513fd5806ba6f98b0ea631e918a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942a65aca4d5fc5b5c859090a6c34d164135398226a09a0dfdb71c2688e5c1e822e69914abfd83e51c352dab5359ec70cfccb6b1d93aa056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000860a9c1834b95f830f2b3f832fefd8808456be2eb398d783010303844765746887676f312e352e31856c696e7578a098977429260804c1f1efa4817a55afc8b2ed9f9a8bf62058b173e8993372ea2688fc33fb995aa6994ac0c00000021df9021af90215a05b4d24387325216ea951874a80a5659b152a02513fd5806ba6f98b0ea631e918a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942a65aca4d5fc5b5c859090a6c34d164135398226a09a0dfdb71c2688e5c1e822e69914abfd83e51c352dab5359ec70cfccb6b1d93aa056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b90100"}}
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
