### PR TITLE
Add overlay layer <-> uTP listener communication channel instead of locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,6 +3735,7 @@ checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 name = "utp-testing"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "discv5",
  "hex",
  "log 0.4.14",

--- a/newsfragments/304.changed.md
+++ b/newsfragments/304.changed.md
@@ -1,0 +1,2 @@
+Change portal overlay to uTP listener communication to use channel instead of locks.
+This change brings performance boost and reduces the number of log warnings about locks held.

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -369,7 +369,7 @@ impl<TContentKey: OverlayContentKey + Send, TMetric: Metric + Send>
         }
 
         self.utp_listener
-            .write()
+            .write_with_warn()
             .await
             .listening
             .insert(connection_id, UtpMessageId::OfferStream);
@@ -377,7 +377,7 @@ impl<TContentKey: OverlayContentKey + Send, TMetric: Metric + Send>
         // initiate the connection to the acceptor
         let mut conn = self
             .utp_listener
-            .write()
+            .write_with_warn()
             .await
             .connect(connection_id, enr.node_id())
             .await?;

--- a/trin-core/tests/overlay.rs
+++ b/trin-core/tests/overlay.rs
@@ -14,15 +14,15 @@ use trin_core::{
         },
         Enr,
     },
-    utp::stream::UtpListener,
 };
 
 use discv5::Discv5Event;
 use ethereum_types::U256;
 use parking_lot::RwLock;
 use tokio::sync::mpsc;
-use tokio::sync::RwLock as RwLockT;
+use tokio::sync::mpsc::unbounded_channel;
 use tokio::time::{self, Duration};
+use trin_core::utp::stream::UtpListenerRequest;
 
 async fn init_overlay(
     discovery: Arc<Discovery>,
@@ -35,12 +35,13 @@ async fn init_overlay(
     .unwrap();
     let db = Arc::new(RwLock::new(PortalStorage::new(storage_config).unwrap()));
     let overlay_config = OverlayConfig::default();
-    let utp_listener = Arc::new(RwLockT::new(UtpListener::new(Arc::clone(&discovery))));
+    // Ignore all uTP events
+    let (utp_listener_tx, _) = unbounded_channel::<UtpListenerRequest>();
 
     OverlayProtocol::new(
         overlay_config,
         discovery,
-        utp_listener,
+        utp_listener_tx,
         db,
         U256::MAX,
         protocol,

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -3,7 +3,7 @@ mod jsonrpc;
 pub mod network;
 
 use log::info;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 use crate::events::HistoryEvents;
@@ -11,15 +11,15 @@ use crate::jsonrpc::HistoryRequestHandler;
 use discv5::TalkRequest;
 use network::HistoryNetwork;
 use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedSender;
 use trin_core::cli::TrinConfig;
 use trin_core::jsonrpc::types::HistoryJsonRpcRequest;
-use trin_core::locks::RwLoggingExt;
 use trin_core::portalnet::discovery::Discovery;
 use trin_core::portalnet::events::PortalnetEvents;
 use trin_core::portalnet::storage::{PortalStorage, PortalStorageConfig};
 use trin_core::portalnet::types::messages::PortalnetConfig;
 use trin_core::utils::bootnodes::parse_bootnodes;
-use trin_core::utp::stream::UtpListener;
+use trin_core::utp::stream::{UtpListener, UtpListenerRequest};
 
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Launching trin-history...");
@@ -49,20 +49,11 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::spawn(Arc::clone(&discovery).bucket_refresh_lookup());
 
     // Initialize and spawn UTP listener
-    let (utp_sender, utp_listener) = UtpListener::new(Arc::clone(&discovery));
-    let utp_listener = Arc::new(RwLock::new(utp_listener));
-    let utp_listener_clone = Arc::clone(&utp_listener);
-    tokio::spawn(async move {
-        utp_listener_clone
-            .write_with_warn()
-            .await
-            .process_utp_request()
-            .await
-    });
+    let (utp_sender, overlay_sender, mut utp_listener) = UtpListener::new(Arc::clone(&discovery));
+    tokio::spawn(async move { utp_listener.start().await });
 
     let (history_event_tx, history_event_rx) = mpsc::unbounded_channel::<TalkRequest>();
     let portal_events_discovery = Arc::clone(&discovery);
-    let portal_events_utp_listener = Arc::clone(&utp_listener);
 
     // Initialize DB config
     let storage_config =
@@ -72,7 +63,6 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::spawn(async move {
         let events = PortalnetEvents::new(
             portal_events_discovery,
-            portal_events_utp_listener,
             Some(history_event_tx),
             None,
             utp_sender,
@@ -83,7 +73,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let history_network = HistoryNetwork::new(
         discovery.clone(),
-        utp_listener.clone(),
+        overlay_sender,
         storage_config,
         portalnet_config.clone(),
     )
@@ -103,7 +93,7 @@ type HistoryJsonRpcTx = Option<mpsc::UnboundedSender<HistoryJsonRpcRequest>>;
 
 pub async fn initialize_history_network(
     discovery: &Arc<Discovery>,
-    utp_listener: &Arc<RwLock<UtpListener>>,
+    utp_listener_tx: UnboundedSender<UtpListenerRequest>,
     portalnet_config: PortalnetConfig,
     storage_config: PortalStorageConfig,
 ) -> (
@@ -117,7 +107,7 @@ pub async fn initialize_history_network(
     let (history_event_tx, history_event_rx) = mpsc::unbounded_channel::<TalkRequest>();
     let history_network = HistoryNetwork::new(
         Arc::clone(discovery),
-        Arc::clone(utp_listener),
+        utp_listener_tx,
         storage_config,
         portalnet_config.clone(),
     )

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -3,7 +3,7 @@ use log::debug;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
-use tokio::sync::RwLock as RwLockT;
+use tokio::sync::mpsc::UnboundedSender;
 
 use trin_core::portalnet::{
     discovery::Discovery,
@@ -15,7 +15,7 @@ use trin_core::portalnet::{
         metric::XorMetric,
     },
 };
-use trin_core::utp::stream::UtpListener;
+use trin_core::utp::stream::UtpListenerRequest;
 
 /// History network layer on top of the overlay protocol. Encapsulates history network specific data and logic.
 #[derive(Clone)]
@@ -26,7 +26,7 @@ pub struct HistoryNetwork {
 impl HistoryNetwork {
     pub async fn new(
         discovery: Arc<Discovery>,
-        utp_listener: Arc<RwLockT<UtpListener>>,
+        utp_listener_tx: UnboundedSender<UtpListenerRequest>,
         storage_config: PortalStorageConfig,
         portal_config: PortalnetConfig,
     ) -> Self {
@@ -39,7 +39,7 @@ impl HistoryNetwork {
         let overlay = OverlayProtocol::new(
             config,
             discovery,
-            utp_listener,
+            utp_listener_tx,
             storage,
             portal_config.data_radius,
             ProtocolId::History,

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -9,6 +9,7 @@ use discv5::TalkRequest;
 use network::StateNetwork;
 use trin_core::cli::TrinConfig;
 use trin_core::jsonrpc::types::StateJsonRpcRequest;
+use trin_core::locks::RwLoggingExt;
 use trin_core::portalnet::discovery::Discovery;
 use trin_core::portalnet::events::PortalnetEvents;
 use trin_core::portalnet::storage::{PortalStorage, PortalStorageConfig};
@@ -45,7 +46,17 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Search for discv5 peers (bucket refresh lookup)
     tokio::spawn(Arc::clone(&discovery).bucket_refresh_lookup());
 
-    let utp_listener = Arc::new(RwLock::new(UtpListener::new(Arc::clone(&discovery))));
+    // Initialize and spawn UTP listener
+    let (utp_sender, utp_listener) = UtpListener::new(Arc::clone(&discovery));
+    let utp_listener = Arc::new(RwLock::new(utp_listener));
+    let utp_listener_clone = Arc::clone(&utp_listener);
+    tokio::spawn(async move {
+        utp_listener_clone
+            .write_with_warn()
+            .await
+            .process_utp_request()
+            .await
+    });
 
     let (state_event_tx, state_event_rx) = mpsc::unbounded_channel::<TalkRequest>();
     let portal_events_discovery = Arc::clone(&discovery);
@@ -62,6 +73,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             portal_events_utp_listener,
             None,
             Some(state_event_tx),
+            utp_sender,
         )
         .await;
         events.process_discv5_requests().await;

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -5,8 +5,7 @@ use discv5::enr::NodeId;
 use eth_trie::EthTrie;
 use log::debug;
 use parking_lot::RwLock;
-use tokio::sync::RwLock as RwLockT;
-
+use tokio::sync::mpsc::UnboundedSender;
 use trin_core::portalnet::{
     discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol, OverlayRequestError},
@@ -17,7 +16,7 @@ use trin_core::portalnet::{
         metric::XorMetric,
     },
 };
-use trin_core::utp::stream::UtpListener;
+use trin_core::utp::stream::UtpListenerRequest;
 
 use crate::trie::TrieDB;
 
@@ -31,7 +30,7 @@ pub struct StateNetwork {
 impl StateNetwork {
     pub async fn new(
         discovery: Arc<Discovery>,
-        utp_listener: Arc<RwLockT<UtpListener>>,
+        utp_listener_tx: UnboundedSender<UtpListenerRequest>,
         storage_config: PortalStorageConfig,
         portal_config: PortalnetConfig,
     ) -> Self {
@@ -49,7 +48,7 @@ impl StateNetwork {
         let overlay = OverlayProtocol::new(
             config,
             discovery,
-            utp_listener,
+            utp_listener_tx,
             storage,
             portal_config.data_radius,
             ProtocolId::State,

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.52"
 tracing = "0.1.26"
 tracing-subscriber = "0.2.18"
 trin-core = { path = "../trin-core" }

--- a/utp-testing/src/main.rs
+++ b/utp-testing/src/main.rs
@@ -3,34 +3,30 @@ use log::debug;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::RwLock;
-use trin_core::locks::RwLoggingExt;
 use trin_core::portalnet::discovery::Discovery;
 use trin_core::portalnet::types::messages::{PortalnetConfig, ProtocolId};
 use trin_core::portalnet::Enr;
-use trin_core::utp::stream::UtpListener;
-use trin_core::utp::trin_helpers::{UtpMessage, UtpMessageId};
+use trin_core::utp::stream::{UtpListener, UtpListenerRequest, UtpSocket};
+use trin_core::utp::trin_helpers::UtpMessage;
 
 pub struct TestApp {
-    utp_listener: Arc<RwLock<UtpListener>>,
-    utp_sender: UnboundedSender<TalkRequest>,
+    discovery: Arc<Discovery>,
+    utp_listener_tx: UnboundedSender<UtpListenerRequest>,
+    utp_event_tx: UnboundedSender<TalkRequest>,
 }
 
 impl TestApp {
-    async fn send_utp_request(&mut self, connection_id: u16, payload: Vec<u8>, enr: Enr) {
-        self.utp_listener
-            .write()
-            .await
-            .listening
-            .insert(connection_id, UtpMessageId::OfferStream);
+    async fn send_utp_request(&mut self, conn_id: u16, payload: Vec<u8>, enr: Enr) {
+        let _ = self
+            .utp_listener_tx
+            .send(UtpListenerRequest::OfferStream(conn_id));
 
-        let mut conn = self
-            .utp_listener
-            .write()
-            .await
-            .connect(connection_id, enr.node_id())
-            .await
-            .unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel::<anyhow::Result<UtpSocket>>();
+        let _ = self
+            .utp_listener_tx
+            .send(UtpListenerRequest::Connect(conn_id, enr.node_id(), tx));
+
+        let mut conn = rx.await.unwrap().unwrap();
 
         let mut buf = [0; 1500];
         conn.recv(&mut buf).await.unwrap();
@@ -46,31 +42,13 @@ impl TestApp {
     }
 
     async fn process_utp_request(&self) {
-        let mut event_stream = self
-            .utp_listener
-            .read_with_warn()
-            .await
-            .discovery
-            .discv5
-            .event_stream()
-            .await
-            .unwrap();
+        let mut event_stream = self.discovery.discv5.event_stream().await.unwrap();
 
-        let listener = Arc::clone(&self.utp_listener);
-        let listener_clone = Arc::clone(&listener);
-        tokio::spawn(async move {
-            listener_clone
-                .write_with_warn()
-                .await
-                .process_utp_request()
-                .await
-        });
-
-        let utp_sender = self.utp_sender.clone();
+        let utp_sender = self.utp_event_tx.clone();
 
         tokio::spawn(async move {
             while let Some(event) = event_stream.recv().await {
-                debug!("event: {event:?}");
+                debug!("utp-testing TestApp handling event: {event:?}");
                 let request = match event {
                     Discv5Event::TalkRequest(r) => r,
                     _ => continue,
@@ -81,26 +59,22 @@ impl TestApp {
 
                 if let ProtocolId::Utp = protocol_id {
                     utp_sender.send(request).unwrap();
-                    // listener.write().await.process_utp_byte_stream().await;
                 };
             }
         });
     }
 
-    async fn prepare_to_receive(&self, connection_id: u16) {
+    async fn prepare_to_receive(&self, conn_id: u16) {
         // listen for incoming connection request on conn_id, as part of utp handshake
-        self.utp_listener
-            .write()
-            .await
-            .listening
-            .insert(connection_id, UtpMessageId::OfferStream);
+        let _ = self
+            .utp_listener_tx
+            .send(UtpListenerRequest::OfferStream(conn_id));
 
         // also listen on conn_id + 1 because this is the actual receive path for acceptor
-        self.utp_listener
-            .write()
-            .await
-            .listening
-            .insert(connection_id + 1, UtpMessageId::OfferStream);
+        let conn_id_recv = conn_id.wrapping_add(1);
+        let _ = self
+            .utp_listener_tx
+            .send(UtpListenerRequest::OfferStream(conn_id_recv));
     }
 }
 
@@ -114,15 +88,12 @@ async fn main() {
     let server_port = 9003;
     let server = run_test_app(server_port).await;
 
-    let server_enr = server.utp_listener.write().await.discovery.local_enr();
+    let server_enr = server.discovery.local_enr();
 
     let connection_id = 66;
     let payload = vec![6; 2000];
 
     client
-        .utp_listener
-        .write_with_warn()
-        .await
         .discovery
         .send_talk_req(server_enr.clone(), ProtocolId::History, vec![])
         .await
@@ -148,12 +119,16 @@ async fn run_test_app(discv5_port: u16) -> TestApp {
 
     let mut discovery = Discovery::new(config).unwrap();
     discovery.start().await.unwrap();
+    let discovery = Arc::new(discovery);
 
-    let (utp_sender, utp_listener) = UtpListener::new(Arc::new(discovery));
+    let (utp_event_sender, utp_listener_tx, mut utp_listener) =
+        UtpListener::new(Arc::clone(&discovery));
+    tokio::spawn(async move { utp_listener.start().await });
 
     let test_app = TestApp {
-        utp_listener: Arc::new(RwLock::new(utp_listener)),
-        utp_sender,
+        discovery,
+        utp_listener_tx,
+        utp_event_tx: utp_event_sender,
     };
 
     test_app.process_utp_request().await;


### PR DESCRIPTION
### What was wrong?

The portal overlay layer communicates with uTP listener with locks which causes some of the locks to wait for too long.

FIxes https://github.com/ethereum/trin/issues/302

### How was it fixed?
- Implement  Overlay <-> uTP listener communication via a channel and remove the locks.
- `UtpListener` now runs as a self-contained service in the background and waits for requests from the overlay layer.

Those changes bring a performance boost and reduce the number of log warnings about locks held.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
