### PR TITLE
Add jsonrpc api docs.

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -63,10 +63,13 @@ cargo run -- --help
 
 ### Connect to the Portal Network testnet
 
-To establish a connection with a peer, pass in one or more bootnode ENRs.
+To immediately connect to the testnet, you can use the `--bootnodes default` argument to automatically connect with the default Trin bootnodes.
 
-Here, we connect to one of the designated Portal Network testnet bootnodes. Find a [testnet bootnode ENR](https://github.com/ethereum/portal-network-specs/blob/master/testnet.md). 
-Pass the ENR as the value for the `--bootnodes` CLI flag.
+```sh
+cargo run -- --bootnodes default
+```
+
+To establish a connection with a specific peer, pass in one or more bootnode ENRs. Pass the ENR as the value for the `--bootnodes` CLI flag.
 
 ```sh
 cargo run -- --bootnodes <bootnode-enr> 
@@ -104,7 +107,7 @@ To request a custom jsonrpc endpoint, provide the endpoint and array of params. 
   'dataRadius': '115792089237316195423570985008687907853269984665640564039457584007913129639935'}}
 ```
 
-See the [wiki](https://eth.wiki/json-rpc/API#json-rpc-methods) for other standard methods that are implemented. You can use the [web3.py](https://web3py.readthedocs.io/en/stable/web3.eth.html#module-web3.eth) API to access these. Note that currently most of them proxy to Infura rather than requesting the data from the Portal Network.
+See the [JSON-RPC API docs](/docs/jsonrpc_api.md) for other standard methods that are implemented. You can use the [web3.py](https://web3py.readthedocs.io/en/stable/web3.eth.html#module-web3.eth) API to access these.
 
 ### Connect over HTTP
 

--- a/docs/jsonrpc_api.md
+++ b/docs/jsonrpc_api.md
@@ -1,0 +1,154 @@
+# JSON-RPC API
+
+This is a document for all JSON-RPC API endpoints currently supported by Trin. Trin plans to eventually support the entire [Portal Network JSON-RPC API](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/portal-network-specs/assembled-spec/jsonrpc/openrpc.json&uiSchema%5BappBar%5D%5Bui:splitView%5D=false&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false) and [Ethereum JSON-RPC API](https://eth.wiki/json-rpc/API#json-rpc-methods).
+
+## Currently supported endpoints
+
+### Portal Network
+The specification for these endpoints can be found [here](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/portal-network-specs/assembled-spec/jsonrpc/openrpc.json&uiSchema%5BappBar%5D%5Bui:splitView%5D=false&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false).
+
+- `discv5_nodeInfo`
+- `discv5_routingTableInfo`
+- `portal_historyFindContent`
+- `portal_stateFindContent`
+- `portal_historyFindNodes`
+- `portal_stateFindNodes`
+- `portal_historyOffer`
+- `portal_stateOffer`
+- `portal_historyStore`
+- `portal_stateStore`
+- `portal_historyPing`
+- `portal_statePing`
+
+### Ethereum endpoints
+The specification for these endpoints can be found [here](https://eth.wiki/json-rpc/API#json-rpc-methods).
+
+- [`eth_blockNumber`](https://eth.wiki/json-rpc/API#eth_blocknumber)
+	- This endpoint is currently proxied to Infura, and not served by the Portal Network.
+- [`eth_getBlockByHash`](https://eth.wiki/json-rpc/API#eth_getblockbyhash)
+	- This endpoint relies on fetching block headers from the Portal Network, so all blocks may not be available until the Portal Network stabilizes.
+- [`eth_getBlockByNumber`](https://eth.wiki/json-rpc/API#eth_getblockbynumber)
+	- This endpoint relies on the master accumulator to lookup the block hash. Since the master accumulator was frozen at the merge block, only pre-merge blocks are currently supported.
+- [`web3_clientVersion`](https://eth.wiki/json-rpc/API#web3_clientversion)
+
+### Custom Trin JSON-RPC endpoints
+- [`portal_historyRadius`](#portal_historyRadius)
+- [`portal_stateRadius`](#portal_stateRadius)
+- [`portal_historyLocalContent`](#portal_historyLocalContent) 
+- [`portal_stateLocalContent`](#portal_stateLocalContent)
+- [`portal_historyRecursiveFindContent`](#portal_historyRecursiveFindContent)
+
+# History Overlay Network
+
+## `portal_historyRadius`
+Returns the current data storage radius being used for the History network.
+
+### Parameters
+`None`
+
+### Returns
+- Data storage radius.
+
+#### Example
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": "18446744073709551615"
+}
+```
+
+## `portal_historyLocalContent`
+Attempts to look up content key in Trin node's local db.
+
+### Parameters
+- `content_key`: Target content key.
+
+### Returns
+- Hex-encoded content value.
+
+#### Example
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+	  "content": "0xf90217a06add1c183f1194eb132ca8079197c7f2bc43f644f96bf5ab00a93aa4be499360a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942a65aca4d5fc5b5c859090a6c34d164135398226a05ae233f6377f0671c612ec2a8bd15c20e428094f2fafc79bead9c55a989294dda064183d9f805f4aecbf532de75e6ad276dc281ba90947ff706beeaecc14eec6f5a059cf53b2f956a914b8360ea6fe271ebe7b10461c736eb16eb1a4121ba3abbb85b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000860710895564a08309a92a832fefd882520884565fc3be98d783010302844765746887676f312e352e31856c696e7578a0c5e99c6e90fbdee5650ff9b6dd41198655872ba32f810de58acb193a954e15898840f1ce50d18d7fdc"
+  }
+}
+```
+
+## `portal_historyRecursiveFindContent`
+This method is for development purposes and unstable. It's not fully recursive, but will perform a single lookup in the Trin client's routing table to find a peer close to the content key, and then request the content value from the found peer. 
+
+### Parameters
+- `content_key`: Target block header content key.
+
+### Returns
+- Block header
+
+#### Example
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+    "author": "0x2a65aca4d5fc5b5c859090a6c34d164135398226",
+    "base_fee_per_gas": null,
+    "difficulty": "0x710895564a0",
+    "extra_data": "0xd783010302844765746887676f312e352e31856c696e7578",
+    "gas_limit": "0x2fefd8",
+    "gas_used": "0x5208",
+    "log_bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "mix_hash": "0xc5e99c6e90fbdee5650ff9b6dd41198655872ba32f810de58acb193a954e1589",
+    "nonce": 4679748334323072988,
+    "number": 633130,
+    "parent_hash": "0x6add1c183f1194eb132ca8079197c7f2bc43f644f96bf5ab00a93aa4be499360",
+    "receipts_root": "0x59cf53b2f956a914b8360ea6fe271ebe7b10461c736eb16eb1a4121ba3abbb85",
+    "state_root": "0x5ae233f6377f0671c612ec2a8bd15c20e428094f2fafc79bead9c55a989294dd",
+    "timestamp": 1449116606,
+    "transactions_root": "0x64183d9f805f4aecbf532de75e6ad276dc281ba90947ff706beeaecc14eec6f5",
+    "uncles_hash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+  }
+}
+```
+
+# State Overlay Network
+
+## `portal_stateRadius`
+Returns the current data storage radius being used for the State network.
+
+### Parameters
+`None`
+
+### Returns
+- Data storage radius.
+
+#### Example
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": "18446744073709551615"
+}
+```
+
+## `portal_stateLocalContent`
+Attempts to look up content key in Trin node's local db.
+
+### Parameters
+- `content_key`: Target content key.
+
+### Returns
+- Hex-encoded content value.
+
+#### Example
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+	  "content": "0x0217a06ebc43f644f96bf5ab00a93aa4be499360a01dcc4de8dec75d0a142fd40d49347942a65aca4d5fc5b5c859090a6c34d164135398226a05ae233f6377f0671c612ec2a8bd15c20e428094f2fafc79bead9c55a989294dda064183d9f805f4aecbf532de75e6ad276dc281ba90947ff706beeaecc14eec6f5a059cf53b2f956a914b8360ea6fe271ebe7b10461c736eb16eb1a4121ba3abbb85b90110895564a08309a92a832fefd882520884565fc3be98d783010302844765746887676f312e352e31856c696e7578a0c5e99c6e90fbdee5650ff9b6dd41198655872ba32f810de58acb193a954e15898840f1ce50d18d7fdc"
+  }
+}
+```

--- a/newsfragments/307.doc.md
+++ b/newsfragments/307.doc.md
@@ -1,0 +1,1 @@
+Add docs for currently supported json rpc endpoints.

--- a/trin-cli/README.md
+++ b/trin-cli/README.md
@@ -3,7 +3,7 @@
 A little utility for running JSON-RPC commands against trin nodes.
 
 ```sh
-$ cargo run -p trin-cli -- discv5_routingTableInfo
+$ cargo run -p trin-cli -- json-rpc discv5_routingTableInfo
 Attempting RPC. endpoint=discv5_routingTableInfo file=/tmp/trin-jsonrpc.ipc
 {
   "id": 0,
@@ -17,13 +17,13 @@ Attempting RPC. endpoint=discv5_routingTableInfo file=/tmp/trin-jsonrpc.ipc
 
 ### To send a parameter, use the `--params` flag. To use multiple parameters, enter them as a comma-separated string.
 ```sh
-$ cargo run -p trin-cli -- portal_statePing --params enr:....
+$ cargo run -p trin-cli -- json-rpc portal_statePing --params enr:....
 ```
 
 ### If you have multiple nodes running you can manually select which one you communicate with:
 
 ```sh
-$ cargo run -p trin-cli -- discv5_routingTableInfo --ipc /tmp/trin-jsonrpc-2.ipc
+$ cargo run -p trin-cli -- json-rpc discv5_routingTableInfo --ipc /tmp/trin-jsonrpc-2.ipc
 ```
 
 ### To use trin-cli to encode content keys:

--- a/trin-core/src/jsonrpc/endpoints.rs
+++ b/trin-core/src/jsonrpc/endpoints.rs
@@ -52,6 +52,9 @@ pub enum PortalEndpoint {
 }
 
 /// Global portal network endpoints supported by trin, including trusted providers, Discv5, Ethereum and all overlay network endpoints supported by portal network requests
+// When adding a json-rpc endpoint, make sure to...
+// - Update `docs/jsonrpc_api.md`
+// - Add tests to ethportal-peertest
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum TrinEndpoint {
     Discv5Endpoint(Discv5Endpoint),

--- a/trin-core/src/portalnet/discovery.rs
+++ b/trin-core/src/portalnet/discovery.rs
@@ -3,6 +3,7 @@ use super::{
     Enr,
 };
 use crate::socket;
+use crate::utils::bytes::hex_encode;
 
 use discv5::{
     enr::{CombinedKey, EnrBuilder, NodeId},
@@ -195,7 +196,7 @@ impl Discovery {
     pub fn node_info(&self) -> Value {
         json!({
             "enr":  self.discv5.local_enr().to_base64(),
-            "nodeId":  self.discv5.local_enr().node_id().to_string(),
+            "nodeId":  hex_encode(self.discv5.local_enr().node_id().raw()),
             "ip":  self.discv5.local_enr().ip4().map_or("None".to_owned(), |ip| ip.to_string())
         })
     }
@@ -208,7 +209,7 @@ impl Discovery {
             .iter()
             .map(|(node_id, enr, node_status)| {
                 (
-                    node_id.to_string(),
+                    hex_encode(node_id.raw()),
                     enr.to_base64(),
                     format!("{:?}", node_status.state),
                 )
@@ -217,7 +218,7 @@ impl Discovery {
 
         json!(
             {
-                "localKey": self.discv5.local_enr().node_id().to_string(),
+                "localKey": hex_encode(self.discv5.local_enr().node_id().raw()),
                 "buckets": buckets
             }
         )

--- a/trin-core/src/portalnet/types/messages.rs
+++ b/trin-core/src/portalnet/types/messages.rs
@@ -21,6 +21,7 @@ use crate::portalnet::{
     types::{content_key::RawContentKey, distance::Distance},
     Enr,
 };
+use crate::utils::bytes::hex_encode;
 
 pub type ByteList = VariableList<u8, typenum::U2048>;
 
@@ -510,7 +511,9 @@ impl TryInto<Value> for Content {
         if let Content::ConnectionId(val) = self {
             Ok(serde_json::json!({ "connection_id": val }))
         } else if let Content::Content(val) = self {
-            Ok(serde_json::json!({"content": hex::encode(val.to_vec())}))
+            Ok(serde_json::json!({
+                "content": hex_encode(val.to_vec())
+            }))
         } else if let Content::Enrs(val) = self {
             Ok(serde_json::json!({ "enrs": format!("{:?}", val) }))
         } else {


### PR DESCRIPTION
### What was wrong?
It seemed to me like it's a good idea to have a resource for currently supported jsonrpc endpoints. We don't fully support the whole ETH spec - or the whole Portal spec. We also currently use a couple custom endpoints that aren't found in either spec. 

Updated return values....
- node ids to be full node ids rather than `0x1234..abcd`
- Hex values to have a `0x` prefix.

### How was it fixed?
Wrote docs

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
