### PR TITLE
Leave IP out of ENR by default

### DIFF
--- a/ethportal-peertest/README.md
+++ b/ethportal-peertest/README.md
@@ -6,7 +6,7 @@ Run a portal network node that you want to test and pass the node's IPC path to 
 
 To start, launch trin:
 ```sh
-RUST_LOG=debug TRIN_INFURA_PROJECT_ID=0 cargo run -p trin -- --internal-ip --web3-ipc-path /tmp/ethportal-peertest-target.ipc
+RUST_LOG=debug TRIN_INFURA_PROJECT_ID=0 cargo run -p trin -- --no-stun --web3-ipc-path /tmp/ethportal-peertest-target.ipc
 ```
 
 Finally, launch the peertester:
@@ -19,7 +19,7 @@ Note that the `--web3-ipc-path` and `--target-ipc-path` flags in trin and peerte
 # Target Node Config
 
 ## IP Address
-The test harness will spawn at least one node, using an internal IP. In order to support devp2p communication between the nodes, launch your target node with `--internal-ip` also.
+The test harness will spawn at least one node, using an internal IP. In order to support devp2p communication between the nodes, launch your target node with `--no-stun` also.
 
 ## Transport selection
 Running the test harness will by default test all jsonrpc endpoints over IPC to the target node. To make sure these pass, please make sure that the target node is running with `--web3-transport ipc`. To test jsonrpc over http, use the `--target-transport http` cli argument for the harness, and make sure the target node is running with `--web3-transport http`. Ideally, both transport methods are tested before PRs.

--- a/newsfragments/286.fixed.md
+++ b/newsfragments/286.fixed.md
@@ -1,0 +1,3 @@
+Use an explicit IP address for nodes during testing, to fix some tests that were flaky failing when
+run on machines with multiple valid local IP addresses (like an ethernet and wifi endpoint). Example
+flaky tests: `test_response_to_triple_ack` and `overlay`.

--- a/newsfragments/309.added.md
+++ b/newsfragments/309.added.md
@@ -1,0 +1,4 @@
+- Added ip output to `discv5_nodeInfo`
+- Switched CLI arg from `--internal-ip` to `--no-stun` (Since we now *never* set an internal IP in
+  the ENR)
+- Renamed `internal_address` to `enr_address` in some code to clarify how the IP was used.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub async fn run_trin(
         external_addr: trin_config.external_addr,
         private_key: trin_config.private_key.clone(),
         listen_port: trin_config.discovery_port,
-        internal_ip: trin_config.internal_ip,
+        no_stun: trin_config.no_stun,
         enable_metrics: trin_config.enable_metrics,
         bootnode_enrs,
         ..Default::default()

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -19,7 +19,7 @@ mod test {
         let trin_config = TrinConfig::new_from(
             [
                 "trin",
-                "--internal-ip",
+                "--no-stun",
                 "--web3-ipc-path",
                 &peertest_config.target_ipc_path,
             ]

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -73,10 +73,10 @@ pub struct TrinConfig {
     pub external_addr: Option<SocketAddr>,
 
     #[structopt(
-        long = "internal-ip",
-        help = "(For testing purposes) Use local ip address rather than external via STUN."
+        long = "no-stun",
+        help = "Do not use STUN to determine an external IP. Leaves ENR entry for IP blank. Some users report better connections over VPN."
     )]
-    pub internal_ip: bool,
+    pub no_stun: bool,
 
     #[structopt(
         validator(check_private_key_length),
@@ -188,7 +188,7 @@ mod test {
             kb: DEFAULT_STORAGE_CAPACITY.parse().unwrap(),
             web3_transport: "ipc".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
-            internal_ip: false,
+            no_stun: false,
             bootnodes: vec![],
             external_addr: None,
             private_key: None,
@@ -221,7 +221,7 @@ mod test {
             pool_size: 3,
             web3_transport: "http".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
-            internal_ip: false,
+            no_stun: false,
             bootnodes: vec![],
             enable_metrics: false,
             metrics_url: None,
@@ -265,7 +265,7 @@ mod test {
             pool_size: 2,
             web3_transport: "ipc".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
-            internal_ip: false,
+            no_stun: false,
             bootnodes: vec![],
             enable_metrics: false,
             metrics_url: None,
@@ -305,7 +305,7 @@ mod test {
             pool_size: 2,
             web3_transport: "ipc".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
-            internal_ip: false,
+            no_stun: false,
             bootnodes: vec![],
             enable_metrics: false,
             metrics_url: None,
@@ -369,7 +369,7 @@ mod test {
             kb: DEFAULT_STORAGE_CAPACITY.parse().unwrap(),
             web3_transport: "ipc".to_string(),
             discovery_port: 999,
-            internal_ip: false,
+            no_stun: false,
             bootnodes: vec![],
             enable_metrics: false,
             metrics_url: None,
@@ -395,7 +395,7 @@ mod test {
             kb: DEFAULT_STORAGE_CAPACITY.parse().unwrap(),
             web3_transport: "ipc".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
-            internal_ip: false,
+            no_stun: false,
             bootnodes: vec!["enr:-aoeu".to_string(), "enr:-htns".to_string()],
             enable_metrics: false,
             metrics_url: None,
@@ -443,7 +443,7 @@ mod test {
             kb: DEFAULT_STORAGE_CAPACITY.parse().unwrap(),
             web3_transport: "ipc".to_string(),
             discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
-            internal_ip: false,
+            no_stun: false,
             bootnodes: vec![],
             enable_metrics: false,
             metrics_url: None,

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -68,12 +68,14 @@ pub struct TrinConfig {
 
     #[structopt(
         long = "external-address",
+        group = "external-ips",
         help = "(Only use this if you are behind a NAT) The address which will be advertised to peers (in an ENR). Changing it does not change which port or address trin binds to. Port number is required, ex: 127.0.0.1:9001"
     )]
     pub external_addr: Option<SocketAddr>,
 
     #[structopt(
         long = "no-stun",
+        group = "external-ips",
         help = "Do not use STUN to determine an external IP. Leaves ENR entry for IP blank. Some users report better connections over VPN."
     )]
     pub no_stun: bool,

--- a/trin-core/src/portalnet/discovery.rs
+++ b/trin-core/src/portalnet/discovery.rs
@@ -53,7 +53,7 @@ impl Discovery {
     pub fn new(portal_config: PortalnetConfig) -> Result<Self, String> {
         let listen_all_ips = SocketAddr::new("0.0.0.0".parse().unwrap(), portal_config.listen_port);
 
-        let (ip_addr, ip_port) = if portal_config.internal_ip {
+        let (ip_addr, ip_port) = if portal_config.no_stun {
             (None, portal_config.listen_port)
         } else {
             let known_external = portal_config

--- a/trin-core/src/portalnet/discovery.rs
+++ b/trin-core/src/portalnet/discovery.rs
@@ -20,7 +20,7 @@ const EXPECTED_NON_EMPTY_BUCKETS: usize = 17;
 
 #[derive(Clone)]
 pub struct Config {
-    pub listen_address: Option<IpAddr>,
+    pub enr_address: Option<IpAddr>,
     pub listen_port: u16,
     pub discv5_config: Discv5Config,
     pub bootnode_enrs: Vec<Enr>,
@@ -30,7 +30,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            listen_address: None,
+            enr_address: None,
             listen_port: 4242,
             discv5_config: Discv5Config::default(),
             bootnode_enrs: vec![],
@@ -69,7 +69,7 @@ impl Discovery {
         let config = Config {
             discv5_config: Discv5ConfigBuilder::default().build(),
             // This is for defining the ENR:
-            listen_address: ip_addr,
+            enr_address: ip_addr,
             listen_port: ip_port,
             bootnode_enrs: portal_config.bootnode_enrs,
             private_key: portal_config.private_key,
@@ -83,7 +83,7 @@ impl Discovery {
 
         let enr = {
             let mut builder = EnrBuilder::new("v4");
-            if let Some(ip_address) = config.listen_address {
+            if let Some(ip_address) = config.enr_address {
                 builder.ip(ip_address);
             }
             builder.udp(config.listen_port);

--- a/trin-core/src/portalnet/discovery.rs
+++ b/trin-core/src/portalnet/discovery.rs
@@ -131,7 +131,8 @@ impl Discovery {
     pub fn node_info(&self) -> Value {
         json!({
             "enr":  self.discv5.local_enr().to_base64(),
-            "nodeId":  self.discv5.local_enr().node_id().to_string()
+            "nodeId":  self.discv5.local_enr().node_id().to_string(),
+            "ip":  self.discv5.local_enr().ip().map_or("None".to_owned(), |ip| ip.to_string())
         })
     }
 

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -1246,7 +1246,7 @@ mod tests {
 
     fn build_service() -> OverlayService<IdentityContentKey, XorMetric> {
         let portal_config = PortalnetConfig {
-            internal_ip: true,
+            no_stun: true,
             ..Default::default()
         };
         let discovery = Arc::new(Discovery::new(portal_config).unwrap());

--- a/trin-core/src/portalnet/types/messages.rs
+++ b/trin-core/src/portalnet/types/messages.rs
@@ -113,7 +113,7 @@ pub struct PortalnetConfig {
     pub listen_port: u16,
     pub bootnode_enrs: Vec<Enr>,
     pub data_radius: U256,
-    pub internal_ip: bool,
+    pub no_stun: bool,
     pub enable_metrics: bool,
 }
 
@@ -125,7 +125,7 @@ impl Default for PortalnetConfig {
             listen_port: 4242,
             bootnode_enrs: Vec::<Enr>::new(),
             data_radius: U256::from(u64::MAX), //TODO better data_radius default?
-            internal_ip: false,
+            no_stun: false,
             enable_metrics: false,
         }
     }

--- a/trin-core/src/socket.rs
+++ b/trin-core/src/socket.rs
@@ -1,5 +1,5 @@
 use log::{debug, info};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
+use std::net::{IpAddr, SocketAddr, UdpSocket};
 
 #[cfg(unix)]
 use interfaces::{self, Interface};
@@ -32,13 +32,8 @@ pub fn stun_for_external(local_socket_addr: &SocketAddr) -> Option<SocketAddr> {
     }
 }
 
-pub fn default_local_address(port: u16) -> SocketAddr {
-    let ip = find_assigned_ip().unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST));
-    SocketAddr::new(ip, port)
-}
-
 #[cfg(unix)]
-fn find_assigned_ip() -> Option<IpAddr> {
+pub fn find_assigned_ip() -> Option<IpAddr> {
     let online_nics = Interface::get_all()
         .unwrap_or_default()
         .into_iter()
@@ -60,7 +55,7 @@ fn find_assigned_ip() -> Option<IpAddr> {
 }
 
 #[cfg(windows)]
-fn find_assigned_ip() -> Option<IpAddr> {
+pub fn find_assigned_ip() -> Option<IpAddr> {
     let adapters = ipconfig::get_adapters().unwrap_or_default();
 
     for adapter in adapters.iter() {

--- a/trin-core/tests/overlay.rs
+++ b/trin-core/tests/overlay.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -14,6 +15,7 @@ use trin_core::{
         },
         Enr,
     },
+    socket,
 };
 
 use discv5::Discv5Event;
@@ -104,11 +106,12 @@ async fn spawn_overlay(
 async fn overlay() {
     let protocol = ProtocolId::History;
     let sleep_duration = Duration::from_millis(5);
+    let ip_addr = socket::find_assigned_ip().expect("Could not find an IP for local connections");
 
     // Node one.
     let portal_config_one = PortalnetConfig {
         listen_port: 8001,
-        internal_ip: true,
+        external_addr: Some(SocketAddr::new(ip_addr, 8001)),
         ..PortalnetConfig::default()
     };
     let mut discovery_one = Discovery::new(portal_config_one).unwrap();
@@ -121,7 +124,7 @@ async fn overlay() {
     // Node two.
     let portal_config_two = PortalnetConfig {
         listen_port: 8002,
-        internal_ip: true,
+        external_addr: Some(SocketAddr::new(ip_addr, 8002)),
         ..PortalnetConfig::default()
     };
     let mut discovery_two = Discovery::new(portal_config_two).unwrap();
@@ -134,7 +137,7 @@ async fn overlay() {
     // Node three.
     let portal_config_three = PortalnetConfig {
         listen_port: 8003,
-        internal_ip: true,
+        external_addr: Some(SocketAddr::new(ip_addr, 8003)),
         ..PortalnetConfig::default()
     };
     let mut discovery_three = Discovery::new(portal_config_three).unwrap();

--- a/utp-testing/src/main.rs
+++ b/utp-testing/src/main.rs
@@ -113,7 +113,7 @@ async fn main() {
 async fn run_test_app(discv5_port: u16) -> TestApp {
     let config = PortalnetConfig {
         listen_port: discv5_port,
-        internal_ip: true,
+        no_stun: true,
         ..Default::default()
     };
 


### PR DESCRIPTION
An alternative fix #286

This fits with the discv5 validation, which hangs up on clients
immediately if the ENR IP does not match the observed IP.

Also, had to update a couple tests to configure local IPs so they can
contact each other. (The internal IP feature randomly chose a local
IP, which caused the discv5 validation to reject the local connections)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
