### PR TITLE
Merge imports from the same crate into a single use statement

### DIFF
--- a/ethportal-peertest/src/cli.rs
+++ b/ethportal-peertest/src/cli.rs
@@ -1,8 +1,9 @@
-use std::env;
-use std::ffi::OsString;
+use std::{env, ffi::OsString};
 use structopt::StructOpt;
-use trin_core::cli::DEFAULT_WEB3_HTTP_ADDRESS as DEFAULT_TARGET_HTTP_ADDRESS;
-use trin_core::cli::DEFAULT_WEB3_IPC_PATH as DEFAULT_TARGET_IPC_PATH;
+use trin_core::cli::{
+    DEFAULT_WEB3_HTTP_ADDRESS as DEFAULT_TARGET_HTTP_ADDRESS,
+    DEFAULT_WEB3_IPC_PATH as DEFAULT_TARGET_IPC_PATH,
+};
 
 const DEFAULT_LISTEN_PORT: &str = "9876";
 

--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -1,21 +1,20 @@
-use std::io::prelude::*;
 #[cfg(unix)]
 use std::os::unix;
-use std::panic;
-use std::time::Duration;
+use std::{io::prelude::*, panic, time::Duration};
 
 use anyhow::anyhow;
 use hyper::{self, Body, Client, Method, Request};
 use log::info;
 use serde_json::{self, json, Value};
 
-use crate::cli::PeertestConfig;
-use crate::Peertest;
-use trin_core::jsonrpc::types::{NodesParams, Params};
-use trin_core::portalnet::types::content_key::{
-    AccountTrieNode, BlockHeader, HistoryContentKey, StateContentKey,
+use crate::{cli::PeertestConfig, Peertest};
+use trin_core::{
+    jsonrpc::types::{NodesParams, Params},
+    portalnet::types::{
+        content_key::{AccountTrieNode, BlockHeader, HistoryContentKey, StateContentKey},
+        messages::SszEnr,
+    },
 };
-use trin_core::portalnet::types::messages::SszEnr;
 
 /// Default data radius value: U256::from(u64::MAX)
 const DATA_RADIUS: &str = "18446744073709551615";

--- a/ethportal-peertest/src/lib.rs
+++ b/ethportal-peertest/src/lib.rs
@@ -4,15 +4,13 @@ pub mod jsonrpc;
 pub use cli::PeertestConfig;
 pub use jsonrpc::get_enode;
 
-use std::sync::Arc;
-use std::{thread, time};
+use std::{sync::Arc, thread, time};
 
 use futures::future;
 
-use trin_core::cli::TrinConfig;
-use trin_core::jsonrpc::service::JsonRpcExiter;
-use trin_core::portalnet::types::messages::SszEnr;
-use trin_core::socket;
+use trin_core::{
+    cli::TrinConfig, jsonrpc::service::JsonRpcExiter, portalnet::types::messages::SszEnr, socket,
+};
 
 pub struct PeertestNode {
     pub enr: SszEnr,

--- a/ethportal-peertest/src/main.rs
+++ b/ethportal-peertest/src/main.rs
@@ -1,11 +1,11 @@
 use log::info;
 use std::{thread, time};
 
-use ethportal_peertest::cli::PeertestConfig;
-use ethportal_peertest::jsonrpc::{
-    test_jsonrpc_endpoints_over_http, test_jsonrpc_endpoints_over_ipc,
+use ethportal_peertest::{
+    cli::PeertestConfig,
+    jsonrpc::{test_jsonrpc_endpoints_over_http, test_jsonrpc_endpoints_over_ipc},
+    launch_peertest_nodes,
 };
-use ethportal_peertest::launch_peertest_nodes;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/bin/seed-database.rs
+++ b/src/bin/seed-database.rs
@@ -1,8 +1,4 @@
-use std::fs;
-use std::fs::File;
-use std::io::BufReader;
-use std::path::Path;
-use std::process::Command;
+use std::{fs, fs::File, io::BufReader, path::Path, process::Command};
 
 use discv5::enr::{CombinedKey, EnrBuilder};
 use log::debug;
@@ -11,12 +7,14 @@ use rlp::{Decodable, DecoderError};
 use serde_json::Value;
 use structopt::StructOpt;
 
-use trin_core::portalnet::storage::PortalStorage;
-use trin_core::portalnet::types::content_key::{
-    BlockHeader, HistoryContentKey, IdentityContentKey,
+use trin_core::{
+    portalnet::{
+        storage::PortalStorage,
+        types::content_key::{BlockHeader, HistoryContentKey, IdentityContentKey},
+    },
+    types::header::Header,
+    utils::db::get_data_dir,
 };
-use trin_core::types::header::Header;
-use trin_core::utils::db::get_data_dir;
 
 // This script is used to seed testnet nodes with data from mainnetMM data dump
 // https://www.dropbox.com/s/y5n36ztppltgs7x/mainnetMM.zip?dl=0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,15 +3,19 @@ use std::sync::Arc;
 use log::debug;
 use tokio::sync::mpsc;
 
-use trin_core::jsonrpc::handlers::JsonRpcHandler;
-use trin_core::jsonrpc::types::PortalJsonRpcRequest;
-use trin_core::portalnet::events::PortalnetEvents;
-use trin_core::utils::bootnodes::parse_bootnodes;
-use trin_core::utp::stream::UtpListener;
 use trin_core::{
     cli::{TrinConfig, HISTORY_NETWORK, STATE_NETWORK},
-    jsonrpc::service::{launch_jsonrpc_server, JsonRpcExiter},
-    portalnet::{discovery::Discovery, storage::PortalStorage, types::messages::PortalnetConfig},
+    jsonrpc::{
+        handlers::JsonRpcHandler,
+        service::{launch_jsonrpc_server, JsonRpcExiter},
+        types::PortalJsonRpcRequest,
+    },
+    portalnet::{
+        discovery::Discovery, events::PortalnetEvents, storage::PortalStorage,
+        types::messages::PortalnetConfig,
+    },
+    utils::bootnodes::parse_bootnodes,
+    utp::stream::UtpListener,
 };
 use trin_history::initialize_history_network;
 use trin_state::initialize_state_network;

--- a/trin-cli/src/main.rs
+++ b/trin-cli/src/main.rs
@@ -1,5 +1,7 @@
-use std::os::unix::net::UnixStream;
-use std::path::{Path, PathBuf};
+use std::{
+    os::unix::net::UnixStream,
+    path::{Path, PathBuf},
+};
 
 use serde_json::value::RawValue;
 use structopt::StructOpt;

--- a/trin-core/src/bin/generate-data.rs
+++ b/trin-core/src/bin/generate-data.rs
@@ -2,9 +2,10 @@ use discv5::enr::NodeId;
 use rand::{distributions::Alphanumeric, Rng};
 use std::process::Command;
 use structopt::StructOpt;
-use trin_core::portalnet::storage::PortalStorage;
-use trin_core::portalnet::types::content_key::IdentityContentKey;
-use trin_core::utils::db::get_data_dir;
+use trin_core::{
+    portalnet::{storage::PortalStorage, types::content_key::IdentityContentKey},
+    utils::db::get_data_dir,
+};
 
 // For every 1 kb of data we store (key + value), RocksDB tends to grow by this many kb on disk...
 // ...but this is a crude empirical estimation that works mainly with default value data size of 32

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -1,6 +1,4 @@
-use std::env;
-use std::ffi::OsString;
-use std::net::SocketAddr;
+use std::{env, ffi::OsString, net::SocketAddr};
 
 use log::info;
 use structopt::StructOpt;

--- a/trin-core/src/jsonrpc/eth.rs
+++ b/trin-core/src/jsonrpc/eth.rs
@@ -2,10 +2,14 @@ use anyhow::anyhow;
 use serde_json::Value;
 use tokio::sync::mpsc;
 
-use crate::jsonrpc::endpoints::HistoryEndpoint;
-use crate::jsonrpc::handlers::proxy_query_to_history_subnet;
-use crate::jsonrpc::types::{GetBlockByHashParams, HistoryJsonRpcRequest, Params};
-use crate::portalnet::types::content_key::{BlockHeader, HistoryContentKey};
+use crate::{
+    jsonrpc::{
+        endpoints::HistoryEndpoint,
+        handlers::proxy_query_to_history_subnet,
+        types::{GetBlockByHashParams, HistoryJsonRpcRequest, Params},
+    },
+    portalnet::types::content_key::{BlockHeader, HistoryContentKey},
+};
 
 /// eth_getBlockByHash
 pub async fn get_block_by_hash(

--- a/trin-core/src/jsonrpc/handlers.rs
+++ b/trin-core/src/jsonrpc/handlers.rs
@@ -7,15 +7,15 @@ use log::debug;
 use serde_json::Value;
 use tokio::sync::mpsc;
 
-use crate::jsonrpc::endpoints::{
-    Discv5Endpoint, HistoryEndpoint, PortalEndpoint, StateEndpoint, TrinEndpoint,
+use crate::{
+    jsonrpc::{
+        endpoints::{Discv5Endpoint, HistoryEndpoint, PortalEndpoint, StateEndpoint, TrinEndpoint},
+        eth,
+        types::{HistoryJsonRpcRequest, Params, PortalJsonRpcRequest, StateJsonRpcRequest},
+    },
+    portalnet::discovery::Discovery,
+    TRIN_VERSION,
 };
-use crate::jsonrpc::eth;
-use crate::jsonrpc::types::{
-    HistoryJsonRpcRequest, Params, PortalJsonRpcRequest, StateJsonRpcRequest,
-};
-use crate::portalnet::discovery::Discovery;
-use crate::TRIN_VERSION;
 
 type Responder<T, E> = mpsc::UnboundedSender<Result<T, E>>;
 

--- a/trin-core/src/jsonrpc/service.rs
+++ b/trin-core/src/jsonrpc/service.rs
@@ -1,26 +1,32 @@
-use std::io::{self, BufRead, Read, Write};
-use std::net::{TcpListener, TcpStream};
 #[cfg(unix)]
 use std::os::unix;
-use std::str::FromStr;
-use std::sync::{Arc, RwLock};
-use std::thread;
-use std::time::Duration;
-use std::{fs, panic, process};
+use std::{
+    fs,
+    io::{self, BufRead, Read, Write},
+    net::{TcpListener, TcpStream},
+    panic, process,
+    str::FromStr,
+    sync::{Arc, RwLock},
+    thread,
+    time::Duration,
+};
 
 use httparse;
 use log::{debug, info, warn};
 use serde_json::{json, Value};
 use thiserror::Error;
 use threadpool::ThreadPool;
-use tokio::sync::mpsc;
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::{mpsc, mpsc::UnboundedSender};
 use ureq;
 use validator::Validate;
 
-use crate::cli::TrinConfig;
-use crate::jsonrpc::endpoints::TrinEndpoint;
-use crate::jsonrpc::types::{JsonRequest, PortalJsonRpcRequest};
+use crate::{
+    cli::TrinConfig,
+    jsonrpc::{
+        endpoints::TrinEndpoint,
+        types::{JsonRequest, PortalJsonRpcRequest},
+    },
+};
 
 pub struct JsonRpcExiter {
     should_exit: Arc<RwLock<bool>>,

--- a/trin-core/src/jsonrpc/types.rs
+++ b/trin-core/src/jsonrpc/types.rs
@@ -7,9 +7,13 @@ use ssz_types::VariableList;
 use tokio::sync::mpsc;
 use validator::{Validate, ValidationError};
 
-use crate::jsonrpc::endpoints::{HistoryEndpoint, StateEndpoint, TrinEndpoint};
-use crate::portalnet::types::content_key::OverlayContentKey;
-use crate::portalnet::types::messages::{ByteList, CustomPayload, SszEnr};
+use crate::{
+    jsonrpc::endpoints::{HistoryEndpoint, StateEndpoint, TrinEndpoint},
+    portalnet::types::{
+        content_key::OverlayContentKey,
+        messages::{ByteList, CustomPayload, SszEnr},
+    },
+};
 
 type Responder<T, E> = mpsc::UnboundedSender<Result<T, E>>;
 

--- a/trin-core/src/locks.rs
+++ b/trin-core/src/locks.rs
@@ -1,16 +1,16 @@
 use futures::future::FutureExt;
-use std::future::Future;
-use std::marker::Sync;
-use std::ops::Deref;
-use std::ops::DerefMut;
-use std::panic::Location;
-use std::pin::Pin;
-use std::time::Duration;
-use std::time::Instant;
-use tokio::sync::RwLock;
-use tokio::sync::RwLockReadGuard;
-use tokio::sync::RwLockWriteGuard;
-use tokio::task::JoinHandle;
+use std::{
+    future::Future,
+    marker::Sync,
+    ops::{Deref, DerefMut},
+    panic::Location,
+    pin::Pin,
+    time::{Duration, Instant},
+};
+use tokio::{
+    sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
+    task::JoinHandle,
+};
 
 const ACQUIRE_TIMEOUT_MS: u64 = 100;
 const HOLD_TIMEOUT_MS: u64 = 100;

--- a/trin-core/src/portalnet/discovery.rs
+++ b/trin-core/src/portalnet/discovery.rs
@@ -1,18 +1,23 @@
 #![allow(dead_code)]
 
-use super::types::messages::{HexData, PortalnetConfig, ProtocolId};
-use super::Enr;
-use crate::socket;
-use crate::utils::node_id::generate_random_node_id;
-use discv5::enr::{CombinedKey, EnrBuilder, NodeId};
-use discv5::{Discv5, Discv5Config, Discv5ConfigBuilder, RequestError};
+use super::{
+    types::messages::{HexData, PortalnetConfig, ProtocolId},
+    Enr,
+};
+use crate::{socket, utils::node_id::generate_random_node_id};
+use discv5::{
+    enr::{CombinedKey, EnrBuilder, NodeId},
+    Discv5, Discv5Config, Discv5ConfigBuilder, RequestError,
+};
 use log::{debug, error, info, warn};
 use rand::seq::SliceRandom;
 use serde_json::{json, Value};
-use std::convert::TryFrom;
-use std::net::{IpAddr, SocketAddr};
-use std::sync::Arc;
-use std::time::Duration;
+use std::{
+    convert::TryFrom,
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
 
 /// With even distribution assumptions, 2**17 is enough to put each node (estimating 100k nodes,
 /// which is more than 10x the ethereum mainnet node count) into a unique bucket by the 17th bucket index.

--- a/trin-core/src/portalnet/events.rs
+++ b/trin-core/src/portalnet/events.rs
@@ -4,8 +4,7 @@ use discv5::{Discv5Event, TalkRequest};
 use log::{debug, warn};
 use tokio::sync::mpsc;
 
-use super::discovery::Discovery;
-use super::types::messages::ProtocolId;
+use super::{discovery::Discovery, types::messages::ProtocolId};
 use hex;
 use std::str::FromStr;
 

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -1,8 +1,5 @@
 use anyhow::anyhow;
-use std::collections::HashSet;
-use std::marker::PhantomData;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{collections::HashSet, marker::PhantomData, sync::Arc, time::Duration};
 
 use super::{
     discovery::Discovery,
@@ -10,14 +7,18 @@ use super::{
     types::{content_key::OverlayContentKey, metric::Metric},
     Enr,
 };
-use crate::portalnet::storage::PortalStorage;
-use crate::portalnet::types::messages::{
-    Accept, Content, CustomPayload, FindContent, FindNodes, Message, Nodes, Offer, Ping, Pong,
-    ProtocolId, Request, Response,
+use crate::portalnet::{
+    storage::PortalStorage,
+    types::messages::{
+        Accept, Content, CustomPayload, FindContent, FindNodes, Message, Nodes, Offer, Ping, Pong,
+        ProtocolId, Request, Response,
+    },
 };
 
-use crate::utp::stream::{UtpListenerRequest, UtpSocket, BUF_SIZE};
-use crate::utp::trin_helpers::{UtpAccept, UtpMessage};
+use crate::utp::{
+    stream::{UtpListenerRequest, UtpSocket, BUF_SIZE},
+    trin_helpers::{UtpAccept, UtpMessage},
+};
 use discv5::{
     enr::NodeId,
     kbucket::{Filter, KBucketsTable},
@@ -31,8 +32,7 @@ use ssz_types::VariableList;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, warn};
 
-pub use super::overlay_service::OverlayRequestError;
-pub use super::overlay_service::RequestDirection;
+pub use super::overlay_service::{OverlayRequestError, RequestDirection};
 
 /// Configuration parameters for the overlay network.
 #[derive(Clone)]

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -1,15 +1,9 @@
-use std::collections::HashMap;
-use std::fmt;
-use std::marker::PhantomData;
-use std::sync::Arc;
-use std::task::Poll;
-use std::time::Duration;
+use std::{collections::HashMap, fmt, marker::PhantomData, sync::Arc, task::Poll, time::Duration};
 
-use crate::portalnet::metrics::OverlayMetrics;
-use crate::utp::stream::UtpListenerRequest;
 use crate::{
     portalnet::{
         discovery::Discovery,
+        metrics::OverlayMetrics,
         storage::PortalStorage,
         types::{
             content_key::OverlayContentKey,
@@ -22,6 +16,7 @@ use crate::{
         Enr,
     },
     utils::node_id,
+    utp::stream::UtpListenerRequest,
 };
 
 use delay_map::HashSetDelay;
@@ -39,8 +34,7 @@ use log::{debug, error, info, warn};
 use parking_lot::RwLock;
 use rand::seq::SliceRandom;
 use ssz::Encode;
-use ssz_types::BitList;
-use ssz_types::VariableList;
+use ssz_types::{BitList, VariableList};
 use thiserror::Error;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 

--- a/trin-core/src/portalnet/storage.rs
+++ b/trin-core/src/portalnet/storage.rs
@@ -1,6 +1,4 @@
-use std::convert::TryInto;
-use std::fs;
-use std::sync::Arc;
+use std::{convert::TryInto, fs, sync::Arc};
 
 use discv5::enr::NodeId;
 use ethereum_types::U256;

--- a/trin-core/src/portalnet/types/content_key.rs
+++ b/trin-core/src/portalnet/types/content_key.rs
@@ -291,8 +291,7 @@ impl OverlayContentKey for StateContentKey {
 mod test {
     use super::*;
 
-    use std::env;
-    use std::sync::Arc;
+    use std::{env, sync::Arc};
 
     use discv5::enr::NodeId;
     use ethereum_types::U256;

--- a/trin-core/src/portalnet/types/messages.rs
+++ b/trin-core/src/portalnet/types/messages.rs
@@ -1,8 +1,10 @@
-use std::convert::{TryFrom, TryInto};
-use std::fmt;
-use std::net::SocketAddr;
-use std::ops::{Deref, DerefMut};
-use std::str::FromStr;
+use std::{
+    convert::{TryFrom, TryInto},
+    fmt,
+    net::SocketAddr,
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
 
 use base64;
 use ethereum_types::U256;

--- a/trin-core/src/utils/db.rs
+++ b/trin-core/src/utils/db.rs
@@ -1,5 +1,4 @@
-use std::path::Path;
-use std::{env, fs};
+use std::{env, fs, path::Path};
 
 use directories::ProjectDirs;
 use discv5::enr::NodeId;

--- a/trin-core/src/utp/packets.rs
+++ b/trin-core/src/utp/packets.rs
@@ -1,8 +1,9 @@
-use crate::utp::bit_iterator::BitIterator;
-use crate::utp::time::{Delay, Timestamp};
+use crate::utp::{
+    bit_iterator::BitIterator,
+    time::{Delay, Timestamp},
+};
 use anyhow::anyhow;
-use std::convert::TryFrom;
-use std::fmt;
+use std::{convert::TryFrom, fmt};
 
 pub const HEADER_SIZE: usize = 20;
 pub const VERSION: u8 = 1;
@@ -501,9 +502,13 @@ impl fmt::Debug for Packet {
 
 #[cfg(test)]
 mod tests {
-    use crate::utp::packets::PacketType::{Data, State};
-    use crate::utp::packets::*;
-    use crate::utp::time::{Delay, Timestamp};
+    use crate::utp::{
+        packets::{
+            PacketType::{Data, State},
+            *,
+        },
+        time::{Delay, Timestamp},
+    };
     use quickcheck::{QuickCheck, TestResult};
     use std::convert::TryFrom;
 

--- a/trin-core/src/utp/stream.rs
+++ b/trin-core/src/utp/stream.rs
@@ -1,25 +1,33 @@
 use crate::portalnet::discovery::Discovery;
 use anyhow::anyhow;
 use async_recursion::async_recursion;
-use discv5::enr::NodeId;
-use discv5::{Enr, TalkRequest};
+use discv5::{enr::NodeId, Enr, TalkRequest};
 use log::{debug, warn};
 use rand::Rng;
 use ssz::Encode;
-use std::cmp::{max, min};
-use std::collections::{HashMap, VecDeque};
-use std::convert::TryFrom;
-use std::sync::Arc;
-use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
-use tokio::sync::{oneshot, RwLock};
-use tokio::time::timeout;
+use std::{
+    cmp::{max, min},
+    collections::{HashMap, VecDeque},
+    convert::TryFrom,
+    sync::Arc,
+};
+use tokio::{
+    sync::{
+        mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+        oneshot, RwLock,
+    },
+    time::timeout,
+};
 
-use crate::portalnet::types::messages::Content::Content;
-use crate::portalnet::types::messages::{ByteList, ProtocolId};
-use crate::utp::packets::{ExtensionType, Packet, PacketType, HEADER_SIZE};
-use crate::utp::time::{now_microseconds, Delay, Timestamp};
-use crate::utp::trin_helpers::{UtpMessage, UtpMessageId};
-use crate::utp::util::{abs_diff, ewma, generate_sequential_identifiers};
+use crate::{
+    portalnet::types::messages::{ByteList, Content::Content, ProtocolId},
+    utp::{
+        packets::{ExtensionType, Packet, PacketType, HEADER_SIZE},
+        time::{now_microseconds, Delay, Timestamp},
+        trin_helpers::{UtpMessage, UtpMessageId},
+        util::{abs_diff, ewma, generate_sequential_identifiers},
+    },
+};
 use std::time::Duration;
 
 // For simplicity's sake, let us assume no packet will ever exceed the
@@ -1340,22 +1348,28 @@ impl UtpSocket {
 
 #[cfg(test)]
 mod tests {
-    use crate::portalnet::discovery::Discovery;
-    use crate::portalnet::types::messages::{PortalnetConfig, ProtocolId};
-    use crate::portalnet::Enr;
-    use crate::socket;
-    use crate::utils::node_id::generate_random_remote_enr;
-    use crate::utp::packets::{Packet, PacketType};
-    use crate::utp::stream::{SocketState, UtpSocket, BUF_SIZE};
-    use crate::utp::time::now_microseconds;
+    use crate::{
+        portalnet::{
+            discovery::Discovery,
+            types::messages::{PortalnetConfig, ProtocolId},
+            Enr,
+        },
+        socket,
+        utils::node_id::generate_random_remote_enr,
+        utp::{
+            packets::{Packet, PacketType},
+            stream::{SocketState, UtpSocket, BUF_SIZE},
+            time::now_microseconds,
+        },
+    };
     use discv5::Discv5Event;
-    use std::convert::TryFrom;
-    use std::net::{IpAddr, SocketAddr};
-    use std::str::FromStr;
-    use std::sync::Arc;
-    use tokio::sync::mpsc;
-    use tokio::sync::mpsc::UnboundedSender;
-    use tokio::sync::RwLock;
+    use std::{
+        convert::TryFrom,
+        net::{IpAddr, SocketAddr},
+        str::FromStr,
+        sync::Arc,
+    };
+    use tokio::sync::{mpsc, mpsc::UnboundedSender, RwLock};
 
     fn next_test_port() -> u16 {
         use std::sync::atomic::{AtomicUsize, Ordering};

--- a/trin-core/src/utp/time.rs
+++ b/trin-core/src/utp/time.rs
@@ -1,7 +1,5 @@
 use num::ToPrimitive;
-use std::fmt;
-use std::ops::Sub;
-use std::time;
+use std::{fmt, ops::Sub, time};
 
 /// Return current time in microseconds since the UNIX epoch.
 pub fn now_microseconds() -> Timestamp {

--- a/trin-core/tests/overlay.rs
+++ b/trin-core/tests/overlay.rs
@@ -1,6 +1,4 @@
-use std::net::SocketAddr;
-use std::str::FromStr;
-use std::sync::Arc;
+use std::{net::SocketAddr, str::FromStr, sync::Arc};
 
 use trin_core::{
     cli::DEFAULT_STORAGE_CAPACITY,
@@ -21,9 +19,10 @@ use trin_core::{
 use discv5::Discv5Event;
 use ethereum_types::U256;
 use parking_lot::RwLock;
-use tokio::sync::mpsc;
-use tokio::sync::mpsc::unbounded_channel;
-use tokio::time::{self, Duration};
+use tokio::{
+    sync::{mpsc, mpsc::unbounded_channel},
+    time::{self, Duration},
+};
 use trin_core::utp::stream::UtpListenerRequest;
 
 async fn init_overlay(

--- a/trin-history/src/events.rs
+++ b/trin-history/src/events.rs
@@ -2,8 +2,7 @@ use crate::network::HistoryNetwork;
 use discv5::TalkRequest;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedReceiver;
-use tracing::Instrument;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, warn, Instrument};
 use trin_core::portalnet::types::messages::Message;
 
 pub struct HistoryEvents {

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -5,18 +5,23 @@ use serde_json::{json, Value};
 use tokio::sync::mpsc;
 
 use crate::network::HistoryNetwork;
-use trin_core::jsonrpc::types::OfferParams;
-use trin_core::jsonrpc::{
-    endpoints::HistoryEndpoint,
-    types::{
-        FindContentParams, FindNodesParams, HistoryJsonRpcRequest, LocalContentParams, PingParams,
-        RecursiveFindContentParams, StoreParams,
+use trin_core::{
+    jsonrpc::{
+        endpoints::HistoryEndpoint,
+        types::{
+            FindContentParams, FindNodesParams, HistoryJsonRpcRequest, LocalContentParams,
+            OfferParams, PingParams, RecursiveFindContentParams, StoreParams,
+        },
     },
+    portalnet::{
+        types::{
+            content_key::HistoryContentKey,
+            messages::{Content, FindContent, Request, Response, SszEnr},
+        },
+        Enr,
+    },
+    types::header::Header,
 };
-use trin_core::portalnet::types::content_key::HistoryContentKey;
-use trin_core::portalnet::types::messages::{Content, FindContent, Request, Response, SszEnr};
-use trin_core::portalnet::Enr;
-use trin_core::types::header::Header;
 
 /// Handles History network JSON-RPC requests
 pub struct HistoryRequestHandler {

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -3,23 +3,25 @@ mod jsonrpc;
 pub mod network;
 
 use log::info;
-use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
+use tokio::{sync::mpsc, task::JoinHandle};
 
-use crate::events::HistoryEvents;
-use crate::jsonrpc::HistoryRequestHandler;
+use crate::{events::HistoryEvents, jsonrpc::HistoryRequestHandler};
 use discv5::TalkRequest;
 use network::HistoryNetwork;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
-use trin_core::cli::TrinConfig;
-use trin_core::jsonrpc::types::HistoryJsonRpcRequest;
-use trin_core::portalnet::discovery::Discovery;
-use trin_core::portalnet::events::PortalnetEvents;
-use trin_core::portalnet::storage::{PortalStorage, PortalStorageConfig};
-use trin_core::portalnet::types::messages::PortalnetConfig;
-use trin_core::utils::bootnodes::parse_bootnodes;
-use trin_core::utp::stream::{UtpListener, UtpListenerRequest};
+use trin_core::{
+    cli::TrinConfig,
+    jsonrpc::types::HistoryJsonRpcRequest,
+    portalnet::{
+        discovery::Discovery,
+        events::PortalnetEvents,
+        storage::{PortalStorage, PortalStorageConfig},
+        types::messages::PortalnetConfig,
+    },
+    utils::bootnodes::parse_bootnodes,
+    utp::stream::{UtpListener, UtpListenerRequest},
+};
 
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Launching trin-history...");

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -5,17 +5,19 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
 
-use trin_core::portalnet::{
-    discovery::Discovery,
-    overlay::{OverlayConfig, OverlayProtocol, OverlayRequestError},
-    storage::{PortalStorage, PortalStorageConfig},
-    types::{
-        content_key::HistoryContentKey,
-        messages::{PortalnetConfig, ProtocolId},
-        metric::XorMetric,
+use trin_core::{
+    portalnet::{
+        discovery::Discovery,
+        overlay::{OverlayConfig, OverlayProtocol, OverlayRequestError},
+        storage::{PortalStorage, PortalStorageConfig},
+        types::{
+            content_key::HistoryContentKey,
+            messages::{PortalnetConfig, ProtocolId},
+            metric::XorMetric,
+        },
     },
+    utp::stream::UtpListenerRequest,
 };
-use trin_core::utp::stream::UtpListenerRequest;
 
 /// History network layer on top of the overlay protocol. Encapsulates history network specific data and logic.
 #[derive(Clone)]

--- a/trin-state/src/events.rs
+++ b/trin-state/src/events.rs
@@ -2,8 +2,7 @@ use crate::network::StateNetwork;
 use discv5::TalkRequest;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedReceiver;
-use tracing::Instrument;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, warn, Instrument};
 use trin_core::portalnet::types::messages::Message;
 
 pub struct StateEvents {

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -4,15 +4,16 @@ use serde_json::Value;
 use tokio::sync::mpsc;
 
 use crate::network::StateNetwork;
-use trin_core::jsonrpc::types::OfferParams;
-use trin_core::jsonrpc::{
-    endpoints::StateEndpoint,
-    types::{
-        FindContentParams, FindNodesParams, LocalContentParams, PingParams, StateJsonRpcRequest,
-        StoreParams,
+use trin_core::{
+    jsonrpc::{
+        endpoints::StateEndpoint,
+        types::{
+            FindContentParams, FindNodesParams, LocalContentParams, OfferParams, PingParams,
+            StateJsonRpcRequest, StoreParams,
+        },
     },
+    portalnet::types::content_key::StateContentKey,
 };
-use trin_core::portalnet::types::content_key::StateContentKey;
 
 /// Handles State network JSON-RPC requests
 pub struct StateRequestHandler {

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -1,21 +1,23 @@
 use log::info;
 use std::sync::Arc;
-use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
+use tokio::{sync::mpsc, task::JoinHandle};
 
-use crate::events::StateEvents;
-use crate::jsonrpc::StateRequestHandler;
+use crate::{events::StateEvents, jsonrpc::StateRequestHandler};
 use discv5::TalkRequest;
 use network::StateNetwork;
 use tokio::sync::mpsc::UnboundedSender;
-use trin_core::cli::TrinConfig;
-use trin_core::jsonrpc::types::StateJsonRpcRequest;
-use trin_core::portalnet::discovery::Discovery;
-use trin_core::portalnet::events::PortalnetEvents;
-use trin_core::portalnet::storage::{PortalStorage, PortalStorageConfig};
-use trin_core::portalnet::types::messages::PortalnetConfig;
-use trin_core::utils::bootnodes::parse_bootnodes;
-use trin_core::utp::stream::{UtpListener, UtpListenerRequest};
+use trin_core::{
+    cli::TrinConfig,
+    jsonrpc::types::StateJsonRpcRequest,
+    portalnet::{
+        discovery::Discovery,
+        events::PortalnetEvents,
+        storage::{PortalStorage, PortalStorageConfig},
+        types::messages::PortalnetConfig,
+    },
+    utils::bootnodes::parse_bootnodes,
+    utp::stream::{UtpListener, UtpListenerRequest},
+};
 
 pub mod events;
 mod jsonrpc;

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -6,17 +6,19 @@ use eth_trie::EthTrie;
 use log::debug;
 use parking_lot::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
-use trin_core::portalnet::{
-    discovery::Discovery,
-    overlay::{OverlayConfig, OverlayProtocol, OverlayRequestError},
-    storage::{PortalStorage, PortalStorageConfig},
-    types::{
-        content_key::StateContentKey,
-        messages::{PortalnetConfig, ProtocolId},
-        metric::XorMetric,
+use trin_core::{
+    portalnet::{
+        discovery::Discovery,
+        overlay::{OverlayConfig, OverlayProtocol, OverlayRequestError},
+        storage::{PortalStorage, PortalStorageConfig},
+        types::{
+            content_key::StateContentKey,
+            messages::{PortalnetConfig, ProtocolId},
+            metric::XorMetric,
+        },
     },
+    utp::stream::UtpListenerRequest,
 };
-use trin_core::utp::stream::UtpListenerRequest;
 
 use crate::trie::TrieDB;
 

--- a/trin-state/src/utils.rs
+++ b/trin-state/src/utils.rs
@@ -1,6 +1,8 @@
 use ethereum_types::U256;
-use num::bigint::{BigInt, Sign};
-use num::Signed;
+use num::{
+    bigint::{BigInt, Sign},
+    Signed,
+};
 
 // 2 ** 256
 const MODULO: [u8; 78] = [

--- a/utp-testing/src/main.rs
+++ b/utp-testing/src/main.rs
@@ -1,13 +1,18 @@
 use discv5::{Discv5Event, TalkRequest};
 use log::debug;
-use std::str::FromStr;
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 use tokio::sync::mpsc::UnboundedSender;
-use trin_core::portalnet::discovery::Discovery;
-use trin_core::portalnet::types::messages::{PortalnetConfig, ProtocolId};
-use trin_core::portalnet::Enr;
-use trin_core::utp::stream::{UtpListener, UtpListenerRequest, UtpSocket};
-use trin_core::utp::trin_helpers::UtpMessage;
+use trin_core::{
+    portalnet::{
+        discovery::Discovery,
+        types::messages::{PortalnetConfig, ProtocolId},
+        Enr,
+    },
+    utp::{
+        stream::{UtpListener, UtpListenerRequest, UtpSocket},
+        trin_helpers::UtpMessage,
+    },
+};
 
 pub struct TestApp {
     discovery: Arc<Discovery>,


### PR DESCRIPTION
### What was wrong?
Imports were messy and not structured in an intuitive way.

### How was it fixed?
 Used `cargo +nightly fmt` with `imports_granularity = "Crate"` [config](https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#imports_granularity).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
