### PR TITLE
Handle concurrently multiple uTP streams

### DIFF
--- a/newsfragments/312.fixed.md
+++ b/newsfragments/312.fixed.md
@@ -1,0 +1,1 @@
+Handle concurrently multiple uTP streams


### PR DESCRIPTION
### What was wrong?
Fixes https://github.com/ethereum/trin/issues/312

### How was it fixed?

1. Create a uTP stream with an internal discv5 packet channel.
2. Every time when we handle a uTP packet, we check for an existing uTP connection matching the remote NodeId and received connection id, and then we send the packet to the corresponding internal uTP stream channel.
3. Refactor RESET packet uTP listener handler.
4. Fix broken local utp-testing execution caused by https://github.com/ethereum/trin/pull/309.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
