### PR TITLE
Set non-expire Discord link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ guidelines for [contributing](/docs/contributing.md),
 then check out issues that are labeled
 [Good First Issue](https://github.com/ethereum/trin/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
 
-Join our [Discord](https://discord.gg/pWVEESXB) to participate in the conversation!
+Join our [Discord](https://discord.gg/JrwTY7FEf4) to participate in the conversation!
 


### PR DESCRIPTION
### What was wrong?
Fixes https://github.com/ethereum/trin/issues/329

### How was it fixed?
Update Discord link to non-expire

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
