### PR TITLE
Decode json-rpc hex with prefix

### DIFF
--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -14,6 +14,7 @@ use trin_core::{
         content_key::{AccountTrieNode, BlockHeader, HistoryContentKey, StateContentKey},
         messages::SszEnr,
     },
+    utils::bytes::hex_encode,
 };
 
 /// Default data radius value: U256::from(u64::MAX)
@@ -212,14 +213,14 @@ fn all_tests(peertest: &Peertest) -> Vec<Test<impl Fn(&Value, &Peertest)>> {
                 method: "portal_historyStore".to_string(),
                 id: 11,
                 params: Params::Array(vec![
-                    Value::String(hex::encode(Into::<Vec<u8>>::into(
+                    Value::String(hex_encode(Into::<Vec<u8>>::into(
                         HistoryContentKey::BlockHeader(BlockHeader {
                             chain_id: 1,
                             block_hash: BLOCK_HASH,
                         }),
                     ))),
                     // todo: replace with valid content
-                    Value::String("01".to_string()),
+                    Value::String("0x01".to_string()),
                 ]),
             },
             validate_portal_store,
@@ -229,7 +230,7 @@ fn all_tests(peertest: &Peertest) -> Vec<Test<impl Fn(&Value, &Peertest)>> {
                 method: "portal_stateStore".to_string(),
                 id: 12,
                 params: Params::Array(vec![
-                    Value::String(hex::encode(Into::<Vec<u8>>::into(
+                    Value::String(hex_encode(Into::<Vec<u8>>::into(
                         StateContentKey::AccountTrieNode(AccountTrieNode {
                             node_hash: NODE_HASH,
                             state_root: STATE_ROOT,
@@ -237,7 +238,7 @@ fn all_tests(peertest: &Peertest) -> Vec<Test<impl Fn(&Value, &Peertest)>> {
                         }),
                     ))),
                     // todo: replace with valid content
-                    Value::String("02".to_string()),
+                    Value::String("0x02".to_string()),
                 ]),
             },
             validate_portal_store,
@@ -248,8 +249,8 @@ fn all_tests(peertest: &Peertest) -> Vec<Test<impl Fn(&Value, &Peertest)>> {
                 method: "portal_historyStore".to_string(),
                 id: 11,
                 params: Params::Array(vec![
-                    Value::String("1234".to_string()),
-                    Value::String("01".to_string()),
+                    Value::String("0x1234".to_string()),
+                    Value::String("0x01".to_string()),
                 ]),
             },
             validate_portal_store_with_invalid_content_key,
@@ -260,8 +261,8 @@ fn all_tests(peertest: &Peertest) -> Vec<Test<impl Fn(&Value, &Peertest)>> {
                 method: "portal_stateStore".to_string(),
                 id: 12,
                 params: Params::Array(vec![
-                    Value::String("1234".to_string()),
-                    Value::String("02".to_string()),
+                    Value::String("0x1234".to_string()),
+                    Value::String("0x02".to_string()),
                 ]),
             },
             validate_portal_store_with_invalid_content_key,

--- a/newsfragments/334.fixed.md
+++ b/newsfragments/334.fixed.md
@@ -1,0 +1,1 @@
+trin now correctly parses parameters to json endpoint `portal_historyStore`. Parameters must be 0x-prefixed, now.

--- a/newsfragments/334.internal.md
+++ b/newsfragments/334.internal.md
@@ -1,0 +1,1 @@
+Move the data directory from `Trin_*` to `trin_*`. Also, display the db directory in the info logs.

--- a/trin-core/src/portalnet/storage.rs
+++ b/trin-core/src/portalnet/storage.rs
@@ -3,7 +3,7 @@ use std::{convert::TryInto, fs, sync::Arc};
 use discv5::enr::NodeId;
 use ethereum_types::U256;
 use hex;
-use log::{debug, error};
+use log::{debug, error, info};
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 use rocksdb::{Options, DB};
@@ -449,7 +449,7 @@ impl PortalStorage {
         let data_path_root: String = get_data_dir(node_id).to_owned();
         let data_suffix: &str = "/trin.sqlite";
         let data_path = data_path_root + data_suffix;
-        debug!("Setting up SqliteDB at path: {:?}", data_path);
+        info!("Setting up SqliteDB at path: {:?}", data_path);
 
         let manager = SqliteConnectionManager::file(data_path);
         let pool = Pool::new(manager)?;

--- a/trin-core/src/utils/bytes.rs
+++ b/trin-core/src/utils/bytes.rs
@@ -1,5 +1,7 @@
 use rand::{Rng, RngCore};
 
+use anyhow::anyhow;
+
 /// Generate 32 byte array with N leading bit zeros
 pub fn random_32byte_array(leading_bit_zeros: u8) -> [u8; 32] {
     let first_zero_bytes: usize = leading_bit_zeros as usize / 8;
@@ -25,6 +27,21 @@ pub fn random_32byte_array(leading_bit_zeros: u8) -> [u8; 32] {
     };
 
     bytes
+}
+
+/// Encode hex with 0x prefix
+pub fn hex_encode<T: AsRef<[u8]>>(data: T) -> String {
+    format!("0x{}", hex::encode(data))
+}
+/// Decode hex with 0x prefix
+pub fn hex_decode(data: &str) -> anyhow::Result<Vec<u8>> {
+    let first_two = &data[..2];
+    match first_two {
+        "0x" => hex::decode(&data[2..]).map_err(|e| e.into()),
+        _ => Err(anyhow!(
+            "Hex strings must start with 0x, but found {first_two}"
+        )),
+    }
 }
 
 #[cfg(test)]
@@ -56,5 +73,33 @@ mod test {
         assert_eq!(bytes.len(), 32);
         assert_eq!(bytes[0], 0);
         assert_eq!(bytes[1], 1);
+    }
+
+    #[test]
+    fn test_hex_encode() {
+        let to_encode = vec![176, 15];
+        let encoded = hex_encode(to_encode);
+        assert_eq!(encoded, "0xb00f");
+    }
+
+    #[test]
+    fn test_hex_decode() {
+        let to_decode = "0xb00f";
+        let decoded = hex_decode(to_decode).unwrap();
+        assert_eq!(decoded, vec![176, 15]);
+    }
+
+    #[test]
+    fn test_hex_decode_invalid_start() {
+        let to_decode = "b00f";
+        let result = hex_decode(to_decode);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_hex_decode_invalid_char() {
+        let to_decode = "0xb00g";
+        let result = hex_decode(to_decode);
+        assert!(result.is_err());
     }
 }

--- a/trin-core/src/utils/db.rs
+++ b/trin-core/src/utils/db.rs
@@ -10,7 +10,7 @@ pub fn get_data_dir(node_id: NodeId) -> String {
     let trin_data_dir = Path::new(&trin_data_dir);
 
     // Append first 8 characters of Node ID
-    let mut application_string = "Trin_".to_owned();
+    let mut application_string = "trin_".to_owned();
     let node_id_string = hex::encode(node_id.raw());
     let suffix = &node_id_string[..8];
     application_string.push_str(suffix);


### PR DESCRIPTION
### What was wrong?

When doing manual testing to push content with `portal_historyStore`, I was getting the error "Unable to decode content_key".

I thought that was a bytes -> key issue, but it was actually a hex -> bytes issue. I updated the error message to be a bit more clear on that point.

It looks like most of the json-decoding was assuming hex without a prefix. The portal json-rpc spec has all content starting with 0x, so this was a bug to fix.

### How was it fixed?

- Added a new `hex_decode` which strips away the "0x" -- plus a little hacky error if it's not there.
- Use the `hex_decode()` method instead of `hex::decode()` (which can't handle a prefix), basically everywhere in the json-rpc type decoding.

Some bonus fixes:
- Log out the database location in `info`. There was no other indication where the data directory is, at the info level.
- Use `trin_` instead of `Trin_` for the data directory prefixes. `trin` is written lowercase roughly everywhere.

With this fix in place, the history data is being stored in response to the `portal_historyStore` call.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
