### PR TITLE
Refactor Query trait with associated types

### DIFF
--- a/trin-core/src/portalnet/find/iterators/findcontent.rs
+++ b/trin-core/src/portalnet/find/iterators/findcontent.rs
@@ -74,11 +74,13 @@ pub struct FindContentQuery<TNodeId> {
     config: QueryConfig,
 }
 
-impl<TNodeId> Query<TNodeId, FindContentQueryResponse<TNodeId>, FindContentQueryResult<TNodeId>>
-    for FindContentQuery<TNodeId>
+impl<TNodeId> Query<TNodeId> for FindContentQuery<TNodeId>
 where
     TNodeId: Into<Key<TNodeId>> + Eq + Clone,
 {
+    type Response = FindContentQueryResponse<TNodeId>;
+    type Result = FindContentQueryResult<TNodeId>;
+
     fn target(&self) -> Key<TNodeId> {
         self.target_key.clone()
     }
@@ -91,7 +93,7 @@ where
         self.started = Some(start);
     }
 
-    fn on_success(&mut self, peer: &TNodeId, peer_response: FindContentQueryResponse<TNodeId>) {
+    fn on_success(&mut self, peer: &TNodeId, peer_response: Self::Response) {
         if let QueryProgress::Finished = self.progress {
             return;
         }
@@ -289,7 +291,7 @@ where
         }
     }
 
-    fn into_result(self) -> FindContentQueryResult<TNodeId> {
+    fn into_result(self) -> Self::Result {
         match self.content {
             Some(content) => {
                 let closest_nodes = self

--- a/trin-core/src/portalnet/find/iterators/findnodes.rs
+++ b/trin-core/src/portalnet/find/iterators/findnodes.rs
@@ -53,10 +53,13 @@ pub struct FindNodeQuery<TNodeId> {
     config: QueryConfig,
 }
 
-impl<TNodeId> Query<TNodeId, Vec<TNodeId>, Vec<TNodeId>> for FindNodeQuery<TNodeId>
+impl<TNodeId> Query<TNodeId> for FindNodeQuery<TNodeId>
 where
     TNodeId: Into<Key<TNodeId>> + Eq + Clone,
 {
+    type Response = Vec<TNodeId>;
+    type Result = Vec<TNodeId>;
+
     fn target(&self) -> Key<TNodeId> {
         self.target_key.clone()
     }
@@ -96,7 +99,7 @@ where
     /// `peer_response` contain a peer closer to the target than any peer seen so far,
     /// or when the query did not yet accumulate `num_results` closest peers and
     /// `peer_response` contains a new peer, regardless of its distance to the target.
-    fn on_success(&mut self, peer: &TNodeId, peer_response: Vec<TNodeId>) {
+    fn on_success(&mut self, peer: &TNodeId, peer_response: Self::Response) {
         if let QueryProgress::Finished = self.progress {
             return;
         }
@@ -247,7 +250,7 @@ where
         }
     }
 
-    fn into_result(self) -> Vec<TNodeId> {
+    fn into_result(self) -> Self::Result {
         self.closest_peers
             .into_iter()
             .filter_map(|(_, peer)| {

--- a/trin-core/src/portalnet/find/iterators/query.rs
+++ b/trin-core/src/portalnet/find/iterators/query.rs
@@ -63,7 +63,13 @@ impl QueryConfig {
     }
 }
 
-pub trait Query<TNodeId, TResponse, TResult> {
+pub trait Query<TNodeId> {
+    /// The type of the response to a request issued for the query.
+    type Response;
+
+    /// The type of the result produced by the query.
+    type Result;
+
     /// Returns the target of the query.
     fn target(&self) -> Key<TNodeId>;
 
@@ -95,7 +101,7 @@ pub trait Query<TNodeId, TResponse, TResult> {
     /// If the query is finished, the query is not currently waiting for a
     /// result from `peer`, or a result for `peer` has already been reported,
     /// calling this function has no effect.
-    fn on_success(&mut self, peer: &TNodeId, peer_response: TResponse);
+    fn on_success(&mut self, peer: &TNodeId, peer_response: Self::Response);
 
     /// Advances the state of the query, potentially getting a new peer to contact.
     ///
@@ -103,7 +109,7 @@ pub trait Query<TNodeId, TResponse, TResult> {
     fn poll(&mut self, now: Instant) -> QueryState<TNodeId>;
 
     /// Consumes the query, returning the result.
-    fn into_result(self) -> TResult;
+    fn into_result(self) -> Self::Result;
 }
 
 /// Stage of the query.

--- a/trin-core/src/portalnet/find/query_pool.rs
+++ b/trin-core/src/portalnet/find/query_pool.rs
@@ -39,11 +39,11 @@ pub trait TargetKey<TNodeId> {
 /// Internally, a `Query` is in turn driven by an underlying `QueryPeerIter`
 /// that determines the peer selection strategy, i.e. the order in which the
 /// peers involved in the query should be contacted.
-pub struct QueryPool<TNodeId, TResponse, TResult, TQuery> {
+pub struct QueryPool<TNodeId, TQuery> {
     _next_id: QueryId,
     query_timeout: Duration,
     queries: FnvHashMap<QueryId, (QueryInfo, TQuery)>,
-    marker: PhantomData<(TNodeId, TResponse, TResult)>,
+    marker: PhantomData<TNodeId>,
 }
 
 /// The observable states emitted by [`QueryPool::poll`].
@@ -60,10 +60,10 @@ pub enum QueryPoolState<'a, TNodeId, TQuery> {
     Timeout(QueryId, QueryInfo, TQuery),
 }
 
-impl<TNodeId, TResponse, TResult, TQuery> QueryPool<TNodeId, TResponse, TResult, TQuery>
+impl<TNodeId, TQuery> QueryPool<TNodeId, TQuery>
 where
     TNodeId: Into<Key<TNodeId>> + Eq + Clone,
-    TQuery: Query<TNodeId, TResponse, TResult>,
+    TQuery: Query<TNodeId>,
 {
     /// Creates a new `QueryPool` with the given configuration.
     pub fn new(query_timeout: Duration) -> Self {


### PR DESCRIPTION
### What was wrong?

The `Query` trait uses generic type parameters for the response and result types, but for a given generic node ID type, there will only ever be one implementation of the `Query` trait for each type of query. Thus, we can use associated types for the response and result types.

This change also cleans up the type signature of `Query` implementers and `QueryPool`.

### How was it fixed?

Move the response and result generic type parameters to associated types of the `Query` trait.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
