### PR TITLE
Add RPC endpoints for retrieving routing table info for state and history networks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3382,6 +3382,7 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4.17"
 prometheus_exporter = "0.8.4"
 rand = "0.8.4"
 rlp = "0.5.0"
-serde_json = "1.0.59"
+serde_json = {version = "1.0.59", features = ["preserve_order"]}
 sha3 = "0.9.1"
 structopt = "0.3"
 tokio = { version = "1.8.0", features = ["full"] }

--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -267,6 +267,22 @@ fn all_tests(peertest: &Peertest) -> Vec<Test<impl Fn(&Value, &Peertest)>> {
             },
             validate_portal_store_with_invalid_content_key,
         ),
+        Test::new(
+            JsonRpcRequest {
+                method: "portal_historyRoutingTableInfo".to_string(),
+                id: 13,
+                params: Params::None,
+            },
+            validate_portal_routing_table_info,
+        ),
+        Test::new(
+            JsonRpcRequest {
+                method: "portal_stateRoutingTableInfo".to_string(),
+                id: 14,
+                params: Params::None,
+            },
+            validate_portal_routing_table_info,
+        ),
     ]
 }
 
@@ -339,6 +355,13 @@ fn validate_portal_store_with_invalid_content_key(result: &Value, _peertest: &Pe
         .as_str()
         .unwrap()
         .contains("Unable to decode content_key"));
+}
+
+fn validate_portal_routing_table_info(result: &Value, _peertest: &Peertest) {
+    assert!(result.get("buckets").unwrap().is_array());
+    assert!(result.get("numBuckets").unwrap().is_u64());
+    assert!(result.get("numNodes").unwrap().is_u64());
+    assert!(result.get("numConnected").unwrap().is_u64());
 }
 
 #[cfg(unix)]

--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -358,7 +358,7 @@ fn validate_portal_store_with_invalid_content_key(result: &Value, _peertest: &Pe
 }
 
 fn validate_portal_routing_table_info(result: &Value, _peertest: &Peertest) {
-    assert!(result.get("buckets").unwrap().is_array());
+    assert!(result.get("buckets").unwrap().is_object());
     assert!(result.get("numBuckets").unwrap().is_u64());
     assert!(result.get("numNodes").unwrap().is_u64());
     assert!(result.get("numConnected").unwrap().is_u64());

--- a/newsfragments/344.added.md
+++ b/newsfragments/344.added.md
@@ -1,0 +1,1 @@
+Add `portal_historyRoutingTableInfo` and `portal_stateRoutingTableInfo` JSON RPC endpoints for viewing overlay routing tables.

--- a/trin-core/src/jsonrpc/endpoints.rs
+++ b/trin-core/src/jsonrpc/endpoints.rs
@@ -17,6 +17,7 @@ pub enum StateEndpoint {
     Offer,
     Store,
     Ping,
+    RoutingTableInfo,
 }
 
 /// History network JSON-RPC endpoints. Start with "portalHistory_" prefix
@@ -30,6 +31,7 @@ pub enum HistoryEndpoint {
     Ping,
     RecursiveFindContent,
     Store,
+    RoutingTableInfo,
 }
 
 /// Ethereum JSON-RPC endpoints not currently supported by portal network requests, proxied to Infura
@@ -86,6 +88,9 @@ impl FromStr for TrinEndpoint {
             "portal_historyRadius" => {
                 Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::DataRadius))
             }
+            "portal_historyRoutingTableInfo" => Ok(TrinEndpoint::HistoryEndpoint(
+                HistoryEndpoint::RoutingTableInfo,
+            )),
             "portal_historyStore" => Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::Store)),
             "portal_stateFindContent" => {
                 Ok(TrinEndpoint::StateEndpoint(StateEndpoint::FindContent))
@@ -98,6 +103,9 @@ impl FromStr for TrinEndpoint {
             "portal_stateStore" => Ok(TrinEndpoint::StateEndpoint(StateEndpoint::Store)),
             "portal_statePing" => Ok(TrinEndpoint::StateEndpoint(StateEndpoint::Ping)),
             "portal_stateRadius" => Ok(TrinEndpoint::StateEndpoint(StateEndpoint::DataRadius)),
+            "portal_stateRoutingTableInfo" => {
+                Ok(TrinEndpoint::StateEndpoint(StateEndpoint::RoutingTableInfo))
+            }
             _ => Err(()),
         }
     }

--- a/trin-core/src/jsonrpc/mod.rs
+++ b/trin-core/src/jsonrpc/mod.rs
@@ -3,3 +3,4 @@ pub mod eth;
 pub mod handlers;
 pub mod service;
 pub mod types;
+pub mod utils;

--- a/trin-core/src/jsonrpc/utils.rs
+++ b/trin-core/src/jsonrpc/utils.rs
@@ -1,17 +1,16 @@
-use serde_json::{json, Value};
-use discv5::{
-    kbucket::{
-        ConnectionState, NodeStatus
-    },
-    enr::NodeId,
-};
 use crate::portalnet::Enr;
+use discv5::{
+    enr::NodeId,
+    kbucket::{ConnectionState, NodeStatus},
+};
+use serde_json::{json, Value};
 
-pub fn bucket_entries_to_json(bucket_entries: Vec<(usize, Vec<(NodeId, Enr, NodeStatus)>)>) -> Value {
-    let mut node_count: u16 = 0; 
+pub fn bucket_entries_to_json(
+    bucket_entries: Vec<(usize, Vec<(NodeId, Enr, NodeStatus)>)>,
+) -> Value {
+    let mut node_count: u16 = 0;
     let mut connected_count: u16 = 0;
-    let buckets_indexed: Vec<(String, Vec<(String, String, String)>)> = 
-        bucket_entries
+    let buckets_indexed: Vec<(String, Vec<(String, String, String)>)> = bucket_entries
         .into_iter()
         .map(|(index, bucket)| {
             (
@@ -20,7 +19,9 @@ pub fn bucket_entries_to_json(bucket_entries: Vec<(usize, Vec<(NodeId, Enr, Node
                     .iter()
                     .map(|(node_id, enr, node_status)| {
                         node_count += 1;
-                        if node_status.state == ConnectionState::Connected { connected_count += 1 }
+                        if node_status.state == ConnectionState::Connected {
+                            connected_count += 1
+                        }
                         (
                             format!("0x{}", hex::encode(node_id.raw())),
                             enr.to_base64(),
@@ -40,5 +41,4 @@ pub fn bucket_entries_to_json(bucket_entries: Vec<(usize, Vec<(NodeId, Enr, Node
             "numConnected": connected_count
         }
     )
-
 }

--- a/trin-core/src/jsonrpc/utils.rs
+++ b/trin-core/src/jsonrpc/utils.rs
@@ -1,0 +1,44 @@
+use serde_json::{json, Value};
+use discv5::{
+    kbucket::{
+        ConnectionState, NodeStatus
+    },
+    enr::NodeId,
+};
+use crate::portalnet::Enr;
+
+pub fn bucket_entries_to_json(bucket_entries: Vec<(usize, Vec<(NodeId, Enr, NodeStatus)>)>) -> Value {
+    let mut node_count: u16 = 0; 
+    let mut connected_count: u16 = 0;
+    let buckets_indexed: Vec<(String, Vec<(String, String, String)>)> = 
+        bucket_entries
+        .into_iter()
+        .map(|(index, bucket)| {
+            (
+                format!("{}", index),
+                bucket
+                    .iter()
+                    .map(|(node_id, enr, node_status)| {
+                        node_count += 1;
+                        if node_status.state == ConnectionState::Connected { connected_count += 1 }
+                        (
+                            format!("0x{}", hex::encode(node_id.raw())),
+                            enr.to_base64(),
+                            format!("{:?}", node_status.state),
+                        )
+                    })
+                    .collect(),
+            )
+        })
+        .collect();
+
+    json!(
+        {
+            "buckets": buckets_indexed,
+            "numBuckets": buckets_indexed.len(),
+            "numNodes": node_count,
+            "numConnected": connected_count
+        }
+    )
+
+}

--- a/trin-core/src/jsonrpc/utils.rs
+++ b/trin-core/src/jsonrpc/utils.rs
@@ -5,16 +5,16 @@ use discv5::{
 };
 use ethereum_types::U256;
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
-type NodeMap = HashMap<String, String>;
+type NodeMap = BTreeMap<String, String>;
 type NodeTuple = (NodeId, Enr, NodeStatus, U256);
 
 /// Converts the output of the Overlay's bucket_entries method to a JSON Value
-pub fn bucket_entries_to_json(bucket_entries: HashMap<usize, Vec<NodeTuple>>) -> Value {
+pub fn bucket_entries_to_json(bucket_entries: BTreeMap<usize, Vec<NodeTuple>>) -> Value {
     let mut node_count: u16 = 0;
     let mut connected_count: u16 = 0;
-    let buckets_indexed: HashMap<usize, Vec<NodeMap>> = bucket_entries
+    let buckets_indexed: BTreeMap<usize, Vec<NodeMap>> = bucket_entries
         .into_iter()
         .map(|(bucket_index, bucket)| {
             (
@@ -26,7 +26,7 @@ pub fn bucket_entries_to_json(bucket_entries: HashMap<usize, Vec<NodeTuple>>) ->
                         if node_status.state == ConnectionState::Connected {
                             connected_count += 1
                         }
-                        let mut map = HashMap::new();
+                        let mut map = BTreeMap::new();
                         map.insert(
                             "node_id".to_owned(),
                             format!("0x{}", hex::encode(node_id.raw())),

--- a/trin-core/src/jsonrpc/utils.rs
+++ b/trin-core/src/jsonrpc/utils.rs
@@ -3,23 +3,37 @@ use discv5::{
     enr::NodeId,
     kbucket::{ConnectionState, NodeStatus},
 };
+use ethereum_types::U256;
 use serde_json::{json, Value};
+use std::collections::HashMap;
 
-pub fn bucket_entries_to_json(bucket_entries: Vec<(usize, NodeId, Enr, NodeStatus)>) -> Value {
+type NodeStringTuple = (String, String, String, String);
+type NodeTuple = (NodeId, Enr, NodeStatus, U256);
+
+pub fn bucket_entries_to_json(bucket_entries: HashMap<usize, Vec<NodeTuple>>) -> Value {
     let mut node_count: u16 = 0;
     let mut connected_count: u16 = 0;
-    let buckets_indexed: Vec<(String, String, String, String)> = bucket_entries
+    let buckets_indexed: HashMap<String, Vec<NodeStringTuple>> = bucket_entries
         .into_iter()
-        .map(|(bucket_index, node_id, enr, node_status)| {
-            node_count += 1;
-            if node_status.state == ConnectionState::Connected {
-                connected_count += 1
-            }
+        .map(|(bucket_index, bucket)| {
             (
                 format!("{}", bucket_index),
-                format!("0x{}", hex::encode(node_id.raw())),
-                enr.to_base64(),
-                format!("{:?}", node_status.state),
+                bucket
+                    .iter()
+                    .map(|(node_id, enr, node_status, data_radius)| {
+                        node_count += 1;
+                        if node_status.state == ConnectionState::Connected {
+                            connected_count += 1
+                        }
+
+                        (
+                            format!("0x{}", hex::encode(node_id.raw())),
+                            enr.to_base64(),
+                            format!("{:?}", node_status.state),
+                            format!("{}", data_radius),
+                        )
+                    })
+                    .collect(),
             )
         })
         .collect();

--- a/trin-core/src/jsonrpc/utils.rs
+++ b/trin-core/src/jsonrpc/utils.rs
@@ -5,30 +5,21 @@ use discv5::{
 };
 use serde_json::{json, Value};
 
-pub fn bucket_entries_to_json(
-    bucket_entries: Vec<(usize, Vec<(NodeId, Enr, NodeStatus)>)>,
-) -> Value {
+pub fn bucket_entries_to_json(bucket_entries: Vec<(usize, NodeId, Enr, NodeStatus)>) -> Value {
     let mut node_count: u16 = 0;
     let mut connected_count: u16 = 0;
-    let buckets_indexed: Vec<(String, Vec<(String, String, String)>)> = bucket_entries
+    let buckets_indexed: Vec<(String, String, String, String)> = bucket_entries
         .into_iter()
-        .map(|(index, bucket)| {
+        .map(|(bucket_index, node_id, enr, node_status)| {
+            node_count += 1;
+            if node_status.state == ConnectionState::Connected {
+                connected_count += 1
+            }
             (
-                format!("{}", index),
-                bucket
-                    .iter()
-                    .map(|(node_id, enr, node_status)| {
-                        node_count += 1;
-                        if node_status.state == ConnectionState::Connected {
-                            connected_count += 1
-                        }
-                        (
-                            format!("0x{}", hex::encode(node_id.raw())),
-                            enr.to_base64(),
-                            format!("{:?}", node_status.state),
-                        )
-                    })
-                    .collect(),
+                format!("{}", bucket_index),
+                format!("0x{}", hex::encode(node_id.raw())),
+                enr.to_base64(),
+                format!("{:?}", node_status.state),
             )
         })
         .collect();

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -1,6 +1,6 @@
 use anyhow::anyhow;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::{Debug, Display},
     marker::{PhantomData, Sync},
     str::FromStr,
@@ -389,10 +389,10 @@ where
             .collect()
     }
 
-    /// Returns a Vec of tuples, where each tuple represents a node in the kbuckets table.
-    ///     the usize represents the index (1-256) of the bucket containing
-    ///     the node with NodeId, Enr, and NodeStatus
-    pub fn bucket_entries(&self) -> HashMap<usize, Vec<(NodeId, Enr, NodeStatus, U256)>> {
+    /// Returns a map (BTree for its ordering guarantees) with:
+    ///     key: usize representing bucket index
+    ///     value: Vec of tuples, each tuple represents a node
+    pub fn bucket_entries(&self) -> BTreeMap<usize, Vec<(NodeId, Enr, NodeStatus, U256)>> {
         self.kbuckets
             .read()
             .buckets_iter()

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -39,7 +39,7 @@ use crate::{
 use discv5::{
     enr::NodeId,
     kbucket,
-    kbucket::{Filter, KBucketsTable, MAX_NODES_PER_BUCKET},
+    kbucket::{Filter, KBucketsTable, NodeStatus, MAX_NODES_PER_BUCKET},
     TalkRequest,
 };
 use ethereum_types::U256;
@@ -386,6 +386,21 @@ where
             .write()
             .iter()
             .map(|entry| entry.node.value.enr().clone())
+            .collect()
+    }
+
+    /// Returns an iterator over all the entries in the routing table.
+    pub fn table_entries(&self) -> Vec<(NodeId, Enr, NodeStatus)> {
+        self.kbuckets
+            .write()
+            .iter()
+            .map(|entry| {
+                (
+                    *entry.node.key.preimage(),
+                    entry.node.value.enr().clone(),
+                    entry.status,
+                )
+            })
             .collect()
     }
 

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -392,26 +392,28 @@ where
     /// Returns a Vec of tuples, where each tuple represents a node in the kbuckets table.
     ///     the usize represents the index (1-256) of the bucket containing
     ///     the node with NodeId, Enr, and NodeStatus
-    pub fn bucket_entries(&self) -> Vec<(usize, NodeId, Enr, NodeStatus)> {
+    pub fn bucket_entries(&self) -> HashMap<usize, Vec<(NodeId, Enr, NodeStatus, U256)>> {
         self.kbuckets
             .write()
             .buckets_iter()
             .enumerate()
             .filter(|(_, bucket)| bucket.num_entries() > 0)
             .map(|(index, bucket)| {
-                bucket
-                    .iter()
-                    .map(|node| {
-                        (
-                            index,
-                            *node.key.preimage(),
-                            node.value.enr().clone(),
-                            node.status,
-                        )
-                    })
-                    .collect::<Vec<(usize, NodeId, Enr, NodeStatus)>>()
+                (
+                    index,
+                    bucket
+                        .iter()
+                        .map(|node| {
+                            (
+                                *node.key.preimage(),
+                                node.value.enr().clone(),
+                                node.status,
+                                node.value.data_radius(),
+                            )
+                        })
+                        .collect(),
+                )
             })
-            .flatten()
             .collect()
     }
 

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -394,7 +394,7 @@ where
     ///     the node with NodeId, Enr, and NodeStatus
     pub fn bucket_entries(&self) -> HashMap<usize, Vec<(NodeId, Enr, NodeStatus, U256)>> {
         self.kbuckets
-            .write()
+            .read()
             .buckets_iter()
             .enumerate()
             .filter(|(_, bucket)| bucket.num_entries() > 0)

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -389,16 +389,23 @@ where
             .collect()
     }
 
-    /// Returns an iterator over all the entries in the routing table.
-    pub fn table_entries(&self) -> Vec<(NodeId, Enr, NodeStatus)> {
+    /// Returns a Vec of tuples, where each tuple contains:
+    ///     a usize representing a bucket's index (1-256)
+    ///     a Vec of tuples, each tuple representing a node in the given bucket
+    /// Only returns buckets that are not empty.
+    pub fn bucket_entries(&self) -> Vec<(usize, Vec<(NodeId, Enr, NodeStatus)>)> {
         self.kbuckets
             .write()
-            .iter()
-            .map(|entry| {
+            .buckets_iter()
+            .enumerate()
+            .filter(|(_, bucket)| bucket.num_entries() > 0)
+            .map(|(index, bucket)| {
                 (
-                    *entry.node.key.preimage(),
-                    entry.node.value.enr().clone(),
-                    entry.status,
+                    index,
+                    bucket
+                        .iter()
+                        .map(|node| (*node.key.preimage(), node.value.enr().clone(), node.status))
+                        .collect(),
                 )
             })
             .collect()

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -389,25 +389,29 @@ where
             .collect()
     }
 
-    /// Returns a Vec of tuples, where each tuple contains:
-    ///     a usize representing a bucket's index (1-256)
-    ///     a Vec of tuples, each tuple representing a node in the given bucket
-    /// Only returns buckets that are not empty.
-    pub fn bucket_entries(&self) -> Vec<(usize, Vec<(NodeId, Enr, NodeStatus)>)> {
+    /// Returns a Vec of tuples, where each tuple represents a node in the kbuckets table.
+    ///     the usize represents the index (1-256) of the bucket containing
+    ///     the node with NodeId, Enr, and NodeStatus
+    pub fn bucket_entries(&self) -> Vec<(usize, NodeId, Enr, NodeStatus)> {
         self.kbuckets
             .write()
             .buckets_iter()
             .enumerate()
             .filter(|(_, bucket)| bucket.num_entries() > 0)
             .map(|(index, bucket)| {
-                (
-                    index,
-                    bucket
-                        .iter()
-                        .map(|node| (*node.key.preimage(), node.value.enr().clone(), node.status))
-                        .collect(),
-                )
+                bucket
+                    .iter()
+                    .map(|node| {
+                        (
+                            index,
+                            *node.key.preimage(),
+                            node.value.enr().clone(),
+                            node.status,
+                        )
+                    })
+                    .collect::<Vec<(usize, NodeId, Enr, NodeStatus)>>()
             })
+            .flatten()
             .collect()
     }
 

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -11,6 +11,7 @@ use trin_core::{
             FindContentParams, FindNodesParams, HistoryJsonRpcRequest, LocalContentParams,
             OfferParams, PingParams, RecursiveFindContentParams, StoreParams,
         },
+        utils::bucket_entries_to_json,
     },
     portalnet::{
         types::{
@@ -223,27 +224,14 @@ impl HistoryRequestHandler {
                     let _ = request.resp.send(response);
                 }
                 HistoryEndpoint::RoutingTableInfo => {
-                    let buckets: Vec<(String, String, String)> = self
+                    let bucket_entries_json = bucket_entries_to_json(
+                        self
                         .network
                         .overlay
-                        .table_entries()
-                        .iter()
-                        .map(|(node_id, enr, node_status)| {
-                            (
-                                format!("0x{}", hex::encode(node_id.raw())),
-                                enr.to_base64(),
-                                format!("{:?}", node_status.state),
-                            )
-                        })
-                        .collect();
+                        .bucket_entries()
+                    );
 
-                    let _ = request.resp.send(Ok(json!(
-                        {
-                            "localKey": format!("0x{}", hex::encode(self.network.overlay.discovery.discv5.local_enr().node_id().raw())),
-                            "buckets": buckets,
-                            "count": buckets.len(),
-                        }
-                    )));
+                    let _ = request.resp.send(Ok(bucket_entries_json));
                 }
             }
         }

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -224,12 +224,8 @@ impl HistoryRequestHandler {
                     let _ = request.resp.send(response);
                 }
                 HistoryEndpoint::RoutingTableInfo => {
-                    let bucket_entries_json = bucket_entries_to_json(
-                        self
-                        .network
-                        .overlay
-                        .bucket_entries()
-                    );
+                    let bucket_entries_json =
+                        bucket_entries_to_json(self.network.overlay.bucket_entries());
 
                     let _ = request.resp.send(Ok(bucket_entries_json));
                 }

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -222,6 +222,29 @@ impl HistoryRequestHandler {
                     };
                     let _ = request.resp.send(response);
                 }
+                HistoryEndpoint::RoutingTableInfo => {
+                    let buckets: Vec<(String, String, String)> = self
+                        .network
+                        .overlay
+                        .table_entries()
+                        .iter()
+                        .map(|(node_id, enr, node_status)| {
+                            (
+                                format!("0x{}", hex::encode(node_id.raw())),
+                                enr.to_base64(),
+                                format!("{:?}", node_status.state),
+                            )
+                        })
+                        .collect();
+
+                    let _ = request.resp.send(Ok(json!(
+                        {
+                            "localKey": format!("0x{}", hex::encode(self.network.overlay.discovery.discv5.local_enr().node_id().raw())),
+                            "buckets": buckets,
+                            "count": buckets.len(),
+                        }
+                    )));
+                }
             }
         }
     }

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use serde_json::{Value};
+use serde_json::Value;
 use tokio::sync::mpsc;
 
 use crate::network::StateNetwork;
@@ -137,12 +137,8 @@ impl StateRequestHandler {
                     let _ = request.resp.send(response);
                 }
                 StateEndpoint::RoutingTableInfo => {
-                    let bucket_entries_json = bucket_entries_to_json(
-                        self
-                        .network
-                        .overlay
-                        .bucket_entries()
-                    );
+                    let bucket_entries_json =
+                        bucket_entries_to_json(self.network.overlay.bucket_entries());
 
                     let _ = request.resp.send(Ok(bucket_entries_json));
                 }


### PR DESCRIPTION
### What was wrong?

Trin has no way of retrieving a list of the nodes in the routing tables of each overlay network.

### How was it fixed?

- Added `portal_historyRoutingTableInfo` & `portal_stateRoutingTableInfo` endpoints. 
- Add corresponding tests to `ethportal-peertest`.

The json output format (under the "result" key) of these endpoints is: 

```
"buckets": {
      "246": [
        {
          "enr": "enr:-IS4QHq0W0mPXc5L5FkWnSB1vygIhnhSUh_xD2ddIZYCD3ycdBeHfU4S7wKLOB20zi93GEjfAa4qHHcE_i6eJaIwJPIBgmlkgnY0gmlwhEFsKgOJc2VjcDI1NmsxoQMlZcyp8md8ISz7m6TQlyYqSZPvZgRmtkV3MYgKLexwzIN1ZHCCI6Y",
          "node_id": "0x5e5feed5e2835682437c7bcae4e56ef55079bb80ace5d4482e2a2b684c86dcfb",
          "radius": "18446744073709551615",
          "status": "Connected"
        }
      ],
      "249": [
        {
          "enr": "enr:-IS4QI3GqhE7c_ufMjFYT7MXz98MqmzNlenWBKqvtFKvNqFHYVwMdM6jhtq8y4NzVYWUaJETm6jeK_V1nmmP0gJsXRgBgmlkgnY0gmlwhEFsKgOJc2VjcDI1NmsxoQNR97HGmoGUsgxt497YSsVl6RqIkrJHobZxBvBX14gEdoN1ZHCCI5I",
          "node_id": "0x5c43a5d46e81bb8cd329230ebc5d9db032c66c9ae97110c9b49e28de94b51f66",
          "radius": "18446744073709551615",
          "status": "Connected"
        }
      ],
      "252": [
        {
          "enr": "enr:-IS4QOA4voX3J7-R_x8pjlaxBTpT1S_CL7ZaNjetjZ-0nnr2VaP0wEZsT2KvjA5UWc8vi9I0XvNSd1bjU0GXUjlt7J0BgmlkgnY0gmlwhEFsKgOJc2VjcDI1NmsxoQI7aL5dFuHhwbxWD-C1yWH7UPlae5wuV_3WbPylCBwPboN1ZHCCI44",
          "node_id": "0x4f42329a2f4aebf4e488b4daa639f5bd03230865e4f5b4a232234618025b0ba8",
          "radius": "18446744073709551615",
          "status": "Connected"
        },
        {
          "enr": "enr:-IS4QNd_PFZkR7zizTltwbLbnYmDhT3TgH3xXH9ai_abUofLBkWr0_8kEdiapiR67Aurecu-E0C6-VPW4HFrHb-eENoBgmlkgnY0gmlwhE7JWtOJc2VjcDI1NmsxoQK8aBdTCqEfDB8D1xucsLrSzg_o7mOL5f6CR7QUNWXLfoN1ZHCCIzE",
          "node_id": "0x550b28434b38cf04cbd745e461ca62a81ec018e16c991d0d6a4a1aa6bb2708e0",
          "radius": "18446744073709551615",
          "status": "Disconnected"
        }
      ],
    },
    "numBuckets": 3,
    "numConnected": 3,
    "numNodes": 4
  }
}
```
I weighed a few different formats, and I think that this format strikes the best balance between human-readable and client-parseable. The previous formats were:
- flat structure where the top level key is `nodes` and each node object has a `bucket_index` key
- keyless structure where each node is represented by a 5-element list. It could be argued that this would save bandwidth by removing all of the repeated keys and just using known indices. 

Open to reverting to either if anyone has strong opinions.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
