### PR TITLE
Fix seed script bug by properly skipping bodies/receipts

### DIFF
--- a/src/bin/seed-database.rs
+++ b/src/bin/seed-database.rs
@@ -68,7 +68,12 @@ pub struct BlockRlp {
 
 impl Decodable for BlockRlp {
     fn decode(rlp: &rlp::Rlp) -> Result<Self, DecoderError> {
-        let header: Option<Header> = Some(rlp::decode(rlp.as_raw()).unwrap());
+        let header = match rlp::decode(rlp.as_raw()) {
+            // Valid header found
+            Ok(val) => Some(val),
+            // Skips block body / receipts
+            Err(_) => None,
+        };
         Ok(Self { header })
     }
 }


### PR DESCRIPTION
### What was wrong?
Recently updated `Header` rlp decoding caused a bug in the `seed-database.rs` script, crashing all of the testnet nodes.

### How was it fixed?
Properly handle bodies / receipts when decoding datastore.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
