### PR TITLE
Print error instead of crashing if bootnode responds with invalid packet

### DIFF
--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -112,12 +112,16 @@ pub enum OverlayRequestError {
     /// uTP request error
     #[error("uTP request error: {0}")]
     UtpError(String),
+
+    #[error("Received invalid remote packet.")]
+    InvalidRemotePacket,
 }
 
 impl From<discv5::RequestError> for OverlayRequestError {
     fn from(err: discv5::RequestError) -> Self {
         match err {
             discv5::RequestError::Timeout => Self::Timeout,
+            discv5::RequestError::InvalidRemotePacket => Self::InvalidRemotePacket,
             err => Self::Discv5Error(err),
         }
     }

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -113,15 +113,15 @@ pub enum OverlayRequestError {
     #[error("uTP request error: {0}")]
     UtpError(String),
 
-    #[error("Received invalid remote packet.")]
-    InvalidRemotePacket,
+    #[error("Received invalid remote discv5 packet")]
+    InvalidRemoteDiscv5Packet,
 }
 
 impl From<discv5::RequestError> for OverlayRequestError {
     fn from(err: discv5::RequestError) -> Self {
         match err {
             discv5::RequestError::Timeout => Self::Timeout,
-            discv5::RequestError::InvalidRemotePacket => Self::InvalidRemotePacket,
+            discv5::RequestError::InvalidRemotePacket => Self::InvalidRemoteDiscv5Packet,
             err => Self::Discv5Error(err),
         }
     }

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use log::debug;
+use log::{debug, error};
 use std::sync::{Arc, RwLock as StdRwLock};
 
 use parking_lot::RwLock;
@@ -107,6 +107,10 @@ impl HistoryNetwork {
                 Err(OverlayRequestError::Discv5Error(error)) => {
                     debug!("Unexpected error while bonding with {} => {:?}", enr, error);
                     return Err(anyhow!(error.to_string()));
+                }
+                Err(OverlayRequestError::InvalidRemotePacket) => {
+                    error!("Received invalid response received after pinging a potentially faulty bootnode: {enr:?}");
+                    continue;
                 }
                 _ => {
                     let msg = format!("Unexpected error while bonding with {enr}");

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -1,4 +1,3 @@
-use anyhow::anyhow;
 use log::{debug, error};
 use std::sync::{Arc, RwLock as StdRwLock};
 
@@ -8,7 +7,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use trin_core::{
     portalnet::{
         discovery::Discovery,
-        overlay::{OverlayConfig, OverlayProtocol, OverlayRequestError},
+        overlay::{OverlayConfig, OverlayProtocol},
         storage::{PortalStorage, PortalStorageConfig},
         types::{
             content_key::HistoryContentKey,
@@ -65,7 +64,7 @@ impl HistoryNetwork {
         // The overlay ping via talkreq will trigger a session at the base layer, then
         // a session on the (overlay) portal network.
         for enr in self.overlay.discovery.discv5.table_entries_enr() {
-            debug!("Pinging {} on portal history network", enr);
+            debug!("Attempting bond with bootnode {}", enr);
             let ping_result = self.overlay.send_ping(enr.clone()).await;
 
             match ping_result {
@@ -73,49 +72,8 @@ impl HistoryNetwork {
                     debug!("Successfully bonded with {}", enr);
                     continue;
                 }
-                Err(OverlayRequestError::ChannelFailure(error)) => {
-                    debug!("Channel failure sending ping: {}", error);
-                    continue;
-                }
-                Err(OverlayRequestError::Timeout) => {
-                    debug!("Timed out while bonding with {}", enr);
-                    continue;
-                }
-                Err(OverlayRequestError::EmptyResponse) => {
-                    debug!("Empty response to ping from: {}", enr);
-                    continue;
-                }
-                Err(OverlayRequestError::InvalidRequest(_)) => {
-                    debug!("Sent invalid ping request to {}", enr);
-                    continue;
-                }
-                Err(OverlayRequestError::InvalidResponse) => {
-                    debug!("Invalid ping response from: {}", enr);
-                    continue;
-                }
-                Err(OverlayRequestError::Failure(_)) => {
-                    debug!("Failure to serve ping response from: {}", enr);
-                    continue;
-                }
-                Err(OverlayRequestError::DecodeError) => {
-                    debug!("Error decoding ping response from: {}", enr);
-                    continue;
-                }
-                Err(OverlayRequestError::AcceptError(error)) => {
-                    debug!("Error building Accept message: {:?}", error);
-                }
-                Err(OverlayRequestError::Discv5Error(error)) => {
-                    debug!("Unexpected error while bonding with {} => {:?}", enr, error);
-                    return Err(anyhow!(error.to_string()));
-                }
-                Err(OverlayRequestError::InvalidRemotePacket) => {
-                    error!("Received invalid response received after pinging a potentially faulty bootnode: {enr:?}");
-                    continue;
-                }
-                _ => {
-                    let msg = format!("Unexpected error while bonding with {enr}");
-                    debug!("{msg}");
-                    return Err(anyhow!(msg));
+                Err(err) => {
+                    error!("{err} while pinging bootnode: {enr:?}");
                 }
             }
         }

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -74,6 +74,7 @@ impl HistoryNetwork {
                 }
                 Err(err) => {
                     error!("{err} while pinging bootnode: {enr:?}");
+                    std::process::exit(1);
                 }
             }
         }


### PR DESCRIPTION
### What was wrong?

Currently, if any of our bootnodes respond to our initial `PING` with an invalid Discv5 packet, Trin crashes with:
`thread 'tokio-runtime-worker' panicked at 'called Result::unwrap() on an Err value: InvalidRemotePacket', trin-history/src/lib.rs:185:40`

Even if a user reads this and thinks "I should try a different bootnode" or "I should alert the Trin team that their default bootnodes are misbehaving", they don't know which ENR is at fault. Turning on `debug` only prints the Node ID and IP, and is lost in a lot of noise. 

To reproduce the error above, run trin with this particular ultralight bootnode (error is intermittent):
`cargo run -- --networks history --bootnodes enr:-IS4QKczGIvcJ5mpqvzQQGhSNIPhyoBqW5H9OEggKYwmgei7egF3VvXNoCohGEcyUUB9jyBh8qY2iN8sJdK7pRgPP-UDgmlkgnY0gmlwhKRc9EGJc2VjcDI1NmsxoQKKnSTsqwcBYg1atI7dlanT8Mo29std_701sLx0g09yXYN1ZHCCE74`

### How was it fixed?

- An `InvalidRemoteDiscv5Packet` type is added to the `OverlayRequestError` enum.

- All errors while initially pinging bootnodes are caught and an error message is displayed:

```Jun 22 17:46:05.324 ERROR trin_history::network: Received invalid remote discv5 packet while pinging bootnode: enr:-IS4QKczGIvcJ5mpqvzQQGhSNIPhyoBqW5H9OEggKYwmgei7egF3VvXNoCohGEcyUUB9jyBh8qY2iN8sJdK7pRgPP-UDgmlkgnY0gmlwhKRc9EGJc2VjcDI1NmsxoQKKnSTsqwcBYg1atI7dlanT8Mo29std_701sLx0g09yXYN1ZHCCE74```

- This PR also simplifies the catching/printing of these errors in both `trin-state` and `trin-history`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
