### PR TITLE
Log during tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
             tag: 1.58.0
         environment:
             RUSTFLAGS: '-D warnings'
+            RUST_LOG: 'debug'
         steps:
             - checkout
             - restore_cache:
@@ -45,7 +46,7 @@ jobs:
                 command: cargo build --workspace --jobs 2
             - run:
                 name: Test Trin workspace
-                command: cargo test --workspace --jobs 2 -- --nocapture
+                command: cargo test --workspace --jobs 2
             - save_cache:
                 key: cargo-{{ checksum "Cargo.lock" }}-v1
                 paths:
@@ -57,6 +58,8 @@ jobs:
     executor:
       name: win/default
       shell: powershell.exe
+    environment:
+        RUST_LOG: 'debug'
     steps:
       - checkout
       - restore_cache:
@@ -88,7 +91,7 @@ jobs:
           command: cargo build --target x86_64-pc-windows-msvc
       - run:
           name: Cargo Test --target x86_64-pc-windows-msvc
-          command: cargo test --target x86_64-pc-windows-msvc -- --nocapture
+          command: cargo test --target x86_64-pc-windows-msvc
       - save_cache:
           key: cargo-{{ checksum "Cargo.lock" }}-v1
           paths:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3748,6 +3748,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-log"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4235dbf7ea878b3ef12dea20a59c134b405a66aafc4fc2c7b9935916e289e735"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4288,6 +4299,7 @@ dependencies = [
  "structopt",
  "stunclient",
  "tempdir",
+ "test-log",
  "thiserror",
  "threadpool",
  "tokio",
@@ -4295,6 +4307,7 @@ dependencies = [
  "tokio-util 0.6.10",
  "tracing",
  "tracing-futures",
+ "tracing-subscriber 0.2.25",
  "uds_windows",
  "uint 0.8.5",
  "ureq",
@@ -4309,6 +4322,7 @@ dependencies = [
  "async-trait",
  "bytes 1.1.0",
  "discv5",
+ "env_logger",
  "ethereum-types 0.12.1",
  "hex",
  "httpmock",
@@ -4320,6 +4334,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempdir",
+ "test-log",
  "tokio",
  "tracing",
  "tracing-subscriber 0.2.25",
@@ -4333,6 +4348,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "discv5",
+ "env_logger",
  "eth_trie",
  "ethereum-types 0.12.1",
  "hex",
@@ -4341,6 +4357,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "rocksdb",
  "serde_json",
+ "test-log",
  "tokio",
  "tracing",
  "tracing-futures",

--- a/ethportal-peertest/src/lib.rs
+++ b/ethportal-peertest/src/lib.rs
@@ -48,6 +48,8 @@ pub async fn launch_node(id: u16, bootnode_enr: Option<&SszEnr>) -> anyhow::Resu
             let enr_base64 = enr.to_base64();
             let trin_config_args = vec![
                 "trin",
+                "--networks",
+                "history,state",
                 "--external-address",
                 external_addr.as_str(),
                 "--bootnodes",
@@ -67,6 +69,8 @@ pub async fn launch_node(id: u16, bootnode_enr: Option<&SszEnr>) -> anyhow::Resu
             let external_addr = format!("{}:{}", ip_addr, discovery_port);
             let trin_config_args = vec![
                 "trin",
+                "--networks",
+                "history,state",
                 "--external-address",
                 external_addr.as_str(),
                 "--discovery-port",

--- a/newsfragments/353.changed.md
+++ b/newsfragments/353.changed.md
@@ -1,0 +1,1 @@
+Disabled state network by default, until support is added.

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -20,6 +20,8 @@ mod test {
         let trin_config = TrinConfig::new_from(
             [
                 "trin",
+                "--networks",
+                "history,state",
                 "--no-stun",
                 "--web3-ipc-path",
                 &peertest_config.target_ipc_path,

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -4,6 +4,7 @@ mod test {
     use std::{thread, time};
     use trin_core::cli::TrinConfig;
 
+    // Logs don't show up when trying to use test_log here, maybe because of multi_thread
     #[tokio::test(flavor = "multi_thread")]
     async fn test_launches() {
         tracing_subscriber::fmt::init();

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -71,5 +71,7 @@ version = "0.26.3"
 features = ["bundled"]
 
 [dev-dependencies]
-quickcheck = "1.0.3"
 ntest = "0.8.0"
+quickcheck = "1.0.3"
+test-log = { version = "0.2.10", features = ["trace"] }
+tracing-subscriber = "0.2.18"

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -173,6 +173,7 @@ fn check_private_key_length(private_key: String) -> Result<(), String> {
 mod test {
     use super::*;
     use std::env;
+    use test_log::test;
 
     fn env_is_set() -> bool {
         matches!(env::var("TRIN_INFURA_PROJECT_ID"), Ok(_))

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -10,7 +10,7 @@ pub const DEFAULT_WEB3_HTTP_ADDRESS: &str = "127.0.0.1:8545";
 const DEFAULT_DISCOVERY_PORT: &str = "9000";
 pub const HISTORY_NETWORK: &str = "history";
 pub const STATE_NETWORK: &str = "state";
-const DEFAULT_SUBNETWORKS: &str = "history,state";
+const DEFAULT_SUBNETWORKS: &str = "history";
 pub const DEFAULT_STORAGE_CAPACITY: &str = "100000"; // 100mb
 
 #[derive(StructOpt, Debug, PartialEq, Clone)]

--- a/trin-core/src/jsonrpc/types.rs
+++ b/trin-core/src/jsonrpc/types.rs
@@ -497,7 +497,7 @@ mod test {
     use rstest::rstest;
     use validator::ValidationErrors;
 
-    #[test]
+    #[test_log::test]
     fn test_json_validator_accepts_valid_json() {
         let request = JsonRequest {
             jsonrpc: "2.0".to_string(),
@@ -508,7 +508,7 @@ mod test {
         assert_eq!(request.validate(), Ok(()));
     }
 
-    #[test]
+    #[test_log::test]
     fn test_json_validator_with_invalid_jsonrpc_field() {
         let request = JsonRequest {
             jsonrpc: "1.0".to_string(),

--- a/trin-core/src/portalnet/find/iterators/findcontent.rs
+++ b/trin-core/src/portalnet/find/iterators/findcontent.rs
@@ -398,6 +398,7 @@ mod tests {
     use quickcheck::*;
     use rand::{thread_rng, Rng};
     use std::time::Duration;
+    use test_log::test;
 
     type TestQuery = FindContentQuery<NodeId>;
 

--- a/trin-core/src/portalnet/find/iterators/findnodes.rs
+++ b/trin-core/src/portalnet/find/iterators/findnodes.rs
@@ -324,6 +324,7 @@ mod tests {
     use quickcheck::*;
     use rand::{thread_rng, Rng};
     use std::time::Duration;
+    use test_log::test;
 
     type TestQuery = FindNodeQuery<NodeId>;
 

--- a/trin-core/src/portalnet/find/query_info.rs
+++ b/trin-core/src/portalnet/find/query_info.rs
@@ -88,6 +88,7 @@ fn findnode_log2distance(target: NodeId, peer: NodeId, size: usize) -> Option<Ve
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_log::test;
 
     #[test]
     fn test_log2distance() {

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -666,7 +666,7 @@ mod test {
         assert_eq!(log2_random_nodes.len(), expected_log2);
     }
 
-    #[test]
+    #[test_log::test]
     #[should_panic]
     fn test_log2_random_enrs_empty_input() {
         let all_nodes = vec![];

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -1803,7 +1803,7 @@ mod tests {
         service
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn process_ping_source_in_table_higher_enr_seq() {
         let mut service = task::spawn(build_service());
@@ -1857,7 +1857,7 @@ mod tests {
         };
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn process_ping_source_not_in_table() {
         let mut service = task::spawn(build_service());
@@ -1876,7 +1876,7 @@ mod tests {
         assert_pending!(poll_request_rx!(service));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn process_request_failure() {
         let mut service = task::spawn(build_service());
@@ -1921,7 +1921,7 @@ mod tests {
         };
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn process_pong_source_in_table_higher_enr_seq() {
         let mut service = task::spawn(build_service());
@@ -1975,7 +1975,7 @@ mod tests {
         };
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn process_pong_source_not_in_table() {
         let mut service = task::spawn(build_service());
@@ -1993,7 +1993,7 @@ mod tests {
         assert_pending!(poll_request_rx!(service));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn process_discovered_enrs_local_enr() {
         let mut service = task::spawn(build_service());
@@ -2013,7 +2013,7 @@ mod tests {
         assert!(service.peers_to_ping.is_empty());
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn process_discovered_enrs_unknown_enrs() {
         let mut service = task::spawn(build_service());
@@ -2059,7 +2059,7 @@ mod tests {
         assert!(service.peers_to_ping.contains_key(&enr2.node_id()));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn process_discovered_enrs_known_enrs() {
         let mut service = task::spawn(build_service());
@@ -2133,7 +2133,7 @@ mod tests {
         };
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn request_node() {
         let mut service = task::spawn(build_service());
@@ -2162,7 +2162,7 @@ mod tests {
         };
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn ping_node() {
         let mut service = task::spawn(build_service());
@@ -2184,7 +2184,7 @@ mod tests {
         assert!(matches!(request.request, Request::Ping { .. }));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn connect_node() {
         let mut service = task::spawn(build_service());
@@ -2219,7 +2219,7 @@ mod tests {
         };
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn update_node_connection_state_disconnected_to_connected() {
         let mut service = task::spawn(build_service());
@@ -2264,7 +2264,7 @@ mod tests {
         };
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn update_node_connection_state_connected_to_disconnected() {
         let mut service = task::spawn(build_service());
@@ -2409,7 +2409,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_advance_findnodes_query() {
         let mut service = build_service();
 
@@ -2532,7 +2532,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_find_enrs() {
         let mut service = task::spawn(build_service());
 

--- a/trin-core/src/portalnet/storage.rs
+++ b/trin-core/src/portalnet/storage.rs
@@ -524,7 +524,7 @@ pub mod test {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn test_new() -> Result<(), PortalStorageError> {
         let temp_dir = setup_temp_dir();
@@ -553,7 +553,7 @@ pub mod test {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn test_store() -> Result<(), PortalStorageError> {
         let temp_dir = setup_temp_dir();
@@ -580,7 +580,7 @@ pub mod test {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn test_get_data() -> Result<(), PortalStorageError> {
         let temp_dir = setup_temp_dir();
@@ -610,7 +610,7 @@ pub mod test {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn test_get_total_storage() -> Result<(), PortalStorageError> {
         let temp_dir = setup_temp_dir();
@@ -641,7 +641,7 @@ pub mod test {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn test_find_farthest_empty_db() -> Result<(), PortalStorageError> {
         let temp_dir = setup_temp_dir();
@@ -668,7 +668,7 @@ pub mod test {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn test_find_farthest() {
         fn prop(x: IdentityContentKey, y: IdentityContentKey) -> TestResult {

--- a/trin-core/src/portalnet/types/content_key.rs
+++ b/trin-core/src/portalnet/types/content_key.rs
@@ -301,6 +301,7 @@ mod test {
     use ethereum_types::U256;
     use serial_test::serial;
     use tempdir::TempDir;
+    use test_log::test;
 
     use crate::portalnet::storage::{
         DistanceFunction, PortalStorage, PortalStorageConfig, PortalStorageError,
@@ -406,7 +407,7 @@ mod test {
     // This test is for PortalStorage functionality, but is located here to take advantage of
     // full-featured content key types, since MockContentKey is insufficient to test
     // some PortalStorage functionality
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn test_should_store() -> Result<(), PortalStorageError> {
         let temp_dir = setup_temp_dir();
@@ -463,7 +464,7 @@ mod test {
     // This test is for PortalStorage functionality, but is located here to take advantage of
     // full-featured content key types, since MockContentKey is insufficient to test
     // some PortalStorage functionality
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[serial]
     async fn test_distance_to_key() -> Result<(), PortalStorageError> {
         let temp_dir = setup_temp_dir();

--- a/trin-core/src/portalnet/types/messages.rs
+++ b/trin-core/src/portalnet/types/messages.rs
@@ -591,6 +591,7 @@ impl FromStr for HexData {
 #[cfg(test)]
 mod test {
     use super::*;
+    use test_log::test;
 
     #[test]
     #[should_panic]

--- a/trin-core/src/portalnet/types/metric.rs
+++ b/trin-core/src/portalnet/types/metric.rs
@@ -25,6 +25,7 @@ mod test {
     use super::*;
 
     use quickcheck::{quickcheck, Arbitrary, Gen, TestResult};
+    use test_log::test;
 
     /// Wrapper type around a 256-bit identifier in the DHT key space.
     ///

--- a/trin-core/src/types/block_body.rs
+++ b/trin-core/src/types/block_body.rs
@@ -235,7 +235,7 @@ mod tests {
         assert_eq!(tx_rlp, encoded_tx);
     }
 
-    #[test]
+    #[test_log::test]
     fn transactions_root() {
         let tx_list: Vec<Transaction> = vec![
             Transaction::decode(&hex::decode(TX1.to_string()).unwrap()).unwrap(),
@@ -264,7 +264,7 @@ mod tests {
         assert_eq!(expected_root, hex::encode(transactions.root().unwrap()));
     }
 
-    #[test]
+    #[test_log::test]
     fn uncles_root() {
         let uncle_rlp = &hex::decode(UNCLE).unwrap();
         let uncle_rlp = Rlp::new(uncle_rlp);

--- a/trin-core/src/types/header.rs
+++ b/trin-core/src/types/header.rs
@@ -169,6 +169,7 @@ impl Encodable for Header {
 mod tests {
     use super::Header;
     use hex;
+    use test_log::test;
 
     // Based on https://github.com/openethereum/openethereum/blob/main/crates/ethcore/types/src/header.rs
     #[test]

--- a/trin-core/src/types/receipts.rs
+++ b/trin-core/src/types/receipts.rs
@@ -243,6 +243,7 @@ mod tests {
     use std::str::FromStr;
 
     use ethereum_types::H160;
+    use test_log::test;
 
     //
     // Tests using custom generated rlp encoded receipts from block 14764013

--- a/trin-core/src/utils/bootnodes.rs
+++ b/trin-core/src/utils/bootnodes.rs
@@ -34,7 +34,7 @@ mod test {
     use crate::cli::TrinConfig;
     use rstest::rstest;
 
-    #[test]
+    #[test_log::test]
     fn test_parse_bootnodes_default_flag() {
         let config = TrinConfig::new_from(["trin", "--bootnodes", "default"].iter()).unwrap();
         let actual = parse_bootnodes(&config.bootnodes).unwrap();

--- a/trin-core/src/utils/bytes.rs
+++ b/trin-core/src/utils/bytes.rs
@@ -47,6 +47,7 @@ pub fn hex_decode(data: &str) -> anyhow::Result<Vec<u8>> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use test_log::test;
 
     #[test]
     fn test_random_32byte_array_1() {

--- a/trin-core/src/utils/node_id.rs
+++ b/trin-core/src/utils/node_id.rs
@@ -55,6 +55,7 @@ pub fn generate_random_remote_enr() -> (CombinedKey, Enr) {
 #[cfg(test)]
 mod test {
     use super::*;
+    use test_log::test;
 
     #[test]
     fn test_generate_random_node_id_1() {

--- a/trin-core/src/utp/bit_iterator.rs
+++ b/trin-core/src/utp/bit_iterator.rs
@@ -47,12 +47,17 @@ impl<'a> Iterator for BitIterator<'a> {
 
 impl<'a> ExactSizeIterator for BitIterator<'a> {}
 
-#[test]
-fn test_iterator() {
-    let bytes = vec![0xCA, 0xFE];
-    let expected_bits = vec![0, 1, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1];
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    for (i, bit) in BitIterator::from_bytes(&bytes).enumerate() {
-        assert_eq!(bit, expected_bits[i] == 1);
+    #[test_log::test]
+    fn test_iterator() {
+        let bytes = vec![0xCA, 0xFE];
+        let expected_bits = vec![0, 1, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1];
+
+        for (i, bit) in BitIterator::from_bytes(&bytes).enumerate() {
+            assert_eq!(bit, expected_bits[i] == 1);
+        }
     }
 }

--- a/trin-core/src/utp/packets.rs
+++ b/trin-core/src/utp/packets.rs
@@ -511,6 +511,7 @@ mod tests {
     };
     use quickcheck::{QuickCheck, TestResult};
     use std::convert::TryFrom;
+    use test_log::test;
 
     #[test]
     fn test_decode_packet() {

--- a/trin-core/src/utp/stream.rs
+++ b/trin-core/src/utp/stream.rs
@@ -1574,7 +1574,7 @@ mod tests {
         });
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_handle_packet() {
         // Boilerplate test setup
         let initial_connection_id: u16 = rand::random();
@@ -1673,7 +1673,7 @@ mod tests {
         assert_eq!(response.ack_nr(), packet.seq_nr());
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_response_to_keepalive_ack() {
         // Boilerplate test setup
         let initial_connection_id: u16 = rand::random();
@@ -1719,7 +1719,7 @@ mod tests {
         stream.state = StreamState::Closed;
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_response_to_wrong_connection_id() {
         // Boilerplate test setup
         let initial_connection_id: u16 = rand::random();
@@ -1759,7 +1759,7 @@ mod tests {
         stream.state = StreamState::Closed;
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_unordered_packets() {
         // Boilerplate test setup
         let initial_connection_id: u16 = rand::random();
@@ -1816,7 +1816,7 @@ mod tests {
         stream.state = StreamState::Closed;
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_base_delay_calculation() {
         let minute_in_microseconds = 60 * 10i64.pow(6);
         let samples = vec![
@@ -1846,7 +1846,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_response_to_triple_ack() {
         let mut buf = [0; BUF_SIZE];
         let mut server = server_setup().await;
@@ -1937,7 +1937,7 @@ mod tests {
         handle.await.unwrap().unwrap();
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_sorted_buffer_insertion() {
         let mut stream = server_setup().await;
 
@@ -1975,7 +1975,7 @@ mod tests {
         assert_eq!(stream.incoming_buffer[1].timestamp(), 128.into());
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_duplicate_packet_handling() {
         let mut buf = [0; BUF_SIZE];
         let mut server = server_setup().await;

--- a/trin-core/src/utp/trin_helpers.rs
+++ b/trin-core/src/utp/trin_helpers.rs
@@ -67,6 +67,7 @@ pub enum UtpStreamId {
 #[cfg(test)]
 mod tests {
     use crate::utp::trin_helpers::UtpMessage;
+    use test_log::test;
 
     #[test]
     fn test_too_short_message() {

--- a/trin-core/src/utp/util.rs
+++ b/trin-core/src/utp/util.rs
@@ -42,6 +42,7 @@ pub fn generate_sequential_identifiers() -> (u16, u16) {
 #[cfg(test)]
 mod test {
     use crate::utp::util::*;
+    use test_log::test;
 
     #[test]
     fn test_ewma_empty_vector() {

--- a/trin-core/tests/overlay.rs
+++ b/trin-core/tests/overlay.rs
@@ -105,7 +105,7 @@ async fn spawn_overlay(
 // multiple nodes.
 //
 // Use sleeps to give time for background routing table processes.
-#[tokio::test]
+#[test_log::test(tokio::test)]
 async fn overlay() {
     let protocol = ProtocolId::History;
     let sleep_duration = Duration::from_millis(5);

--- a/trin-core/tests/utp_listener.rs
+++ b/trin-core/tests/utp_listener.rs
@@ -72,7 +72,7 @@ async fn spawn_utp_listener() -> (
     (enr, utp_listener_tx, utp_listener_rx)
 }
 
-#[tokio::test]
+#[test_log::test(tokio::test)]
 #[timeout(100)]
 /// Simulate simple OFFER -> ACCEPT uTP payload transfer
 async fn utp_listener_events() {

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -27,3 +27,8 @@ tracing = "0.1.26"
 tracing-subscriber = "0.2.18"
 tokio = { version = "1.8.0", features = ["full"] }
 trin-core = { path = "../trin-core" }
+
+[dev-dependencies]
+env_logger = "0.8.2"
+test-log = { version = "0.2.10", features = ["trace"] }
+tracing-subscriber = "0.2.18"

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -116,7 +116,7 @@ mod tests {
         server
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn validate_header() {
         let server = setup_mock_infura_server();
         let header_rlp = get_header_rlp();
@@ -139,7 +139,7 @@ mod tests {
             .unwrap();
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[should_panic]
     async fn invalidate_header_with_invalid_number() {
         let server = setup_mock_infura_server();
@@ -167,7 +167,7 @@ mod tests {
             .unwrap();
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[should_panic]
     async fn invalidate_header_with_invalid_gaslimit() {
         let server = setup_mock_infura_server();

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -24,3 +24,8 @@ tracing-futures = "0.2.5"
 tokio = {version = "1.8.0", features = ["full"]}
 trin-core = { path = "../trin-core" }
 rocksdb = "0.18.0"
+
+[dev-dependencies]
+env_logger = "0.8.2"
+test-log = { version = "0.2.10", features = ["trace"] }
+tracing-subscriber = "0.2.18"

--- a/trin-state/src/utils.rs
+++ b/trin-state/src/utils.rs
@@ -72,6 +72,7 @@ pub fn distance(node_id: U256, content_id: U256) -> Result<U256, String> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use test_log::test;
 
     // 2 ** 256 - 1
     const MOD_SUB_ONE: &str =


### PR DESCRIPTION
### What was wrong?

Logs were not being initialized/generated during test runs. It's so much nicer to debug a failing test when the logs are shown on failure.

Also, bonus: **disable state network by default**. This was discussed on a call. Soon, history will be properly supported and state won't, so don't launch state by default.

### How was it fixed?

Add the test-log crate to use an easy attribute that initializes logging during tests.

Sometimes, when there are sibling `rstest` attributes, or a `tokio::test`, we need to manually wrap the macro.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
