### PR TITLE
Add find content query type and make query event generic over query

### DIFF
--- a/trin-core/src/portalnet/find/query_info.rs
+++ b/trin-core/src/portalnet/find/query_info.rs
@@ -39,7 +39,7 @@ pub enum QueryType<TContentKey> {
         target: TContentKey,
 
         /// A callback channel for the result of the query.
-        callback: Option<oneshot::Sender<Vec<u8>>>,
+        callback: Option<oneshot::Sender<Option<Vec<u8>>>>,
     },
 }
 


### PR DESCRIPTION
### What was wrong?

- There was no find content variant for `QueryType`.
- `FindNodeQueryEvent` was not generic over `Query`.

### How was it fixed?

- Add `FindContent` variant for `QueryType` with generic type parameter for `OverlayContentKey`.
- Add necessary generic type parameters to `QueryInfo` and `QueryPool` and `QueryEvent`.
- Rename `FindNodeQueryEvent` to `QueryEvent` and make generic over `Query` and `OverlayContentKey`.
- Add generic type parameter for `Query` to `query_event_poll` so that we can call the function with `QueryPool` for any type of `Query`.

### Questions

The data type of the `callback` channel for `QueryType::FindContent` is `Option<Vec<u8>>` here for the data that corresponds to the (possibly not found) content. I could not find a (recursive) content lookup RPC in the portal JSON-RPC spec, so I was not sure whether this data type should be an enum with another variant for the closest ENRs.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
