### PR TITLE
[demo] weird crashing test behavior

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ trin-state = { path = "trin-state" }
 
 [dev-dependencies]
 ethportal-peertest = { path = "ethportal-peertest" }
+env_logger = "0.8.2"
+test-log = { version = "0.2.10", features = ["trace"] }
+tracing-subscriber = "0.2.18"
 
 [workspace]
 members = [

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -4,12 +4,20 @@ mod test {
     use std::{thread, time};
     use trin_core::cli::TrinConfig;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_launches() {
-        tracing_subscriber::fmt::init();
+        log::debug!("debug log");
+
+
+        // if the first failure is here, then `cargo test` *does* capture output
+        assert!(false);
 
         // Run a client, as a buddy peer for ping tests, etc.
         let peertest = peertest::launch_peertest_nodes(2).await;
+
+        // if the first failure is here or later, then `cargo test` does *not* capture output
+        assert!(false);
+
         // Short sleep to make sure all peertest nodes can connect
         thread::sleep(time::Duration::from_secs(1));
 


### PR DESCRIPTION
The test does not capture log/stdout on a failure, if it fails after
launching the peertest nodes...

### What was wrong?

#355 

### How was it fixed?

This is not a fix, it's a problem demonstration