### PR TITLE
Add node in overlay routing table before returning overlay response

### DIFF
--- a/newsfragments/357.changed.md
+++ b/newsfragments/357.changed.md
@@ -1,0 +1,1 @@
+ Before sending overlay response, update overlay routing table upon overlay request receive.


### PR DESCRIPTION
### What was wrong?

We are responding to an overlay request before updating the overlay routing table with the remote `NodeId`.

This can lead to some unexpected behavior, for example when we receive an `OFFER` request, we want to check the overlay routing table if the node already exists and start listening for incoming uTP packets, **before** sending the `ACCEPT` response.

For reference, the discv5 implementation first adds the remote node to the routing table (after a successful handshake) and then responds with a talk response.

### How was it fixed?
1. Extract a new method from existing code encapsulating the logic for overlay routing table update.
2. Call the method before building the overlay response.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
