### PR TITLE
refactor: remove binaries for trin-history and trin-state

### DIFF
--- a/trin-history/src/main.rs
+++ b/trin-history/src/main.rs
@@ -1,9 +1,0 @@
-use trin_core::utils::infura::build_infura_project_url_from_env;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
-
-    let infura_url = build_infura_project_url_from_env();
-    trin_history::main(infura_url).await
-}

--- a/trin-state/src/main.rs
+++ b/trin-state/src/main.rs
@@ -1,6 +1,0 @@
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
-
-    trin_state::main().await
-}


### PR DESCRIPTION
### What was wrong?

The binaries for `trin-state` and `trin-history` are unused and are not necessary to run the individual subnetworks.

### How was it fixed?

Remove `trin-state` and `trin-history` binaries so that `trin` is the single entry point.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
