### PR TITLE
Increase the utp_listener_events timeout to avoid sporadic CI failure

### DIFF
--- a/trin-core/tests/utp_listener.rs
+++ b/trin-core/tests/utp_listener.rs
@@ -73,7 +73,7 @@ async fn spawn_utp_listener() -> (
 }
 
 #[test_log::test(tokio::test)]
-#[timeout(100)]
+#[timeout(1000)]
 /// Simulate simple OFFER -> ACCEPT uTP payload transfer
 async fn utp_listener_events() {
     let protocol_id = ProtocolId::History;


### PR DESCRIPTION
### What was wrong?

Fix #362 

### How was it fixed?

Increase timeout to 1s

### To-Do

- [x] Clean up commit history
