### PR TITLE
Implement `--ephemeral` CLI flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4299,7 +4299,7 @@ dependencies = [
  "smallvec 1.8.0",
  "structopt",
  "stunclient",
- "tempdir",
+ "tempfile",
  "test-log",
  "thiserror",
  "threadpool",

--- a/ethportal-peertest/src/lib.rs
+++ b/ethportal-peertest/src/lib.rs
@@ -60,6 +60,7 @@ pub async fn launch_node(id: u16, bootnode_enr: Option<&SszEnr>) -> anyhow::Resu
                 web3_ipc_path.as_str(),
                 "--unsafe-private-key",
                 private_key.as_str(),
+                "--ephemeral",
             ];
             TrinConfig::new_from(trin_config_args.iter()).unwrap()
         }
@@ -79,6 +80,7 @@ pub async fn launch_node(id: u16, bootnode_enr: Option<&SszEnr>) -> anyhow::Resu
                 web3_ipc_path.as_str(),
                 "--unsafe-private-key",
                 private_key.as_str(),
+                "--ephemeral",
             ];
             TrinConfig::new_from(trin_config_args.iter()).unwrap()
         }

--- a/newsfragments/364.added.md
+++ b/newsfragments/364.added.md
@@ -1,0 +1,2 @@
+- Implement `--ephemeral` CLI flag which creates temporarily data folder.
+- Migrate from `tempdir` to `tempfile` crate because of depreciation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, RwLock};
 use log::debug;
 use tokio::sync::mpsc;
 
+use trin_core::utils::db::setup_temp_dir;
 use trin_core::{
     cli::{TrinConfig, HISTORY_NETWORK, STATE_NETWORK},
     jsonrpc::{
@@ -57,6 +58,10 @@ pub async fn run_trin(
     tokio::spawn(async move { utp_listener.start().await });
 
     // Initialize Storage config
+    if trin_config.ephemeral {
+        setup_temp_dir();
+    }
+
     let storage_config =
         PortalStorage::setup_config(discovery.local_enr().node_id(), trin_config.kb)?;
 

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -25,6 +25,7 @@ mod test {
                 "--no-stun",
                 "--web3-ipc-path",
                 &peertest_config.target_ipc_path,
+                "--ephemeral",
             ]
             .iter(),
         )

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -47,7 +47,7 @@ stunclient = "0.1.2"
 structopt = "0.3"
 sha3 = "0.9.1"
 smallvec = "1.8.0"
-tempdir = "0.3.7"
+tempfile = "3.3.0"
 thiserror = "1.0.29"
 threadpool = "1.8.1"
 tokio = { version = "1.8.0", features = ["full"] }

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -110,6 +110,37 @@ pub struct TrinConfig {
 
     #[structopt(long = "metrics-url", help = "URL for prometheus server")]
     pub metrics_url: Option<String>,
+
+    #[structopt(
+        short = "e",
+        long = "ephemeral",
+        help = "Use temporary data storage that is deleted on exit."
+    )]
+    pub ephemeral: bool,
+}
+
+impl Default for TrinConfig {
+    fn default() -> Self {
+        TrinConfig {
+            web3_transport: "ipc".to_string(),
+            web3_http_address: DEFAULT_WEB3_HTTP_ADDRESS.to_string(),
+            web3_ipc_path: DEFAULT_WEB3_IPC_PATH.to_string(),
+            pool_size: 2,
+            discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
+            bootnodes: vec![],
+            external_addr: None,
+            no_stun: false,
+            private_key: None,
+            networks: DEFAULT_SUBNETWORKS
+                .split(',')
+                .map(|n| n.to_string())
+                .collect(),
+            kb: DEFAULT_STORAGE_CAPACITY.parse().unwrap(),
+            enable_metrics: false,
+            metrics_url: None,
+            ephemeral: false,
+        }
+    }
 }
 
 impl TrinConfig {
@@ -182,24 +213,7 @@ mod test {
     #[test]
     fn test_default_args() {
         assert!(env_is_set());
-        let expected_config = TrinConfig {
-            web3_http_address: DEFAULT_WEB3_HTTP_ADDRESS.to_string(),
-            web3_ipc_path: DEFAULT_WEB3_IPC_PATH.to_string(),
-            pool_size: 2,
-            kb: DEFAULT_STORAGE_CAPACITY.parse().unwrap(),
-            web3_transport: "ipc".to_string(),
-            discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
-            no_stun: false,
-            bootnodes: vec![],
-            external_addr: None,
-            private_key: None,
-            enable_metrics: false,
-            metrics_url: None,
-            networks: DEFAULT_SUBNETWORKS
-                .split(',')
-                .map(|n| n.to_string())
-                .collect(),
-        };
+        let expected_config = TrinConfig::default();
         let actual_config = TrinConfig::new_from(["trin"].iter()).unwrap();
         assert_eq!(actual_config.web3_transport, expected_config.web3_transport);
         assert_eq!(
@@ -208,28 +222,18 @@ mod test {
         );
         assert_eq!(actual_config.pool_size, expected_config.pool_size);
         assert_eq!(actual_config.external_addr, expected_config.external_addr);
+        assert_eq!(actual_config.no_stun, expected_config.no_stun);
+        assert_eq!(actual_config.ephemeral, expected_config.ephemeral);
     }
 
     #[test]
     fn test_custom_http_args() {
         assert!(env_is_set());
         let expected_config = TrinConfig {
-            external_addr: None,
-            private_key: None,
-            kb: DEFAULT_STORAGE_CAPACITY.parse().unwrap(),
             web3_http_address: "0.0.0.0:8080".to_string(),
-            web3_ipc_path: DEFAULT_WEB3_IPC_PATH.to_string(),
             pool_size: 3,
             web3_transport: "http".to_string(),
-            discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
-            no_stun: false,
-            bootnodes: vec![],
-            enable_metrics: false,
-            metrics_url: None,
-            networks: DEFAULT_SUBNETWORKS
-                .split(',')
-                .map(|n| n.to_string())
-                .collect(),
+            ..Default::default()
         };
         let actual_config = TrinConfig::new_from(
             [
@@ -258,22 +262,10 @@ mod test {
         let actual_config =
             TrinConfig::new_from(["trin", "--web3-transport", "ipc"].iter()).unwrap();
         let expected_config = TrinConfig {
-            external_addr: None,
-            private_key: None,
-            kb: DEFAULT_STORAGE_CAPACITY.parse().unwrap(),
             web3_http_address: DEFAULT_WEB3_HTTP_ADDRESS.to_string(),
-            web3_ipc_path: DEFAULT_WEB3_IPC_PATH.to_string(),
             pool_size: 2,
             web3_transport: "ipc".to_string(),
-            discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
-            no_stun: false,
-            bootnodes: vec![],
-            enable_metrics: false,
-            metrics_url: None,
-            networks: DEFAULT_SUBNETWORKS
-                .split(',')
-                .map(|n| n.to_string())
-                .collect(),
+            ..Default::default()
         };
         assert_eq!(actual_config.web3_transport, expected_config.web3_transport);
         assert_eq!(
@@ -298,22 +290,11 @@ mod test {
         )
         .unwrap();
         let expected_config = TrinConfig {
-            private_key: None,
-            external_addr: None,
             web3_http_address: DEFAULT_WEB3_HTTP_ADDRESS.to_string(),
             web3_ipc_path: "/path/test.ipc".to_string(),
-            kb: DEFAULT_STORAGE_CAPACITY.parse().unwrap(),
             pool_size: 2,
             web3_transport: "ipc".to_string(),
-            discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
-            no_stun: false,
-            bootnodes: vec![],
-            enable_metrics: false,
-            metrics_url: None,
-            networks: DEFAULT_SUBNETWORKS
-                .split(',')
-                .map(|n| n.to_string())
-                .collect(),
+            ..Default::default()
         };
         assert_eq!(actual_config.web3_transport, expected_config.web3_transport);
         assert_eq!(
@@ -362,22 +343,8 @@ mod test {
     fn test_custom_discovery_port() {
         assert!(env_is_set());
         let expected_config = TrinConfig {
-            external_addr: None,
-            private_key: None,
-            web3_http_address: DEFAULT_WEB3_HTTP_ADDRESS.to_string(),
-            web3_ipc_path: DEFAULT_WEB3_IPC_PATH.to_string(),
-            pool_size: 2,
-            kb: DEFAULT_STORAGE_CAPACITY.parse().unwrap(),
-            web3_transport: "ipc".to_string(),
             discovery_port: 999,
-            no_stun: false,
-            bootnodes: vec![],
-            enable_metrics: false,
-            metrics_url: None,
-            networks: DEFAULT_SUBNETWORKS
-                .split(',')
-                .map(|n| n.to_string())
-                .collect(),
+            ..Default::default()
         };
         let actual_config =
             TrinConfig::new_from(["trin", "--discovery-port", "999"].iter()).unwrap();
@@ -388,22 +355,8 @@ mod test {
     fn test_custom_bootnodes() {
         assert!(env_is_set());
         let expected_config = TrinConfig {
-            external_addr: None,
-            private_key: None,
-            web3_http_address: DEFAULT_WEB3_HTTP_ADDRESS.to_string(),
-            web3_ipc_path: DEFAULT_WEB3_IPC_PATH.to_string(),
-            pool_size: 2,
-            kb: DEFAULT_STORAGE_CAPACITY.parse().unwrap(),
-            web3_transport: "ipc".to_string(),
-            discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
-            no_stun: false,
             bootnodes: vec!["enr:-aoeu".to_string(), "enr:-htns".to_string()],
-            enable_metrics: false,
-            metrics_url: None,
-            networks: DEFAULT_SUBNETWORKS
-                .split(',')
-                .map(|n| n.to_string())
-                .collect(),
+            ..Default::default()
         };
         let actual_config =
             TrinConfig::new_from(["trin", "--bootnodes", "enr:-aoeu,enr:-htns"].iter()).unwrap();
@@ -436,22 +389,8 @@ mod test {
     fn test_custom_private_key() {
         assert!(env_is_set());
         let expected_config = TrinConfig {
-            external_addr: None,
             private_key: Some(HexData(vec![1; 32])),
-            web3_http_address: DEFAULT_WEB3_HTTP_ADDRESS.to_string(),
-            web3_ipc_path: DEFAULT_WEB3_IPC_PATH.to_string(),
-            pool_size: 2,
-            kb: DEFAULT_STORAGE_CAPACITY.parse().unwrap(),
-            web3_transport: "ipc".to_string(),
-            discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
-            no_stun: false,
-            bootnodes: vec![],
-            enable_metrics: false,
-            metrics_url: None,
-            networks: DEFAULT_SUBNETWORKS
-                .split(',')
-                .map(|n| n.to_string())
-                .collect(),
+            ..Default::default()
         };
         let actual_config = TrinConfig::new_from(
             [
@@ -463,6 +402,17 @@ mod test {
         )
         .unwrap();
         assert_eq!(actual_config.private_key, expected_config.private_key);
+    }
+
+    #[test]
+    fn test_ephemeral() {
+        assert!(env_is_set());
+        let expected_config = TrinConfig {
+            ephemeral: true,
+            ..Default::default()
+        };
+        let actual_config = TrinConfig::new_from(["trin", "--ephemeral"].iter()).unwrap();
+        assert_eq!(actual_config.ephemeral, expected_config.ephemeral);
     }
 
     #[test]

--- a/trin-core/src/portalnet/storage.rs
+++ b/trin-core/src/portalnet/storage.rs
@@ -1,3 +1,4 @@
+use std::path::{Path, PathBuf};
 use std::{convert::TryInto, fs, sync::Arc};
 
 use discv5::enr::NodeId;
@@ -358,7 +359,7 @@ impl PortalStorage {
     /// Internal method used to measure on-disk storage usage.
     fn get_total_size_of_directory_in_bytes(
         &self,
-        path: String,
+        path: impl AsRef<Path>,
     ) -> Result<u64, PortalStorageError> {
         let metadata = match fs::metadata(&path) {
             Ok(metadata) => metadata,
@@ -433,9 +434,8 @@ impl PortalStorage {
     /// Helper function for opening a SQLite connection.
     /// Used for testing.
     pub fn setup_rocksdb(node_id: NodeId) -> Result<rocksdb::DB, PortalStorageError> {
-        let data_path_root: String = get_data_dir(node_id).to_owned();
-        let data_suffix: &str = "/rocksdb";
-        let data_path = data_path_root + data_suffix;
+        let mut data_path: PathBuf = get_data_dir(node_id);
+        data_path.push("rocksdb");
         debug!("Setting up RocksDB at path: {:?}", data_path);
 
         let mut db_opts = Options::default();
@@ -446,9 +446,8 @@ impl PortalStorage {
     /// Helper function for opening a SQLite connection.
     /// Used for testing.
     pub fn setup_sql(node_id: NodeId) -> Result<Pool<SqliteConnectionManager>, PortalStorageError> {
-        let data_path_root: String = get_data_dir(node_id).to_owned();
-        let data_suffix: &str = "/trin.sqlite";
-        let data_path = data_path_root + data_suffix;
+        let mut data_path: PathBuf = get_data_dir(node_id);
+        data_path.push("trin.sqlite");
         info!("Setting up SqliteDB at path: {:?}", data_path);
 
         let manager = SqliteConnectionManager::file(data_path);

--- a/trin-core/src/portalnet/storage.rs
+++ b/trin-core/src/portalnet/storage.rs
@@ -494,23 +494,15 @@ pub mod test {
     use super::*;
     use crate::portalnet::types::content_key::IdentityContentKey;
 
-    use std::env;
-
+    use crate::utils::db::setup_temp_dir;
     use quickcheck::{quickcheck, Arbitrary, Gen, QuickCheck, TestResult};
     use rand::RngCore;
     use serial_test::serial;
-    use tempdir::TempDir;
 
     fn generate_random_content_key() -> IdentityContentKey {
         let mut key = [0u8; 32];
         rand::thread_rng().fill_bytes(&mut key);
         IdentityContentKey::new(key)
-    }
-
-    fn setup_temp_dir() -> TempDir {
-        let temp_dir = TempDir::new("trin").unwrap();
-        env::set_var("TRIN_DATA_PATH", temp_dir.path());
-        temp_dir
     }
 
     impl Arbitrary for IdentityContentKey {

--- a/trin-core/src/portalnet/types/content_key.rs
+++ b/trin-core/src/portalnet/types/content_key.rs
@@ -295,18 +295,18 @@ impl OverlayContentKey for StateContentKey {
 mod test {
     use super::*;
 
-    use std::{env, sync::Arc};
+    use std::sync::Arc;
 
     use discv5::enr::NodeId;
     use ethereum_types::U256;
     use serial_test::serial;
-    use tempdir::TempDir;
     use test_log::test;
 
     use crate::portalnet::storage::{
         DistanceFunction, PortalStorage, PortalStorageConfig, PortalStorageError,
     };
 
+    use crate::utils::db::setup_temp_dir;
     use hex;
 
     //
@@ -396,12 +396,6 @@ mod test {
             chain_id: 1u16,
             block_hash: key,
         })
-    }
-
-    fn setup_temp_dir() -> TempDir {
-        let temp_dir = TempDir::new("trin").unwrap();
-        env::set_var("TRIN_DATA_PATH", temp_dir.path());
-        temp_dir
     }
 
     // This test is for PortalStorage functionality, but is located here to take advantage of

--- a/trin-core/src/utils/db.rs
+++ b/trin-core/src/utils/db.rs
@@ -1,13 +1,26 @@
-use std::{env, fs, path::Path};
+use std::path::PathBuf;
+use std::{env, fs};
 
 use directories::ProjectDirs;
 use discv5::enr::NodeId;
+use tempfile::TempDir;
 
 const TRIN_DATA_ENV_VAR: &str = "TRIN_DATA_PATH";
 
-pub fn get_data_dir(node_id: NodeId) -> String {
-    let trin_data_dir = env::var(TRIN_DATA_ENV_VAR).unwrap_or_else(|_| get_default_data_dir());
-    let trin_data_dir = Path::new(&trin_data_dir);
+/// Creates a directory on the file system that is deleted once it goes out of scope
+pub fn setup_temp_dir() -> TempDir {
+    let mut os_temp = env::temp_dir();
+    os_temp.push("trin");
+    let _ = fs::remove_dir_all(&os_temp);
+    fs::create_dir_all(&os_temp).unwrap();
+
+    let temp_dir = TempDir::new_in(&os_temp).unwrap();
+    env::set_var(TRIN_DATA_ENV_VAR, temp_dir.path());
+    temp_dir
+}
+
+pub fn get_data_dir(node_id: NodeId) -> PathBuf {
+    let mut trin_data_dir = get_root_path();
 
     // Append first 8 characters of Node ID
     let mut application_string = "trin_".to_owned();
@@ -15,13 +28,16 @@ pub fn get_data_dir(node_id: NodeId) -> String {
     let suffix = &node_id_string[..8];
     application_string.push_str(suffix);
 
-    let node_id_data_dir = trin_data_dir
-        .join(application_string)
-        .to_str()
-        .unwrap()
-        .to_string();
-    fs::create_dir_all(&node_id_data_dir).expect("Unable to create data directory folder");
-    node_id_data_dir
+    trin_data_dir.push(application_string);
+
+    fs::create_dir_all(&trin_data_dir).expect("Unable to create data directory folder");
+    trin_data_dir
+}
+
+/// Get root data path
+pub fn get_root_path() -> PathBuf {
+    let trin_data_dir = env::var(TRIN_DATA_ENV_VAR).unwrap_or_else(|_| get_default_data_dir());
+    PathBuf::from(&trin_data_dir)
 }
 
 pub fn get_default_data_dir() -> String {


### PR DESCRIPTION
### What was wrong?

Fixes #81 

### How was it fixed?

This PR supersedes https://github.com/ethereum/trin/pull/277. Thanks to @hmrtn for his initial work!

Changes:
1. Add --ephemeral flag in trin CLI and implement `Default` trait for `TrinConfig`.
2. Use --ephemeral flag in `self_peertest`.

Bonus:
- migrate from [tempdir](https://crates.io/crates/tempdir) crate to `tempfile`

As I was experimenting with temp dirs, I realized that the `tempdir` crate is deprecated in favor of `tempfile` and some duplicated code was present.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
