### PR TITLE
Improve Routing Table Initialization 

### DIFF
--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -411,10 +411,15 @@ where
     /// Begins initial FINDNODES query to populate the routing table.
     fn initialize_routing_table(&mut self, bootnodes: Vec<Enr>) {
         self.add_bootnodes(bootnodes.clone());
-        let node_id = self.local_enr().node_id();
-        // Begin request for our local node ID.
+        let local_node_id = self.local_enr().node_id();
 
-        self.init_find_nodes_query_with_initial_enrs(&node_id, bootnodes);
+        // Begin request for our local node ID.
+        self.init_find_nodes_query(&local_node_id);
+
+        for bucket_index in (255 - EXPECTED_NON_EMPTY_BUCKETS as u8)..255 {
+            let target_node_id = self.generate_random_node_id(bucket_index);
+            self.init_find_nodes_query(&target_node_id);
+        }
     }
 
     /// The main loop for the overlay service. The loop selects over different possible tasks to


### PR DESCRIPTION
### What was wrong?

A trin node currently initializes its overlay routing table at boot by running a find nodes query for only its own node ID, with queries for node IDs in farther buckets being run once per minute. With `EXPECTED_NON_EMPTY_BUCKETS` at 17, it will take 17 minutes from boot to run a query for node IDs in all of the expected buckets.

### How was it fixed?

A FindNode query for each of the expected non-empty buckets is run at boot.

**Also**: 

- Cleans up `overlay_service`'s `!select` loop by breaking out findnode query logic.
- Consolidates multiple variations of `init_find_nodes_query` functions into single function.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
