### PR TITLE
Remove blocking async from overlay service loop

### DIFF
--- a/newsfragments/373.fixed.md
+++ b/newsfragments/373.fixed.md
@@ -1,0 +1,1 @@
+Remove blocking async from overlay service loop via spawning new tasks for utp & content validation.

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -50,7 +50,6 @@ use rand::seq::IteratorRandom;
 use ssz::{Decode, Encode};
 use ssz_types::VariableList;
 use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::Mutex;
 use tracing::{debug, warn};
 
 pub use super::overlay_service::{OverlayRequestError, RequestDirection};
@@ -136,7 +135,7 @@ where
         storage: Arc<RwLock<PortalStorage>>,
         data_radius: U256,
         protocol: ProtocolId,
-        validator: Arc<Mutex<TValidator>>,
+        validator: Arc<TValidator>,
     ) -> Self {
         let kbuckets = Arc::new(RwLock::new(KBucketsTable::new(
             discovery.local_enr().node_id().into(),

--- a/trin-core/src/types/validation.rs
+++ b/trin-core/src/types/validation.rs
@@ -42,7 +42,7 @@ impl Default for HeaderOracle {
 
 impl HeaderOracle {
     // Currently falls back to infura, to be updated to use canonical block indices network.
-    pub fn get_hash_at_height(&mut self, block_number: u64) -> anyhow::Result<String> {
+    pub fn get_hash_at_height(&self, block_number: u64) -> anyhow::Result<String> {
         let hex_number = format!("0x:{:02X}", block_number);
         let request = JsonRequest {
             jsonrpc: "2.0".to_string(),
@@ -70,7 +70,7 @@ impl HeaderOracle {
         Ok(infura_hash.to_owned())
     }
 
-    pub fn get_header_by_hash(&mut self, block_hash: H256) -> anyhow::Result<Header> {
+    pub fn get_header_by_hash(&self, block_hash: H256) -> anyhow::Result<Header> {
         let block_hash = format!("0x{:02X}", block_hash);
         let request = JsonRequest {
             jsonrpc: "2.0".to_string(),
@@ -101,7 +101,7 @@ impl HeaderOracle {
 #[async_trait]
 pub trait Validator<TContentKey> {
     async fn validate_content(
-        &mut self,
+        &self,
         content_key: &TContentKey,
         content: &[u8],
     ) -> anyhow::Result<()>
@@ -115,7 +115,7 @@ pub struct MockValidator {}
 #[async_trait]
 impl Validator<IdentityContentKey> for MockValidator {
     async fn validate_content(
-        &mut self,
+        &self,
         _content_key: &IdentityContentKey,
         _content: &[u8],
     ) -> anyhow::Result<()>

--- a/trin-core/tests/overlay.rs
+++ b/trin-core/tests/overlay.rs
@@ -21,7 +21,7 @@ use discv5::Discv5Event;
 use ethereum_types::U256;
 use parking_lot::RwLock;
 use tokio::{
-    sync::{mpsc, mpsc::unbounded_channel},
+    sync::{mpsc, mpsc::unbounded_channel, Mutex},
     time::{self, Duration},
 };
 
@@ -40,7 +40,7 @@ async fn init_overlay(
     let overlay_config = OverlayConfig::default();
     // Ignore all uTP events
     let (utp_listener_tx, _) = unbounded_channel::<UtpListenerRequest>();
-    let validator = MockValidator {};
+    let validator = Arc::new(Mutex::new(MockValidator {}));
 
     OverlayProtocol::new(
         overlay_config,

--- a/trin-core/tests/overlay.rs
+++ b/trin-core/tests/overlay.rs
@@ -21,7 +21,7 @@ use discv5::Discv5Event;
 use ethereum_types::U256;
 use parking_lot::RwLock;
 use tokio::{
-    sync::{mpsc, mpsc::unbounded_channel, Mutex},
+    sync::{mpsc, mpsc::unbounded_channel},
     time::{self, Duration},
 };
 
@@ -40,7 +40,7 @@ async fn init_overlay(
     let overlay_config = OverlayConfig::default();
     // Ignore all uTP events
     let (utp_listener_tx, _) = unbounded_channel::<UtpListenerRequest>();
-    let validator = Arc::new(Mutex::new(MockValidator {}));
+    let validator = Arc::new(MockValidator {});
 
     OverlayProtocol::new(
         overlay_config,

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, RwLock as StdRwLock};
 
 use parking_lot::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::Mutex;
 
 use trin_core::{
     portalnet::{
@@ -41,7 +42,7 @@ impl HistoryNetwork {
             ..Default::default()
         };
         let storage = Arc::new(RwLock::new(PortalStorage::new(storage_config).unwrap()));
-        let validator = ChainHistoryValidator { header_oracle };
+        let validator = Arc::new(Mutex::new(ChainHistoryValidator { header_oracle }));
         let overlay = OverlayProtocol::new(
             config,
             discovery,

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -3,7 +3,6 @@ use std::sync::{Arc, RwLock as StdRwLock};
 
 use parking_lot::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::Mutex;
 
 use trin_core::{
     portalnet::{
@@ -42,7 +41,7 @@ impl HistoryNetwork {
             ..Default::default()
         };
         let storage = Arc::new(RwLock::new(PortalStorage::new(storage_config).unwrap()));
-        let validator = Arc::new(Mutex::new(ChainHistoryValidator { header_oracle }));
+        let validator = Arc::new(ChainHistoryValidator { header_oracle });
         let overlay = OverlayProtocol::new(
             config,
             discovery,

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -22,7 +22,7 @@ pub struct ChainHistoryValidator {
 #[async_trait]
 impl Validator<HistoryContentKey> for ChainHistoryValidator {
     async fn validate_content(
-        &mut self,
+        &self,
         content_key: &HistoryContentKey,
         content: &[u8],
     ) -> anyhow::Result<()>
@@ -212,7 +212,7 @@ mod tests {
             infura_url,
             ..HeaderOracle::default()
         }));
-        let mut chain_history_validator = ChainHistoryValidator { header_oracle };
+        let chain_history_validator = ChainHistoryValidator { header_oracle };
         let content_key = HistoryContentKey::BlockHeader(BlockHeader {
             chain_id: 1,
             block_hash: header.hash().0,
@@ -240,7 +240,7 @@ mod tests {
             infura_url,
             ..HeaderOracle::default()
         }));
-        let mut chain_history_validator = ChainHistoryValidator { header_oracle };
+        let chain_history_validator = ChainHistoryValidator { header_oracle };
         let content_key = HistoryContentKey::BlockHeader(BlockHeader {
             chain_id: 1,
             block_hash: header.hash().0,
@@ -269,7 +269,7 @@ mod tests {
             infura_url,
             ..HeaderOracle::default()
         }));
-        let mut chain_history_validator = ChainHistoryValidator { header_oracle };
+        let chain_history_validator = ChainHistoryValidator { header_oracle };
         let content_key = HistoryContentKey::BlockHeader(BlockHeader {
             chain_id: 1,
             block_hash: header.hash().0,
@@ -294,7 +294,7 @@ mod tests {
             infura_url,
             ..HeaderOracle::default()
         }));
-        let mut chain_history_validator = ChainHistoryValidator { header_oracle };
+        let chain_history_validator = ChainHistoryValidator { header_oracle };
         let content_key = block_14764013_body_key();
 
         chain_history_validator
@@ -327,7 +327,7 @@ mod tests {
             infura_url,
             ..HeaderOracle::default()
         }));
-        let mut chain_history_validator = ChainHistoryValidator { header_oracle };
+        let chain_history_validator = ChainHistoryValidator { header_oracle };
         let content_key = block_14764013_body_key();
 
         chain_history_validator
@@ -348,7 +348,7 @@ mod tests {
             infura_url,
             ..HeaderOracle::default()
         }));
-        let mut chain_history_validator = ChainHistoryValidator { header_oracle };
+        let chain_history_validator = ChainHistoryValidator { header_oracle };
         let content_key = block_14764013_receipts_key();
 
         chain_history_validator
@@ -379,7 +379,7 @@ mod tests {
             infura_url,
             ..HeaderOracle::default()
         }));
-        let mut chain_history_validator = ChainHistoryValidator { header_oracle };
+        let chain_history_validator = ChainHistoryValidator { header_oracle };
         let content_key = block_14764013_receipts_key();
 
         chain_history_validator

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -5,6 +5,7 @@ use eth_trie::EthTrie;
 use log::{debug, error};
 use parking_lot::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::Mutex;
 use trin_core::{
     portalnet::{
         discovery::Discovery,
@@ -42,9 +43,9 @@ impl StateNetwork {
         let trie = EthTrie::new(Arc::new(triedb));
 
         let storage = Arc::new(RwLock::new(PortalStorage::new(storage_config).unwrap()));
-        let validator = StateValidator {
+        let validator = Arc::new(Mutex::new(StateValidator {
             header_oracle: HeaderOracle::default(),
-        };
+        }));
         let config = OverlayConfig {
             bootnode_enrs: portal_config.bootnode_enrs.clone(),
             enable_metrics: portal_config.enable_metrics,

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -5,7 +5,6 @@ use eth_trie::EthTrie;
 use log::{debug, error};
 use parking_lot::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::Mutex;
 use trin_core::{
     portalnet::{
         discovery::Discovery,
@@ -43,9 +42,9 @@ impl StateNetwork {
         let trie = EthTrie::new(Arc::new(triedb));
 
         let storage = Arc::new(RwLock::new(PortalStorage::new(storage_config).unwrap()));
-        let validator = Arc::new(Mutex::new(StateValidator {
+        let validator = Arc::new(StateValidator {
             header_oracle: HeaderOracle::default(),
-        }));
+        });
         let config = OverlayConfig {
             bootnode_enrs: portal_config.bootnode_enrs.clone(),
             enable_metrics: portal_config.enable_metrics,

--- a/trin-state/src/validation.rs
+++ b/trin-state/src/validation.rs
@@ -12,7 +12,7 @@ pub struct StateValidator {
 #[async_trait]
 impl Validator<StateContentKey> for StateValidator {
     async fn validate_content(
-        &mut self,
+        &self,
         _content_key: &StateContentKey,
         _content: &[u8],
     ) -> anyhow::Result<()>


### PR DESCRIPTION
### What was wrong?
Fixes #342 

`async` expressions in the handlers of main `OverlayService` loop block the loop from continuing while they are awaited
- validation of content
- processing an accept message

### How was it fixed?
Spawn new tasks for `async` expressions.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
