### PR TITLE
Update portal_*RoutingTableInfo endpoints output

### DIFF
--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -364,8 +364,7 @@ fn validate_portal_store_with_invalid_content_key(result: &Value, _peertest: &Pe
 }
 
 fn validate_portal_routing_table_info(result: &Value, _peertest: &Peertest) {
-    assert!(result.get("buckets").unwrap().is_object());
-    assert!(result.get("numBuckets").unwrap().is_u64());
+    assert!(result.get("nodes").unwrap().is_array());
     assert!(result.get("numNodes").unwrap().is_u64());
     assert!(result.get("numConnected").unwrap().is_u64());
 }

--- a/trin-core/src/jsonrpc/utils.rs
+++ b/trin-core/src/jsonrpc/utils.rs
@@ -8,43 +8,35 @@ use serde_json::{json, Value};
 use std::collections::BTreeMap;
 
 type NodeMap = BTreeMap<String, String>;
-type NodeTuple = (NodeId, Enr, NodeStatus, U256);
+type NodeTuple = (usize, NodeId, Enr, NodeStatus, U256);
 
 /// Converts the output of the Overlay's bucket_entries method to a JSON Value
-pub fn bucket_entries_to_json(bucket_entries: BTreeMap<usize, Vec<NodeTuple>>) -> Value {
+pub fn bucket_entries_to_json(bucket_entries: Vec<NodeTuple>) -> Value {
     let mut node_count: u16 = 0;
     let mut connected_count: u16 = 0;
-    let buckets_indexed: BTreeMap<usize, Vec<NodeMap>> = bucket_entries
+    let nodes_indexed: Vec<NodeMap> = bucket_entries
         .into_iter()
-        .map(|(bucket_index, bucket)| {
-            (
-                bucket_index,
-                bucket
-                    .iter()
-                    .map(|(node_id, enr, node_status, data_radius)| {
-                        node_count += 1;
-                        if node_status.state == ConnectionState::Connected {
-                            connected_count += 1
-                        }
-                        let mut map = BTreeMap::new();
-                        map.insert(
-                            "node_id".to_owned(),
-                            format!("0x{}", hex::encode(node_id.raw())),
-                        );
-                        map.insert("enr".to_owned(), enr.to_base64());
-                        map.insert("status".to_owned(), format!("{:?}", node_status.state));
-                        map.insert("radius".to_owned(), format!("{}", data_radius));
-                        map
-                    })
-                    .collect(),
-            )
+        .map(|(bucket_index, node_id, enr, node_status, data_radius)| {
+            node_count += 1;
+            if node_status.state == ConnectionState::Connected {
+                connected_count += 1
+            }
+            let mut map = BTreeMap::new();
+            map.insert("bucket".to_owned(), format!("{}", bucket_index));
+            map.insert(
+                "node_id".to_owned(),
+                format!("0x{}", hex::encode(node_id.raw())),
+            );
+            map.insert("enr".to_owned(), enr.to_base64());
+            map.insert("status".to_owned(), format!("{:?}", node_status.state));
+            map.insert("radius".to_owned(), format!("{}", data_radius));
+            map
         })
         .collect();
 
     json!(
         {
-            "buckets": buckets_indexed,
-            "numBuckets": buckets_indexed.len(),
+            "nodes": nodes_indexed,
             "numNodes": node_count,
             "numConnected": connected_count
         }

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -1,6 +1,6 @@
 use anyhow::anyhow;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     fmt::{Debug, Display},
     marker::{PhantomData, Sync},
     str::FromStr,
@@ -389,31 +389,30 @@ where
             .collect()
     }
 
-    /// Returns a map (BTree for its ordering guarantees) with:
+    /// Returns a tuple of:
     ///     key: usize representing bucket index
     ///     value: Vec of tuples, each tuple represents a node
-    pub fn bucket_entries(&self) -> BTreeMap<usize, Vec<(NodeId, Enr, NodeStatus, U256)>> {
+    pub fn bucket_entries(&self) -> Vec<(usize, NodeId, Enr, NodeStatus, U256)> {
         self.kbuckets
             .read()
             .buckets_iter()
             .enumerate()
             .filter(|(_, bucket)| bucket.num_entries() > 0)
             .map(|(index, bucket)| {
-                (
-                    index,
-                    bucket
-                        .iter()
-                        .map(|node| {
-                            (
-                                *node.key.preimage(),
-                                node.value.enr().clone(),
-                                node.status,
-                                node.value.data_radius(),
-                            )
-                        })
-                        .collect(),
-                )
+                bucket
+                    .iter()
+                    .map(|node| {
+                        (
+                            index,
+                            *node.key.preimage(),
+                            node.value.enr().clone(),
+                            node.status,
+                            node.value.data_radius(),
+                        )
+                    })
+                    .collect::<Vec<(usize, NodeId, Enr, NodeStatus, U256)>>()
             })
+            .flatten()
             .collect()
     }
 


### PR DESCRIPTION
### What was wrong?

JSON output from `portal_historyRoutingTableInfo` (or `state`) endpoint violates the Portal RPC spec and isn't very parseable, especially for querying via something like `JSONPath`. 

```
"255": [
        {
          "enr": "enr:-IS4QK24utSDKT-S5vC9CZCima2O-_cD7-5zUyi2FSXN1vXCIJAIP9-g1XPyR59hB077vVoxVXp0jRiceNZ5Jyg3IY4DgmlkgnY0gmlwhC-Gq8qJc2VjcDI1NmsxoQK95M0PBsvDQATFpRIX3lGZP_k2nW0XgDmlE2ERWQ4rIIN1ZHCCBAA",
          "node_id": "0x5ede1c20e15e7a7023c076b5ad23c4be88366978d4001dba8aac69cb20de14f6",
          "radius": "18446744073709551615",
          "status": "Disconnected"
        },
        {
          "enr": "enr:-IS4QO22MlXZ6IgajhKLMV6_3vu94OPzHRrUEpZxG35FOmJxVOaYG6cpZulT5GQalKikSuzHgQHO2Y0-vxBFBzbdSOMBgmlkgnY0gmlwhLnHZkCJc2VjcDI1NmsxoQMlHPijnVxy2jbE8O7UCL6jUHz9Ka9l8YJS_L7Di7Qh5YN1ZHCCIyk",
          "node_id": "0x5adec702a808cc05917f4357af6e8fd28516e32b8a70d4526ac2bde962a13500",
          "radius": "18446744073709551615",
          "status": "Disconnected"
        },
        {
          "enr": "enr:-IS4QAU21mMYwh7K1ogWY7JtjF8zuPVCaH3Hf8AYiD1lVMJHFzV0tPEIFNdolJjy6olFvAQUK4SyoNnB1TWJmnYdDekBgmlkgnY0gmlwhIe0JYGJc2VjcDI1NmsxoQKj6JF7GFKeLF7qbNYqepB481atQ8_mVEdVRg1NUf5lmoN1ZHCCIyo",
          "node_id": "0x4002eb4a0645f4f8f3ea2ea75d8b2df567de5a95d7ce9d9a87f2b2f6aa550e77",
          "radius": "18446744073709551615",
          "status": "Disconnected"
        },
        {
          "enr": "enr:-IS4QG-eWJugwQARv-pdfepbW8oxoOe6knXb79ZMXtAgcdq_elP1fFAz8IF1MHcDZJATTt4nuqdfuSGMcgLn7wX8hJEDgmlkgnY0gmlwhKRc9EGJc2VjcDI1NmsxoQMo1NBoJfVY367ZHKA-UBgOE--U7sffGf5NBsNSVG629oN1ZHCCE7w",
          "node_id": "0x525b02c1264753a67b7ed8eac0f2225cf2a7c3c04749866b27511d1788334a23",
          "radius": "18446744073709551615",
          "status": "Disconnected"
        },
        {
          "enr": "enr:-IS4QOA4voX3J7-R_x8pjlaxBTpT1S_CL7ZaNjetjZ-0nnr2VaP0wEZsT2KvjA5UWc8vi9I0XvNSd1bjU0GXUjlt7J0BgmlkgnY0gmlwhEFsKgOJc2VjcDI1NmsxoQI7aL5dFuHhwbxWD-C1yWH7UPlae5wuV_3WbPylCBwPboN1ZHCCI44",
          "node_id": "0x4f42329a2f4aebf4e488b4daa639f5bd03230865e4f5b4a232234618025b0ba8",
          "radius": "18446744073709551615",
          "status": "Connected"
        }
      ]
```

### How was it fixed?

Note: This still requires an update to the spec, PR inbound. 

Flattened the output to include the bucket in each node entry, rather than each node entry in a bucket:

```
{
        "bucket": "255",
        "enr": "enr:-IS4QCwO5lgoKcB80sPWO9oeDCvrZSQb1IX1buSmjiKipoZcehH8VUlbjXQzjZ7T2ZvpPm-PbVLUkykZW_FyaFNwcZMBgmlkgnY0gmlwhEXLgPiJc2VjcDI1NmsxoQPMGbFgW9wDTZqtoKZ_PgkkRSl2o8CCw3lVUhQzeOJjHYN1ZHCCIyk",
        "node_id": "0x488a8dbfe11551dd3e43a01cf3f86efe28927afb0961d3bdfea53d902eef80fc",
        "radius": "18446744073709551615",
        "status": "Disconnected"
      },
      {
        "bucket": "255",
        "enr": "enr:-IS4QMCYnTTW296DoHl-TxgU7WD-vYMvgrOVmac8RHEFirqQbB6ON5Pdy9lXeiKA0OBmg5vRVhZ7Yrx7gN7CnGsarqkBgmlkgnY0gmlwhFlDfT2Jc2VjcDI1NmsxoQJxJq6VTvol_36Kx9zSbWucnmNc7sxPl4xJI051iKUsUYN1ZHCCdl8",
        "node_id": "0x403d1bc416fc69a31676d01f65c76d306bc3bc8f03a5f0faafba9f80fc64b061",
        "radius": "18446744073709551615",
        "status": "Disconnected"
      },
      {
        "bucket": "255",
        "enr": "enr:-IS4QJBALBigZVoKyz-NDBV8z34-pkVHU9yMxa6qXEqhCKYxOs5Psw6r5ueFOnBDOjsmgMGpC3Qjyr41By34wab1sKIBgmlkgnY0gmlwhKEjVaWJc2VjcDI1NmsxoQOSGugH1jSdiE_fRK1FIBe9oLxaWH8D_7xXSnaOVBe-SYN1ZHCCIyg",
        "node_id": "0x639ab17d4327ae42826b838ca77796778ebbc22ee0279d5cfe3a86016fe2d9bd",
        "radius": "18446744073709551615",
        "status": "Connected"
      },
      {
        "bucket": "255",
        "enr": "enr:-IS4QOA4voX3J7-R_x8pjlaxBTpT1S_CL7ZaNjetjZ-0nnr2VaP0wEZsT2KvjA5UWc8vi9I0XvNSd1bjU0GXUjlt7J0BgmlkgnY0gmlwhEFsKgOJc2VjcDI1NmsxoQI7aL5dFuHhwbxWD-C1yWH7UPlae5wuV_3WbPylCBwPboN1ZHCCI44",
        "node_id": "0x4f42329a2f4aebf4e488b4daa639f5bd03230865e4f5b4a232234618025b0ba8",
        "radius": "18446744073709551615",
        "status": "Connected"
      }
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
