### PR TITLE
History network types for accumulator content

### DIFF
--- a/newsfragments/381.added.md
+++ b/newsfragments/381.added.md
@@ -1,0 +1,1 @@
+Add content key types for history network accumulator content.

--- a/trin-core/src/portalnet/types/messages.rs
+++ b/trin-core/src/portalnet/types/messages.rs
@@ -63,7 +63,7 @@ impl ssz::Decode for CustomPayload {
     }
 
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        Ok(CustomPayload {
+        Ok(Self {
             payload: ByteList::from(bytes.to_vec()),
         })
     }

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, RwLock};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use ethereum_types::H256;
+use log::warn;
 use ssz::Decode;
 
 use trin_core::{
@@ -104,6 +105,14 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
                         trusted_header.receipts_root
                     ));
                 }
+                Ok(())
+            }
+            HistoryContentKey::MasterAccumulator(_key) => {
+                warn!("Skipping content validation for master accumulator content.");
+                Ok(())
+            }
+            HistoryContentKey::EpochAccumulator(_key) => {
+                warn!("Skipping content validation for epoch accumulator content.");
                 Ok(())
             }
         }


### PR DESCRIPTION
### What was wrong?
Added basic content key types for `EpochAccumulator` and `MasterAccumulator` content in the history network, as defined [here](https://github.com/ethereum/portal-network-specs/pull/155/files).

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
