### PR TITLE
Remove blocking async from overlay events loop

### DIFF
--- a/newsfragments/382.fixed.md
+++ b/newsfragments/382.fixed.md
@@ -1,0 +1,1 @@
+Remove blocking async from overlay events loop.

--- a/trin-history/src/events.rs
+++ b/trin-history/src/events.rs
@@ -16,7 +16,7 @@ impl HistoryEvents {
         loop {
             tokio::select! {
                 Some(talk_request) = self.event_rx.recv() => {
-                    self.handle_history_talk_request(talk_request).await;
+                    self.handle_history_talk_request(talk_request);
                 }
                 Some(event) = self.utp_listener_rx.recv() => {
                     if let Err(err) = self.network.overlay.process_utp_event(event) {
@@ -28,25 +28,27 @@ impl HistoryEvents {
     }
 
     /// Handle history network TalkRequest event
-    async fn handle_history_talk_request(&self, talk_request: TalkRequest) {
-        let reply = match self
-            .network
-            .overlay
-            .process_one_request(&talk_request)
-            .instrument(tracing::info_span!("history_network"))
-            .await
-        {
-            Ok(response) => {
-                debug!("Sending reply: {:?}", response);
-                Message::from(response).into()
+    fn handle_history_talk_request(&self, talk_request: TalkRequest) {
+        let network = Arc::clone(&self.network);
+        tokio::spawn(async move {
+            let reply = match network
+                .overlay
+                .process_one_request(&talk_request)
+                .instrument(tracing::info_span!("history_network"))
+                .await
+            {
+                Ok(response) => {
+                    debug!("Sending reply: {:?}", response);
+                    Message::from(response).into()
+                }
+                Err(error) => {
+                    error!("Failed to process portal history event: {error}");
+                    error.to_string().into_bytes()
+                }
+            };
+            if let Err(error) = talk_request.respond(reply) {
+                warn!("Failed to send reply: {error}");
             }
-            Err(error) => {
-                error!("Failed to process portal history event: {error}");
-                error.to_string().into_bytes()
-            }
-        };
-        if let Err(error) = talk_request.respond(reply) {
-            warn!("Failed to send reply: {error}");
-        }
+        });
     }
 }

--- a/trin-state/src/events.rs
+++ b/trin-state/src/events.rs
@@ -16,7 +16,7 @@ impl StateEvents {
         loop {
             tokio::select! {
                 Some(talk_request) = self.event_rx.recv() => {
-                    self.handle_state_talk_request(talk_request).await;
+                    self.handle_state_talk_request(talk_request);
                 }
                 Some(event) = self.utp_listener_rx.recv() => {
                     if let Err(err) = self.network.overlay.process_utp_event(event) {
@@ -28,25 +28,27 @@ impl StateEvents {
     }
 
     /// Handle state network TalkRequest event
-    async fn handle_state_talk_request(&self, talk_request: TalkRequest) {
-        let reply = match self
-            .network
-            .overlay
-            .process_one_request(&talk_request)
-            .instrument(tracing::info_span!("state_network"))
-            .await
-        {
-            Ok(response) => {
-                debug!("Sending reply: {:?}", response);
-                Message::from(response).into()
+    fn handle_state_talk_request(&self, talk_request: TalkRequest) {
+        let network = Arc::clone(&self.network);
+        tokio::spawn(async move {
+            let reply = match network
+                .overlay
+                .process_one_request(&talk_request)
+                .instrument(tracing::info_span!("state_network"))
+                .await
+            {
+                Ok(response) => {
+                    debug!("Sending reply: {:?}", response);
+                    Message::from(response).into()
+                }
+                Err(error) => {
+                    error!("Failed to process portal state event: {error}");
+                    error.to_string().into_bytes()
+                }
+            };
+            if let Err(error) = talk_request.respond(reply) {
+                warn!("Failed to send reply: {error}");
             }
-            Err(error) => {
-                error!("Failed to process portal state event: {error}");
-                error.to_string().into_bytes()
-            }
-        };
-        if let Err(error) = talk_request.respond(reply) {
-            warn!("Failed to send reply: {error}");
-        }
+        });
     }
 }


### PR DESCRIPTION
### What was wrong?
Similar to #373 We had blocking async inside of the overlay events processing loop.

### How was it fixed?
Spawned new non-blocking tokio task to process an event when it's received.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
