### PR TITLE
Propagate after rpc history store

### DIFF
--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -279,7 +279,7 @@ where
     }
 
     /// Propagate gossip accepted content via OFFER/ACCEPT:
-    fn propagate_gossip(&self, offer_keys: Vec<TContentKey>) -> anyhow::Result<()> {
+    pub fn propagate_gossip(&self, offer_keys: Vec<TContentKey>) -> anyhow::Result<()> {
         // Get all nodes from overlay routing table
         let kbuckets = self.kbuckets.read();
         let all_nodes: Vec<&kbucket::Node<NodeId, Node>> = kbuckets


### PR DESCRIPTION
### What was wrong?

We need to propogate data to peers after calling `portal_historyStore`, in order for the bridge node to work.

### How was it fixed?

Add a propagate, to the end of the rpc handling for `portal_historyStore`

Bonus: Includes #383 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
