### PR TITLE
We don't need to exit during panic handling

### DIFF
--- a/trin-core/src/jsonrpc/service.rs
+++ b/trin-core/src/jsonrpc/service.rs
@@ -4,7 +4,7 @@ use std::{
     fs,
     io::{self, BufRead, Read, Write},
     net::{TcpListener, TcpStream},
-    panic, process,
+    panic,
     str::FromStr,
     sync::{Arc, RwLock},
     thread,
@@ -103,7 +103,6 @@ fn set_ipc_cleanup_handlers(ipc_path: &str) {
                 debug!("Panic hook: Skipped removing {} because: {}", ipc_path, err);
             };
             original_panic(panic_info);
-            process::exit(1);
         }));
     }
 }


### PR DESCRIPTION
... I think

The panic hook only needs to display information we want, and delete the
IPC file. The Rust machinery will handle the rest on its own.

But, it does seem to cause the json-rpc server to hang on panic. Which I don't understand yet...

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
