### PR TITLE
Print errors without exiting on bootnode failures

### DIFF
--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -639,6 +639,44 @@ where
             Err(error) => Err(OverlayRequestError::ChannelFailure(error.to_string())),
         }
     }
+
+    pub async fn ping_bootnodes(&self) {
+        // Trigger bonding with bootnodes, at both the base layer and portal overlay.
+        // The overlay ping via talkreq will trigger a session at the base layer, then
+        // a session on the (overlay) portal network.
+        let mut successfully_bonded_bootnode = false;
+        let enrs = self.discovery.discv5.table_entries_enr();
+        if enrs.is_empty() {
+            error!(
+                "No bootnodes provided, cannot join Portal {:?} Network.",
+                self.protocol
+            );
+            return;
+        }
+        for enr in enrs {
+            debug!("Attempting to bond with bootnode: {}", enr);
+            let ping_result = self.send_ping(enr.clone()).await;
+
+            match ping_result {
+                Ok(_) => {
+                    debug!("Successfully bonded with bootnode: {}", enr);
+                    successfully_bonded_bootnode = true;
+                }
+                Err(err) => {
+                    error!(
+                        "{err} while pinging {:?} network bootnode: {enr:?}",
+                        self.protocol
+                    );
+                }
+            }
+        }
+        if !successfully_bonded_bootnode {
+            error!(
+                "Failed to bond with any bootnodes, cannot join Portal {:?} Network.",
+                self.protocol
+            );
+        }
+    }
 }
 
 /// Randomly select log2 nodes. log2() is stable only for floats, that's why we cast it first to f32

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -97,7 +97,7 @@ pub fn spawn_history_network(
         tokio::spawn(history_events.start());
 
         // hacky test: make sure we establish a session with the boot node
-        network.ping_bootnodes().await.unwrap();
+        network.ping_bootnodes().await;
 
         tokio::signal::ctrl_c()
             .await

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -97,7 +97,7 @@ pub fn spawn_history_network(
         tokio::spawn(history_events.start());
 
         // hacky test: make sure we establish a session with the boot node
-        network.ping_bootnodes().await;
+        network.overlay.ping_bootnodes().await;
 
         tokio::signal::ctrl_c()
             .await

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -59,25 +59,32 @@ impl HistoryNetwork {
     }
 
     /// Convenience call for testing, quick way to ping bootnodes
-    pub async fn ping_bootnodes(&self) -> anyhow::Result<()> {
+    pub async fn ping_bootnodes(&self) {
         // Trigger bonding with bootnodes, at both the base layer and portal overlay.
         // The overlay ping via talkreq will trigger a session at the base layer, then
         // a session on the (overlay) portal network.
-        for enr in self.overlay.discovery.discv5.table_entries_enr() {
+        let mut successfully_bonded_bootnode = false;
+        let enrs = self.overlay.discovery.discv5.table_entries_enr();
+        if enrs.is_empty() {
+            error!("No bootnodes provided, cannot join Portal History Network.");
+            return;
+        }
+        for enr in enrs {
             debug!("Attempting bond with bootnode {}", enr);
             let ping_result = self.overlay.send_ping(enr.clone()).await;
 
             match ping_result {
                 Ok(_) => {
                     debug!("Successfully bonded with {}", enr);
-                    continue;
+                    successfully_bonded_bootnode = true;
                 }
                 Err(err) => {
                     error!("{err} while pinging bootnode: {enr:?}");
-                    std::process::exit(1);
                 }
             }
         }
-        Ok(())
+        if !successfully_bonded_bootnode {
+            error!("Failed to bond with any bootnodes, cannot join Portal History Network.");
+        }
     }
 }

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -1,4 +1,3 @@
-use log::{debug, error};
 use std::sync::{Arc, RwLock as StdRwLock};
 
 use parking_lot::RwLock;
@@ -55,36 +54,6 @@ impl HistoryNetwork {
 
         Self {
             overlay: Arc::new(overlay),
-        }
-    }
-
-    /// Convenience call for testing, quick way to ping bootnodes
-    pub async fn ping_bootnodes(&self) {
-        // Trigger bonding with bootnodes, at both the base layer and portal overlay.
-        // The overlay ping via talkreq will trigger a session at the base layer, then
-        // a session on the (overlay) portal network.
-        let mut successfully_bonded_bootnode = false;
-        let enrs = self.overlay.discovery.discv5.table_entries_enr();
-        if enrs.is_empty() {
-            error!("No bootnodes provided, cannot join Portal History Network.");
-            return;
-        }
-        for enr in enrs {
-            debug!("Attempting bond with bootnode {}", enr);
-            let ping_result = self.overlay.send_ping(enr.clone()).await;
-
-            match ping_result {
-                Ok(_) => {
-                    debug!("Successfully bonded with {}", enr);
-                    successfully_bonded_bootnode = true;
-                }
-                Err(err) => {
-                    error!("{err} while pinging bootnode: {enr:?}");
-                }
-            }
-        }
-        if !successfully_bonded_bootnode {
-            error!("Failed to bond with any bootnodes, cannot join Portal History Network.");
         }
     }
 }

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -91,7 +91,7 @@ pub fn spawn_state_network(
         tokio::spawn(state_events.start());
 
         // hacky test: make sure we establish a session with the boot node
-        network.ping_bootnodes().await;
+        network.overlay.ping_bootnodes().await;
 
         tokio::signal::ctrl_c()
             .await

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -91,7 +91,7 @@ pub fn spawn_state_network(
         tokio::spawn(state_events.start());
 
         // hacky test: make sure we establish a session with the boot node
-        network.ping_bootnodes().await.unwrap();
+        network.ping_bootnodes().await;
 
         tokio::signal::ctrl_c()
             .await


### PR DESCRIPTION
### What was wrong?

In #348, the line `std::process::exit(1)` was added in order to end the program "gracefully" in case initial bootnode pings fail. Turns out this does not gracefully clean things up at all, and was leaving an orphaned IPC file.

Additionally, #348 had replaced the panic that occurred if a bootnode failed ping with an error printout, which made the `network.ping_bootnodes()` method returning a `Result` pointless because it always returned `Ok(())`. 

### How was it fixed?

This PR makes it so that specific errors are printed with no panic or exit for the cases in which:
- a single bootnode fails ping
- all bootnodes fail ping
- no bootnodes were provided

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
