### PR TITLE
utp: Fix packet's `wnd_size` value and handle bidirectional FIN packets

### DIFF
--- a/newsfragments/395.fixed.md
+++ b/newsfragments/395.fixed.md
@@ -1,0 +1,2 @@
+- uTP: Fix advertised remote window value (wnd_size) in packet header
+- uTP: Allow FIN packets to be handled bidirectionally in uTP listener

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -1521,11 +1521,6 @@ where
             .map_err(|_| anyhow!("Unable to decode our own offered content keys"))?;
 
         let mut content_items: Vec<ByteList> = Vec::new();
-        // =======
-        //         content_keys_offered: Vec<TContentKey>,
-        //     ) -> anyhow::Result<Vec<Bytes>> {
-        //         let mut content_items: Vec<Bytes> = Vec::new();
-        // >>>>>>> 33b16f1 (Add varint prefix to content send over uTP stream)
 
         for (i, key) in accept_message
             .content_keys

--- a/trin-core/src/utp/stream.rs
+++ b/trin-core/src/utp/stream.rs
@@ -273,7 +273,9 @@ impl UtpListener {
                                 };
                             }
                         } else {
-                            warn!("Received SYN packet for an unknown active uTP stream");
+                            warn!(
+                                "Received SYN packet for an unknown active uTP stream: {packet:?}"
+                            );
                         }
                     }
                     // Receive DATA and FIN packets
@@ -300,7 +302,9 @@ impl UtpListener {
                                 Err(err) => error!("Unable to receive uTP DATA packet: {err}"),
                             }
                         } else {
-                            warn!("Received DATA packet for an unknown active uTP stream")
+                            warn!(
+                                "Received DATA packet for an unknown active uTP stream: {packet:?}"
+                            )
                         }
                     }
                     PacketType::Fin => {
@@ -312,13 +316,10 @@ impl UtpListener {
                                 error!("Unable to send FIN packet to uTP stream handler");
                                 return;
                             }
-
-                            let mut buf = [0; BUF_SIZE];
-                            if let Err(msg) = conn.recv(&mut buf).await {
-                                error!("Unable to receive uTP FIN packet: {msg}")
-                            }
                         } else {
-                            warn!("Received FIN packet for an unknown active uTP stream")
+                            warn!(
+                                "Received FIN packet for an unknown active uTP stream: {packet:?}"
+                            )
                         }
                     }
                     PacketType::State => {
@@ -332,7 +333,7 @@ impl UtpListener {
                             // We don't handle STATE packets here, because the uTP client is handling them
                             // implicitly in the background when sending FIN packet with conn.close()
                         } else {
-                            warn!("Received STATE packet for an unknown active uTP stream");
+                            warn!("Received STATE packet for an unknown active uTP stream: {packet:?}");
                         }
                     }
                 }
@@ -606,6 +607,7 @@ impl UtpStream {
             let mut packet = Packet::with_payload(chunk);
             packet.set_seq_nr(self.seq_nr);
             packet.set_ack_nr(self.ack_nr);
+            packet.set_wnd_size(WINDOW_SIZE.saturating_sub(self.cur_window));
             packet.set_connection_id(self.sender_connection_id);
 
             self.unsent_queue.push_back(packet);
@@ -761,6 +763,7 @@ impl UtpStream {
             let mut packet = Packet::new();
             packet.set_type(PacketType::Syn);
             packet.set_connection_id(self.receiver_connection_id);
+            packet.set_wnd_size(WINDOW_SIZE);
             packet.set_seq_nr(self.seq_nr);
 
             self.send_packet(&mut packet).await;
@@ -1276,7 +1279,7 @@ impl UtpStream {
             .handle_packet(&packet, self.connected_to.clone())
             .await?
         {
-            pkt.set_wnd_size(WINDOW_SIZE);
+            pkt.set_wnd_size(WINDOW_SIZE.saturating_sub(self.cur_window));
             self.socket
                 .send_talk_req(
                     self.connected_to.clone(),
@@ -1417,6 +1420,7 @@ impl UtpStream {
         packet.set_connection_id(self.sender_connection_id);
         packet.set_seq_nr(self.seq_nr);
         packet.set_ack_nr(self.ack_nr);
+        packet.set_wnd_size(WINDOW_SIZE.saturating_sub(self.cur_window));
         packet.set_timestamp(now_microseconds());
         packet.set_type(PacketType::Fin);
 


### PR DESCRIPTION
### What was wrong?
During interop testing with Fluffy, the following issues were found:

- `wnd_size` value in the uTP packet header was set to 0 when sending SYN, DATA, and FIN packets.
-  we don't check for active uTP connection matching remote packet `connection_id` when we receive the FIN packet on the same socket where we are the senders of the DATA packet.

### How was it fixed?
- Set `wnd_size` to max window size for `SYN` packets and `max_window_size - curr_window` for DATA and FIN packets.
- Handle FIN packets when we are senders of the data (bidirectional FIN).

### To-Do
[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
