### PR TITLE
Update Rust to 1.62.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
             Check linting with Clippy and rustfmt, build the crate, and run tests.
         executor:
             name: rust/default
-            tag: 1.58.0
+            tag: 1.62.0
         environment:
             RUSTFLAGS: '-D warnings'
             RUST_LOG: 'debug'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "trin"
 version = "0.1.0"
 authors = ["Jacob Kaufmann <jacobkaufmann18@gmail.com>", "Jason Carver <ut96caarrs@snkmail.com>"]
 edition = "2021"
-rust-version = "1.58.0"
+rust-version = "1.62.0"
 default-run = "trin"
 repository = "https://github.com/ethereum/trin"
 

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ethportal-peertest"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.58.0"
+rust-version = "1.62.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/newsfragments/396.changed.md
+++ b/newsfragments/396.changed.md
@@ -1,0 +1,1 @@
+Update Rust version to latest stable (1.62.0).

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trin-core"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.58.0"
+rust-version = "1.62.0"
 
 [dependencies]
 anyhow = "1.0.57"

--- a/trin-core/src/types/block_body.rs
+++ b/trin-core/src/types/block_body.rs
@@ -295,7 +295,7 @@ mod tests {
     // EIP1559 w/ populated access list
     #[case(TX6, 41942)]
     fn encode_and_decode_txs(#[case] tx: &str, #[case] expected_nonce: u32) {
-        let tx_rlp = hex::decode(tx.to_string()).unwrap();
+        let tx_rlp = hex::decode(tx).unwrap();
         let tx = Transaction::decode(&tx_rlp).expect("error decoding tx");
         let expected_nonce = U256::from(expected_nonce);
         match &tx {
@@ -385,25 +385,25 @@ mod tests {
 
     fn get_14764013_block_body() -> BlockBody {
         let txs: Vec<Transaction> = vec![
-            Transaction::decode(&hex::decode(TX1.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX2.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX3.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX4.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX5.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX6.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX7.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX8.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX9.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX10.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX11.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX12.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX13.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX14.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX15.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX16.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX17.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX18.to_string()).unwrap()).unwrap(),
-            Transaction::decode(&hex::decode(TX19.to_string()).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX1).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX2).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX3).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX4).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX5).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX6).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX7).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX8).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX9).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX10).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX11).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX12).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX13).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX14).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX15).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX16).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX17).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX18).unwrap()).unwrap(),
+            Transaction::decode(&hex::decode(TX19).unwrap()).unwrap(),
         ];
         let uncles_rlp = &hex::decode(UNCLE).unwrap();
         let uncles: Vec<Header> = rlp::decode_list(uncles_rlp);

--- a/trin-core/src/types/receipts.rs
+++ b/trin-core/src/types/receipts.rs
@@ -337,7 +337,7 @@ mod tests {
 
     #[test]
     fn legacy_receipt() {
-        let receipt_rlp = hex::decode(RECEIPT_6.to_owned()).unwrap();
+        let receipt_rlp = hex::decode(RECEIPT_6).unwrap();
         let receipt = Receipt::decode(&receipt_rlp).expect("error decoding receipt");
         // tx link: https://etherscan.io/tx/0x147c84ddb366ae572ce5aa4d815e62de3a151133479fbb414e25d32bd7db9aa5
         assert_eq!(receipt.cumulative_gas_used, U256::from(579367));
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn typed_receipt() {
-        let receipt_rlp = hex::decode(RECEIPT_0.to_owned()).unwrap();
+        let receipt_rlp = hex::decode(RECEIPT_0).unwrap();
         let receipt = Receipt::decode(&receipt_rlp).expect("error decoding receipt");
         // tx link: https://etherscan.io/tx/0x163dae461ab32787eaecdad0748c9cf5fe0a22b443bc694efae9b80e319d9559
         assert_eq!(receipt.cumulative_gas_used, U256::from(189807));
@@ -362,7 +362,7 @@ mod tests {
     #[test]
     fn cumulative_gas_used() {
         // cumulative gas for last tx in block should match block's gas used
-        let receipt_rlp = hex::decode(RECEIPT_18.to_owned()).unwrap();
+        let receipt_rlp = hex::decode(RECEIPT_18).unwrap();
         let receipt = Receipt::decode(&receipt_rlp).expect("error decoding receipt");
         // https://etherscan.io/block/14764013
         assert_eq!(receipt.cumulative_gas_used, U256::from(1314225));

--- a/trin-core/tests/overlay.rs
+++ b/trin-core/tests/overlay.rs
@@ -118,7 +118,7 @@ async fn overlay() {
         ..PortalnetConfig::default()
     };
     let mut discovery_one = Discovery::new(portal_config_one).unwrap();
-    let _ = discovery_one.start().await.unwrap();
+    discovery_one.start().await.unwrap();
     let discovery_one = Arc::new(discovery_one);
     let overlay_one = Arc::new(init_overlay(Arc::clone(&discovery_one), protocol.clone()).await);
     spawn_overlay(Arc::clone(&discovery_one), Arc::clone(&overlay_one)).await;
@@ -131,7 +131,7 @@ async fn overlay() {
         ..PortalnetConfig::default()
     };
     let mut discovery_two = Discovery::new(portal_config_two).unwrap();
-    let _ = discovery_two.start().await.unwrap();
+    discovery_two.start().await.unwrap();
     let discovery_two = Arc::new(discovery_two);
     let overlay_two = Arc::new(init_overlay(Arc::clone(&discovery_two), protocol.clone()).await);
     spawn_overlay(Arc::clone(&discovery_two), Arc::clone(&overlay_two)).await;
@@ -144,7 +144,7 @@ async fn overlay() {
         ..PortalnetConfig::default()
     };
     let mut discovery_three = Discovery::new(portal_config_three).unwrap();
-    let _ = discovery_three.start().await.unwrap();
+    discovery_three.start().await.unwrap();
     let discovery_three = Arc::new(discovery_three);
     let overlay_three =
         Arc::new(init_overlay(Arc::clone(&discovery_three), protocol.clone()).await);

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -3,7 +3,7 @@ name = "trin-history"
 version = "0.1.0"
 authors = ["Jacob Kaufmann <jacobkaufmann18@gmail.com>"]
 edition = "2021"
-rust-version = "1.58.0"
+rust-version = "1.62.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -3,7 +3,7 @@ name = "trin-state"
 version = "0.1.0"
 authors = ["Jason Carver <ut96caarrs@snkmail.com>"]
 edition = "2021"
-rust-version = "1.58.0"
+rust-version = "1.62.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
### What was wrong?
The Rust version has not been updated since January 2022.

### How was it fixed?
Update to the latest stable version (1.62.0).
Check [here](https://github.com/rust-lang/rust/blob/master/RELEASES.md) for release changes.

Fixes also some Clippy warnings.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
