### PR TITLE
Add client info to ENR

### DIFF
--- a/newsfragments/397.added.md
+++ b/newsfragments/397.added.md
@@ -1,0 +1,3 @@
+- Add `c` (short for `client`) key to ENR, whose value contains a client info string, eg `t v0.1.0` (as shorthand for `trin v0.1.0`)
+- Add `client` key to node objects within output of portal `RoutingTableInfo` endpoints
+- Add `address` key containing IP:Port 

--- a/trin-core/src/jsonrpc/utils.rs
+++ b/trin-core/src/jsonrpc/utils.rs
@@ -10,7 +10,7 @@ use validator::ValidationError;
 use crate::{portalnet::types::content_key::OverlayContentKey, utils::bytes::hex_decode};
 
 type NodeMap = BTreeMap<String, String>;
-type NodeTuple = (NodeId, Enr, NodeStatus, Distance);
+type NodeTuple = (NodeId, Enr, NodeStatus, Distance, Option<String>);
 
 /// Converts the output of the Overlay's bucket_entries method to a JSON Value
 pub fn bucket_entries_to_json(bucket_entries: BTreeMap<usize, Vec<NodeTuple>>) -> Value {
@@ -23,7 +23,7 @@ pub fn bucket_entries_to_json(bucket_entries: BTreeMap<usize, Vec<NodeTuple>>) -
                 bucket_index,
                 bucket
                     .iter()
-                    .map(|(node_id, enr, node_status, data_radius)| {
+                    .map(|(node_id, enr, node_status, data_radius, client_info)| {
                         node_count += 1;
                         if node_status.state == ConnectionState::Connected {
                             connected_count += 1
@@ -36,6 +36,17 @@ pub fn bucket_entries_to_json(bucket_entries: BTreeMap<usize, Vec<NodeTuple>>) -
                         map.insert("enr".to_owned(), enr.to_base64());
                         map.insert("status".to_owned(), format!("{:?}", node_status.state));
                         map.insert("radius".to_owned(), format!("{}", data_radius));
+                        if let Some(client_info) = client_info {
+                            // Expand client name if possible, otherwise leave as-is.
+                            match expand_client_name(client_info) {
+                                Some(expanded_name) => {
+                                    map.insert("client".to_owned(), expanded_name);
+                                }
+                                None => {
+                                    map.insert("client".to_owned(), client_info.to_string());
+                                }
+                            };
+                        }
                         map
                     })
                     .collect(),
@@ -51,6 +62,43 @@ pub fn bucket_entries_to_json(bucket_entries: BTreeMap<usize, Vec<NodeTuple>>) -
             "numConnected": connected_count
         }
     )
+}
+
+/// Expands first word of client string if it is one of:
+/// f -> fluffy
+/// t -> trin
+/// u -> ultralight
+/// Returns None if the shorthand is formatted unexpectedly.
+fn expand_client_name(client_shorthand: &str) -> Option<String> {
+    let mut client_shorthand_words = client_shorthand.split(' ');
+
+    let client_shorthand = match client_shorthand_words.next() {
+        Some(client_shorthand) => client_shorthand,
+        None => return None,
+    };
+
+    let client_name: Option<&str> = match client_shorthand {
+        "f" => Some("fluffy"),
+        "t" => Some("trin"),
+        "u" => Some("ultralight"),
+        _ => None,
+    };
+
+    match client_name {
+        Some(client_name) => {
+            let mut expanded_string: String = client_name.to_owned();
+
+            match client_shorthand_words.next() {
+                Some(version_string) => {
+                    expanded_string.push(' ');
+                    expanded_string.push_str(version_string);
+                }
+                None => {}
+            }
+            Some(expanded_string)
+        }
+        None => None,
+    }
 }
 
 /// Parse out a (content_key, content_value) pair from the given json parameter list
@@ -82,4 +130,24 @@ pub fn parse_content_item<TContentKey: OverlayContentKey>(
         Err(_) => return Err(ValidationError::new("Unable to decode content")),
     };
     Ok((content_key, content))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("f 3", Some("fluffy 3".to_owned()))]
+    #[case("t v0.1.0", Some("trin v0.1.0".to_owned()))]
+    #[case("u", Some("ultralight".to_owned()))]
+    #[case("j v0.1.0", None)]
+    fn test_expand_client_name(
+        #[case] shorthand_client_name: String,
+        #[case] expected_expanded: Option<String>,
+    ) {
+        let expanded = expand_client_name(&shorthand_client_name);
+        assert_eq!(expanded, expected_expanded);
+    }
 }

--- a/trin-core/src/jsonrpc/utils.rs
+++ b/trin-core/src/jsonrpc/utils.rs
@@ -46,7 +46,16 @@ pub fn bucket_entries_to_json(bucket_entries: BTreeMap<usize, Vec<NodeTuple>>) -
                                     map.insert("client".to_owned(), client_info.to_string());
                                 }
                             };
+                        } else {
+                            // Include address (IP:port) for convenience.
+                            // TODO: Can be removed once a portal dashboard does UI-side ENR decoding.
+                            let port = match enr.udp4_socket() {
+                                Some(port) => format!("{}", port),
+                                None => "None".to_string(),
+                            };
+                            map.insert("address".to_owned(), port);
                         }
+
                         map
                     })
                     .collect(),

--- a/trin-core/src/portalnet/discovery.rs
+++ b/trin-core/src/portalnet/discovery.rs
@@ -2,9 +2,8 @@ use super::{
     types::messages::{HexData, PortalnetConfig, ProtocolId},
     Enr,
 };
-use crate::socket;
 use crate::utils::bytes::hex_encode;
-
+use crate::{socket, TRIN_VERSION};
 use discv5::{
     enr::{CombinedKey, EnrBuilder, NodeId},
     Discv5, Discv5Config, Discv5ConfigBuilder, Discv5Event, RequestError, TalkRequest,
@@ -119,6 +118,11 @@ impl Discovery {
                 builder.ip(ip_address);
             }
             builder.udp4(config.listen_port);
+
+            // Use "t" as short-hand for "Trin" to save bytes in ENR.
+            let client_info = format!("t {}", TRIN_VERSION);
+            // Use "c" as short-hand for "client".
+            builder.add_value("c", client_info.as_bytes());
             builder.build(&enr_key).unwrap()
         };
 


### PR DESCRIPTION
### What was wrong?

Knowing which client and version of that client your node is failing to connect to is helpful for debugging issues on the portal network.

Getting a node's info via RPC is either cumbersome or impossible, depending on the node's settings.

### How was it fixed?

- A client string (e.g. `t 0.1.0` for Trin v0.1.0) is added  to trin's ENR as a value under the key `client`.
- If a portal node has a `c` key in its ENR, it is displayed in the output of the `portal_*RoutingTableInfo` RPC endpoint, like so: 
```
{
  "client": "trin 0.1.0",
  "enr": "enr:-Je4QFui-99WVnY8Q4C3rR6iZokv_rK1d7Q4fUaWHEd6PEqPcPbVmSoaXOnHG-dFZd0L0v5GWIJXhz7XP3unaqBJv0YBhmNsaWVudIt0cmluIHYwLjEuMIJpZIJ2NIJpcIR_AAABiXNlY3AyNTZrMaEC64Hx6X6On6OQSGP-X5PaXZsCkEzUrimYclGbmwhFAXyDdWRwgiMq",
  "node_id": "0x0241dc8d483d628cbad18704e3a9b094642a07882d329c92e25fa5da4eb4155c",
  "radius": "18446744073709551615",
  "status": "Connected"
}
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
