### PR TITLE
Set `no_output_timeout` in CircleCI `win-build` pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ jobs:
       - run:
           name: Cargo Test --target x86_64-pc-windows-msvc
           command: cargo test --target x86_64-pc-windows-msvc
+          no_output_timeout: 30m
 workflows:
   merge-test:
     jobs:


### PR DESCRIPTION
### What was wrong?
A lot of recent win-build CI workflows [fail](https://app.circleci.com/pipelines/github/ethereum/trin/1761/workflows/6b4c7d82-45e3-4cbb-8f9d-5df6d010decc/jobs/3552) with: `Too long with no output (exceeded 10m0s): context deadline exceeded`.

### How was it fixed?
Increase default output timeout from 10m to 30m.

https://support.circleci.com/hc/en-us/articles/360007188574-Build-has-hit-timeout-limit

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
