### PR TITLE
Increase default pool size

### DIFF
--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -44,7 +44,7 @@ pub struct TrinConfig {
     pub web3_ipc_path: String, // TODO: Change to PathBuf
 
     #[structopt(
-        default_value = "2",
+        default_value = "5",
         long = "pool-size",
         help = "max size of threadpool"
     )]


### PR DESCRIPTION
### What was wrong?
Seems like the default poolsize of `2` is causing our win-build ci workflow to crash. Using this pr to validate. 

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
