### PR TITLE
Test and build the Trin workspace in `win-build` CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
           # Remove the first two lines of gitconfig as work around
           command: |
             (gc ..\.gitconfig | select -Skip 2) | sc ..\.gitconfig
-            cargo clippy --package trin -- --deny warnings
+            cargo clippy --workspace --all-targets --all-features --no-deps -- --deny warnings
       - run:
           name: Build Trin workspace
           command: cargo build --workspace --target x86_64-pc-windows-msvc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,11 +77,11 @@ jobs:
             (gc ..\.gitconfig | select -Skip 2) | sc ..\.gitconfig
             cargo clippy --package trin -- --deny warnings
       - run:
-          name: Cargo Build --target x86_64-pc-windows-msvc
-          command: cargo build --target x86_64-pc-windows-msvc
+          name: Build Trin workspace
+          command: cargo build --workspace --target x86_64-pc-windows-msvc
       - run:
-          name: Cargo Test --target x86_64-pc-windows-msvc
-          command: cargo test --target x86_64-pc-windows-msvc
+          name: Test Trin workspace
+          command: cargo test --workspace --target x86_64-pc-windows-msvc
 workflows:
   merge-test:
     jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4263,6 +4263,7 @@ dependencies = [
  "structopt",
  "thiserror",
  "trin-core",
+ "uds_windows",
 ]
 
 [[package]]

--- a/trin-cli/Cargo.toml
+++ b/trin-cli/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = { version = "1.0.68", features = ["raw_value"] }
 structopt="0.3.25"
 thiserror = "1.0.29"
 trin-core = { path = "../trin-core" }
+uds_windows = "1.0.2"
 
 [[bin]]
 name="trin-cli"

--- a/trin-cli/src/main.rs
+++ b/trin-cli/src/main.rs
@@ -1,7 +1,9 @@
-use std::{
-    os::unix::net::UnixStream,
-    path::{Path, PathBuf},
-};
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
+#[cfg(windows)]
+use uds_windows::UnixStream;
+
+use std::path::{Path, PathBuf};
 
 use ethereum_types::H256;
 use serde_json::value::RawValue;


### PR DESCRIPTION
### What was wrong?
Since genesis, win-build workflow in CI doesn't run all tests in the workspace.

### How was it fixed?
- Add `--workspace` flag to `cargo build` and `cargo test`
- Update the` clippy` command to check for all features and remove depreciated `--all` flag.
-  Add windows support for `trin-cli`. (this issue was found with the updated clippy command)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
