### PR TITLE
Run windows unit tests and fix storage test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
           # Remove the first two lines of gitconfig as work around
           command: |
             (gc ..\.gitconfig | select -Skip 2) | sc ..\.gitconfig
-            cargo clippy --package trin -- --deny warnings
+            cargo clippy --workspace --all-targets --all-features --no-deps -- --deny warnings
       - run:
           name: Build Trin workspace
           command: cargo build --workspace --target x86_64-pc-windows-msvc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,18 +70,6 @@ jobs:
           name: Install target toolchain
           command: rustup toolchain install stable-x86_64-pc-windows-msvc
       - run:
-          name: Install Clippy
-          command: rustup component add clippy
-      - run:
-          name: Run Clippy
-          # Remove the first two lines of gitconfig as work around
-          command: |
-            (gc ..\.gitconfig | select -Skip 2) | sc ..\.gitconfig
-            cargo clippy --workspace --all-targets --all-features --no-deps -- --deny warnings
-      - run:
-          name: Build Trin workspace
-          command: cargo build --workspace --target x86_64-pc-windows-msvc
-      - run:
           name: Cargo Test --target x86_64-pc-windows-msvc
           command: cargo test --workspace --target x86_64-pc-windows-msvc
   utp-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,20 @@ jobs:
           name: Install target toolchain
           command: rustup toolchain install stable-x86_64-pc-windows-msvc
       - run:
+          name: Install Clippy
+          command: rustup component add clippy
+      - run:
+          name: Run Clippy
+          # Remove the first two lines of gitconfig as work around
+          command: |
+            (gc ..\.gitconfig | select -Skip 2) | sc ..\.gitconfig
+            cargo clippy --package trin -- --deny warnings
+      - run:
+          name: Build Trin workspace
+          command: cargo build --workspace --target x86_64-pc-windows-msvc
+      - run:
           name: Cargo Test --target x86_64-pc-windows-msvc
-          command: cargo test --target x86_64-pc-windows-msvc
+          command: cargo test --workspace --target x86_64-pc-windows-msvc
   utp-test:
     description: |
       Run uTP network simulator
@@ -125,7 +137,6 @@ jobs:
       - run:
           name: Stop containers
           command: docker-compose -f utp-testing/docker/docker-compose.yml down
-
 workflows:
   merge-test:
     jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4641,6 +4641,7 @@ dependencies = [
  "structopt",
  "thiserror",
  "trin-core",
+ "uds_windows",
 ]
 
 [[package]]

--- a/trin-cli/Cargo.toml
+++ b/trin-cli/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = { version = "1.0.68", features = ["raw_value"] }
 structopt="0.3.25"
 thiserror = "1.0.29"
 trin-core = { path = "../trin-core" }
+uds_windows = "1.0.2"
 
 [[bin]]
 name="trin-cli"

--- a/trin-cli/src/main.rs
+++ b/trin-cli/src/main.rs
@@ -1,7 +1,9 @@
-use std::{
-    os::unix::net::UnixStream,
-    path::{Path, PathBuf},
-};
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
+#[cfg(windows)]
+use uds_windows::UnixStream;
+
+use std::path::{Path, PathBuf};
 
 use ethereum_types::H256;
 use serde_json::value::RawValue;

--- a/trin-core/src/portalnet/storage.rs
+++ b/trin-core/src/portalnet/storage.rs
@@ -555,6 +555,7 @@ pub mod test {
         assert_eq!(storage.node_id, node_id);
         assert_eq!(storage.storage_capacity_in_bytes, CAPACITY * 1000);
 
+        std::mem::drop(storage);
         temp_dir.close()?;
         Ok(())
     }
@@ -583,6 +584,8 @@ pub mod test {
             let mut value = [0u8; 32];
             rand::thread_rng().fill_bytes(&mut value);
             storage.store(&content_key, &value.to_vec()).unwrap();
+
+            std::mem::drop(storage);
             temp_dir.close().unwrap();
         }
         QuickCheck::new()
@@ -617,6 +620,7 @@ pub mod test {
 
         assert_eq!(result, value);
 
+        std::mem::drop(storage);
         temp_dir.close()?;
         Ok(())
     }
@@ -648,6 +652,7 @@ pub mod test {
 
         assert_eq!(32, bytes);
 
+        std::mem::drop(storage);
         temp_dir.close()?;
         Ok(())
     }
@@ -675,6 +680,7 @@ pub mod test {
         let result = storage.find_farthest_content_id()?;
         assert!(result.is_none());
 
+        std::mem::drop(storage);
         temp_dir.close()?;
         Ok(())
     }
@@ -713,6 +719,7 @@ pub mod test {
 
             let farthest = storage.find_farthest_content_id();
 
+            std::mem::drop(storage);
             temp_dir.close().unwrap();
 
             TestResult::from_bool(farthest.unwrap().unwrap() == expected_farthest)

--- a/trin-core/src/portalnet/types/content_key.rs
+++ b/trin-core/src/portalnet/types/content_key.rs
@@ -510,6 +510,7 @@ mod test {
         let should_store_b = storage.should_store(&content_key_b)?;
         assert!(!should_store_b);
 
+        std::mem::drop(storage);
         temp_dir.close()?;
         Ok(())
     }
@@ -565,6 +566,7 @@ mod test {
         let expected = U256::from(expected_distance);
         assert_eq!(distance, expected.0[3]);
 
+        std::mem::drop(storage);
         temp_dir.close()?;
         Ok(())
     }


### PR DESCRIPTION
### What was wrong?

This is a branch of #403, which runs windows unit tests, which fail

### How was it fixed?

Modifies the offending 8 unit tests to call `std::mem::drop` on the `PortalStorage` instance, thereby closing the files that rocksdb and sqlite have open in the directory that `TempDir` tries to delete. This avoids the conflict that was causing any unit test that uses `setup_temp_dir` to fail on windows.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
