### PR TITLE
Increase CircleCI linux and windows pipeline resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
   lint-build-test:
         description: |
             Check linting with Clippy and rustfmt, build the crate, and run tests.
+        resource_class: xlarge
         executor:
             name: rust/default
             tag: 1.62.0
@@ -40,16 +41,17 @@ jobs:
                 command: cargo clippy --all --all-targets --all-features --no-deps -- --deny warnings
             - run:
                 name: Build Trin workspace
-                command: cargo build --workspace --jobs 2
+                command: cargo build --workspace
             - run:
                 name: Test Trin workspace
-                command: cargo test --workspace --jobs 2
+                command: cargo test --workspace
   win-build:
     description: |
       Build the crate for windows.
     executor:
       name: win/default
       shell: powershell.exe
+      size: large
     environment:
         RUST_LOG: 'debug'
     steps:


### PR DESCRIPTION
### What was wrong?

Not enough resources when compiling and testing in CIrcleCI linux pipeline

### How was it fixed?

- Increase CircleCI resource class from medium to [xlarge](https://circleci.com/product/features/resource-classes/)
- Remove the `--job` flag from `cargo build` and `cargo test`


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
