### PR TITLE
Offer history content to all peers over rpc

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[net]
+git-fetch-with-cli = true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,18 +70,6 @@ jobs:
           name: Install target toolchain
           command: rustup toolchain install stable-x86_64-pc-windows-msvc
       - run:
-          name: Install Clippy
-          command: rustup component add clippy
-      - run:
-          name: Run Clippy
-          # Remove the first two lines of gitconfig as work around
-          command: |
-            (gc ..\.gitconfig | select -Skip 2) | sc ..\.gitconfig
-            cargo clippy --package trin -- --deny warnings
-      - run:
-          name: Cargo Build --target x86_64-pc-windows-msvc
-          command: cargo build --target x86_64-pc-windows-msvc
-      - run:
           name: Cargo Test --target x86_64-pc-windows-msvc
           command: cargo test --target x86_64-pc-windows-msvc
   utp-test:

--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -4,7 +4,7 @@ use std::{io::prelude::*, panic, time::Duration};
 
 use anyhow::anyhow;
 use hyper::{self, Body, Client, Method, Request};
-use log::info;
+use log::{error, info};
 use serde_json::{self, json, Value};
 
 use crate::{cli::PeertestConfig, Peertest};
@@ -448,10 +448,13 @@ pub async fn test_jsonrpc_endpoints_over_ipc(peertest_config: PeertestConfig, pe
         let response = make_ipc_request(&peertest_config.target_ipc_path, &test.request);
         match response {
             Ok(val) => test.validate(&val, peertest),
-            Err(msg) => panic!(
-                "Jsonrpc error for {:?} endpoint ('os error 11' means timeout): {:?}",
-                test.request.method, msg
-            ),
+            Err(msg) => {
+                error!(
+                    "Jsonrpc error for {:?} endpoint ('os error 11' means timeout): {:?}",
+                    test.request.method, msg
+                );
+                panic!("Must always get jsonrpc success");
+            }
         }
     }
 }

--- a/ethportal-peertest/src/scenarios.rs
+++ b/ethportal-peertest/src/scenarios.rs
@@ -3,7 +3,7 @@ use crate::jsonrpc::{
     HISTORY_CONTENT_VALUE,
 };
 use crate::{Peertest, PeertestConfig};
-use log::info;
+use log::{error, info};
 use serde_json::{json, Value};
 use trin_core::jsonrpc::types::Params;
 
@@ -45,10 +45,19 @@ pub fn test_offer_accept(peertest_config: PeertestConfig, peertest: &Peertest) {
         params: Params::Array(vec![Value::String(HISTORY_CONTENT_KEY.to_string())]),
     };
     let received_content_value =
-        make_ipc_request(&peertest.bootnode.web3_ipc_path, &local_content_request).unwrap();
+        make_ipc_request(&peertest.bootnode.web3_ipc_path, &local_content_request);
+    let received_content_value = match received_content_value {
+        Ok(val) => val,
+        Err(err) => {
+            error!("Failed to find content that should be present: {err}");
+            panic!("Could not get local content");
+        }
+    };
 
+    let received_content_str = received_content_value.as_str().unwrap();
     assert_eq!(
-        HISTORY_CONTENT_VALUE,
-        received_content_value.as_str().unwrap()
+        HISTORY_CONTENT_VALUE, received_content_str,
+        "The received content {}, must match the expected {}",
+        HISTORY_CONTENT_VALUE, received_content_str,
     );
 }

--- a/ethportal-peertest/src/scenarios.rs
+++ b/ethportal-peertest/src/scenarios.rs
@@ -25,7 +25,7 @@ pub fn test_offer_accept(peertest_config: PeertestConfig, peertest: &Peertest) {
 
     // Send offer request from testnode to bootnode
     let offer_request = JsonRpcRequest {
-        method: "portal_historyOffer".to_string(),
+        method: "portal_historySendOffer".to_string(),
         id: 11,
         params: Params::Array(vec![
             Value::String(peertest.bootnode.enr.to_base64()),

--- a/newsfragments/411.added.md
+++ b/newsfragments/411.added.md
@@ -1,0 +1,1 @@
+Add ``portal_historyOffer`` JSON-RPC endpoint, to broadcast a piece of content to all relevant peers

--- a/newsfragments/411.changed.md
+++ b/newsfragments/411.changed.md
@@ -1,0 +1,1 @@
+Move current logic for JSON-RPC endpoint ``portal_historyOffer`` to ``portal_historySendOffer``

--- a/newsfragments/411.fixed.md
+++ b/newsfragments/411.fixed.md
@@ -1,0 +1,2 @@
+When validating accepted content, and finding that it fails, skip that one piece of content instead
+of panicking

--- a/trin-core/src/jsonrpc/endpoints.rs
+++ b/trin-core/src/jsonrpc/endpoints.rs
@@ -14,7 +14,7 @@ pub enum StateEndpoint {
     FindContent,
     FindNodes,
     LocalContent,
-    Offer,
+    SendOffer,
     Store,
     Ping,
     RoutingTableInfo,
@@ -27,7 +27,7 @@ pub enum HistoryEndpoint {
     FindContent,
     FindNodes,
     LocalContent,
-    Offer,
+    SendOffer,
     Ping,
     RecursiveFindContent,
     Store,
@@ -83,7 +83,9 @@ impl FromStr for TrinEndpoint {
             "portal_historyLocalContent" => {
                 Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::LocalContent))
             }
-            "portal_historyOffer" => Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::Offer)),
+            "portal_historySendOffer" => {
+                Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::SendOffer))
+            }
             "portal_historyPing" => Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::Ping)),
             "portal_historyRadius" => {
                 Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::DataRadius))
@@ -99,7 +101,7 @@ impl FromStr for TrinEndpoint {
             "portal_stateLocalContent" => {
                 Ok(TrinEndpoint::StateEndpoint(StateEndpoint::LocalContent))
             }
-            "portal_stateOffer" => Ok(TrinEndpoint::StateEndpoint(StateEndpoint::Offer)),
+            "portal_stateSendOffer" => Ok(TrinEndpoint::StateEndpoint(StateEndpoint::SendOffer)),
             "portal_stateStore" => Ok(TrinEndpoint::StateEndpoint(StateEndpoint::Store)),
             "portal_statePing" => Ok(TrinEndpoint::StateEndpoint(StateEndpoint::Ping)),
             "portal_stateRadius" => Ok(TrinEndpoint::StateEndpoint(StateEndpoint::DataRadius)),

--- a/trin-core/src/jsonrpc/endpoints.rs
+++ b/trin-core/src/jsonrpc/endpoints.rs
@@ -27,6 +27,7 @@ pub enum HistoryEndpoint {
     FindContent,
     FindNodes,
     LocalContent,
+    Offer,
     SendOffer,
     Ping,
     RecursiveFindContent,
@@ -83,6 +84,7 @@ impl FromStr for TrinEndpoint {
             "portal_historyLocalContent" => {
                 Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::LocalContent))
             }
+            "portal_historyOffer" => Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::Offer)),
             "portal_historySendOffer" => {
                 Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::SendOffer))
             }

--- a/trin-core/src/jsonrpc/types.rs
+++ b/trin-core/src/jsonrpc/types.rs
@@ -239,12 +239,12 @@ impl TryFrom<[&Value; 2]> for FindContentParams {
     }
 }
 
-pub struct OfferParams {
+pub struct SendOfferParams {
     pub enr: SszEnr,
     pub content_keys: Vec<ByteList>,
 }
 
-impl TryFrom<Params> for OfferParams {
+impl TryFrom<Params> for SendOfferParams {
     type Error = ValidationError;
 
     fn try_from(params: Params) -> Result<Self, Self::Error> {
@@ -258,7 +258,7 @@ impl TryFrom<Params> for OfferParams {
     }
 }
 
-impl TryFrom<[&Value; 2]> for OfferParams {
+impl TryFrom<[&Value; 2]> for SendOfferParams {
     type Error = ValidationError;
 
     fn try_from(params: [&Value; 2]) -> Result<Self, Self::Error> {

--- a/trin-core/src/jsonrpc/types.rs
+++ b/trin-core/src/jsonrpc/types.rs
@@ -8,7 +8,10 @@ use tokio::sync::mpsc;
 use validator::{Validate, ValidationError};
 
 use crate::{
-    jsonrpc::endpoints::{HistoryEndpoint, StateEndpoint, TrinEndpoint},
+    jsonrpc::{
+        endpoints::{HistoryEndpoint, StateEndpoint, TrinEndpoint},
+        utils::parse_content_item,
+    },
     portalnet::types::{
         content_key::{OverlayContentKey, RawContentKey},
         messages::{ByteList, CustomPayload, SszEnr},
@@ -239,6 +242,37 @@ impl TryFrom<[&Value; 2]> for FindContentParams {
     }
 }
 
+pub struct OfferParams<TContentKey> {
+    pub content_key: TContentKey,
+    pub content: Vec<u8>,
+}
+
+impl<TContentKey: OverlayContentKey> TryFrom<Params> for OfferParams<TContentKey> {
+    type Error = ValidationError;
+
+    fn try_from(params: Params) -> Result<Self, Self::Error> {
+        match params {
+            Params::Array(val) => match val.len() {
+                2 => OfferParams::<TContentKey>::try_from([&val[0], &val[1]]),
+                _ => Err(ValidationError::new("Expected 2 params")),
+            },
+            _ => Err(ValidationError::new("Expected array of params")),
+        }
+    }
+}
+
+impl<TContentKey: OverlayContentKey> TryFrom<[&Value; 2]> for OfferParams<TContentKey> {
+    type Error = ValidationError;
+
+    fn try_from(params: [&Value; 2]) -> Result<Self, Self::Error> {
+        let (content_key, content) = parse_content_item(params)?;
+        Ok(Self {
+            content_key,
+            content,
+        })
+    }
+}
+
 pub struct SendOfferParams {
     pub enr: SszEnr,
     pub content_keys: Vec<ByteList>,
@@ -460,30 +494,7 @@ impl<TContentKey: OverlayContentKey> TryFrom<[&Value; 2]> for StoreParams<TConte
     type Error = ValidationError;
 
     fn try_from(params: [&Value; 2]) -> Result<Self, Self::Error> {
-        let content_key = params[0]
-            .as_str()
-            .ok_or_else(|| ValidationError::new("Empty content key param"))?;
-        let content_key = match hex_decode(content_key) {
-            Ok(val) => match TContentKey::try_from(val) {
-                Ok(val) => val,
-                Err(_) => return Err(ValidationError::new("Unable to decode content_key")),
-            },
-            Err(err) => {
-                let mut ve = ValidationError::new("Cannot convert content_key hex to bytes");
-                ve.add_param(
-                    std::borrow::Cow::Borrowed("hex_decode_exception"),
-                    &err.to_string(),
-                );
-                return Err(ve);
-            }
-        };
-        let content = params[1]
-            .as_str()
-            .ok_or_else(|| ValidationError::new("Empty content param"))?;
-        let content = match hex_decode(content) {
-            Ok(val) => val,
-            Err(_) => return Err(ValidationError::new("Unable to decode content")),
-        };
+        let (content_key, content) = parse_content_item(params)?;
         Ok(Self {
             content_key,
             content,

--- a/trin-core/src/jsonrpc/utils.rs
+++ b/trin-core/src/jsonrpc/utils.rs
@@ -6,6 +6,9 @@ use discv5::{
 use ethereum_types::U256;
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
+use validator::ValidationError;
+
+use crate::{portalnet::types::content_key::OverlayContentKey, utils::bytes::hex_decode};
 
 type NodeMap = BTreeMap<String, String>;
 type NodeTuple = (NodeId, Enr, NodeStatus, U256);
@@ -49,4 +52,35 @@ pub fn bucket_entries_to_json(bucket_entries: BTreeMap<usize, Vec<NodeTuple>>) -
             "numConnected": connected_count
         }
     )
+}
+
+/// Parse out a (content_key, content_value) pair from the given json parameter list
+pub fn parse_content_item<TContentKey: OverlayContentKey>(
+    params: [&Value; 2],
+) -> Result<(TContentKey, Vec<u8>), ValidationError> {
+    let content_key = params[0]
+        .as_str()
+        .ok_or_else(|| ValidationError::new("Empty content key param"))?;
+    let content_key = match hex_decode(content_key) {
+        Ok(val) => match TContentKey::try_from(val) {
+            Ok(val) => val,
+            Err(_) => return Err(ValidationError::new("Unable to decode content_key")),
+        },
+        Err(err) => {
+            let mut ve = ValidationError::new("Cannot convert content_key hex to bytes");
+            ve.add_param(
+                std::borrow::Cow::Borrowed("hex_decode_exception"),
+                &err.to_string(),
+            );
+            return Err(ve);
+        }
+    };
+    let content = params[1]
+        .as_str()
+        .ok_or_else(|| ValidationError::new("Empty content param"))?;
+    let content = match hex_decode(content) {
+        Ok(val) => val,
+        Err(_) => return Err(ValidationError::new("Unable to decode content")),
+    };
+    Ok((content_key, content))
 }

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -10,7 +10,7 @@ use trin_core::{
         endpoints::HistoryEndpoint,
         types::{
             FindContentParams, FindNodesParams, HistoryJsonRpcRequest, LocalContentParams,
-            OfferParams, PingParams, RecursiveFindContentParams, StoreParams,
+            PingParams, RecursiveFindContentParams, SendOfferParams, StoreParams,
         },
         utils::bucket_entries_to_json,
     },
@@ -194,8 +194,8 @@ impl HistoryRequestHandler {
                     };
                     let _ = request.resp.send(response);
                 }
-                HistoryEndpoint::Offer => {
-                    let response = match OfferParams::try_from(request.params) {
+                HistoryEndpoint::SendOffer => {
+                    let response = match SendOfferParams::try_from(request.params) {
                         Ok(val) => {
                             let content_keys =
                                 val.content_keys.iter().map(|key| key.to_vec()).collect();
@@ -207,10 +207,10 @@ impl HistoryRequestHandler {
                                 .await
                             {
                                 Ok(accept) => Ok(accept.into()),
-                                Err(msg) => Err(format!("Offer request timeout: {:?}", msg)),
+                                Err(msg) => Err(format!("SendOffer request timeout: {:?}", msg)),
                             }
                         }
-                        Err(msg) => Err(format!("Invalid Offer params: {:?}", msg)),
+                        Err(msg) => Err(format!("Invalid SendOffer params: {:?}", msg)),
                     };
                     let _ = request.resp.send(response);
                 }

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -9,7 +9,7 @@ use trin_core::{
     jsonrpc::{
         endpoints::StateEndpoint,
         types::{
-            FindContentParams, FindNodesParams, LocalContentParams, OfferParams, PingParams,
+            FindContentParams, FindNodesParams, LocalContentParams, PingParams, SendOfferParams,
             StateJsonRpcRequest, StoreParams,
         },
         utils::bucket_entries_to_json,
@@ -107,8 +107,8 @@ impl StateRequestHandler {
                     };
                     let _ = request.resp.send(response);
                 }
-                StateEndpoint::Offer => {
-                    let response = match OfferParams::try_from(request.params) {
+                StateEndpoint::SendOffer => {
+                    let response = match SendOfferParams::try_from(request.params) {
                         Ok(val) => {
                             let content_keys =
                                 val.content_keys.iter().map(|key| key.to_vec()).collect();


### PR DESCRIPTION
### What was wrong?

Replacing #384 

Need a way to push content over RPC, to build bridge node.

### How was it fixed?

- Move current logic in `portal_historyOffer` to `portal_historySendOffer`
- Add `portal_historyOffer` to broadcast a piece of content to all relevant peers
- slightly more convenient public function for propagating gossip in the overlay
- When validating accepted content, and finding that it fails, skip it instead of panicking

It's probably easiest to read through each commit in the PR individually.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
- [x] Confirmation from other teams about the shift of the meaning of `portal_historyOffer`
- [x] re-enable `test_offer_accept()`, with a retry after sleep

Probably as good as it gets for client team confirmation, over Discord:

> acolytec3 — 8/23 at 5:26 PM
> Should be fine for us.  I don't know that we've even implemented this endpoint since our RPC is woefully lacking
> deme — 8/24 at 1:20 AM
> We didn't implement exactly that one either. But we can add it, and I'd be fine with such change I think.