### PR TITLE
fix: address clippy errors

### DIFF
--- a/ethportal-peertest/src/cli.rs
+++ b/ethportal-peertest/src/cli.rs
@@ -7,7 +7,7 @@ use trin_core::cli::{
 
 const DEFAULT_LISTEN_PORT: &str = "9876";
 
-#[derive(StructOpt, Debug, PartialEq, Clone)]
+#[derive(StructOpt, Debug, PartialEq, Eq, Clone)]
 #[structopt(
     name = "ethportal-peertest",
     version = "0.0.1",

--- a/src/bin/seed-database.rs
+++ b/src/bin/seed-database.rs
@@ -172,7 +172,7 @@ fn generate_random_value(number_of_bytes: u32) -> Vec<u8> {
 }
 
 // CLI Parameter Handling
-#[derive(StructOpt, Debug, PartialEq)]
+#[derive(StructOpt, Debug, PartialEq, Eq)]
 #[structopt(
     name = "Trin DB Util",
     version = "0.0.1",

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -41,7 +41,6 @@ mod test {
 
         peertest::jsonrpc::test_jsonrpc_endpoints_over_ipc(peertest_config.clone(), &peertest)
             .await;
-        peertest::scenarios::test_offer_accept(peertest_config, &peertest);
 
         peertest.exit_all_nodes();
         test_client_exiter.exit();

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -41,6 +41,7 @@ mod test {
 
         peertest::jsonrpc::test_jsonrpc_endpoints_over_ipc(peertest_config.clone(), &peertest)
             .await;
+        peertest::scenarios::test_offer_accept(peertest_config, &peertest);
 
         peertest.exit_all_nodes();
         test_client_exiter.exit();

--- a/trin-core/src/jsonrpc/endpoints.rs
+++ b/trin-core/src/jsonrpc/endpoints.rs
@@ -1,14 +1,14 @@
 use std::str::FromStr;
 
 /// Discv5 JSON-RPC endpoints. Start with "discv5_" prefix
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Discv5Endpoint {
     NodeInfo,
     RoutingTableInfo,
 }
 
 /// State network JSON-RPC endpoints. Start with "portalState_" prefix
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum StateEndpoint {
     DataRadius,
     FindContent,
@@ -21,7 +21,7 @@ pub enum StateEndpoint {
 }
 
 /// History network JSON-RPC endpoints. Start with "portalHistory_" prefix
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum HistoryEndpoint {
     DataRadius,
     FindContent,
@@ -35,20 +35,20 @@ pub enum HistoryEndpoint {
 }
 
 /// Ethereum JSON-RPC endpoints not currently supported by portal network requests, proxied to Infura
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum InfuraEndpoint {
     BlockNumber,
 }
 
 /// Ethereum JSON-RPC endpoints supported by portal network requests
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum PortalEndpoint {
     ClientVersion, // Doesn't actually rely on portal network data, but it makes sense to live here
     GetBlockByHash,
 }
 
 /// Global portal network endpoints supported by trin, including infura proxies, Discv5, Ethereum and all overlay network endpoints supported by portal network requests
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum TrinEndpoint {
     Discv5Endpoint(Discv5Endpoint),
     HistoryEndpoint(HistoryEndpoint),

--- a/trin-core/src/jsonrpc/types.rs
+++ b/trin-core/src/jsonrpc/types.rs
@@ -18,7 +18,7 @@ use crate::{
 
 type Responder<T, E> = mpsc::UnboundedSender<Result<T, E>>;
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(untagged)]
 pub enum Params {

--- a/trin-core/src/utp/packets.rs
+++ b/trin-core/src/utp/packets.rs
@@ -32,7 +32,7 @@ macro_rules! make_setter {
     };
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum PacketType {
     Data,  // packet carries a data payload
     Fin,   // signals the end of a connection

--- a/trin-core/src/utp/time.rs
+++ b/trin-core/src/utp/time.rs
@@ -11,7 +11,7 @@ pub fn now_microseconds() -> Timestamp {
         .into()
 }
 
-#[derive(Debug, Clone, Default, Copy, PartialOrd, PartialEq)]
+#[derive(Debug, Clone, Default, Copy, PartialOrd, PartialEq, Ord, Eq)]
 pub struct Timestamp(pub u32);
 
 impl Sub for Timestamp {

--- a/trin-core/src/utp/trin_helpers.rs
+++ b/trin-core/src/utp/trin_helpers.rs
@@ -46,13 +46,13 @@ impl UtpMessage {
     }
 }
 
-#[derive(PartialEq, Debug, Encode, Decode)]
+#[derive(PartialEq, Eq, Debug, Encode, Decode)]
 pub struct UtpAccept {
     pub message: Vec<(Vec<u8>, Vec<u8>)>,
 }
 
 /// Used to track which stream an overlay request corresponds with
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UtpStreamId {
     /// Stream id to initialize FindContent uTP connection and to listen for content payload
     FindContentStream,

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -228,7 +228,7 @@ mod tests {
             block_hash: header.hash().0,
         });
         chain_history_validator
-            .validate_content(&content_key, &header_bytelist.to_vec())
+            .validate_content(&content_key, &header_bytelist)
             .await
             .unwrap();
     }
@@ -256,7 +256,7 @@ mod tests {
             block_hash: header.hash().0,
         });
         chain_history_validator
-            .validate_content(&content_key, &header_bytelist.to_vec())
+            .validate_content(&content_key, &header_bytelist)
             .await
             .unwrap();
     }
@@ -285,7 +285,7 @@ mod tests {
             block_hash: header.hash().0,
         });
         chain_history_validator
-            .validate_content(&content_key, &header_bytelist.to_vec())
+            .validate_content(&content_key, &header_bytelist)
             .await
             .unwrap();
     }
@@ -308,7 +308,7 @@ mod tests {
         let content_key = block_14764013_body_key();
 
         chain_history_validator
-            .validate_content(&content_key, &block_body_bytelist.to_vec())
+            .validate_content(&content_key, &block_body_bytelist)
             .await
             .unwrap();
     }
@@ -341,7 +341,7 @@ mod tests {
         let content_key = block_14764013_body_key();
 
         chain_history_validator
-            .validate_content(&content_key, &invalid_content.to_vec())
+            .validate_content(&content_key, &invalid_content)
             .await
             .unwrap();
     }
@@ -362,7 +362,7 @@ mod tests {
         let content_key = block_14764013_receipts_key();
 
         chain_history_validator
-            .validate_content(&content_key, &content.to_vec())
+            .validate_content(&content_key, &content)
             .await
             .unwrap();
     }
@@ -393,7 +393,7 @@ mod tests {
         let content_key = block_14764013_receipts_key();
 
         chain_history_validator
-            .validate_content(&content_key, &invalid_content.to_vec())
+            .validate_content(&content_key, &invalid_content)
             .await
             .unwrap();
     }


### PR DESCRIPTION
### What was wrong?

- `clippy` throws new errors, perhaps after #396.

### How was it fixed?

- Fix `clippy` errors based on suggestions.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
