### PR TITLE
Validate content received over utp for findcontent requests

### DIFF
--- a/newsfragments/413.added.md
+++ b/newsfragments/413.added.md
@@ -1,0 +1,1 @@
+Added validation for content received over utp for findcontent/content.

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -119,6 +119,10 @@ pub enum OverlayRequestError {
     #[error("Invalid response")]
     InvalidResponse,
 
+    /// Received content failed validation for a response.
+    #[error("Response content failed validation: {0}")]
+    FailedValidation(String),
+
     #[error("The request returned an empty response")]
     EmptyResponse,
 


### PR DESCRIPTION
### What was wrong?
Validation via `HeaderOracle` needed for content returned from a `FindContent` request.

Wraps up #311 

### How was it fixed?
Added validation for returned content

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
