### PR TITLE
Move node type out of overlay service

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -212,8 +212,8 @@ cargo run -p trin-cli -- json-rpc portal_historyFindContent --params <enr>,<cont
 
 1. Install [Grafana & Prometheus](https://grafana.com/docs/grafana/latest/getting-started/getting-started-prometheus/)
 2. Configure your Prometheus server to target an open port to where `prometheus_exporter` will export Trin metrics.
-3. Start your Trin process with `--enable-metrics --metrics-url 127.0.0.1:9100` as flags
-	- The `--metrics-url` parameter is the address for `prometheus_exporter` to export metrics to, and should be equal to the port to which your Prometheus server is targeting.
+3. Start your Trin process with `--enable-metrics-with-url 127.0.0.1:9100` as flags
+	- The `--enable-metrics-with-url` parameter is the address for `prometheus_exporter` to export metrics to, and should be equal to the port to which your Prometheus server is targeting.
 4. Navigate to the URL on which Grafana is running in your browser (probably `localhost:3000`) and login.
 5. Add your Prometheus server as a Data Source, using the URL on which your Prometheus server is running.
 6. Use the "Import" dashboard feature in Grafana to create your Trin dashboard, and copy and paste `metrics_dashboard.json` as the template.

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -1,4 +1,3 @@
-use anyhow::anyhow;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt::{Debug, Display},
@@ -7,32 +6,8 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use utils::bytes::hex_encode;
 
-use super::{
-    discovery::Discovery,
-    overlay_service::{Node, OverlayCommand, OverlayRequest, OverlayService},
-    types::{content_key::OverlayContentKey, metric::Metric},
-    Enr,
-};
-use crate::portalnet::{
-    storage::PortalStorage,
-    types::messages::{
-        Accept, Content, CustomPayload, FindContent, FindNodes, Message, Nodes, Offer, Ping, Pong,
-        PopulatedOffer, ProtocolId, Request, Response,
-    },
-};
-
-use crate::utils::portal_wire;
-use crate::{
-    portalnet::types::{content_key::RawContentKey, messages::ByteList, metric::XorMetric},
-    types::validation::Validator,
-    utils,
-    utp::{
-        stream::{UtpListenerEvent, UtpListenerRequest, UtpPayload, UtpStream, BUF_SIZE},
-        trin_helpers::UtpStreamId,
-    },
-};
+use anyhow::anyhow;
 use discv5::{
     enr::NodeId,
     kbucket,
@@ -40,18 +15,40 @@ use discv5::{
     TalkRequest,
 };
 use ethereum_types::U256;
-use futures::channel::oneshot;
-use futures::future::join_all;
+use futures::{channel::oneshot, future::join_all};
 use log::error;
 use parking_lot::RwLock;
 use rand::seq::IteratorRandom;
 use ssz::Encode;
 use ssz_types::VariableList;
-use tokio::sync::mpsc::UnboundedSender;
-use tokio::task::JoinHandle;
+use tokio::{sync::mpsc::UnboundedSender, task::JoinHandle};
 use tracing::{debug, warn};
 
-pub use super::overlay_service::{OverlayRequestError, RequestDirection};
+use crate::{
+    portalnet::{
+        discovery::Discovery,
+        overlay_service::{
+            OverlayCommand, OverlayRequest, OverlayRequestError, OverlayService, RequestDirection,
+        },
+        storage::PortalStorage,
+        types::{
+            content_key::{OverlayContentKey, RawContentKey},
+            messages::{
+                Accept, ByteList, Content, CustomPayload, FindContent, FindNodes, Message, Nodes,
+                Offer, Ping, Pong, PopulatedOffer, ProtocolId, Request, Response,
+            },
+            metric::{Metric, XorMetric},
+            node::Node,
+        },
+        Enr,
+    },
+    types::validation::Validator,
+    utils::{bytes::hex_encode, portal_wire},
+    utp::{
+        stream::{UtpListenerEvent, UtpListenerRequest, UtpPayload, UtpStream, BUF_SIZE},
+        trin_helpers::UtpStreamId,
+    },
+};
 
 /// Configuration parameters for the overlay network.
 #[derive(Clone)]

--- a/trin-core/src/portalnet/types/mod.rs
+++ b/trin-core/src/portalnet/types/mod.rs
@@ -1,3 +1,4 @@
 pub mod content_key;
 pub mod messages;
 pub mod metric;
+pub mod node;

--- a/trin-core/src/portalnet/types/node.rs
+++ b/trin-core/src/portalnet/types/node.rs
@@ -1,0 +1,60 @@
+use std::fmt;
+
+use ethereum_types::U256;
+
+use crate::portalnet::Enr;
+
+/// A node in the overlay network routing table.
+#[derive(Clone, Debug)]
+pub struct Node {
+    /// The node's ENR.
+    pub enr: Enr,
+    /// The node's data radius.
+    pub data_radius: U256,
+}
+
+impl Node {
+    /// Creates a new node.
+    pub fn new(enr: Enr, data_radius: U256) -> Node {
+        Node { enr, data_radius }
+    }
+
+    /// Returns the ENR of the node.
+    pub fn enr(&self) -> Enr {
+        self.enr.clone()
+    }
+
+    /// Returns the data radius of the node.
+    pub fn data_radius(&self) -> U256 {
+        self.data_radius.clone()
+    }
+
+    /// Sets the ENR of the node.
+    pub fn set_enr(&mut self, enr: Enr) {
+        self.enr = enr;
+    }
+
+    /// Sets the data radius of the node.
+    pub fn set_data_radius(&mut self, radius: U256) {
+        self.data_radius = radius;
+    }
+}
+
+impl fmt::Display for Node {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Node(node_id={}, radius={})",
+            self.enr.node_id(),
+            self.data_radius,
+        )
+    }
+}
+
+impl std::cmp::Eq for Node {}
+
+impl PartialEq for Node {
+    fn eq(&self, other: &Self) -> bool {
+        self.enr == other.enr
+    }
+}


### PR DESCRIPTION
### What was wrong?
`overlay_service.rs` file is becoming quite cluttered.

### How was it fixed?
Moved the `Node` type into its own file.
Some refactoring of imports.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
