### PR TITLE
Fix some uTP issues

### DIFF
--- a/newsfragments/417.fixed.md
+++ b/newsfragments/417.fixed.md
@@ -1,0 +1,2 @@
+- Fix selective ask bug in uTP protocol.
+- Fix a bug caused by emitting uTP stream close event before the incoming buffer is flushed.

--- a/newsfragments/417.fixed.md
+++ b/newsfragments/417.fixed.md
@@ -1,2 +1,2 @@
-- Fix selective ask bug in uTP protocol.
+- Fix selective ack bug in uTP protocol.
 - Fix a bug caused by emitting uTP stream close event before the incoming buffer is flushed.

--- a/trin-core/src/utp/stream.rs
+++ b/trin-core/src/utp/stream.rs
@@ -789,6 +789,14 @@ impl UtpStream {
 
     /// Builds the selective acknowledgement extension data for usage in packets.
     fn build_selective_ack(&self) -> Vec<u8> {
+        // Build selective ack for empty incoming buffer
+        if self.incoming_buffer.is_empty() {
+            let mut sack: Vec<u8> = vec![0u8; 4];
+            sack[0] |= 1 << 0;
+
+            return sack;
+        }
+
         let stashed = self
             .incoming_buffer
             .iter()

--- a/utp-testing/docker/circleci/Dockerfile
+++ b/utp-testing/docker/circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM ubuntu:22.04
 
 RUN apt-get update \
  && apt-get install -y ethtool net-tools \

--- a/utp-testing/src/bin/test_suite.rs
+++ b/utp-testing/src/bin/test_suite.rs
@@ -35,7 +35,7 @@ async fn send_1000_bytes() -> anyhow::Result<()> {
     assert_eq!(response, "true");
 
     // Send uTP payload from client to server
-    let payload: Vec<u8> = vec![thread_rng().gen(); 1000];
+    let payload: Vec<u8> = vec![thread_rng().gen(); 100_000];
 
     let params = rpc_params!(server_enr, connection_id, payload.clone());
     let response: String = client_rpc
@@ -54,7 +54,7 @@ async fn send_1000_bytes() -> anyhow::Result<()> {
 
     assert_eq!(expected_payload, utp_payload);
 
-    println!("Sent 1000 bytes uTP payload from client to server: OK");
+    println!("Sent 100k bytes uTP payload from client to server: OK");
 
     Ok(())
 }

--- a/utp-testing/src/bin/test_suite.rs
+++ b/utp-testing/src/bin/test_suite.rs
@@ -11,14 +11,14 @@ const CLIENT_ADDR: &str = "193.167.0.100:9042";
 /// Test suite for testing uTP protocol with network simulator
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    send_1000_bytes().await?;
+    send_10k_bytes().await?;
 
     Ok(())
 }
 
-/// Send 1k bytes payload from client to server
-async fn send_1000_bytes() -> anyhow::Result<()> {
-    println!("Sending 1000 bytes uTP payload from client to server...");
+/// Send 10k bytes payload from client to server
+async fn send_10k_bytes() -> anyhow::Result<()> {
+    println!("Sending 10k bytes uTP payload from client to server...");
     let client_url = format!("http://{}", CLIENT_ADDR);
     let client_rpc = HttpClientBuilder::default().build(client_url)?;
     let client_enr: String = client_rpc.request("local_enr", None).await.unwrap();
@@ -35,7 +35,7 @@ async fn send_1000_bytes() -> anyhow::Result<()> {
     assert_eq!(response, "true");
 
     // Send uTP payload from client to server
-    let payload: Vec<u8> = vec![thread_rng().gen(); 100_000];
+    let payload: Vec<u8> = vec![thread_rng().gen(); 10_000];
 
     let params = rpc_params!(server_enr, connection_id, payload.clone());
     let response: String = client_rpc
@@ -54,7 +54,7 @@ async fn send_1000_bytes() -> anyhow::Result<()> {
 
     assert_eq!(expected_payload, utp_payload);
 
-    println!("Sent 100k bytes uTP payload from client to server: OK");
+    println!("Sent 10k bytes uTP payload from client to server: OK");
 
     Ok(())
 }


### PR DESCRIPTION
### What was wrong?
Fixes https://github.com/ethereum/trin/issues/417

Some uTP issues were observed when testing uTP protocol with 10k byte transfer and network delay.

### How was it fixed?
- Build selective ack for an empty incoming buffer, this case was not handled.
- Insert packets into the incoming buffer before packet handling.
- Remove all acknowledged packets from send window upon selective ack receive.
- Emit close event after FIN packet is fully handled.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
