### PR TITLE
Add how to use encode-key cli tool to readme & include link to contributing docs on how to create a newsfragment

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -35,7 +35,7 @@ through github via pull requests.
   * `cargo fmt --all -- --check` and `cargo clippy --all -- --deny warnings` for linting checks
   * `RUSTFLAGS='-D warnings' cargo test --workspace` to run all tests
   * Run the `ethportal-peertest` harness against a locally running node. Instructions
-	can be found in [README](ethportal-peertest/README.md).
+	can be found in [README](../ethportal-peertest/README.md).
 * Pull requests **should** always be reviewed by another member of the team
   prior to being merged.
     * Obvious exceptions include very small pull requests.
@@ -91,6 +91,9 @@ One way to test whether you have it right is to complete the following sentence.
 
 > If you apply this commit it will ________________.
 
+### Release Notes
+
+Every pull request should include a Newsfragment markdown file to describe the contents of the pull request. These files are automatically formatted & collected upon each new release. The format for creating a Newsfragment file can be found in the [README](../newsfragments/README.md).
 
 ## Code Review
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -200,6 +200,12 @@ See arguments for a specific content key:
 cargo run -p trin-cli -- encode-key block-header -h
 ```
 
+Example:
+
+```sh
+$ cargo run -p trin-cli -- encode-key block-body --chain-id 1 --block-hash 59834fe81c78b1838745e4ac352e455ec23cb542658cbba91a4337759f5bf3fc 
+```
+
 ### Request Content
 
 Send a `FindContent` message to a Portal Network bootnode.

--- a/newsfragments/423.fixed.md
+++ b/newsfragments/423.fixed.md
@@ -1,0 +1,1 @@
+Fixed broken links in docs & added link to create a newsfragment in contributing docs.

--- a/trin-cli/README.md
+++ b/trin-cli/README.md
@@ -25,3 +25,6 @@ $ cargo run -p trin-cli -- portal_statePing --params enr:....
 ```sh
 $ cargo run -p trin-cli -- discv5_routingTableInfo --ipc /tmp/trin-jsonrpc-2.ipc
 ```
+
+### To use trin-cli to encode content keys:
+Check out the `Encode Content Keys` section of the [Getting Started docs](../docs/getting_started.md#encode-content-keys).


### PR DESCRIPTION
### What was wrong?
Missing documentation on how to use `encode-key` utility in `trin-cli`

Fixes #428 

### How was it fixed?
Added a blurb to docs.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
