### PR TITLE
Add error check for uTP reply packet: Issue/#415 

### DIFF
--- a/newsfragments/415.added.md
+++ b/newsfragments/415.added.md
@@ -1,0 +1,1 @@
+Added error check for uTP reply packet handling.

--- a/trin-core/src/utp/stream.rs
+++ b/trin-core/src/utp/stream.rs
@@ -1296,14 +1296,20 @@ impl UtpStream {
             .await?
         {
             pkt.set_wnd_size(WINDOW_SIZE.saturating_sub(self.cur_window));
-            self.socket
+            if let Err(msg) = self
+                .socket
                 .send_talk_req(
                     self.connected_to.clone(),
                     ProtocolId::Utp,
                     Vec::from(pkt.as_ref()),
                 )
                 .await
-                .unwrap();
+            {
+                let msg = format!("reply packet error: {msg}");
+                warn!("{msg}");
+                return Err(anyhow!(msg));
+            }
+
             debug!("sent {:?}", pkt);
         }
 


### PR DESCRIPTION
### What was wrong?
Closes #415. 

### How was it fixed?

Implemented the error handling of `send_talk_req()`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
