### PR TITLE
Add compare fn to MasterAccumulator

### DIFF
--- a/newsfragments/429.added.md
+++ b/newsfragments/429.added.md
@@ -1,0 +1,1 @@
+Added compare fn to master accumulators to determine whether two accumulators have matching validation data.


### PR DESCRIPTION
### What was wrong?
Need a function to validate that one `MasterAccumulator` contains the same validation data as another. For example, when bootstrapping & fetching `N` master accumulators from network peers, we want to validate that all of these accumulators contain the same validation data, even if they are not at the same height.

This means that all historical epoch roots should match, up to the point that both accumulators have the same number of historical epoch roots.

If one accumulator is not in the same current epoch as the other, there is no reason to validate that the header records from different current epochs match. So we return a valid check.

If the accumulators are both in the same current epoch, then we validate that both sets of header records check, up to the point that both accumulators have the same number of header records in their current epoch.

### How was it fixed?
Added `master_accumulator.validation_data_matches(other_master_accumulator) -> anyhow::Result<()>`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
