### PR TITLE
Resend lost uTP packets on timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,8 @@ jobs:
           command: docker build -t test-utp --no-cache utp-testing/docker/circleci/
       - run:
           name: Run Test App with network simulator
-          command: SCENARIO="drop-rate --delay=15ms --bandwidth=10Mbps --queue=25 --rate_to_client=0 --rate_to_server=0" docker-compose -f utp-testing/docker/docker-compose.yml up -d
+          # Dropping packets from both sides of the stream to test dealing with lost packets
+          command: SCENARIO="droplist --delay=15ms --bandwidth=10Mbps --queue=25 --drops_to_server=2,5,7 --drops_to_client=6,8" docker-compose -f utp-testing/docker/docker-compose.yml up -d
       - run:
           name: Wait all containers to start
           command: sleep 5

--- a/newsfragments/416.fixed.md
+++ b/newsfragments/416.fixed.md
@@ -1,0 +1,1 @@
+- Resend lost uTP packets due to timeout.

--- a/utp-testing/src/bin/test_suite.rs
+++ b/utp-testing/src/bin/test_suite.rs
@@ -46,7 +46,7 @@ async fn send_10k_bytes() -> anyhow::Result<()> {
     assert_eq!(response, "true");
 
     // Sleep to allow time for uTP transmission
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_secs(4)).await;
 
     // Verify received uTP payload
     let utp_payload: String = server_rpc.request("get_utp_payload", None).await.unwrap();

--- a/utp-testing/src/lib.rs
+++ b/utp-testing/src/lib.rs
@@ -85,7 +85,7 @@ impl TestApp {
         conn.send_to(&payload).await.unwrap();
 
         tokio::spawn(async move {
-            conn.close().await.unwrap();
+            let _ = conn.close().await;
             debug!("Connection state: {:?}", conn.state)
         });
     }


### PR DESCRIPTION
### What was wrong?
Closes #416 

A feature to resend lost uTP packets caused by a timeout was missing.

### How was it fixed?

If we don't receive acknowledgment for the sent uTP packet from remote, we mark the packet as lost and try to resend it.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
