### PR TITLE
uTP: Do not return error when handling RESET packet

### DIFF
--- a/newsfragments/414.fixed.md
+++ b/newsfragments/414.fixed.md
@@ -1,0 +1,1 @@
+uTP: Do not log error when handling RESET packet

--- a/trin-core/src/utp/stream.rs
+++ b/trin-core/src/utp/stream.rs
@@ -1074,7 +1074,11 @@ impl UtpStream {
                         error!("Unable to send uTP RESET event to uTP listener: {err}");
                     }
                 }
-                Err(anyhow!("Connection reset by remote peer"))
+                debug!(
+                    "Connection reset by remote peer. Connection id: {}",
+                    packet.connection_id()
+                );
+                Ok(None)
             }
             (state, ty) => {
                 let message = format!("Unimplemented handling for ({state:?},{ty:?})");


### PR DESCRIPTION
### What was wrong?
Closes #414 

A bug caused a misleading error message when handling uTP RESET packet.

### How was it fixed?
Return `Ok(None)` instead of `Err(..)` when handling the RESET packet.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
