### PR TITLE
format ENRs in bootnode info log

### DIFF
--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -82,9 +82,15 @@ pub fn spawn_history_network(
     utp_listener_rx: mpsc::UnboundedReceiver<UtpListenerEvent>,
     history_event_rx: mpsc::UnboundedReceiver<TalkRequest>,
 ) -> JoinHandle<()> {
+    let bootnodes: Vec<String> = portalnet_config
+        .bootnode_enrs
+        .iter()
+        .map(|enr| format!("{{ {}, Encoded ENR: {} }}", enr, enr.to_base64()))
+        .collect();
+    let bootnodes = bootnodes.join(", ");
     info!(
-        "About to spawn History Network with boot nodes: {:?}",
-        portalnet_config.bootnode_enrs
+        "About to spawn History Network with boot nodes: {}",
+        bootnodes
     );
 
     tokio::spawn(async move {

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -76,9 +76,15 @@ pub fn spawn_state_network(
     utp_listener_rx: mpsc::UnboundedReceiver<UtpListenerEvent>,
     state_event_rx: mpsc::UnboundedReceiver<TalkRequest>,
 ) -> JoinHandle<()> {
+    let bootnodes: Vec<String> = portalnet_config
+        .bootnode_enrs
+        .iter()
+        .map(|enr| format!("{{ {}, Encoded ENR: {} }}", enr, enr.to_base64()))
+        .collect();
+    let bootnodes = bootnodes.join(", ");
     info!(
-        "About to spawn State Network with boot nodes: {:?}",
-        portalnet_config.bootnode_enrs
+        "About to spawn State Network with boot nodes: {}",
+        bootnodes
     );
 
     tokio::spawn(async move {


### PR DESCRIPTION
### What was wrong?

Fixes #430.

### How was it fixed?

Log base-64-encoded and non-encoded (node ID and socket addresses) ENR for each boot node.

Example printout:

```shell
{ ENR: NodeId: 0x639a..d9bd, IpV4 Socket: Some(161.35.85.165:9000) IpV6 Socket: None, Encoded ENR: enr:-IS4QBISSFfBzsBrjq61iSIxPMfp5ShBTW6KQUglzH_tj8_SJaehXdlnZI-NAkTGeoclwnTB-pU544BQA44BiDZ2rkMBgmlkgnY0gmlwhKEjVaWJc2VjcDI1NmsxoQOSGugH1jSdiE_fRK1FIBe9oLxaWH8D_7xXSnaOVBe-SYN1ZHCCIyg }
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
