### PR TITLE
feat: look up unknown ENRs in node address cache

### DIFF
--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -1024,18 +1024,13 @@ where
                 }
             }
         } else {
-            // The node is not in the overlay routing table, so look for the node's ENR
-            // in the underlying Discovery v5 routing table. If an entry is found, then
-            // attempt to insert the node as a connected peer.
-            //
-            // TODO: Remove this fallback logic. Request ENR via Discovery v5. If the
-            // ENR sequence number has changed, then the node's address info may have
-            // changed. The TalkRequest object does not contain the requester's ENR, only
-            // its NodeAddress.
-            if let Some(enr) = self.discovery.find_enr(&source) {
+            // The node is not in the overlay routing table, so look for the node's ENR in the node
+            // address cache. If an entry is found, then attempt to insert the node as a connected
+            // peer.
+            if let Some(node_addr) = self.discovery.cached_node_addr(&source) {
                 // TODO: Decide default data radius, and define a constant.
                 let node = Node {
-                    enr,
+                    enr: node_addr.enr,
                     data_radius: Distance::MAX,
                 };
                 self.connect_node(node, ConnectionDirection::Incoming);


### PR DESCRIPTION
### What was wrong?

For remote peers who are not in the subnetwork routing table, we rely on the `Discv5` routing table. However, the limited capacity of the `Discv5` routing table is shared among all active subnetworks.

### How was it fixed?

Look up ENR for unrecognized remote peer in the node address cache. The node address cache contains the ENR and observed socket address from the latest established session for a given `NodeId`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
