### PR TITLE
feat: Adds local check for content in lookup_content

### DIFF
--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -4,6 +4,7 @@ use rand::seq::SliceRandom;
 use serde_json::{json, Value};
 use ssz::Decode;
 use tokio::sync::mpsc;
+use tracing::error;
 
 use crate::network::HistoryNetwork;
 use trin_core::{
@@ -98,12 +99,31 @@ impl HistoryRequestHandler {
                         match HistoryContentKey::try_from(find_content_params.content_key.to_vec())
                         {
                             Ok(content_key) => {
-                                match self.network.overlay.lookup_content(content_key).await {
-                                    Some(content) => {
-                                        let value = Value::String(hex_encode(content));
-                                        Ok(value)
+                                // Check whether we have the data locally.
+                                let local_content: Option<Vec<u8>> =
+                                    match self.network.overlay.storage.read().get(&content_key) {
+                                        Ok(Some(data)) => Some(data),
+                                        Ok(None) => None,
+                                        Err(err) => {
+                                            error!(
+                                            "Error while checking local storage for content: {}",
+                                            err
+                                        );
+                                            None
+                                        }
+                                    };
+                                match local_content {
+                                    None => {
+                                        match self.network.overlay.lookup_content(content_key).await
+                                        {
+                                            Some(content) => {
+                                                let value = Value::String(hex_encode(content));
+                                                Ok(value)
+                                            }
+                                            None => Ok(Value::Null),
+                                        }
                                     }
-                                    None => Ok(Value::Null),
+                                    Some(content) => Ok(Value::String(hex_encode(content))),
                                 }
                             }
                             Err(err) => Err(format!("Invalid content key requested: {}", err)),

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use serde_json::Value;
 use tokio::sync::mpsc;
+use tracing::error;
 
 use crate::network::StateNetwork;
 use trin_core::utils::bytes::hex_encode;
@@ -86,12 +87,31 @@ impl StateRequestHandler {
                     let response =
                         match StateContentKey::try_from(find_content_params.content_key.to_vec()) {
                             Ok(content_key) => {
-                                match self.network.overlay.lookup_content(content_key).await {
-                                    Some(content) => {
-                                        let value = Value::String(hex_encode(content));
-                                        Ok(value)
+                                // Check whether we have the data locally.
+                                let local_content: Option<Vec<u8>> =
+                                    match self.network.overlay.storage.read().get(&content_key) {
+                                        Ok(Some(data)) => Some(data),
+                                        Ok(None) => None,
+                                        Err(err) => {
+                                            error!(
+                                            "Error while checking local storage for content: {}",
+                                            err
+                                        );
+                                            None
+                                        }
+                                    };
+                                match local_content {
+                                    None => {
+                                        match self.network.overlay.lookup_content(content_key).await
+                                        {
+                                            Some(content) => {
+                                                let value = Value::String(hex_encode(content));
+                                                Ok(value)
+                                            }
+                                            None => Ok(Value::Null),
+                                        }
                                     }
-                                    None => Ok(Value::Null),
+                                    Some(content) => Ok(Value::String(hex_encode(content))),
                                 }
                             }
                             Err(err) => Err(format!("Invalid content key requested: {}", err)),


### PR DESCRIPTION
### What was wrong?

Initiating a `RecursiveFindContent` via RPC does not first check whether the content is stored locally.

### How was it fixed?

`lookup_content` will immediately return content if it is stored locally. If the data is not stored locally or we get a storage error, proceed with network lookup.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
