### PR TITLE
bugfix: Removes quartering of capacity

### DIFF
--- a/src/bin/seed-database.rs
+++ b/src/bin/seed-database.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 use trin_core::{
     portalnet::{
-        storage::PortalStorage,
+        storage::{PortalStorage, PortalStorageConfig},
         types::content_key::{BlockHeader, HistoryContentKey, IdentityContentKey},
     },
     types::header::Header,
@@ -49,7 +49,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let num_kilobytes = generator_config.kb;
 
-    let storage_config = PortalStorage::setup_config(node_id, num_kilobytes)?;
+    let storage_config = PortalStorageConfig::new(num_kilobytes.into(), node_id);
     let storage = PortalStorage::new(storage_config)?;
 
     match generator_config.data_folder {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use trin_core::{
         types::PortalJsonRpcRequest,
     },
     portalnet::{
-        discovery::Discovery, events::PortalnetEvents, storage::PortalStorage,
+        discovery::Discovery, events::PortalnetEvents, storage::PortalStorageConfig,
         types::messages::PortalnetConfig,
     },
     types::validation::HeaderOracle,
@@ -59,7 +59,7 @@ pub async fn run_trin(
     }
 
     let storage_config =
-        PortalStorage::setup_config(discovery.local_enr().node_id(), trin_config.kb)?;
+        PortalStorageConfig::new(trin_config.kb.into(), discovery.local_enr().node_id());
 
     // Initialize validation oracle
     let header_oracle = HeaderOracle::new(trusted_provider.clone(), storage_config.clone());

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -1940,7 +1940,7 @@ mod tests {
         portalnet::{
             discovery::Discovery,
             overlay::OverlayConfig,
-            storage::PortalStorage,
+            storage::{PortalStorage, PortalStorageConfig},
             types::{
                 content_key::IdentityContentKey, distance::XorMetric, messages::PortalnetConfig,
             },
@@ -1972,7 +1972,7 @@ mod tests {
         // Initialize DB config
         let storage_capacity: u32 = DEFAULT_STORAGE_CAPACITY.parse().unwrap();
         let node_id = discovery.local_enr().node_id();
-        let storage_config = PortalStorage::setup_config(node_id, storage_capacity).unwrap();
+        let storage_config = PortalStorageConfig::new(storage_capacity.into(), node_id);
         let storage = Arc::new(RwLock::new(PortalStorage::new(storage_config).unwrap()));
 
         let overlay_config = OverlayConfig::default();

--- a/trin-core/src/portalnet/storage.rs
+++ b/trin-core/src/portalnet/storage.rs
@@ -460,16 +460,6 @@ impl PortalStorage {
         u32::from_be_bytes(array)
     }
 
-    pub fn setup_config(
-        node_id: NodeId,
-        storage_capacity_kb: u32,
-    ) -> Result<PortalStorageConfig, PortalStorageError> {
-        // Arbitrarily set capacity at a quarter of what we're storing.
-        // todo: make this ratio configurable
-        let storage_capacity_kb = (storage_capacity_kb / 4) as u64;
-        Ok(PortalStorageConfig::new(storage_capacity_kb, node_id))
-    }
-
     /// Helper function for opening a RocksDB connection for the accumulatordb.
     pub fn setup_accumulatordb(node_id: NodeId) -> Result<rocksdb::DB, PortalStorageError> {
         let mut data_path: PathBuf = get_data_dir(node_id);

--- a/trin-core/tests/overlay.rs
+++ b/trin-core/tests/overlay.rs
@@ -5,7 +5,7 @@ use trin_core::{
     portalnet::{
         discovery::Discovery,
         overlay::{OverlayConfig, OverlayProtocol},
-        storage::PortalStorage,
+        storage::{PortalStorage, PortalStorageConfig},
         types::{
             content_key::IdentityContentKey,
             distance::{Distance, XorMetric},
@@ -30,11 +30,10 @@ async fn init_overlay(
     discovery: Arc<Discovery>,
     protocol: ProtocolId,
 ) -> OverlayProtocol<IdentityContentKey, XorMetric, MockValidator> {
-    let storage_config = PortalStorage::setup_config(
-        discovery.local_enr().node_id(),
+    let storage_config = PortalStorageConfig::new(
         DEFAULT_STORAGE_CAPACITY.parse().unwrap(),
-    )
-    .unwrap();
+        discovery.local_enr().node_id(),
+    );
     let db = Arc::new(RwLock::new(PortalStorage::new(storage_config).unwrap()));
     let overlay_config = OverlayConfig::default();
     // Ignore all uTP events


### PR DESCRIPTION
### What was wrong?

`PortalStorage::setup_config` was being used in the main trin binary to create a `PortalStorageConfig`, but the `setup_config` method was dividing the storage capacity by 4. This was originally done for testing/debugging purposes but seems to have moved to the main-execution-path undetected.

### How was it fixed?

Removed the `setup_config` method, which was simply dividing the capacity by 4 and then returning a Result even though it couldn't fail. Replaced this method with direct calls to the method it had been calling, `PortalStorageConfig::new`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
