### PR TITLE
refactor: log protocol as structured field

### DIFF
--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -636,8 +636,8 @@ where
             callback: tx,
         }) {
             warn!(
-                "Failure sending query over {:?} service channel",
-                self.protocol
+                protocol = %self.protocol,
+                "Failure sending query over service channel",
             );
             return None;
         }
@@ -646,8 +646,8 @@ where
             Ok(result) => result,
             Err(_) => {
                 warn!(
-                    "Unable to receive content over {:?} service channel",
-                    self.protocol
+                    protocol = %self.protocol,
+                    "Unable to receive content over service channel",
                 );
                 None
             }
@@ -667,8 +667,8 @@ where
             .send(OverlayCommand::Request(overlay_request))
         {
             warn!(
-                "Failure sending request over {:?} service channel",
-                self.protocol
+                protocol = %self.protocol,
+                "Failure sending request over service channel",
             );
             return Err(OverlayRequestError::ChannelFailure(error.to_string()));
         }
@@ -688,8 +688,8 @@ where
         let enrs = self.discovery.table_entries_enr();
         if enrs.is_empty() {
             error!(
-                "No bootnodes provided, cannot join Portal {:?} Network.",
-                self.protocol
+                protocol = %self.protocol,
+                "No bootnodes provided, cannot join Portal {} Network.", self.protocol,
             );
             return;
         }
@@ -704,7 +704,8 @@ where
                 }
                 Err(err) => {
                     error!(
-                        "{err} while pinging {:?} network bootnode: {enr:?}",
+                        protocol = %self.protocol,
+                        "{err} while pinging {} network bootnode: {enr:?}",
                         self.protocol
                     );
                 }
@@ -712,7 +713,8 @@ where
         }
         if !successfully_bonded_bootnode {
             error!(
-                "Failed to bond with any bootnodes, cannot join Portal {:?} Network.",
+                protocol = %self.protocol,
+                "Failed to bond with any bootnodes, cannot join Portal {} Network.",
                 self.protocol
             );
         }

--- a/trin-core/src/portalnet/types/messages.rs
+++ b/trin-core/src/portalnet/types/messages.rs
@@ -182,6 +182,20 @@ impl FromStr for ProtocolId {
     }
 }
 
+impl fmt::Display for ProtocolId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let protocol = match self {
+            ProtocolId::State => "State",
+            ProtocolId::History => "History",
+            ProtocolId::TransactionGossip => "Transaction Gossip",
+            ProtocolId::HeaderGossip => "Header Gossip",
+            ProtocolId::CanonicalIndices => "Canonical Indices",
+            ProtocolId::Utp => "uTP",
+        };
+        write!(f, "{}", protocol)
+    }
+}
+
 /// Decode ProtocolId to raw bytes
 impl TryFrom<ProtocolId> for Vec<u8> {
     type Error = ProtocolIdError;


### PR DESCRIPTION
### What was wrong?

We log `ProtocolId` of the overlay (i.e. subnetwork) as a prefix in most logs. This is tedious and does not utilize structured logging provided by `tracing`.

### How was it fixed?

- Implement `fmt::Display` for `ProtocolId`.
- Log `ProtocolId` as a structured field.

Sample logs:

```shell
Starting overlay service protocol=History
...
Inserted bootnode into overlay routing table, adding to ping queue. Node 0xe6cd..c511 protocol=History
...
Processing Nodes response from node. Node: 0xc875..c6f2 protocol=History
...
Request 232667426343827416813305233791474747796 failed. Error: The request timed out protocol=History
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
