### PR TITLE
feat: offer content from query to closest nodes

### DIFF
--- a/newsfragments/447.added.md
+++ b/newsfragments/447.added.md
@@ -1,0 +1,1 @@
+Disseminate content found via find content queries to other peers who may store it (i.e. poke content).

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -26,7 +26,7 @@ use ssz::Encode;
 use ssz_types::{BitList, VariableList};
 use thiserror::Error;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     portalnet::{
@@ -800,6 +800,7 @@ where
 
                 // Only increment the number of offers made if the transmission succeeds.
                 if let Ok(..) = self.command_tx.send(OverlayCommand::Request(request)) {
+                    trace!(protocol = %self.protocol, "Content {:?} offered to {}", content_id, node_id);
                     offers_made += 1;
                 }
             }

--- a/trin-core/src/portalnet/types/node.rs
+++ b/trin-core/src/portalnet/types/node.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::portalnet::{types::distance::Distance, Enr};
 
 /// A node in the overlay network routing table.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Node {
     /// The node's ENR.
     pub enr: Enr,
@@ -46,13 +46,5 @@ impl fmt::Display for Node {
             self.enr.node_id(),
             self.data_radius,
         )
-    }
-}
-
-impl std::cmp::Eq for Node {}
-
-impl PartialEq for Node {
-    fn eq(&self, other: &Self) -> bool {
-        self.enr == other.enr
     }
 }


### PR DESCRIPTION
### What was wrong?

Content found via find content queries is not disseminated to other peers who may store it.

### How was it fixed?

Implement "poke" mechanism to offer the content found by a find content query to the nodes involved in the query who did not possess the desired content and whose radius is sufficiently large.

Also addressed:

- Fix `PartialEq` implementation for `Node` so that non-ENR changes are recognized by the routing table.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
