### PR TITLE
Limit Content message ENR contents

### DIFF
--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -909,7 +909,10 @@ where
             Ok(None) => {
                 let enrs = self.find_nodes_close_to_content(content_key);
                 match enrs {
-                    Ok(val) => Ok(Content::Enrs(val)),
+                    Ok(val) => {
+                        let enrs = limit_enr_list_to_max_bytes(val, MAX_NODES_SIZE);
+                        Ok(Content::Enrs(enrs))
+                    }
                     Err(msg) => Err(OverlayRequestError::InvalidRequest(msg.to_string())),
                 }
             }


### PR DESCRIPTION
### What was wrong?

```
WARN discv5::socket::send: Sending packet larger than max size: 1899 max: 1280
```

When responding to a FINDNODES with a NODES message, Trin limits the number of ENRs to put in the NODES message so as to not go over discv5's packet size limit. 

However, Content messages can also contain a list of ENRs (when we don't have content but respond with ENRs who might), and we were not limiting the number of ENRs here. This was causing the above warnings.

### How was it fixed?

By modifying `handle_find_content` to use the ` limit_enr_list_to_max_bytes` function like `handle_find_nodes` does.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
