### PR TITLE
Remove chain id from history network message

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -203,7 +203,7 @@ cargo run -p trin-cli -- encode-key block-header -h
 Example:
 
 ```sh
-$ cargo run -p trin-cli -- encode-key block-body --chain-id 1 --block-hash 59834fe81c78b1838745e4ac352e455ec23cb542658cbba91a4337759f5bf3fc 
+$ cargo run -p trin-cli -- encode-key block-body --block-hash 59834fe81c78b1838745e4ac352e455ec23cb542658cbba91a4337759f5bf3fc 
 ```
 
 ### Request Content

--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -22,9 +22,9 @@ use trin_core::{
 const DATA_RADIUS: Distance = Distance::MAX;
 /// Default enr seq value
 const ENR_SEQ: &str = "1";
-/// Default history header content key presuming chain ID 3
+/// Default history header content key
 pub const HISTORY_CONTENT_KEY: &str =
-    "0x000300720704f3aa11c53cf344ea069db95cecb81ad7453c8f276b2a1062979611f09c";
+    "0x00720704f3aa11c53cf344ea069db95cecb81ad7453c8f276b2a1062979611f09c";
 /// Default history header content value
 pub const HISTORY_CONTENT_VALUE: &str =
     "0xf90222a02c58e3212c085178dbb1277e2f3c24b3f451267a75a234945c15\

--- a/newsfragments/451.fixed.md
+++ b/newsfragments/451.fixed.md
@@ -1,0 +1,1 @@
+Remove chain id from history content keys.

--- a/src/bin/seed-database.rs
+++ b/src/bin/seed-database.rs
@@ -106,7 +106,6 @@ fn load_file_data(path: &Path, storage: &mut PortalStorage) {
 
                         if block.header.is_some() {
                             let content_key = HistoryContentKey::BlockHeader(BlockHeader {
-                                chain_id: 1u16,
                                 block_hash: block.clone().header.unwrap().hash().into(),
                             });
 

--- a/trin-cli/src/main.rs
+++ b/trin-cli/src/main.rs
@@ -50,27 +50,18 @@ struct JsonRpc {
 enum EncodeKey {
     /// Encode the content key for a block header.
     BlockHeader {
-        /// Unsigned integer chain ID.
-        #[structopt(long)]
-        chain_id: u16,
         /// Hex-encoded block hash (omit '0x' prefix).
         #[structopt(long)]
         block_hash: H256,
     },
     /// Encode the content key for a block body.
     BlockBody {
-        /// Unsigned integer chain ID.
-        #[structopt(long)]
-        chain_id: u16,
         /// Hex-encoded block hash (omit '0x' prefix).
         #[structopt(long)]
         block_hash: H256,
     },
     /// Encode the content key for a block's transaction receipts.
     BlockReceipts {
-        /// Unsigned integer chain ID.
-        #[structopt(long)]
-        chain_id: u16,
         /// Hex-encoded block hash (omit '0x' prefix).
         #[structopt(long)]
         block_hash: H256,
@@ -106,27 +97,17 @@ fn json_rpc(rpc: JsonRpc) -> Result<(), Box<dyn std::error::Error>> {
 
 fn encode_content_key(content_key: EncodeKey) -> Result<(), Box<dyn std::error::Error>> {
     let key = match content_key {
-        EncodeKey::BlockHeader {
-            chain_id,
-            block_hash,
-        } => HistoryContentKey::BlockHeader(BlockHeader {
-            chain_id,
+        EncodeKey::BlockHeader { block_hash } => HistoryContentKey::BlockHeader(BlockHeader {
             block_hash: block_hash.into(),
         }),
-        EncodeKey::BlockBody {
-            chain_id,
-            block_hash,
-        } => HistoryContentKey::BlockBody(BlockBody {
-            chain_id,
+        EncodeKey::BlockBody { block_hash } => HistoryContentKey::BlockBody(BlockBody {
             block_hash: block_hash.into(),
         }),
-        EncodeKey::BlockReceipts {
-            chain_id,
-            block_hash,
-        } => HistoryContentKey::BlockReceipts(BlockReceipts {
-            chain_id,
-            block_hash: block_hash.into(),
-        }),
+        EncodeKey::BlockReceipts { block_hash } => {
+            HistoryContentKey::BlockReceipts(BlockReceipts {
+                block_hash: block_hash.into(),
+            })
+        }
     };
 
     println!("{}", hex::encode(Into::<Vec<u8>>::into(key)));

--- a/trin-core/src/jsonrpc/eth.rs
+++ b/trin-core/src/jsonrpc/eth.rs
@@ -20,7 +20,6 @@ pub async fn get_block_by_hash(
 ) -> anyhow::Result<Value> {
     let params: GetBlockByHashParams = params.clone().try_into()?;
     let content_key = HistoryContentKey::BlockHeader(BlockHeader {
-        chain_id: 1,
         block_hash: params.block_hash,
     });
     let endpoint = HistoryEndpoint::RecursiveFindContent;

--- a/trin-core/src/portalnet/types/content_key.rs
+++ b/trin-core/src/portalnet/types/content_key.rs
@@ -85,7 +85,6 @@ pub enum HistoryContentKey {
 #[derive(Clone, Debug, Decode, Encode, PartialEq)]
 pub struct BlockHeader {
     /// Chain identifier.
-    pub chain_id: u16,
     /// Hash of the block.
     pub block_hash: [u8; 32],
 }
@@ -94,7 +93,6 @@ pub struct BlockHeader {
 #[derive(Clone, Debug, Decode, Encode, PartialEq)]
 pub struct BlockBody {
     /// Chain identifier.
-    pub chain_id: u16,
     /// Hash of the block.
     pub block_hash: [u8; 32],
 }
@@ -103,7 +101,6 @@ pub struct BlockBody {
 #[derive(Clone, Debug, Decode, Encode, PartialEq)]
 pub struct BlockReceipts {
     /// Chain identifier.
-    pub chain_id: u16,
     /// Hash of the block.
     pub block_hash: [u8; 32],
 }
@@ -372,16 +369,15 @@ mod test {
     #[test]
     fn block_header() {
         let expected_content_key =
-            hex::decode("000f00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d")
+            hex::decode("00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d")
                 .unwrap();
         let expected_content_id: [u8; 32] = [
-            0x21, 0x37, 0xf1, 0x85, 0xb7, 0x13, 0xa6, 0x0d, 0xd1, 0x19, 0x0e, 0x65, 0x0d, 0x01,
-            0x22, 0x7b, 0x4f, 0x94, 0xec, 0xdd, 0xc9, 0xc9, 0x54, 0x78, 0xe2, 0xc5, 0x91, 0xc4,
-            0x05, 0x57, 0xda, 0x99,
+            0x3e, 0x86, 0xb3, 0x76, 0x7b, 0x57, 0x40, 0x2e, 0xa7, 0x2e, 0x36, 0x9a, 0xe0, 0x49,
+            0x6c, 0xe4, 0x7c, 0xc1, 0x5b, 0xe6, 0x85, 0xbe, 0xc3, 0xb4, 0x72, 0x6b, 0x9f, 0x31,
+            0x6e, 0x38, 0x95, 0xfe,
         ];
 
         let header = BlockHeader {
-            chain_id: 15,
             block_hash: BLOCK_HASH,
         };
 
@@ -395,16 +391,15 @@ mod test {
     #[test]
     fn block_body() {
         let expected_content_key =
-            hex::decode("011400d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d")
+            hex::decode("01d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d")
                 .unwrap();
         let expected_content_id: [u8; 32] = [
-            0x1c, 0x60, 0x46, 0x47, 0x5f, 0x07, 0x72, 0x13, 0x27, 0x74, 0xab, 0x54, 0x91, 0x73,
-            0xca, 0x84, 0x87, 0xbe, 0xa0, 0x31, 0xce, 0x53, 0x9c, 0xad, 0x8e, 0x99, 0x0c, 0x08,
-            0xdf, 0x58, 0x02, 0xca,
+            0xeb, 0xe4, 0x14, 0x85, 0x46, 0x29, 0xd6, 0x0c, 0x58, 0xdd, 0xd5, 0xbf, 0x60, 0xfd,
+            0x72, 0xe4, 0x17, 0x60, 0xa5, 0xf7, 0xa4, 0x63, 0xfd, 0xcb, 0x16, 0x9f, 0x13, 0xee,
+            0x4a, 0x26, 0x78, 0x6b,
         ];
 
         let body = BlockBody {
-            chain_id: 20,
             block_hash: BLOCK_HASH,
         };
 
@@ -418,20 +413,19 @@ mod test {
     #[test]
     fn block_receipts() {
         let expected_content_key =
-            hex::decode("020400d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d")
+            hex::decode("02d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d")
                 .unwrap();
         let expected_content_id: [u8; 32] = [
-            0xaa, 0x39, 0xe1, 0x42, 0x3e, 0x92, 0xf5, 0xa6, 0x67, 0xac, 0xe5, 0xb7, 0x9c, 0x2c,
-            0x98, 0xad, 0xbf, 0xd7, 0x9c, 0x05, 0x5d, 0x89, 0x1d, 0x0b, 0x9c, 0x49, 0xc4, 0x0f,
-            0x81, 0x65, 0x63, 0xb2,
+            0xa8, 0x88, 0xf4, 0xaa, 0xfe, 0x91, 0x09, 0xd4, 0x95, 0xac, 0x4d, 0x47, 0x74, 0xa6,
+            0x27, 0x7c, 0x1a, 0xda, 0x42, 0x03, 0x5e, 0x3d, 0xa5, 0xe1, 0x0a, 0x04, 0xcc, 0x93,
+            0x24, 0x7c, 0x04, 0xa4,
         ];
 
-        let body = BlockReceipts {
-            chain_id: 4,
+        let receipts = BlockReceipts {
             block_hash: BLOCK_HASH,
         };
 
-        let key = HistoryContentKey::BlockReceipts(body);
+        let key = HistoryContentKey::BlockReceipts(receipts);
         let encoded: Vec<u8> = key.clone().into();
 
         assert_eq!(encoded, expected_content_key);

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -228,7 +228,6 @@ mod tests {
         let header_oracle = default_header_oracle(server.url("/get_header"));
         let chain_history_validator = ChainHistoryValidator { header_oracle };
         let content_key = HistoryContentKey::BlockHeader(BlockHeader {
-            chain_id: 1,
             block_hash: header.hash().0,
         });
         chain_history_validator
@@ -252,7 +251,6 @@ mod tests {
         let header_oracle = default_header_oracle(server.url("/get_header"));
         let chain_history_validator = ChainHistoryValidator { header_oracle };
         let content_key = HistoryContentKey::BlockHeader(BlockHeader {
-            chain_id: 1,
             block_hash: header.hash().0,
         });
         chain_history_validator
@@ -277,7 +275,6 @@ mod tests {
         let header_oracle = default_header_oracle(server.url("/get_header"));
         let chain_history_validator = ChainHistoryValidator { header_oracle };
         let content_key = HistoryContentKey::BlockHeader(BlockHeader {
-            chain_id: 1,
             block_hash: header.hash().0,
         });
         chain_history_validator
@@ -401,7 +398,6 @@ mod tests {
     fn block_14764013_body_key() -> HistoryContentKey {
         let block_hash = block_14764013_hash();
         HistoryContentKey::BlockBody(BlockBodyKey {
-            chain_id: 1,
             block_hash: block_hash.0,
         })
     }
@@ -409,7 +405,6 @@ mod tests {
     fn block_14764013_receipts_key() -> HistoryContentKey {
         let block_hash = block_14764013_hash();
         HistoryContentKey::BlockReceipts(BlockReceipts {
-            chain_id: 1,
             block_hash: block_hash.0,
         })
     }


### PR DESCRIPTION
### What was wrong?
`chain_id` field has just been removed from history network keys in the latest spec update.

### How was it fixed?
Removed the chain id field from history network content key type & test values.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
