### PR TITLE
add Debug and Display as supertraits of OverlayContentKey

### DIFF
--- a/trin-core/src/utils/bytes.rs
+++ b/trin-core/src/utils/bytes.rs
@@ -45,6 +45,16 @@ pub fn hex_decode(data: &str) -> anyhow::Result<Vec<u8>> {
     }
 }
 
+/// Returns a compact hex-encoded `String` representation of `data`.
+pub fn hex_encode_compact<T: AsRef<[u8]>>(data: T) -> String {
+    if data.as_ref().len() <= 8 {
+        hex_encode(data)
+    } else {
+        let hex = hex::encode(data);
+        format!("0x{}..{}", &hex[0..4], &hex[hex.len() - 4..])
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
### What was wrong?

We do not have clean string representations of the content key types. More compact representations can improve legibility of these types in logs.

### How was it fixed?

- add `fmt::Debug` and `fmt::Display` as supertraits of `OverlayContentKey`
- define a utility function `hex_encode_compact` to build compact representations of byte arrays

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
