### PR TITLE
refactor: add structured logging

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use tokio::sync::{mpsc, RwLock};
-use tracing::debug;
+use tracing::info;
 
 use trin_core::{
     cli::{TrinConfig, HISTORY_NETWORK, STATE_NETWORK},
@@ -25,7 +25,7 @@ pub async fn run_trin(
     trin_config: TrinConfig,
     trusted_provider: TrustedProvider,
 ) -> Result<Arc<JsonRpcExiter>, Box<dyn std::error::Error>> {
-    trin_config.display_config();
+    info!(config = %trin_config, "Launching trin");
 
     let bootnode_enrs = parse_bootnodes(&trin_config.bootnodes)?;
     let portalnet_config = PortalnetConfig {
@@ -69,7 +69,6 @@ pub async fn run_trin(
     let header_oracle = HeaderOracle::new(trusted_provider.clone(), master_accumulator);
     let header_oracle = Arc::new(RwLock::new(header_oracle));
 
-    debug!("Selected networks to spawn: {:?}", trin_config.networks);
     // Initialize state sub-network service and event handlers, if selected
     let (state_handler, state_network_task, state_event_tx, state_utp_tx, state_jsonrpc_tx) =
         if trin_config.networks.iter().any(|val| val == STATE_NETWORK) {

--- a/trin-core/src/jsonrpc/service.rs
+++ b/trin-core/src/jsonrpc/service.rs
@@ -146,7 +146,7 @@ fn launch_ipc_client(
         }
     };
 
-    info!("Listening for commands: {}", ipc_path);
+    info!(path = %ipc_path, "IPC JSON-RPC server listening for commands");
     std::thread::spawn(move || {
         live_server_tx.blocking_send(true).unwrap();
     });
@@ -182,7 +182,7 @@ fn launch_ipc_client(
             serve_ipc_client(&mut rx, &mut tx, trusted_provider, portal_tx);
         });
     }
-    info!("JSON-RPC server over IPC exited cleanly");
+    info!("IPC JSON-RPC server exited cleanly");
 
     if let Err(err) = fs::remove_file(ipc_path) {
         debug!("Clean Exit: Skipped removing {} because: {}", ipc_path, err);
@@ -203,7 +203,7 @@ fn launch_http_client(
 
     let listener = TcpListener::bind(&trin_config.web3_http_address).unwrap();
 
-    info!("Listening for commands: {}", trin_config.web3_http_address);
+    info!(url = %trin_config.web3_http_address, "HTTP JSON-RPC server listening for commands");
     std::thread::spawn(move || {
         live_server_tx.blocking_send(true).unwrap();
     });
@@ -222,7 +222,7 @@ fn launch_http_client(
             }
         };
     }
-    info!("Clean exit");
+    info!("HTTP JSON-RPC server exited cleanly");
 }
 
 fn serve_ipc_client(

--- a/trin-core/src/portalnet/discovery.rs
+++ b/trin-core/src/portalnet/discovery.rs
@@ -143,9 +143,9 @@ impl Discovery {
 
     pub async fn start(&mut self) -> Result<mpsc::Receiver<TalkRequest>, String> {
         info!(
-            "Starting discv5 with local enr encoded={:?} decoded={}",
-            self.local_enr(),
-            self.local_enr()
+            enr.encoded = ?self.local_enr(),
+            enr.decoded = %self.local_enr(),
+            "Starting discv5",
         );
 
         let _ = self

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -666,12 +666,13 @@ where
         let (tx, rx) = oneshot::channel();
         let content_id = target.content_id();
 
-        if let Err(_) = self.command_tx.send(OverlayCommand::FindContentQuery {
+        if let Err(err) = self.command_tx.send(OverlayCommand::FindContentQuery {
             target,
             callback: tx,
         }) {
             warn!(
                 protocol = %self.protocol,
+                error = %err,
                 content.id = %hex_encode(content_id),
                 "Error submitting FindContent query to service"
             );

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -54,7 +54,7 @@ use crate::{
         Enr,
     },
     types::validation::Validator,
-    utils::{node_id, portal_wire},
+    utils::{bytes::hex_encode, node_id, portal_wire},
     utp::{
         stream::{UtpListenerRequest, UtpStream, BUF_SIZE},
         trin_helpers::UtpStreamId,
@@ -391,15 +391,16 @@ where
                 InsertResult::Failed(reason) => {
                     warn!(
                         protocol = %self.protocol,
-                        "Failed to insert bootnode into overlay routing table. Node: {}, Reason {:?}",
-                        node_id, reason
+                        bootnode.node_id = %node_id,
+                        error = ?reason,
+                        "Error inserting bootnode into routing table",
                     );
                 }
                 _ => {
                     debug!(
                         protocol = %self.protocol,
-                        "Inserted bootnode into overlay routing table, adding to ping queue. Node {}",
-                        node_id
+                        bootnode.node_id = %node_id,
+                        "Inserted bootnode into routing table",
                     );
 
                     // Queue the node in the ping queue.
@@ -448,7 +449,7 @@ where
                         OverlayCommand::Request(request) => self.process_request(request),
                         OverlayCommand::FindContentQuery { target, callback } => {
                             if let Some(query_id) = self.init_find_content_query(target, Some(callback)) {
-                                debug!("Find content query {} initialized", query_id);
+                                trace!(query.id = %query_id, "FindContent query initialized");
                             }
                         }
                     }
@@ -470,7 +471,7 @@ where
                         }
 
                     } else {
-                        warn!("No active request with id {} for response", response.request_id);
+                        warn!(request.id = %response.request_id, "No request found for response");
                     }
                 }
                 Some(Ok(node_id)) = self.peers_to_ping.next() => {
@@ -490,7 +491,7 @@ where
                 }
                 _ = OverlayService::<TContentKey, TMetric, TValidator, TStore>::bucket_maintenance_poll(self.protocol.clone(), &self.kbuckets) => {}
                 _ = bucket_refresh_interval.tick() => {
-                    info!(protocol = %self.protocol, "Overlay bucket refresh lookup");
+                    trace!(protocol = %self.protocol, "Routing table bucket refresh");
                     self.bucket_refresh_lookup();
                 }
             }
@@ -539,17 +540,17 @@ where
             let target_bucket = buckets.choose(&mut rand::thread_rng());
             let random_node_id_in_bucket = match target_bucket {
                 Some(bucket) => {
-                    debug!(protocol = %self.protocol, "Refreshing bucket {}", bucket.0);
+                    trace!(protocol = %self.protocol, bucket= %bucket.0, "Refreshing routing table bucket");
                     match u8::try_from(bucket.0) {
                         Ok(idx) => self.generate_random_node_id(idx),
                         Err(err) => {
-                            error!("Unable to downcast bucket index: {}", err);
+                            error!(error = %err, "Error downcasting bucket index");
                             return;
                         }
                     }
                 }
                 None => {
-                    error!("Failed to choose random bucket index");
+                    error!("Error choosing random bucket index for refresh");
                     return;
                 }
             };
@@ -583,9 +584,10 @@ where
             if let Some(entry) = kbuckets.write().take_applied_pending() {
                 debug!(
                     %protocol,
-                    "Node {:?} inserted and node {:?} evicted",
-                    entry.inserted.into_preimage(),
-                    entry.evicted.map(|n| n.key.into_preimage())
+                    inserted = %entry.inserted.into_preimage(),
+                    evicted = ?entry.evicted.map(|n| n.key.into_preimage()),
+                    "Pending node inserted",
+
                 );
                 return Poll::Ready(());
             }
@@ -606,7 +608,7 @@ where
                 Poll::Ready(QueryEvent::Finished(query_id, query_info, query))
             }
             QueryPoolState::Timeout(query_id, query_info, query) => {
-                warn!("Query id: {:?} timed out", query_id);
+                warn!(query.id = %query_id, "Query timed out");
                 Poll::Ready(QueryEvent::TimedOut(query_id, query_info, query))
             }
             QueryPoolState::Waiting(Some((query_id, query_info, query, return_peer))) => {
@@ -648,8 +650,9 @@ where
                 } else {
                     error!(
                         protocol = %self.protocol,
-                        "Unable to send FINDNODES to unknown ENR with node ID {}",
-                        node_id
+                        peer.node_id = %node_id,
+                        query.id = %query_id,
+                        "Cannot query peer with unknown ENR",
                     );
                     if let Some((_, query)) = self.find_node_query_pool.get_mut(query_id) {
                         query.on_failure(&node_id);
@@ -674,7 +677,10 @@ where
                         // look up from the routing table
                         found_enrs.push(enr);
                     } else {
-                        warn!("ENR not present in queries results.");
+                        warn!(
+                            query.id = %query_id,
+                            "ENR from FindNode query not present in query results"
+                        );
                     }
                 }
                 if let QueryType::FindNode {
@@ -682,18 +688,18 @@ where
                     ..
                 } = query_info.query_type
                 {
-                    if let Err(_) = callback.send(found_enrs.clone()) {
+                    if let Err(err) = callback.send(found_enrs.clone()) {
                         error!(
-                            "Failed to send FindNode query {} results to callback",
-                            query_id
+                            query.id = %query_id,
+                            error = ?err,
+                            "Error sending FindNode query result to callback",
                         );
                     }
                 }
-                debug!(
+                trace!(
                     protocol = %self.protocol,
-                    "Query {} complete, discovered {} ENRs",
-
-                    query_id,
+                    query.id = %query_id,
+                    "Discovered {} ENRs via FindNode query",
                     found_enrs.len()
                 );
             }
@@ -723,8 +729,9 @@ where
                     // node, so fail the query for this node.
                     error!(
                         protocol = %self.protocol,
-                        "Unable to send FINDCONTENT to unknown ENR with node ID {}",
-                        node_id
+                        peer.node_id = %node_id,
+                        query.id = %query_id,
+                        "Cannot query peer with unknown ENR"
                     );
                     if let Some((_, query)) = self.find_node_query_pool.get_mut(query_id) {
                         query.on_failure(&node_id);
@@ -748,10 +755,11 @@ where
                 } = query_info.query_type
                 {
                     // Send (possibly `None`) content on callback channel.
-                    if let Err(_) = callback.send(content.clone()) {
+                    if let Err(err) = callback.send(content) {
                         error!(
-                            "Failed to send FindContent query {} result to callback",
-                            query_id
+                            query.id = %query_id,
+                            error = ?err,
+                            "Error sending FindContent query result to callback",
                         );
                     }
 
@@ -858,16 +866,17 @@ where
         id: RequestId,
         source: &NodeId,
     ) -> Result<Response, OverlayRequestError> {
-        debug!(protocol = %self.protocol, "Handling request {}", id);
         match request {
-            Request::Ping(ping) => Ok(Response::Pong(self.handle_ping(ping, &source))),
-            Request::FindNodes(find_nodes) => {
-                Ok(Response::Nodes(self.handle_find_nodes(find_nodes)))
-            }
-            Request::FindContent(find_content) => Ok(Response::Content(
-                self.handle_find_content(find_content, &source)?,
+            Request::Ping(ping) => Ok(Response::Pong(self.handle_ping(ping, &source, id))),
+            Request::FindNodes(find_nodes) => Ok(Response::Nodes(
+                self.handle_find_nodes(find_nodes, &source, id),
             )),
-            Request::Offer(offer) => Ok(Response::Accept(self.handle_offer(offer, source)?)),
+            Request::FindContent(find_content) => Ok(Response::Content(self.handle_find_content(
+                find_content,
+                &source,
+                id,
+            )?)),
+            Request::Offer(offer) => Ok(Response::Accept(self.handle_offer(offer, source, id)?)),
             Request::PopulatedOffer(_) => Err(OverlayRequestError::InvalidRequest(
                 "An offer with content attached is not a valid network message to receive"
                     .to_owned(),
@@ -876,12 +885,15 @@ where
     }
 
     /// Builds a `Pong` response for a `Ping` request.
-    fn handle_ping(&self, request: Ping, source: &NodeId) -> Pong {
-        debug!(
+    fn handle_ping(&self, request: Ping, source: &NodeId, request_id: RequestId) -> Pong {
+        trace!(
             protocol = %self.protocol,
-            "Handling ping request from node={}. Ping={:?}",
-            source, request
+            request.source = %source,
+            request.discv5.id = %request_id,
+            "Handling Ping message {}",
+            request
         );
+
         self.metrics
             .as_ref()
             .and_then(|m| Some(m.report_inbound_ping()));
@@ -895,7 +907,19 @@ where
     }
 
     /// Builds a `Nodes` response for a `FindNodes` request.
-    fn handle_find_nodes(&self, request: FindNodes) -> Nodes {
+    fn handle_find_nodes(
+        &self,
+        request: FindNodes,
+        source: &NodeId,
+        request_id: RequestId,
+    ) -> Nodes {
+        trace!(
+            protocol = %self.protocol,
+            request.source = %source,
+            request.discv5.id = %request_id,
+            "Handling FindNodes message",
+        );
+
         self.metrics
             .as_ref()
             .and_then(|m| Some(m.report_inbound_find_nodes()));
@@ -913,7 +937,15 @@ where
         &self,
         request: FindContent,
         source: &NodeId,
+        request_id: RequestId,
     ) -> Result<Content, OverlayRequestError> {
+        trace!(
+            protocol = %self.protocol,
+            request.source = %source,
+            request.discv5.id = %request_id,
+            "Handling FindContent message",
+        );
+
         self.metrics
             .as_ref()
             .and_then(|m| Some(m.report_inbound_find_content()));
@@ -969,7 +1001,19 @@ where
     }
 
     /// Attempts to build an `Accept` response for an `Offer` request.
-    fn handle_offer(&self, request: Offer, source: &NodeId) -> Result<Accept, OverlayRequestError> {
+    fn handle_offer(
+        &self,
+        request: Offer,
+        source: &NodeId,
+        request_id: RequestId,
+    ) -> Result<Accept, OverlayRequestError> {
+        trace!(
+            protocol = %self.protocol,
+            request.source = %source,
+            request.discv5.id = %request_id,
+            "Handling Offer message",
+        );
+
         self.metrics
             .as_ref()
             .and_then(|m| Some(m.report_inbound_offer()));
@@ -1128,8 +1172,10 @@ where
     ) {
         debug!(
             protocol = %self.protocol,
-            "Request {} failed. Error: {}",
-            request_id, error
+            request.id = %request_id,
+            request.dest = %destination.node_id(),
+            request.error = %error,
+            "Request failed",
         );
 
         // Attempt to mark the node as disconnected.
@@ -1195,7 +1241,10 @@ where
                 let find_content_request = match request {
                     Request::FindContent(find_content) => find_content,
                     _ => {
-                        error!("Unable to process received content: Invalid request message.");
+                        error!(
+                            response.source = %source.node_id(),
+                            "Content response associated with non-FindContent request"
+                        );
                         return;
                     }
                 };
@@ -1203,7 +1252,7 @@ where
             }
             Response::Accept(accept) => {
                 if let Err(err) = self.process_accept(accept, source, request) {
-                    error!("Error processing ACCEPT response in overlay service: {err}")
+                    error!(response.error = %err, "Error processing ACCEPT message")
                 }
             }
         }
@@ -1230,7 +1279,7 @@ where
         let (tx, rx) = tokio::sync::oneshot::channel::<UtpStream>();
         let utp_request = UtpListenerRequest::Connect(
             conn_id,
-            enr,
+            enr.clone(),
             self.protocol.clone(),
             UtpStreamId::OfferStream,
             tx,
@@ -1269,7 +1318,11 @@ where
                     .map(|item| Bytes::from(item.to_vec()))
                     .collect(),
                 Err(err) => {
-                    warn!("Could not serve offered content to peer: {err}");
+                    error!(
+                        error = %err,
+                        peer = %enr.node_id(),
+                        "Error decoding previously offered content items"
+                    );
                     return;
                 }
             };
@@ -1279,11 +1332,21 @@ where
 
             // send the content to the acceptor over a uTP stream
             if let Err(err) = conn.send_to(&content_payload).await {
-                warn!("Error sending content {err}");
+                warn!(
+                    utp.error = %err,
+                    utp.conn_id = %conn_id,
+                    utp.peer = %conn.connected_to,
+                    "Error sending content over uTP connection"
+                );
             };
             // Close uTP connection
             if let Err(err) = conn.close().await {
-                warn!("Unable to close uTP connection!: {err}")
+                warn!(
+                    utp.error = %err,
+                    utp.conn_id = %conn_id,
+                    utp.peer = %conn.connected_to,
+                    "Error closing uTP connection"
+                );
             };
         });
         Ok(response)
@@ -1294,11 +1357,12 @@ where
     /// Refreshes the node if necessary. Attempts to mark the node as connected.
     fn process_pong(&mut self, pong: Pong, source: Enr) {
         let node_id = source.node_id();
-        debug!(
+        trace!(
             protocol = %self.protocol,
-            "Processing Pong response from node. Node: {}",
-            node_id
+            response.source = %node_id,
+            "Processing Pong message {}", pong
         );
+
         // If the ENR sequence number in pong is less than the ENR sequence number for the routing
         // table entry, then request the node.
         //
@@ -1318,10 +1382,11 @@ where
 
     /// Processes a Nodes response.
     fn process_nodes(&mut self, nodes: Nodes, source: Enr, query_id: Option<QueryId>) {
-        debug!(
+        trace!(
             protocol = %self.protocol,
-            "Processing Nodes response from node. Node: {}",
-            source.node_id()
+            response.source = %source.node_id(),
+            query.id = ?query_id,
+            "Processing Nodes message",
         );
 
         let enrs: Vec<Enr> = nodes
@@ -1344,17 +1409,13 @@ where
         request: FindContent,
         query_id: Option<QueryId>,
     ) {
-        debug!(
+        trace!(
             protocol = %self.protocol,
-            "Processing Content response from node. Node: {}",
-            source.node_id()
+            response.source = %source.node_id(),
+            "Processing Content message",
         );
         match content {
-            Content::ConnectionId(id) => debug!(
-                protocol = %self.protocol,
-                "Skipping processing for content connection ID {}",
-                id
-            ),
+            Content::ConnectionId(_) => {}
             Content::Content(content) => {
                 self.process_received_content(content.clone(), request);
                 // TODO: Should we only advance the query if the content has been validated?
@@ -1376,10 +1437,15 @@ where
         let content_key = match TContentKey::try_from(request.content_key) {
             Ok(val) => val,
             Err(msg) => {
-                error!("Unable to process received content: We sent a request with an invalid content key: {msg:?}");
+                error!(
+                    protocol = %self.protocol,
+                    error = ?msg,
+                    "Error decoding content key requested by local node"
+                );
                 return;
             }
         };
+        let content_id = content_key.content_id();
 
         match self
             .store
@@ -1396,20 +1462,23 @@ where
                         .validate_content(&content_key, &content.to_vec())
                         .await
                     {
-                        warn!("Unable to validate received content: {err:?}");
+                        warn!(error = ?err, content.id = %hex_encode(content_id), "Error validating content");
                         return;
                     };
 
-                    if let Err(err) = store.write().put(content_key, content.to_vec()) {
-                        error!("Content received, but not stored: {err}")
+                    if let Err(err) = store.write().put(content_key.clone(), content.to_vec()) {
+                        error!(error = %err, content.id = %hex_encode(content_id), "Error storing content")
                     }
                 });
             }
             Ok(false) => {
-                debug!("Content received, but not stored: key not within radius or already stored");
+                debug!(
+                    content.id = %hex_encode(content_id),
+                    "Content not stored (key outside radius or already stored)"
+                );
             }
             Err(err) => {
-                error!("Content received, but not stored: {}", err);
+                error!(error = %err, content.id = %hex_encode(content_id), "Error storing content");
             }
         }
     }
@@ -1456,8 +1525,9 @@ where
                     {
                         self.peers_to_ping.remove(&node_id);
                         debug!(
-                            "Failed to update discovered node. Node: {}, Reason: {:?}",
-                            node_id, reason
+                            peer = %node_id,
+                            error = ?reason,
+                            "Error updating entry for discovered node",
                         );
                     }
                 }
@@ -1469,7 +1539,7 @@ where
                 };
                 match kbuckets.insert_or_update(&key, node, status) {
                     InsertResult::Inserted => {
-                        debug!("Discovered node added to routing table. Node: {}", node_id);
+                        debug!(inserted = %node_id, "Inserted discovered node into routing table");
                         self.peers_to_ping.insert(node_id);
                     }
                     InsertResult::Pending { disconnected } => {
@@ -1485,10 +1555,11 @@ where
                             self.ping_node(&node_to_ping.value().enr());
                         }
                     }
-                    _ => {
+                    other => {
                         debug!(
-                            "Discovered node not added to routing table. Node: {}",
-                            node_id
+                            peer = %node_id,
+                            reason = ?other,
+                            "Discovered node not inserted into routing table"
                         );
                     }
                 }
@@ -1556,11 +1627,6 @@ where
                 &source.node_id(),
                 enrs.iter().map(|enr| enr.into()).collect(),
             );
-        } else {
-            debug!(
-                "Response returned for inactive find node query {:?}",
-                query_id
-            )
         }
     }
 
@@ -1616,10 +1682,10 @@ where
 
     /// Submits a request to ping a destination (target) node.
     fn ping_node(&self, destination: &Enr) {
-        debug!(
+        trace!(
             protocol = %self.protocol,
-            "Sending Ping request to node. Node: {}",
-            destination.node_id()
+            message.dest = %destination.node_id(),
+            "Sending Ping message",
         );
 
         let enr_seq = self.local_enr().seq();
@@ -1669,8 +1735,8 @@ where
                 // The node was inserted into the routing table. Add the node to the ping queue.
                 debug!(
                     protocol = %self.protocol,
-                    "New connected node added to routing table. Node: {}",
-                    node_id
+                    inserted = %node_id,
+                    "Node inserted into routing table",
                 );
 
                 self.peers_to_ping.insert(node_id);
@@ -1691,8 +1757,8 @@ where
                 if promoted_to_connected {
                     debug!(
                         protocol = %self.protocol,
-                        "Node promoted to connected. Node: {}",
-                        node_id
+                        promoted = %node_id,
+                        "Node promoted to connected",
                     );
                     self.peers_to_ping.insert(node_id);
                 }
@@ -1702,8 +1768,9 @@ where
                 self.peers_to_ping.remove(&node_id);
                 debug!(
                     protocol = %self.protocol,
-                    "Could not insert node. Node: {}, Reason: {:?}",
-                    node_id, reason
+                    peer = %node_id,
+                    error = ?reason,
+                    "Error inserting/updating node into routing table",
                 );
             }
         }
@@ -1730,18 +1797,20 @@ where
                 other => {
                     warn!(
                         protocol = %self.protocol,
-                        "Could not update node to {:?}. Node: {}, Reason: {:?}",
-                        state, node_id, other
+                        peer = %node_id,
+                        error = ?other,
+                        "Error updating node connection state",
                     );
 
                     Err(other)
                 }
             },
             _ => {
-                debug!(
+                trace!(
                     protocol = %self.protocol,
-                    "Node set to {:?}. Node: {}",
-                    state, node_id
+                    updated = %node_id,
+                    updated.conn_state = ?state,
+                    "Node connection state updated",
                 );
                 Ok(())
             }
@@ -1850,9 +1919,7 @@ where
             .collect();
 
         if known_closest_peers.is_empty() {
-            warn!(
-                "FindNodes query initiated but no closest peers in routing table. Aborting query."
-            );
+            warn!("Cannot initialize FindNode query (no known close peers)");
         } else {
             let find_nodes_query =
                 FindNodeQuery::with_config(query_config, query_info.key(), known_closest_peers);
@@ -1902,7 +1969,7 @@ where
         // If the initial set of peers is non-empty, then add the query to the query pool.
         // Otherwise, there is no way for the query to progress, so drop it.
         if closest_enrs.is_empty() {
-            warn!("Unable to initialize find content query without any known close peers");
+            warn!("Cannot initialize FindContent query (no known close peers)");
             None
         } else {
             let query = FindContentQuery::with_config(query_config, target_key, closest_enrs);

--- a/trin-core/src/portalnet/storage.rs
+++ b/trin-core/src/portalnet/storage.rs
@@ -609,7 +609,7 @@ impl PortalStorage {
     pub fn setup_rocksdb(node_id: NodeId) -> Result<rocksdb::DB, ContentStoreError> {
         let mut data_path: PathBuf = get_data_dir(node_id);
         data_path.push("rocksdb");
-        debug!("Setting up RocksDB at path: {:?}", data_path);
+        info!(path = %data_path.display(), "Setting up RocksDB");
 
         let mut db_opts = Options::default();
         db_opts.create_if_missing(true);
@@ -620,7 +620,7 @@ impl PortalStorage {
     pub fn setup_sql(node_id: NodeId) -> Result<Pool<SqliteConnectionManager>, ContentStoreError> {
         let mut data_path: PathBuf = get_data_dir(node_id);
         data_path.push("trin.sqlite");
-        info!("Setting up SqliteDB at path: {:?}", data_path);
+        info!(path = %data_path.display(), "Setting up SqliteDB");
 
         let manager = SqliteConnectionManager::file(data_path);
         let pool = Pool::new(manager)?;

--- a/trin-core/src/socket.rs
+++ b/trin-core/src/socket.rs
@@ -16,17 +16,17 @@ const STUN_SERVER: &str = "159.223.0.83:3478";
 /// - Returns the public IP and port that corresponds to your local port
 pub fn stun_for_external(local_socket_addr: &SocketAddr) -> Option<SocketAddr> {
     let socket = UdpSocket::bind(local_socket_addr).unwrap();
-    info!("Blocking: connecting to STUN server to find public network endpoint");
+    info!("Connecting to STUN server to find public network endpoint");
     let external_addr =
         stunclient::StunClient::new(STUN_SERVER.parse().unwrap()).query_external_address(&socket);
 
     match external_addr {
         Ok(addr) => {
-            debug!("STUN gave us a public address: {:?}", addr);
+            debug!(addr = ?addr, "Public address returned from STUN server");
             Some(addr)
         }
         Err(err) => {
-            debug!("Failed to setup STUN traversal: {:?}", err);
+            debug!(error = %err, "Error setting up STUN traversal");
             None
         }
     }

--- a/trin-core/src/socket.rs
+++ b/trin-core/src/socket.rs
@@ -1,5 +1,5 @@
 use std::net::{IpAddr, SocketAddr, UdpSocket};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 #[cfg(unix)]
 use interfaces::{self, Interface};
@@ -26,7 +26,7 @@ pub fn stun_for_external(local_socket_addr: &SocketAddr) -> Option<SocketAddr> {
             Some(addr)
         }
         Err(err) => {
-            debug!(error = %err, "Error setting up STUN traversal");
+            warn!(error = %err, "Error setting up STUN traversal");
             None
         }
     }

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -97,9 +97,10 @@ impl HistoryRequestHandler {
                                         Ok(None) => None,
                                         Err(err) => {
                                             error!(
-                                            "Error while checking local storage for content: {}",
-                                            err
-                                        );
+                                                error = %err,
+                                                content.key = %content_key,
+                                                "Error checking data store for content",
+                                            );
                                             None
                                         }
                                     };

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -93,9 +93,10 @@ impl StateRequestHandler {
                                         Ok(None) => None,
                                         Err(err) => {
                                             error!(
-                                            "Error while checking local storage for content: {}",
-                                            err
-                                        );
+                                                error = %err,
+                                                content.key = %content_key,
+                                                "Error checking data store for content",
+                                            );
                                             None
                                         }
                                     };


### PR DESCRIPTION
### What was wrong?

Generally speaking, the logging for `trin` is not very helpful. Significant information is not prominent, and insignificant information is not being logged at the appropriate level.

### How was it fixed?

- move a lot of event logs to `trace` level
- log structured fields to track requests and see event metadata
- prefer short log messages and move details into structured fields
- implement `fmt::Display` for `TrinConfig` and log this representation

#### Example logs

```sh
INFO trin: Launching trin config=TrinConfig { networks: ["history"], capacity_kb: 100000, ephemeral: false, json_rpc_url: /tmp/trin-jsonrpc.ipc, pool_size: 5, metrics_enabled: false }
..
INFO trin_core::portalnet::discovery: Starting discv5 enr.encoded=enr:-IS4QBoEfZfpeGJ0fZnRh-kFRhsv1xEr2006H2hpFN4UJib-VclV7D8krb7HvgHP8HU-sPDxLmGB7paK6kIkgGt33TkBgmlkgnY0gmlwhDLR9r6Jc2VjcDI1NmsxoQLa_T-HXa3L8fVM_P_X_TIjWBa4O7XDnMRR89spsaQIA4N1ZHCCIyg enr.decoded=ENR: NodeId: 0x710f..6256, IpV4 Socket: Some(50.209.246.190:9000) IpV6 Socket: None
..
INFO trin_core::portalnet::storage: Setting up RocksDB path=/Users/jacobkaufmann/Library/Application Support/trin/trin_710fb587/rocksdb
..
INFO trin_core::portalnet::overlay_service: Starting overlay service protocol=History
..
DEBUG trin_core::portalnet::overlay_service: Inserted bootnode into routing table protocol=History bootnode=0x639a..d9bd
..
DEBUG trin_core::portalnet::overlay: Attempting to bond with bootnode bootnode.enr=ENR: NodeId: 0x639a..d9bd, IpV4 Socket: Some(161.35.85.165:9000) IpV6 Socket: None
..
INFO trin_core::jsonrpc::service: IPC JSON-RPC server listening for commands path=/tmp/trin-jsonrpc.ipc
..
TRACE trin_core::portalnet::overlay_service: Refreshing routing table bucket protocol=History bucket=241
..
DEBUG trin_core::portalnet::overlay_service: Request failed protocol=History request.id=0x6706..eb66 request.dest=0xe6cd..c511 error=The message was unable to be decoded
..
INFO trin_core::portalnet::overlay: Bonded with bootnode bootnode.enr=ENR: NodeId: 0x639a..d9bd, IpV4 Socket: Some(161.35.85.165:9000) IpV6 Socket: None
..
DEBUG trin_core::portalnet::overlay_service: Request failed protocol=History request.id=0x1a6c..3d70 request.dest=0x4572..2915 error=The request timed out
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
