### PR TITLE
Remove master accumulator content key

### DIFF
--- a/newsfragments/456.removed.md
+++ b/newsfragments/456.removed.md
@@ -1,0 +1,1 @@
+Removed the master accumulator content key type.

--- a/trin-core/src/portalnet/types/content_key.rs
+++ b/trin-core/src/portalnet/types/content_key.rs
@@ -93,8 +93,6 @@ pub enum HistoryContentKey {
     BlockReceipts(BlockReceipts),
     /// An epoch header accumulator.
     EpochAccumulator(EpochAccumulator),
-    /// The master header accumulator.
-    MasterAccumulator(MasterAccumulator),
 }
 
 /// A key for a block header.
@@ -119,55 +117,6 @@ pub struct BlockReceipts {
     /// Chain identifier.
     /// Hash of the block.
     pub block_hash: [u8; 32],
-}
-
-/// A key for the master header accumulator.
-#[derive(Clone, Debug, Decode, Encode, PartialEq)]
-#[ssz(enum_behaviour = "union")]
-pub enum MasterAccumulator {
-    Latest(SszNone),
-    MasterHash(H256),
-}
-
-/// Struct to represent encodable/decodable None value for an SSZ enum
-#[derive(Clone, Debug, PartialEq)]
-pub struct SszNone {
-    // In rust, None is a variant not a type,
-    // so we must use Option here to represent a None value
-    value: Option<()>,
-}
-
-impl SszNone {
-    pub fn new() -> Self {
-        Self { value: None }
-    }
-}
-
-impl ssz::Decode for SszNone {
-    fn is_ssz_fixed_len() -> bool {
-        true
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        match bytes.len() {
-            0 => Ok(Self { value: None }),
-            _ => Err(ssz::DecodeError::BytesInvalid(
-                "Expected None value to be empty, found bytes.".to_string(),
-            )),
-        }
-    }
-}
-
-impl ssz::Encode for SszNone {
-    fn is_ssz_fixed_len() -> bool {
-        true
-    }
-
-    fn ssz_append(&self, _buf: &mut Vec<u8>) {}
-
-    fn ssz_bytes_len(&self) -> usize {
-        0
-    }
 }
 
 /// A key for an epoch header accumulator.
@@ -218,15 +167,6 @@ impl fmt::Display for HistoryContentKey {
                     bytes::hex_encode_compact(acc.epoch_hash.as_fixed_bytes())
                 )
             }
-            Self::MasterAccumulator(acc) => match acc {
-                MasterAccumulator::Latest(..) => format!("MasterAccumulator (latest)"),
-                MasterAccumulator::MasterHash(hash) => {
-                    format!(
-                        "MasterAccumulator {{ hash: {} }}",
-                        bytes::hex_encode_compact(hash.as_fixed_bytes())
-                    )
-                }
-            },
         };
 
         write!(f, "{}", s)
@@ -689,49 +629,6 @@ mod test {
         let content_key = HistoryContentKey::EpochAccumulator(EpochAccumulator {
             epoch_hash: H256::from_slice(&epoch_hash),
         });
-        assert_eq!(&content_key.content_id().to_vec(), expected_content_id);
-
-        let encoded_content_key: Vec<u8> = content_key.clone().into();
-        assert_eq!(encoded_content_key, expected_content_key_encoding);
-
-        // round trip
-        let decoded = HistoryContentKey::try_from(encoded_content_key).unwrap();
-        assert_eq!(decoded, content_key);
-    }
-
-    #[test]
-    fn master_accumulator_key_none() {
-        let expected_content_id =
-            &hex::decode("c0ba8a33ac67f44abff5984dfbb6f56c46b880ac2b86e1f23e7fa9c402c53ae7")
-                .unwrap();
-        let expected_content_key_encoding = hex::decode("0400").unwrap();
-
-        let content_key =
-            HistoryContentKey::MasterAccumulator(MasterAccumulator::Latest(SszNone::new()));
-        assert_eq!(&content_key.content_id().to_vec(), expected_content_id);
-
-        let encoded_content_key: Vec<u8> = content_key.clone().into();
-        assert_eq!(encoded_content_key, expected_content_key_encoding);
-
-        // round trip
-        let decoded = HistoryContentKey::try_from(encoded_content_key).unwrap();
-        assert_eq!(decoded, content_key);
-    }
-
-    #[test]
-    fn master_accumulator_key_master_hash() {
-        let expected_content_id =
-            &hex::decode("af75c3c9d0e89a5083361a3334a9c5583955f0dbe9a413eb79ba26400d1824a6")
-                .unwrap();
-        let expected_content_key_encoding =
-            hex::decode("040188cce8439ebc0c1d007177ffb6831c15c07b4361984cc52235b6fd728434f0c7")
-                .unwrap();
-        let master_hash = H256::from_slice(
-            &hex::decode("88cce8439ebc0c1d007177ffb6831c15c07b4361984cc52235b6fd728434f0c7")
-                .unwrap(),
-        );
-        let content_key =
-            HistoryContentKey::MasterAccumulator(MasterAccumulator::MasterHash(master_hash));
         assert_eq!(&content_key.content_id().to_vec(), expected_content_id);
 
         let encoded_content_key: Vec<u8> = content_key.clone().into();

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -98,10 +98,6 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
                 }
                 Ok(())
             }
-            HistoryContentKey::MasterAccumulator(_key) => {
-                warn!("Skipping content validation for master accumulator content.");
-                Ok(())
-            }
             HistoryContentKey::EpochAccumulator(_key) => {
                 warn!("Skipping content validation for epoch accumulator content.");
                 Ok(())


### PR DESCRIPTION
### What was wrong?
Master Accumulator content keys are no longer needed now that they are no longer a network-supported content type according to the latest spec update.

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
