### PR TITLE
Add support for eth_getBlockByNumber for pre-merge blocks.

### DIFF
--- a/ethportal-peertest/src/scenarios.rs
+++ b/ethportal-peertest/src/scenarios.rs
@@ -73,3 +73,70 @@ pub fn test_offer_accept(peertest_config: PeertestConfig, peertest: &Peertest) {
         HISTORY_CONTENT_VALUE, received_content_str,
     );
 }
+
+pub fn test_eth_get_block_by_hash(_peertest_config: PeertestConfig, peertest: &Peertest) {
+    // Store content to offer in the testnode db
+    let store_request = JsonRpcRequest {
+        method: "portal_historyStore".to_string(),
+        id: 11,
+        params: Params::Array(vec![
+            Value::String(HISTORY_CONTENT_KEY.to_string()),
+            Value::String(HISTORY_CONTENT_VALUE.to_string()),
+        ]),
+    };
+
+    let store_result = make_ipc_request(&peertest.bootnode.web3_ipc_path, &store_request).unwrap();
+    assert_eq!(store_result.as_str().unwrap(), "true");
+
+    // Send eth_getBlockByHash request
+    let request = JsonRpcRequest {
+        method: "eth_getBlockByHash".to_string(),
+        id: 11,
+        params: Params::Array(vec![
+            json!("0x55b11b918355b1ef9c5db810302ebad0bf2544255b530cdce90674d5887bb286"),
+            json!(false),
+        ]),
+    };
+
+    let result = make_ipc_request(&peertest.nodes[0].web3_ipc_path, &request).unwrap();
+    assert_eq!(json!(15537393), result["number"]);
+}
+
+pub fn test_eth_get_block_by_number(_peertest_config: PeertestConfig, peertest: &Peertest) {
+    // Store content to offer in the testnode db
+    let store_request = JsonRpcRequest {
+        method: "portal_historyStore".to_string(),
+        id: 11,
+        params: Params::Array(vec![
+            Value::String(HISTORY_CONTENT_KEY.to_string()),
+            Value::String(HISTORY_CONTENT_VALUE.to_string()),
+        ]),
+    };
+
+    let store_result = make_ipc_request(&peertest.bootnode.web3_ipc_path, &store_request).unwrap();
+    assert_eq!(store_result.as_str().unwrap(), "true");
+
+    // Send supported eth_getBlockByNumber request (pre-merge)
+    let request = JsonRpcRequest {
+        method: "eth_getBlockByNumber".to_string(),
+        id: 11,
+        params: Params::Array(vec![json!("0xed14f1"), json!(false)]),
+    };
+
+    let result = make_ipc_request(&peertest.nodes[0].web3_ipc_path, &request).unwrap();
+    assert_eq!(json!(15537393), result["number"]);
+
+    // Send unsupported eth_getBlockByNumber request (post-merge)
+    let request = JsonRpcRequest {
+        method: "eth_getBlockByNumber".to_string(),
+        id: 11,
+        params: Params::Array(vec![
+            // Block #15537395
+            json!("0xed14f3"),
+            json!(false),
+        ]),
+    };
+
+    let result = make_ipc_request(&peertest.nodes[0].web3_ipc_path, &request).unwrap_err();
+    assert_eq!(result.to_string(), "JsonRpc response contains an error: String(\"Error while processing eth_getBlockByNumber: eth_getBlockByNumber not currently supported for blocks after the merge (#15537394)\")");
+}

--- a/newsfragments/457.added.md
+++ b/newsfragments/457.added.md
@@ -1,0 +1,1 @@
+Add eth_getBlockByNumber support for pre-merge blocks.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@ pub async fn run_trin(
         portal_jsonrpc_rx,
         state_jsonrpc_tx,
         history_jsonrpc_tx,
+        header_oracle: header_oracle.clone(),
     };
 
     tokio::spawn(rpc_handler.process_jsonrpc_requests());

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -51,6 +51,8 @@ mod test {
         peertest::jsonrpc::test_jsonrpc_endpoints_over_ipc(peertest_config.clone(), &peertest)
             .await;
         peertest::scenarios::test_offer_accept(peertest_config.clone(), &peertest);
+        peertest::scenarios::test_eth_get_block_by_hash(peertest_config.clone(), &peertest);
+        peertest::scenarios::test_eth_get_block_by_number(peertest_config.clone(), &peertest);
 
         peertest.exit_all_nodes();
         test_client_exiter.exit();

--- a/trin-core/src/jsonrpc/endpoints.rs
+++ b/trin-core/src/jsonrpc/endpoints.rs
@@ -48,6 +48,7 @@ pub enum TrustedProviderEndpoint {
 pub enum PortalEndpoint {
     ClientVersion, // Doesn't actually rely on portal network data, but it makes sense to live here
     GetBlockByHash,
+    GetBlockByNumber,
 }
 
 /// Global portal network endpoints supported by trin, including trusted providers, Discv5, Ethereum and all overlay network endpoints supported by portal network requests
@@ -76,6 +77,9 @@ impl FromStr for TrinEndpoint {
             "eth_getBlockByHash" => {
                 Ok(TrinEndpoint::PortalEndpoint(PortalEndpoint::GetBlockByHash))
             }
+            "eth_getBlockByNumber" => Ok(TrinEndpoint::PortalEndpoint(
+                PortalEndpoint::GetBlockByNumber,
+            )),
             "portal_historyFindContent" => {
                 Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::FindContent))
             }

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -925,7 +925,6 @@ where
                 ))
             }
         };
-
         match self.store.read().get(&content_key) {
             Ok(Some(value)) => {
                 let content = ByteList::from(VariableList::from(value));

--- a/trin-core/src/types/accumulator.rs
+++ b/trin-core/src/types/accumulator.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::anyhow;
-use ethereum_types::U256;
+use ethereum_types::{H256, U256};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use ssz::{Decode, Encode};
@@ -91,6 +91,26 @@ impl MasterAccumulator {
 
     fn get_epoch_index_of_header(&self, header: &Header) -> u64 {
         header.number / EPOCH_SIZE as u64
+    }
+
+    pub async fn lookup_premerge_hash_by_number(
+        &self,
+        block_number: u64,
+        history_jsonrpc_tx: mpsc::UnboundedSender<HistoryJsonRpcRequest>,
+    ) -> anyhow::Result<H256> {
+        if block_number > MERGE_BLOCK_NUMBER {
+            return Err(anyhow!("Post-merge blocks are not supported."));
+        }
+        let rel_index = block_number % EPOCH_SIZE as u64;
+        if block_number > self.epoch_number() * EPOCH_SIZE as u64 {
+            return Ok(self.current_epoch.header_records[rel_index as usize].block_hash);
+        }
+        let epoch_index = block_number / EPOCH_SIZE as u64;
+        let epoch_hash = self.historical_epochs.epochs[epoch_index as usize];
+        let epoch_acc = self
+            .lookup_epoch_acc(epoch_hash, history_jsonrpc_tx)
+            .await?;
+        Ok(epoch_acc.header_records[rel_index as usize].block_hash)
     }
 
     fn is_header_in_current_epoch(&self, header: &Header) -> bool {
@@ -183,39 +203,49 @@ impl MasterAccumulator {
         } else {
             let epoch_index = self.get_epoch_index_of_header(header);
             let epoch_hash = self.historical_epochs.epochs[epoch_index as usize];
-            let content_key: Vec<u8> =
-                HistoryContentKey::EpochAccumulator(EpochAccumulatorKey { epoch_hash }).into();
-            let content_key = hex_encode(content_key);
-            let endpoint = HistoryEndpoint::RecursiveFindContent;
-            let params = Params::Array(vec![json!(content_key)]);
-            let (resp_tx, mut resp_rx) = mpsc::unbounded_channel::<Result<Value, String>>();
-            let request = HistoryJsonRpcRequest {
-                endpoint,
-                resp: resp_tx,
-                params,
-            };
-            history_jsonrpc_tx.send(request).unwrap();
-
-            let epoch_acc_ssz = match resp_rx.recv().await {
-                Some(val) => {
-                    val.map_err(|msg| anyhow!("Chain history subnetwork request error: {:?}", msg))?
-                }
-                None => return Err(anyhow!("No response from chain history subnetwork")),
-            };
-            let epoch_acc_ssz = epoch_acc_ssz
-                .as_str()
-                .ok_or_else(|| anyhow!("Invalid epoch acc received from chain history network"))?;
-            let epoch_acc_ssz = hex_decode(epoch_acc_ssz)?;
-            let epoch_acc = EpochAccumulator::from_ssz_bytes(&epoch_acc_ssz).map_err(|msg| {
-                anyhow!(
-                    "Invalid epoch acc received from chain history network: {:?}",
-                    msg
-                )
-            })?;
+            let epoch_acc = self
+                .lookup_epoch_acc(epoch_hash, history_jsonrpc_tx)
+                .await?;
             let header_index = (header.number as u64) - epoch_index * (EPOCH_SIZE as u64);
             let header_record = epoch_acc.header_records[header_index as usize];
             Ok(header_record.block_hash == header.hash())
         }
+    }
+
+    pub async fn lookup_epoch_acc(
+        &self,
+        epoch_hash: H256,
+        history_jsonrpc_tx: mpsc::UnboundedSender<HistoryJsonRpcRequest>,
+    ) -> anyhow::Result<EpochAccumulator> {
+        let content_key: Vec<u8> =
+            HistoryContentKey::EpochAccumulator(EpochAccumulatorKey { epoch_hash }).into();
+        let content_key = hex_encode(content_key);
+        let endpoint = HistoryEndpoint::RecursiveFindContent;
+        let params = Params::Array(vec![json!(content_key)]);
+        let (resp_tx, mut resp_rx) = mpsc::unbounded_channel::<Result<Value, String>>();
+        let request = HistoryJsonRpcRequest {
+            endpoint,
+            resp: resp_tx,
+            params,
+        };
+        history_jsonrpc_tx.send(request).unwrap();
+
+        let epoch_acc_ssz = match resp_rx.recv().await {
+            Some(val) => {
+                val.map_err(|msg| anyhow!("Chain history subnetwork request error: {:?}", msg))?
+            }
+            None => return Err(anyhow!("No response from chain history subnetwork")),
+        };
+        let epoch_acc_ssz = epoch_acc_ssz
+            .as_str()
+            .ok_or_else(|| anyhow!("Invalid epoch acc received from chain history network"))?;
+        let epoch_acc_ssz = hex_decode(epoch_acc_ssz)?;
+        EpochAccumulator::from_ssz_bytes(&epoch_acc_ssz).map_err(|msg| {
+            anyhow!(
+                "Invalid epoch acc received from chain history network: {:?}",
+                msg
+            )
+        })
     }
 }
 


### PR DESCRIPTION
### What was wrong?
Adds jsonrpc support for the `eth_getBlockByNumber` endpoint, but only for pre-merge blocks, where we can look up the header hash via the master accumulator, before retrieving the header from the chain history network.

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
