### PR TITLE
Handle broken ipc sockets due to timeouts

### DIFF
--- a/newsfragments/460.fixed.md
+++ b/newsfragments/460.fixed.md
@@ -1,0 +1,1 @@
+Handle requestor timeouts over ipc socket.

--- a/trin-core/src/jsonrpc/service.rs
+++ b/trin-core/src/jsonrpc/service.rs
@@ -253,8 +253,10 @@ fn serve_ipc_client(
                     .to_string()
                     .into_bytes(),
                 };
-                tx.write_all(&formatted_response).unwrap();
-                tx.flush().unwrap();
+                match tx.write_all(&formatted_response) {
+                    Ok(_) => tx.flush().unwrap(),
+                    Err(msg) => warn!("Unable to write bytes to unix stream, the requestor has likely timed out: {:?}", msg),
+                }
             }
             Err(e) => {
                 debug!("An error occurred while parsing the JSON text. {}", e);


### PR DESCRIPTION
### What was wrong?
`web3.py`'s default timeout is 10seconds, which will break the ipc socket if its timeout is reached before the jsonrpc request responds. 

### How was it fixed?
Just handle the error, and we can make multiple, sequential jsonrpc requests to the same ipc socket that result in a timeout. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
