### PR TITLE
Added some OS build dependencies to the guide

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -15,7 +15,7 @@ Note: If you use a VPN, you should disable it before running Trin.
 Install dependencies (Ubuntu/Debian):
 
 ```sh
-apt install libssl-dev librocksdb-dev libclang-dev 
+apt install libssl-dev librocksdb-dev libclang-dev pkg-config build-essentials 
 ```
 
 Environment variables:


### PR DESCRIPTION
### What was wrong?

Noticed a couple dependencies missing, while installing on Windows Subsystem for Linux

### How was it fixed?
 Added them
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
