### PR TITLE
Support tracing recursive find content history network requests

### DIFF
--- a/docs/jsonrpc_api.md
+++ b/docs/jsonrpc_api.md
@@ -37,6 +37,7 @@ The specification for these endpoints can be found [here](https://eth.wiki/json-
 - [`portal_historyLocalContent`](#portal_historyLocalContent) 
 - [`portal_stateLocalContent`](#portal_stateLocalContent)
 - [`portal_historyRecursiveFindContent`](#portal_historyRecursiveFindContent)
+- [`portal_historyTraceRecursiveFindContent`](#portal_historyTraceRecursiveFindContent)
 - [`portal_paginateLocalContentKeys`](#portal_paginateLocalContentKeys)
 
 # History Overlay Network
@@ -80,13 +81,13 @@ Attempts to look up content key in Trin node's local db.
 ```
 
 ## `portal_historyRecursiveFindContent`
-This method is for development purposes and unstable. It's not fully recursive, but will perform a single lookup in the Trin client's routing table to find a peer close to the content key, and then request the content value from the found peer. 
+Traverses the network by recursively sending `FINDCONTENT` messages in order to retrieve the target content.
 
 ### Parameters
-- `content_key`: Target block header content key.
+- `content_key`: Target content key.
 
 ### Returns
-- Block header
+- Target content value, or `0x` if the content was not found.
 
 #### Example
 ```json
@@ -94,22 +95,32 @@ This method is for development purposes and unstable. It's not fully recursive, 
   "id": 1,
   "jsonrpc": "2.0",
   "result": {
-    "author": "0x2a65aca4d5fc5b5c859090a6c34d164135398226",
-    "base_fee_per_gas": null,
-    "difficulty": "0x710895564a0",
-    "extra_data": "0xd783010302844765746887676f312e352e31856c696e7578",
-    "gas_limit": "0x2fefd8",
-    "gas_used": "0x5208",
-    "log_bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-    "mix_hash": "0xc5e99c6e90fbdee5650ff9b6dd41198655872ba32f810de58acb193a954e1589",
-    "nonce": 4679748334323072988,
-    "number": 633130,
-    "parent_hash": "0x6add1c183f1194eb132ca8079197c7f2bc43f644f96bf5ab00a93aa4be499360",
-    "receipts_root": "0x59cf53b2f956a914b8360ea6fe271ebe7b10461c736eb16eb1a4121ba3abbb85",
-    "state_root": "0x5ae233f6377f0671c612ec2a8bd15c20e428094f2fafc79bead9c55a989294dd",
-    "timestamp": 1449116606,
-    "transactions_root": "0x64183d9f805f4aecbf532de75e6ad276dc281ba90947ff706beeaecc14eec6f5",
-    "uncles_hash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+	  "content": "0xf90217a06add1c183f1194eb132ca8079197c7f2bc43f644f96bf5ab00a93aa4be499360a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942a65aca4d5fc5b5c859090a6c34d164135398226a05ae233f6377f0671c612ec2a8bd15c20e428094f2fafc79bead9c55a989294dda064183d9f805f4aecbf532de75e6ad276dc281ba90947ff706beeaecc14eec6f5a059cf53b2f956a914b8360ea6fe271ebe7b10461c736eb16eb1a4121ba3abbb85b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000860710895564a08309a92a832fefd882520884565fc3be98d783010302844765746887676f312e352e31856c696e7578a0c5e99c6e90fbdee5650ff9b6dd41198655872ba32f810de58acb193a954e15898840f1ce50d18d7fdc"
+  }
+}
+```
+
+## `portal_historyTraceRecursiveFindContent`
+Same as `portal_historyRecursiveFindContent`, but will also return a "route" with the content. The "route" contains all of the ENR's contacted during the lookup, and their respective distance to the target content. If the content is available in local storage, the route will contain an empty array.
+
+### Parameters
+- `content_key`: Target content key.
+
+### Returns
+- Target content value, or `0x` if the content was not found.
+- Network ENRs traversed to find the target content along with their base-2 log distance from the content. If the target content was found in local storage, this will be an empty array.
+
+#### Example
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+	  "content": "0xf90217a06add1c183f1194eb132ca8079197c7f2bc43f644f96bf5ab00a93aa4be499360a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942a65aca4d5fc5b5c859090a6c34d164135398226a05ae233f6377f0671c612ec2a8bd15c20e428094f2fafc79bead9c55a989294dda064183d9f805f4aecbf532de75e6ad276dc281ba90947ff706beeaecc14eec6f5a059cf53b2f956a914b8360ea6fe271ebe7b10461c736eb16eb1a4121ba3abbb85b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000860710895564a08309a92a832fefd882520884565fc3be98d783010302844765746887676f312e352e31856c696e7578a0c5e99c6e90fbdee5650ff9b6dd41198655872ba32f810de58acb193a954e15898840f1ce50d18d7fdc",
+	  "route": [{
+            "enr": "enr:-IS4QFoKx0TNU0i-O2Bg7qf4Ohypb14-jb7Osuotnm74UVgfXjF4ohvk55ijI_UiOyStfLjpWUZsjugayK-k8WFxhzkBgmlkgnY0gmlwhISdQv2Jc2VjcDI1NmsxoQOuY9X8mZHUYbjqVTV4dXA4LYZarOIxnhcAqb40vMU9-YN1ZHCCZoU",
+            "distance": 256
+	  }]
   }
 }
 ```

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -1,0 +1,85 @@
+use serde_json::{json, Value};
+
+use crate::{
+    jsonrpc::{make_ipc_request, JsonRpcRequest, HISTORY_CONTENT_VALUE},
+    Peertest, PeertestConfig,
+};
+use trin_core::jsonrpc::types::Params;
+
+pub fn test_trace_recursive_find_content(_peertest_config: PeertestConfig, peertest: &Peertest) {
+    let uniq_content_key = "0x0015b11b918355b1ef9c5db810302ebad0bf2544255b530cdce90674d5887bb286";
+    // Store content to offer in the testnode db
+    let store_request = JsonRpcRequest {
+        method: "portal_historyStore".to_string(),
+        id: 11,
+        params: Params::Array(vec![
+            Value::String(uniq_content_key.to_string()),
+            Value::String(HISTORY_CONTENT_VALUE.to_string()),
+        ]),
+    };
+
+    let store_result = make_ipc_request(&peertest.bootnode.web3_ipc_path, &store_request).unwrap();
+    assert_eq!(store_result.as_str().unwrap(), "true");
+
+    // Send trace recursive find content request
+    let request = JsonRpcRequest {
+        method: "portal_historyTraceRecursiveFindContent".to_string(),
+        id: 12,
+        params: Params::Array(vec![json!(uniq_content_key)]),
+    };
+
+    let result = make_ipc_request(&peertest.nodes[0].web3_ipc_path, &request).unwrap();
+    assert_eq!(result["content"], json!(HISTORY_CONTENT_VALUE.to_string()));
+    assert_eq!(
+        result["route"],
+        json!([{"enr": &peertest.bootnode.enr.to_base64(), "distance": 256}])
+    );
+}
+
+// This test ensures that the jsonrpc channels don't close if there is an invalid recursive find
+// content request
+pub fn test_recursive_find_content_invalid_params(
+    _peertest_config: PeertestConfig,
+    peertest: &Peertest,
+) {
+    let invalid_content_key = "0x00";
+    // Send trace recursive find content request
+    let request = JsonRpcRequest {
+        method: "portal_historyRecursiveFindContent".to_string(),
+        id: 12,
+        params: Params::Array(vec![json!(invalid_content_key)]),
+    };
+
+    let error = make_ipc_request(&peertest.nodes[0].web3_ipc_path, &request).unwrap_err();
+    assert!(error.to_string().contains("Invalid content key requested"));
+}
+
+pub fn test_trace_recursive_find_content_local_db(
+    _peertest_config: PeertestConfig,
+    peertest: &Peertest,
+) {
+    let uniq_content_key = "0x0025b11b918355b1ef9c5db810302ebad0bf2544255b530cdce90674d5887bb286";
+    // Store content to offer in the testnode db
+    let store_request = JsonRpcRequest {
+        method: "portal_historyStore".to_string(),
+        id: 13,
+        params: Params::Array(vec![
+            Value::String(uniq_content_key.to_string()),
+            Value::String(HISTORY_CONTENT_VALUE.to_string()),
+        ]),
+    };
+
+    let store_result = make_ipc_request(&peertest.bootnode.web3_ipc_path, &store_request).unwrap();
+    assert_eq!(store_result.as_str().unwrap(), "true");
+
+    // Send trace recursive find content request
+    let request = JsonRpcRequest {
+        method: "portal_historyTraceRecursiveFindContent".to_string(),
+        id: 14,
+        params: Params::Array(vec![json!(uniq_content_key)]),
+    };
+
+    let result = make_ipc_request(&peertest.bootnode.web3_ipc_path, &request).unwrap();
+    assert_eq!(result["content"], json!(HISTORY_CONTENT_VALUE.to_string()));
+    assert_eq!(result["route"], json!([]));
+}

--- a/ethportal-peertest/src/scenarios/mod.rs
+++ b/ethportal-peertest/src/scenarios/mod.rs
@@ -1,3 +1,4 @@
 pub mod eth_rpc;
+pub mod find;
 pub mod offer_accept;
 pub mod paginate;

--- a/newsfragments/471.added.md
+++ b/newsfragments/471.added.md
@@ -1,0 +1,1 @@
+Add support for tracing recurisve find content requests.

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -63,6 +63,18 @@ mod test {
             peertest_config.clone(),
             &peertest,
         );
+        peertest::scenarios::find::test_trace_recursive_find_content(
+            peertest_config.clone(),
+            &peertest,
+        );
+        peertest::scenarios::find::test_recursive_find_content_invalid_params(
+            peertest_config.clone(),
+            &peertest,
+        );
+        peertest::scenarios::find::test_trace_recursive_find_content_local_db(
+            peertest_config.clone(),
+            &peertest,
+        );
 
         peertest.exit_all_nodes();
         test_client_exiter.exit();

--- a/trin-core/src/jsonrpc/endpoints.rs
+++ b/trin-core/src/jsonrpc/endpoints.rs
@@ -32,6 +32,7 @@ pub enum HistoryEndpoint {
     SendOffer,
     Ping,
     RecursiveFindContent,
+    TraceRecursiveFindContent,
     Store,
     RoutingTableInfo,
     // This endpoint is not History network specific
@@ -90,6 +91,9 @@ impl FromStr for TrinEndpoint {
             }
             "portal_historyRecursiveFindContent" => Ok(TrinEndpoint::HistoryEndpoint(
                 HistoryEndpoint::RecursiveFindContent,
+            )),
+            "portal_historyTraceRecursiveFindContent" => Ok(TrinEndpoint::HistoryEndpoint(
+                HistoryEndpoint::TraceRecursiveFindContent,
             )),
             "portal_historyFindNodes" => {
                 Ok(TrinEndpoint::HistoryEndpoint(HistoryEndpoint::FindNodes))

--- a/trin-core/src/jsonrpc/utils.rs
+++ b/trin-core/src/jsonrpc/utils.rs
@@ -97,12 +97,9 @@ fn expand_client_name(client_shorthand: &str) -> Option<String> {
         Some(client_name) => {
             let mut expanded_string: String = client_name.to_owned();
 
-            match client_shorthand_words.next() {
-                Some(version_string) => {
-                    expanded_string.push(' ');
-                    expanded_string.push_str(version_string);
-                }
-                None => {}
+            if let Some(version_string) = client_shorthand_words.next() {
+                expanded_string.push(' ');
+                expanded_string.push_str(version_string);
             }
             Some(expanded_string)
         }

--- a/trin-core/src/portalnet/find/iterators/findcontent.rs
+++ b/trin-core/src/portalnet/find/iterators/findcontent.rs
@@ -40,6 +40,8 @@ pub enum FindContentQueryResult<TNodeId> {
     Content {
         content: Vec<u8>,
         closest_nodes: Vec<TNodeId>,
+        // Peer who actually returns the target content
+        content_provider: TNodeId,
     },
 }
 
@@ -314,6 +316,7 @@ where
 
                 FindContentQueryResult::Content {
                     content: content.content,
+                    content_provider: content.peer,
                     closest_nodes,
                 }
             }
@@ -571,6 +574,7 @@ mod tests {
                 FindContentQueryResult::Content {
                     content,
                     closest_nodes,
+                    content_provider,
                 } => {
                     let closest_nodes =
                         closest_nodes.into_iter().map(Key::from).collect::<Vec<_>>();
@@ -581,6 +585,7 @@ mod tests {
                     // The peer who returned the content should not be included in the closest
                     // nodes.
                     assert!(!closest_nodes.contains(&content_peer));
+                    assert_eq!(Key::from(content_provider), content_peer);
 
                     assert_eq!(content, found_content);
                 }

--- a/trin-core/src/portalnet/find/query_info.rs
+++ b/trin-core/src/portalnet/find/query_info.rs
@@ -1,3 +1,7 @@
+use discv5::{enr::NodeId, kbucket::Key, Enr};
+use futures::channel::oneshot;
+use smallvec::SmallVec;
+
 use crate::portalnet::{
     find::query_pool::TargetKey,
     types::{
@@ -5,9 +9,6 @@ use crate::portalnet::{
         messages::{FindContent, FindNodes, Request},
     },
 };
-use discv5::{enr::NodeId, kbucket::Key, Enr};
-use futures::channel::oneshot;
-use smallvec::SmallVec;
 
 /// Information about a query.
 #[derive(Debug)]
@@ -39,7 +40,7 @@ pub enum QueryType<TContentKey> {
         target: TContentKey,
 
         /// A callback channel for the result of the query.
-        callback: Option<oneshot::Sender<Option<Vec<u8>>>>,
+        callback: Option<oneshot::Sender<(Option<Vec<u8>>, Vec<NodeId>)>>,
     },
 }
 

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -678,7 +678,8 @@ where
     }
 
     /// Performs a content lookup for `target`.
-    pub async fn lookup_content(&self, target: TContentKey) -> Option<Vec<u8>> {
+    /// Returns the target content along with the peers traversed during content lookup.
+    pub async fn lookup_content(&self, target: TContentKey) -> (Option<Vec<u8>>, Vec<NodeId>) {
         let (tx, rx) = oneshot::channel();
         let content_id = target.content_id();
 
@@ -692,7 +693,7 @@ where
                 content.id = %hex_encode(content_id),
                 "Error submitting FindContent query to service"
             );
-            return None;
+            return (None, vec![]);
         }
 
         match rx.await {
@@ -704,7 +705,7 @@ where
                     content.id = %hex_encode(content_id),
                     "Error receiving content from service",
                 );
-                None
+                (None, vec![])
             }
         }
     }

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -90,7 +90,7 @@ pub enum OverlayCommand<TContentKey> {
         /// The query target.
         target: TContentKey,
         /// A callback channel to transmit the result of the query.
-        callback: oneshot::Sender<Option<Vec<u8>>>,
+        callback: oneshot::Sender<(Option<Vec<u8>>, Vec<NodeId>)>,
     },
 }
 
@@ -746,12 +746,15 @@ where
             QueryEvent::Finished(query_id, query_info, query)
             | QueryEvent::TimedOut(query_id, query_info, query) => {
                 let result = query.into_result();
-                let (content, closest_nodes) = match result {
-                    FindContentQueryResult::ClosestNodes(closest_nodes) => (None, closest_nodes),
+                let (content, closest_nodes, content_provider) = match result {
+                    FindContentQueryResult::ClosestNodes(closest_nodes) => {
+                        (None, closest_nodes, None)
+                    }
                     FindContentQueryResult::Content {
                         content,
                         closest_nodes,
-                    } => (Some(content), closest_nodes),
+                        content_provider,
+                    } => (Some(content), closest_nodes, Some(content_provider)),
                 };
 
                 if let QueryType::FindContent {
@@ -759,8 +762,13 @@ where
                     target: content_key,
                 } = query_info.query_type
                 {
+                    let mut all_closest_nodes = closest_nodes.clone();
+                    if let Some(val) = content_provider {
+                        all_closest_nodes.push(val);
+                    }
+                    let response = (content.clone(), all_closest_nodes);
                     // Send (possibly `None`) content on callback channel.
-                    if let Err(err) = callback.send(content.clone()) {
+                    if let Err(err) = callback.send(response) {
                         error!(
                             query.id = %query_id,
                             error = ?err,
@@ -1951,7 +1959,7 @@ where
     fn init_find_content_query(
         &mut self,
         target: TContentKey,
-        callback: Option<oneshot::Sender<Option<Vec<u8>>>>,
+        callback: Option<oneshot::Sender<(Option<Vec<u8>>, Vec<NodeId>)>>,
     ) -> Option<QueryId> {
         // Represent the target content ID with a node ID.
         let target_node_id = NodeId::new(&target.content_id());
@@ -3079,7 +3087,7 @@ mod tests {
             &query_info.query_type,
             QueryType::FindContent {
                 target: _target_content_key,
-                callback: None
+                callback: None,
             }
         ));
 
@@ -3309,7 +3317,7 @@ mod tests {
             .await
             .expect("Expected result on callback channel receiver")
         {
-            Some(result_content) => {
+            (Some(result_content), _) => {
                 assert_eq!(result_content, content);
             }
             _ => panic!("Unexpected find content query result type"),

--- a/trin-core/src/utils/provider.rs
+++ b/trin-core/src/utils/provider.rs
@@ -14,7 +14,7 @@ pub const INFURA_BASE_HTTP_URL: &str = "https://mainnet.infura.io:443/v3/";
 pub const INFURA_BASE_WS_URL: &str = "wss://mainnet.infura.io:443/ws/v3/";
 
 // Type used for parsing cli args
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TrustedProviderType {
     Infura,
     Geth,
@@ -84,12 +84,9 @@ impl TrustedProvider {
         };
         match dispatch_trusted_http_request(request, self.http.clone()) {
             Ok(val) => Ok(serde_json::from_str(&val)?),
-            Err(msg) => {
-                return Err(anyhow!(
-                    "Unable to request validation data from trusted provider: {:?}",
-                    msg
-                ))
-            }
+            Err(err) => Err(anyhow!(
+                "Unable to request validation data from trusted provider: {err:?}",
+            )),
         }
     }
 }

--- a/trin-core/tests/overlay.rs
+++ b/trin-core/tests/overlay.rs
@@ -231,10 +231,10 @@ async fn overlay() {
         .put(content_key.clone(), &content)
         .expect("Unable to store content");
     match overlay_one.lookup_content(content_key).await {
-        Some(found_content) => {
+        (Some(found_content), _) => {
             assert_eq!(found_content, content);
         }
-        None => {
+        (None, _) => {
             panic!("Unable to find content stored with peer");
         }
     }

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -104,11 +104,11 @@ impl StateRequestHandler {
                                     None => {
                                         match self.network.overlay.lookup_content(content_key).await
                                         {
-                                            Some(content) => {
+                                            (Some(content), _) => {
                                                 let value = Value::String(hex_encode(content));
                                                 Ok(value)
                                             }
-                                            None => Ok(Value::Null),
+                                            (None, _) => Ok(Value::Null),
                                         }
                                     }
                                     Some(content) => Ok(Value::String(hex_encode(content))),


### PR DESCRIPTION
### What was wrong?
It's tricky to see the path a recursive find network request follows as it hops from enr to enr in the network looking up the target content. Also, it's useful to know which enr actually returns the target content.

### How was it fixed?
Add support for a `portal_traceHistoryRecursiveFindContent` request.

Fixes #469 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
