### PR TITLE
Return an empty response for requests which result in an error during processing.

### DIFF
--- a/newsfragments/475.fixed.md
+++ b/newsfragments/475.fixed.md
@@ -1,0 +1,1 @@
+Respond with empty TALKRESP for TALKREQs that result in an error during processing.

--- a/trin-history/src/events.rs
+++ b/trin-history/src/events.rs
@@ -43,9 +43,10 @@ impl HistoryEvents {
                     error!(
                         error = %error,
                         request.discv5.id = %talk_request_id,
-                        "Error processing portal history request"
+                        "Error processing portal history request, responding with empty TALKRESP"
                     );
-                    error.to_string().into_bytes()
+                    // Return an empty TALKRESP if there was an error executing the request
+                    "".into()
                 }
             };
             if let Err(error) = talk_request.respond(reply) {

--- a/trin-state/src/events.rs
+++ b/trin-state/src/events.rs
@@ -43,9 +43,10 @@ impl StateEvents {
                     error!(
                         error = %error,
                         request.discv5.id = %talk_request_id,
-                        "Error processing portal state request"
+                        "Error processing portal state request, responding with empty TALKRESP."
                     );
-                    error.to_string().into_bytes()
+                    // Return an empty TALKRESP if there was an error executing the request
+                    "".into()
                 }
             };
             if let Err(error) = talk_request.respond(reply) {


### PR DESCRIPTION
### What was wrong?
Related to #473 

If there is an error in processing a `TALKREQ`, we respond to the request with a bytes representation of the error message. 

This pr doesn't resolve the core bug, which is likely something to do with enr caching, but at least it prevents responding the the request with trin's internal error message.

### How was it fixed?
Respond to the request with an empty string rather than responding with an error message. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
