### PR TITLE
Support loading custom master accumulators

### DIFF
--- a/newsfragments/478.added.md
+++ b/newsfragments/478.added.md
@@ -1,0 +1,1 @@
+Add support for loading a custom master acc from file via cli arg.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,10 @@ pub async fn run_trin(
 
     // Initialize validation oracle
     let master_accumulator = MasterAccumulator::try_from_file(trin_config.master_acc_path.clone())?;
+    info!(
+        "Loaded master accumulator from: {:?}",
+        trin_config.master_acc_path
+    );
     let header_oracle = HeaderOracle::new(trusted_provider.clone(), master_accumulator);
     let header_oracle = Arc::new(RwLock::new(header_oracle));
 

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -129,10 +129,9 @@ pub struct TrinConfig {
     )]
     pub geth_url: Option<String>,
 
-    // todo: support custom master accs
     #[structopt(
         long = "master-accumulator-path",
-        help = "Path to master accumulator for validation (not currently supported)",
+        help = "Path to master accumulator for validation",
         default_value(DEFAULT_MASTER_ACC_PATH),
         parse(from_os_str)
     )]
@@ -175,10 +174,6 @@ impl TrinConfig {
         T: Into<OsString> + Clone,
     {
         let config = Self::from_iter(args);
-
-        if config.master_acc_path != PathBuf::from(DEFAULT_MASTER_ACC_PATH.to_string()) {
-            panic!("Custom master accumulators are not yet supported.")
-        }
 
         match config.web3_transport.as_str() {
             "http" => match &config.web3_ipc_path[..] {

--- a/trin-core/src/types/accumulator.rs
+++ b/trin-core/src/types/accumulator.rs
@@ -51,9 +51,10 @@ impl MasterAccumulator {
     pub fn try_from_file(master_acc_path: PathBuf) -> anyhow::Result<MasterAccumulator> {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push(master_acc_path);
-        let raw = std::fs::read(path)?;
+        let raw = std::fs::read(&path)
+            .map_err(|_| anyhow!("Unable to find master accumulator at path: {:?}", path))?;
         MasterAccumulator::from_ssz_bytes(&raw)
-            .map_err(|msg| anyhow!("Unable to decode master accumulator: {:?}", msg))
+            .map_err(|err| anyhow!("Unable to decode master accumulator: {err:?}"))
     }
 
     /// Number of the last block to be included in the accumulator


### PR DESCRIPTION
### What was wrong?
Fixes #449 

While docker-izing [eth-portal](https://github.com/carver/eth-portal), it turns out it would actually be quite useful to support loading a custom macc, due to a naming conflict b/w the executable ethportal (`./trin`) tries to launch and the directory (`./trin/`) in which we look up the default master accumulator. 

This pr also updates the error message if trin is unable to find the master accumulator. Which before was simple (`Not a directory, OS error 20`) which wasn't explicit about what file was unable to be found. 

### How was it fixed?
Added support for loading a custom master acc from path. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
