### PR TITLE
Possible bug in uTP packet duplication check 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
             - run:
                 name: Install rustfmt
                 command: rustup component add rustfmt
-            - run: 
+            - run:
                 name: Validate release notes entry
                 command: ./newsfragments/validate_files.py
             - run:

--- a/trin-core/src/utp/stream.rs
+++ b/trin-core/src/utp/stream.rs
@@ -1465,7 +1465,7 @@ impl UtpStream {
         // Insert data packet into the incoming buffer if it isn't a duplicate of a previously
         // discarded packet
         if packet.get_type() == PacketType::Data
-            && packet.seq_nr().wrapping_sub(self.last_dropped) > 0
+            && packet.seq_nr().saturating_sub(self.last_dropped) > 0
         {
             self.insert_into_buffer(packet.clone());
         }


### PR DESCRIPTION
### What was wrong?
The duplicate check with `wrapping_sub()` will miss packets whose `seq_nr` is less than the most recently handled one, ie. `self.last_dropped`. As a result, it writes the duplicated bytes into the buffer and messes up the state of UtpStream when performing `flush_incoming_buffer()`.

### How was it fixed?
Changed to `saturating_sub` so that any packet with `seq_nr` less or equal to `self.last_dropped` will be skipped.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
