### PR TITLE
core/jsonrpc: Do not drop TCP stream before reaching EOF

### DIFF
--- a/newsfragments/486.fixed.md
+++ b/newsfragments/486.fixed.md
@@ -1,0 +1,1 @@
+Keep processing JSON-RPC requests until TCP stream EOF. 


### PR DESCRIPTION
### What was wrong?
When receiving HTTP JSON-RPC request,  Trin drops the TCP stream right after the request is processed (the stream goes out of scope). This is unexpected behavior because the stream may not reach EOF and more requests should be expected on the same stream.

### How was it fixed?
Add a loop to keep processing JSON-RPC requests until stream EOF.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
