### PR TITLE
docker: Save binaries to /usr/bin folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,9 @@ FROM ubuntu:22.04
 RUN mkdir -p /trin/trin-core/src/assets
 COPY --from=builder /trin/trin-core/src/assets/merge_macc.bin ./trin/trin-core/src/assets/merge_macc.bin
 # copy build artifacts from build stage
-COPY --from=builder /trin/target/release/trin .
-COPY --from=builder /trin/target/release/trin-cli .
+COPY --from=builder /trin/target/release/trin /usr/bin/
+COPY --from=builder /trin/target/release/trin-cli /usr/bin/
 
 ENV RUST_LOG=debug
 
-ENTRYPOINT ["./trin"]
+ENTRYPOINT ["/usr/bin/trin"]


### PR DESCRIPTION
### What was wrong?
When trying to use the docker image as a building block for another image, executing `./trin` command returns an error because there is a folder with the same name.

### How was it fixed?
Move trin binaries in `/usr/bin/` folder which allows running with `trin` command instead of `./trin`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
