### PR TITLE
Add serde deserialization to header

### DIFF
--- a/newsfragments/492.fixed.md
+++ b/newsfragments/492.fixed.md
@@ -1,0 +1,1 @@
+Add serde deserialization to Header and remove redundant helper methods.

--- a/trin-core/src/types/accumulator.rs
+++ b/trin-core/src/types/accumulator.rs
@@ -664,7 +664,7 @@ mod test {
             state_root: H256::random(),
             transactions_root: H256::random(),
             receipts_root: H256::random(),
-            log_bloom: Bloom::zero(),
+            logs_bloom: Bloom::zero(),
             difficulty: U256::from_dec_str("1").unwrap(),
             number: *height,
             gas_limit: U256::from_dec_str("1").unwrap(),

--- a/trin-core/src/types/validation.rs
+++ b/trin-core/src/types/validation.rs
@@ -56,7 +56,7 @@ impl HeaderOracle {
         let response: Value = self
             .trusted_provider
             .dispatch_http_request(method, params)?;
-        let header = Header::from_get_block_jsonrpc_response(response)?;
+        let header: Header = serde_json::from_value(response["result"].clone())?;
         Ok(header)
     }
 


### PR DESCRIPTION
### What was wrong?
The primary pr I'm working on (introducing some bridge capability to trin) has grown quite large. This pr is an attempt to decrease the size of the upcoming pr by extracting some simple value conversion types. These types are going to be shared amongst `block_body.rs` / `header.rs` / `receipts.rs`. The verbose structure of the old conversion fns became quite cumbersome, so I introduced these types to simplify reusing the conversion logic in the different modules.

### How was it fixed?
Added type conversion helper types. Didn't feel like unit tests are necessary for these, since they're being tested implicitly inside `Header`. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
