### PR TITLE
jsonrpc LocalContent: Return `0x0` when content is not available

### DIFF
--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -280,6 +280,22 @@ fn all_tests(peertest: &Peertest) -> Vec<Test<impl Fn(&Value, &Peertest)>> {
             },
             validate_portal_routing_table_info,
         ),
+        Test::new(
+            JsonRpcRequest {
+                method: "portal_historyLocalContent".to_string(),
+                id: 15,
+                params: Params::Array(vec![Value::String("0x00cb5cab7266694daa0d28cbf40496c08dd30bf732c41e0455e7ad389c10d79f4f".to_string())]),
+            },
+            validate_portal_local_content,
+        ),
+        Test::new(
+            JsonRpcRequest {
+                method: "portal_stateLocalContent".to_string(),
+                id: 16,
+                params: Params::Array(vec![Value::String("0x02829bd824b016326a401d083b33d092293333a830d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d".to_string())]),
+            },
+            validate_portal_local_content,
+        ),
     ]
 }
 
@@ -367,6 +383,10 @@ pub fn validate_portal_offer(result: &Value, _peertest: &Peertest) {
     assert!(connection_id.parse::<u64>().is_ok());
     // Should accept the requested content
     assert_eq!(result.get("content_keys").unwrap().as_str(), Some("0x03"))
+}
+
+pub fn validate_portal_local_content(result: &Value, _peertest: &Peertest) {
+    assert_eq!(result.as_str().unwrap(), "0x0");
 }
 
 #[cfg(unix)]

--- a/newsfragments/493.fixed.md
+++ b/newsfragments/493.fixed.md
@@ -1,0 +1,1 @@
+Returns "0x0" when content is not available upon LocalContent RPC endpoint call.

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -44,10 +44,7 @@ impl HistoryRequestHandler {
                                 {
                                     Ok(val) => match val {
                                         Some(val) => Ok(Value::String(hex_encode(val.clone()))),
-                                        None => Err(format!(
-                                            "Content key is not in local storage: {:?}",
-                                            params.content_key
-                                        )),
+                                        None => Ok(Value::String("0x0".to_string())),
                                     },
                                     Err(err) => Err(format!(
                                         "Database error while looking for content key in local storage: {:?}, with error: {}",

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -35,10 +35,7 @@ impl StateRequestHandler {
                                 match &self.network.overlay.store.read().get(&params.content_key) {
                                     Ok(val) => match val {
                                         Some(val) => Ok(Value::String(hex_encode(val.clone()))),
-                                        None => Err(format!(
-                                            "Unable to find content key in local storage: {:?}",
-                                            params.content_key
-                                        )),
+                                        None => Ok(Value::String("0x0".to_string())),
                                     },
                                     Err(_) => Err(format!(
                                         "Unable to find content key in local storage: {:?}",


### PR DESCRIPTION
### What was wrong?
The Portal hive LocalContent test fails because we return an error instead of `0x0` when local content is not available.

### How was it fixed?
Return `0x0` when local content is not available according to https://github.com/ethereum/portal-network-specs/pull/176.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
