### PR TITLE
jsonrpc: Return a boolean instead of a string from the `portal_*Store endpoint`

### DIFF
--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -360,7 +360,7 @@ fn validate_portal_find_nodes_zero_distance(result: &Value, peertest: &Peertest)
 }
 
 fn validate_portal_store(result: &Value, _peertest: &Peertest) {
-    assert_eq!(result.as_str().unwrap(), "true");
+    assert!(result.as_bool().unwrap());
 }
 
 fn validate_portal_store_with_invalid_content_key(result: &Value, _peertest: &Peertest) {

--- a/ethportal-peertest/src/scenarios/eth_rpc.rs
+++ b/ethportal-peertest/src/scenarios/eth_rpc.rs
@@ -18,7 +18,7 @@ pub fn test_eth_get_block_by_hash(_peertest_config: PeertestConfig, peertest: &P
     };
 
     let store_result = make_ipc_request(&peertest.bootnode.web3_ipc_path, &store_request).unwrap();
-    assert_eq!(store_result.as_str().unwrap(), "true");
+    assert!(store_result.as_bool().unwrap());
 
     // Send eth_getBlockByHash request
     let request = JsonRpcRequest {
@@ -46,7 +46,7 @@ pub fn test_eth_get_block_by_number(_peertest_config: PeertestConfig, peertest: 
     };
 
     let store_result = make_ipc_request(&peertest.bootnode.web3_ipc_path, &store_request).unwrap();
-    assert_eq!(store_result.as_str().unwrap(), "true");
+    assert!(store_result.as_bool().unwrap());
 
     // Send supported eth_getBlockByNumber request (pre-merge)
     let request = JsonRpcRequest {

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -19,7 +19,7 @@ pub fn test_trace_recursive_find_content(_peertest_config: PeertestConfig, peert
     };
 
     let store_result = make_ipc_request(&peertest.bootnode.web3_ipc_path, &store_request).unwrap();
-    assert_eq!(store_result.as_str().unwrap(), "true");
+    assert!(store_result.as_bool().unwrap());
 
     // Send trace recursive find content request
     let request = JsonRpcRequest {
@@ -70,7 +70,7 @@ pub fn test_trace_recursive_find_content_local_db(
     };
 
     let store_result = make_ipc_request(&peertest.bootnode.web3_ipc_path, &store_request).unwrap();
-    assert_eq!(store_result.as_str().unwrap(), "true");
+    assert!(store_result.as_bool().unwrap());
 
     // Send trace recursive find content request
     let request = JsonRpcRequest {

--- a/ethportal-peertest/src/scenarios/offer_accept.rs
+++ b/ethportal-peertest/src/scenarios/offer_accept.rs
@@ -26,7 +26,7 @@ pub fn test_offer_accept(peertest_config: PeertestConfig, peertest: &Peertest) {
     };
 
     let store_result = make_ipc_request(&peertest_config.target_ipc_path, &store_request).unwrap();
-    assert_eq!(store_result.as_str().unwrap(), "true");
+    assert!(store_result.as_bool().unwrap());
 
     // Send offer request from testnode to bootnode
     let offer_request = JsonRpcRequest {

--- a/ethportal-peertest/src/scenarios/paginate.rs
+++ b/ethportal-peertest/src/scenarios/paginate.rs
@@ -35,7 +35,7 @@ pub fn test_paginate_local_storage(peertest_config: PeertestConfig, _peertest: &
 
         let store_result =
             make_ipc_request(&peertest_config.target_ipc_path, &store_request).unwrap();
-        assert_eq!(store_result.as_str().unwrap(), "true");
+        assert!(store_result.as_bool().unwrap());
     }
     // Sort content keys to use for testing
     content_keys.sort();

--- a/newsfragments/496.fixed.md
+++ b/newsfragments/496.fixed.md
@@ -1,0 +1,1 @@
+Return a boolean instead of a string from the `portal_*Store endpoint`.

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -87,7 +87,7 @@ impl HistoryRequestHandler {
                                 .write()
                                 .put(content_key, &content)
                             {
-                                Ok(_) => Ok(Value::String("true".to_string())),
+                                Ok(_) => Ok(Value::Bool(true)),
                                 Err(msg) => Ok(Value::String(msg.to_string())),
                             }
                         }

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -59,7 +59,7 @@ impl StateRequestHandler {
                                 .write()
                                 .put(content_key, &content)
                             {
-                                Ok(_) => Ok(Value::String("true".to_string())),
+                                Ok(_) => Ok(Value::Bool(true)),
                                 Err(msg) => Ok(Value::String(msg.to_string())),
                             }
                         }


### PR DESCRIPTION
### What was wrong?
According to JSON-RPC [specs](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/portal-network-specs/assembled-spec/jsonrpc/openrpc.json&uiSchema%5BappBar%5D%5Bui:splitView%5D=false&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false), Trin should return a boolean instead of a  string from the `portal_*Store` endpoint.

### How was it fixed?
Return JSON boolean.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
