### PR TITLE
circleci: Add no_output_timeout value to docker-build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,14 @@ executors:
       - image: cimg/rust:1.62.0
 jobs:
   docker-build:
+    resource_class: xlarge
     executor: docker-publisher
     steps:
       - checkout
       - setup_remote_docker
       - run:
           name: Build Docker image
+          no_output_timeout: 30m
           command: docker build -t $IMAGE_NAME:latest .
       - run:
           name: Archive Docker image


### PR DESCRIPTION
### What was wrong?

The Docker build pipeline fails on the master branch.

### How was it fixed?
Increases the no_output_timeout ` setting.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
