### PR TITLE
ethportal-api: Implement `From` trait for `&HistoryContentKey`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,7 @@ checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
 
 [[package]]
 name = "ethportal-api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes 1.3.0",
  "enr 0.7.0",

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethportal-api"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Definitions for various Ethereum Portal Network JSONRPC APIs"
 license = "GPL-3.0"

--- a/ethportal-api/README.md
+++ b/ethportal-api/README.md
@@ -40,7 +40,7 @@ async fn main() {
         .unwrap();
     assert!(result);
 
-    // Call portal_historyLocalContent endpoint and deserialize to HistoryContentItem::AccumulatoProof type
+    // Call portal_historyLocalContent endpoint and deserialize to `HistoryContentItem::BlockHeaderWithProof` type
     let result: HistoryContentItem = client.local_content(content_key).await.unwrap();
     assert_eq!(result, content_item);
 }

--- a/ethportal-api/src/types/content_key.rs
+++ b/ethportal-api/src/types/content_key.rs
@@ -116,11 +116,15 @@ pub struct EpochAccumulatorKey {
     pub epoch_hash: H256,
 }
 
-// Silence clippy to avoid implementing newtype pattern on imported type.
-#[allow(clippy::from_over_into)]
-impl Into<Vec<u8>> for HistoryContentKey {
-    fn into(self) -> Vec<u8> {
-        self.as_ssz_bytes()
+impl From<&HistoryContentKey> for Vec<u8> {
+    fn from(val: &HistoryContentKey) -> Self {
+        val.as_ssz_bytes()
+    }
+}
+
+impl From<HistoryContentKey> for Vec<u8> {
+    fn from(val: HistoryContentKey) -> Self {
+        val.as_ssz_bytes()
     }
 }
 


### PR DESCRIPTION
### What was wrong?
We want to pass a reference to `HistoryContentKey` as a function signature and be able to decode it into Vec<u8>.

### How was it fixed?
- Implement `From<&HistoryContentKey>` for `Vec<u8>` trait
- Replace `Into<Vec<u8>>` for `HistoryContentKey`  with the From trait which implicitly implements `Into`.
- Release the new `ethportal-api` version with the patch above
- Fix Readme typo

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
