### PR TITLE
Fix build-essential typo

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -15,7 +15,7 @@ Note: If you use a VPN, you should disable it before running Trin.
 Install dependencies (Ubuntu/Debian):
 
 ```sh
-apt install libssl-dev librocksdb-dev libclang-dev pkg-config build-essentials 
+apt install libssl-dev librocksdb-dev libclang-dev pkg-config build-essential
 ```
 
 Environment variables:


### PR DESCRIPTION
### What was wrong?
`build-essentials` package should be `build-essential` - [link](https://askubuntu.com/questions/674449/install-build-essentials)

### How was it fixed?
Fixed command

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
