### PR TITLE
Remove ByteList as type for offered content

### DIFF
--- a/newsfragments/506.fixed.md
+++ b/newsfragments/506.fixed.md
@@ -1,0 +1,1 @@
+Replaced ByteList with Vec<u8> as type for offered content values.

--- a/trin-core/src/portalnet/types/messages.rs
+++ b/trin-core/src/portalnet/types/messages.rs
@@ -500,7 +500,7 @@ pub struct FindContent {
 #[ssz(enum_behaviour = "union")]
 pub enum Content {
     ConnectionId(u16),
-    Content(ByteList),
+    Content(Vec<u8>),
     Enrs(Vec<SszEnr>),
 }
 
@@ -531,7 +531,7 @@ pub struct Offer {
 #[derive(Debug, Clone)]
 pub struct PopulatedOffer {
     /// All the offered content, pairing the keys and values
-    pub content_items: Vec<(RawContentKey, ByteList)>,
+    pub content_items: Vec<(RawContentKey, Vec<u8>)>,
 }
 
 impl Into<Offer> for PopulatedOffer {
@@ -781,7 +781,6 @@ mod test {
     #[test]
     fn message_encoding_content_content() {
         let content_val = hex::decode("7468652063616b652069732061206c6965").unwrap();
-        let content_val = ByteList::from(VariableList::from(content_val));
         let content = Content::Content(content_val);
         let content = Message::Content(content);
 

--- a/trin-core/src/utils/portal_wire.rs
+++ b/trin-core/src/utils/portal_wire.rs
@@ -1,14 +1,13 @@
-use crate::portalnet::types::messages::ByteList;
 use anyhow::anyhow;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::io::{Read, Write};
 
 /// Decode content values from uTP payload. All content values are encoded with a LEB128 varint prefix
 /// which indicates the length in bytes of the consecutive content item.
-pub fn decode_content_payload(payload: Vec<u8>) -> anyhow::Result<Vec<ByteList>> {
+pub fn decode_content_payload(payload: Vec<u8>) -> anyhow::Result<Vec<Vec<u8>>> {
     let mut payload = BytesMut::from(&payload[..]).reader();
 
-    let mut content_values: Vec<ByteList> = Vec::new();
+    let mut content_values: Vec<Vec<u8>> = Vec::new();
 
     // Read LEB128 encoded index and content items until all payload bytes are consumed
     while !payload.get_ref().is_empty() {
@@ -24,7 +23,7 @@ pub fn decode_content_payload(payload: Vec<u8>) -> anyhow::Result<Vec<ByteList>>
         payload
             .read_exact(&mut buf)
             .map_err(|err| anyhow!("Error reading content item: {err}"))?;
-        content_values.push(buf.into());
+        content_values.push(buf);
     }
     Ok(content_values)
 }

--- a/trin-core/src/utp/stream.rs
+++ b/trin-core/src/utp/stream.rs
@@ -256,7 +256,7 @@ impl UtpListener {
                             if let UtpStreamId::ContentStream(content_data) = conn.stream_id.clone()
                             // TODO: Change this `clone` to borrow after rust 1.62
                             {
-                                // We want to send uTP data only if the content is Content(ByteList)
+                                // We want to send uTP data only if the content is Content(Vec<u8>)
                                 debug!(
                                     "Sending content data via uTP with len: {}",
                                     content_data.len()

--- a/trin-core/src/utp/trin_helpers.rs
+++ b/trin-core/src/utp/trin_helpers.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 // These are just some Trin helper functions
 
-use crate::portalnet::types::{content_key::RawContentKey, messages::ByteList};
+use crate::portalnet::types::content_key::RawContentKey;
 use ssz_derive::{Decode, Encode};
 
 // These Utp impl are related to sending messages over uTP not the implementation itself or stream
@@ -57,7 +57,7 @@ pub enum UtpStreamId {
     /// Stream id to initialize FindContent uTP connection and to listen for content payload
     FindContentStream,
     /// Stream id to listen for incoming FindContent connection and to send back the content data to the requester
-    ContentStream(ByteList),
+    ContentStream(Vec<u8>),
     /// Stream id to send requested content from received ACCEPT response
     OfferStream,
     /// Stream id to listen for OFFER uTP payload. Contains requested content keys.

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -220,8 +220,7 @@ impl HistoryRequestHandler {
                     {
                         Ok(params) => {
                             let content_key = params.content_key.clone();
-                            let content = params.content.into();
-                            let content_items = vec![(content_key, content)];
+                            let content_items = vec![(content_key, params.content)];
                             let num_peers = self.network.overlay.propagate_gossip(content_items);
                             Ok(num_peers.into())
                         }

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -136,12 +136,9 @@ mod tests {
 
     use trin_core::{
         cli::DEFAULT_MASTER_ACC_PATH,
-        portalnet::types::{
-            content_key::{
-                BlockBody as BlockBodyKey, BlockHeader, BlockReceipts,
-                EpochAccumulator as EpochAccumulatorKey,
-            },
-            messages::ByteList,
+        portalnet::types::content_key::{
+            BlockBody as BlockBodyKey, BlockHeader, BlockReceipts,
+            EpochAccumulator as EpochAccumulatorKey,
         },
         types::accumulator::MasterAccumulator,
         utils::{bytes::hex_decode, provider::TrustedProvider},
@@ -230,8 +227,6 @@ mod tests {
     async fn validate_header() {
         let server = setup_mock_infura_server();
         let header_rlp = get_header_rlp();
-        let header_bytelist = ByteList::try_from(header_rlp.clone()).unwrap();
-
         let header: Header = rlp::decode(&header_rlp).expect("error decoding header");
         let header_oracle = default_header_oracle(server.url("/get_header"));
         let chain_history_validator = ChainHistoryValidator { header_oracle };
@@ -239,7 +234,7 @@ mod tests {
             block_hash: header.hash().0,
         });
         chain_history_validator
-            .validate_content(&content_key, &header_bytelist)
+            .validate_content(&content_key, &header_rlp)
             .await
             .unwrap();
     }
@@ -255,14 +250,14 @@ mod tests {
         // set invalid block height
         header.number = 669052;
 
-        let header_bytelist = ByteList::from(rlp::encode(&header).to_vec());
+        let header_rlp = rlp::encode(&header).to_vec();
         let header_oracle = default_header_oracle(server.url("/get_header"));
         let chain_history_validator = ChainHistoryValidator { header_oracle };
         let content_key = HistoryContentKey::BlockHeader(BlockHeader {
             block_hash: header.hash().0,
         });
         chain_history_validator
-            .validate_content(&content_key, &header_bytelist)
+            .validate_content(&content_key, &header_rlp)
             .await
             .unwrap();
     }
@@ -279,14 +274,14 @@ mod tests {
         // valid gaslimit = 3141592
         header.gas_limit = U256::from(3141591);
 
-        let header_bytelist = ByteList::from(rlp::encode(&header).to_vec());
+        let content_value = rlp::encode(&header).to_vec();
         let header_oracle = default_header_oracle(server.url("/get_header"));
         let chain_history_validator = ChainHistoryValidator { header_oracle };
         let content_key = HistoryContentKey::BlockHeader(BlockHeader {
             block_hash: header.hash().0,
         });
         chain_history_validator
-            .validate_content(&content_key, &header_bytelist)
+            .validate_content(&content_key, &content_value)
             .await
             .unwrap();
     }


### PR DESCRIPTION
### What was wrong?
Using `ByteList` as the type for content we offer was a mistake... `ByteList` is just an alias for `VariableList` with max length `2048` - so every piece of content we offered was truncated to 2048... which obviously meant that it didn't pass validation on the receiving side, and is likely the reason for poor testnet performance recently.

### How was it fixed?
Changed use of `ByteList` -> `Vec<u8>`

Why didn't testing catch this? Well, utp testing isn't covered extensively inside trin, and that will be covered in `portal-hive` scenario testing. @ogenev (who helped debug this, thanks!) I would just make sure to document in some todo-list that this situation is one we should definitely cover as soon as `portal-hive` is capable of executing this type of test.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
