### PR TITLE
add CLI flag and docs for local trusted provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5091,6 +5091,7 @@ dependencies = [
  "uds_windows",
  "uint 0.8.5",
  "ureq",
+ "url",
  "validator",
 ]
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Check out the [Getting Started](/docs/getting_started.md) guide to quickly get u
 
 Trin is a prototype Portal Network client. This implementation and the Portal Network specifications will continue to co-evolve.
 
-In this stage of development, Trin relies on Infura to respond to some requests that it cannot fulfill itself. Additionally, Trin lacks comprehensive data validation.
+In this stage of development, Trin relies on a separate execution node (local node or Infura) to respond to some requests that it cannot fulfill itself. Additionally, Trin lacks comprehensive data validation.
 
 ## Want to help?
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -5,7 +5,9 @@
 **Check out the [Release Notes](/docs/release_notes.md) to see the latest supported features.**
 
 ## Prerequisites
-- [Infura](https://infura.io/) project ID
+- Execution node, either:
+    - Local node
+    - [Infura](https://infura.io/) project ID
 - [Rust](https://www.rust-lang.org/) installation
 
 ## Building, Testing, and Running
@@ -21,10 +23,10 @@ apt install libssl-dev librocksdb-dev libclang-dev pkg-config build-essential
 Environment variables:
 
 ```sh
-# Required 
+# Required if not using a local node ("--trusted-provider custom" flag).
 export TRIN_INFURA_PROJECT_ID=<infura-project-id>
 
-# Optional 
+# Optional
 export RUST_LOG=<error/warn/info/debug/trace>
 export TRIN_DATA_PATH=<path-to-data-directory>
 ```
@@ -59,6 +61,25 @@ View CLI options:
 
 ```sh
 cargo run -- --help
+```
+
+### Run locally
+
+Run with the `--trusted-provider` as a local execution node (normally runs on `127.0.0.1:8545`), which can be configured with the `--trusted-provider-url` flag.
+
+Serve portal node web3 access over a different port (such as `8547`) using the `--web3-http-address` flag. The `--web3-transport` for a local node will be over `http`
+(rather than `ipc`).
+
+```
+RUST_LOG=debug cargo run -- \
+    --trusted-provider custom \
+    --trusted-provider-url http://127.0.0.1:8545 \
+    --web3-http-address http://127.0.0.1:8547 \
+    --web3-transport http \
+    --discovery-port 9009 \
+    --bootnodes default \
+    --kb 200000 \
+    --no-stun
 ```
 
 ### Connect to the Portal Network testnet

--- a/docs/jsonrpc_api.md
+++ b/docs/jsonrpc_api.md
@@ -24,7 +24,7 @@ The specification for these endpoints can be found [here](https://playground.ope
 The specification for these endpoints can be found [here](https://eth.wiki/json-rpc/API#json-rpc-methods).
 
 - [`eth_blockNumber`](https://eth.wiki/json-rpc/API#eth_blocknumber)
-	- This endpoint is currently proxied to Infura, and not served by the Portal Network.
+	- This endpoint is currently proxied to a trusted provider (local node or Infura), and not served by the Portal Network.
 - [`eth_getBlockByHash`](https://eth.wiki/json-rpc/API#eth_getblockbyhash)
 	- This endpoint relies on fetching block headers from the Portal Network, so all blocks may not be available until the Portal Network stabilizes.
 - [`eth_getBlockByNumber`](https://eth.wiki/json-rpc/API#eth_getblockbynumber)
@@ -34,7 +34,7 @@ The specification for these endpoints can be found [here](https://eth.wiki/json-
 ### Custom Trin JSON-RPC endpoints
 - [`portal_historyRadius`](#portal_historyRadius)
 - [`portal_stateRadius`](#portal_stateRadius)
-- [`portal_historyLocalContent`](#portal_historyLocalContent) 
+- [`portal_historyLocalContent`](#portal_historyLocalContent)
 - [`portal_stateLocalContent`](#portal_stateLocalContent)
 - [`portal_historyRecursiveFindContent`](#portal_historyRecursiveFindContent)
 - [`portal_historyTraceRecursiveFindContent`](#portal_historyTraceRecursiveFindContent)

--- a/docs/ubuntu_guide.md
+++ b/docs/ubuntu_guide.md
@@ -126,7 +126,7 @@ Paste the following, replace the Infura ID with your own.
 > Tip: The 'info' level of logs is a good starting value.
 ```sh
 [Service]
-# (required)
+# (required unless the '--trusted-provider' is set to 'local')
 Environment="TRIN_INFURA_PROJECT_ID=<infura-project-id>"
 # (optional) Rust log level: <error/warn/info/debug/trace>
 Environment="RUST_LOG=info"

--- a/newsfragments/509.added.md
+++ b/newsfragments/509.added.md
@@ -1,0 +1,1 @@
+Added flag for running with local execution node.

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -57,6 +57,7 @@ tree_hash_derive = "0.4.0"
 uint = { version = "0.8.5", default-features = false }
 ureq = { version = "2.2.0", features = ["json"] }
 validator = { version = "0.13.0", features = ["derive"] }
+url = "2.3.1"
 
 [target.'cfg(windows)'.dependencies]
 ipconfig = "0.2.2"

--- a/trin-core/src/utils/provider.rs
+++ b/trin-core/src/utils/provider.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use anyhow::anyhow;
 use serde_json::Value;
 use ureq::Request;
+use url::Url;
 
 use crate::cli::TrinConfig;
 use crate::jsonrpc::service::dispatch_trusted_http_request;
@@ -12,19 +13,22 @@ use crate::jsonrpc::types::{JsonRequest, Params};
 
 pub const INFURA_BASE_HTTP_URL: &str = "https://mainnet.infura.io:443/v3/";
 pub const INFURA_BASE_WS_URL: &str = "wss://mainnet.infura.io:443/ws/v3/";
+pub const DEFAULT_LOCAL_PROVIDER: &str = "http://127.0.0.1:8545";
 
 // Type used for parsing cli args
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TrustedProviderType {
     Infura,
-    Geth,
+    Pandaops,
+    Custom,
 }
 
 impl fmt::Display for TrustedProviderType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Infura => write!(f, "infura"),
-            Self::Geth => write!(f, "geth"),
+            Self::Pandaops => write!(f, "pandaops"),
+            Self::Custom => write!(f, "custom"),
         }
     }
 }
@@ -36,8 +40,9 @@ impl FromStr for TrustedProviderType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "geth" => Ok(TrustedProviderType::Geth),
+            "pandaops" => Ok(TrustedProviderType::Pandaops),
             "infura" => Ok(TrustedProviderType::Infura),
+            "custom" => Ok(TrustedProviderType::Custom),
             _ => panic!("Invalid trusted provider arg: {s} is not an option."),
         }
     }
@@ -56,18 +61,26 @@ impl TrustedProvider {
     pub fn from_trin_config(trin_config: &TrinConfig) -> Self {
         let trusted_http_client = match trin_config.trusted_provider {
             TrustedProviderType::Infura => build_infura_http_client_from_env(),
-            TrustedProviderType::Geth => match trin_config.geth_url.clone() {
-                Some(val) => build_geth_http_client_from_env(val),
+            TrustedProviderType::Pandaops => match &trin_config.trusted_provider_url {
+                Some(val) => build_pandaops_http_client_from_env(val.to_string()),
                 None => {
-                    panic!("Must supply --geth-url cli flag to use Geth as a trusted provider.")
+                    panic!("Must supply --trusted-provider-url cli flag to use pandaops as a trusted provider.")
                 }
+            },
+            TrustedProviderType::Custom => match trin_config.trusted_provider_url.clone() {
+                Some(val) => build_custom_provider_http_client(val),
+                None => build_custom_provider_http_client(
+                    Url::parse(DEFAULT_LOCAL_PROVIDER)
+                        .expect("Could not parse default local provider."),
+                ),
             },
         };
         let trusted_ws_url = match trin_config.trusted_provider {
             TrustedProviderType::Infura => Some(build_infura_ws_url_from_env()),
-            TrustedProviderType::Geth => {
-                panic!("Geth connection is not currently supported over websockets.")
+            TrustedProviderType::Pandaops => {
+                panic!("Pandaops connection is not currently supported over websockets.")
             }
+            TrustedProviderType::Custom => None,
         };
         Self {
             http: trusted_http_client,
@@ -112,31 +125,35 @@ fn build_infura_ws_url_from_env() -> String {
     format!("{INFURA_BASE_WS_URL}{infura_project_id}")
 }
 
-fn get_geth_client_id_from_env() -> String {
-    match env::var("GETH_CLIENT_ID") {
+fn get_pandaops_client_id_from_env() -> String {
+    match env::var("PANDAOPS_CLIENT_ID") {
         Ok(val) => val,
         Err(_) => panic!(
-            "Must supply Geth client id as environment variable, like:\n\
-            GETH_CLIENT_ID=\"your-key-here\" trin"
+            "Must supply pandaops client id as environment variable, like:\n\
+            PANDAOPS_CLIENT_ID=\"your-key-here\" trin"
         ),
     }
 }
 
-fn get_geth_client_secret_from_env() -> String {
-    match env::var("GETH_CLIENT_SECRET") {
+fn get_pandaops_client_secret_from_env() -> String {
+    match env::var("PANDAOPS_CLIENT_SECRET") {
         Ok(val) => val,
         Err(_) => panic!(
-            "Must supply Geth client secret as environment variable, like:\n\
-            GETH_CLIENT_SECRET=\"your-key-here\" trin"
+            "Must supply pandaops client secret as environment variable, like:\n\
+            PANDAOPS_CLIENT_SECRET=\"your-key-here\" trin"
         ),
     }
 }
 
-fn build_geth_http_client_from_env(geth_url: String) -> ureq::Request {
-    let client_id = get_geth_client_id_from_env();
-    let client_secret = get_geth_client_secret_from_env();
-    ureq::post(&geth_url)
+fn build_pandaops_http_client_from_env(pandaops_url: String) -> ureq::Request {
+    let client_id = get_pandaops_client_id_from_env();
+    let client_secret = get_pandaops_client_secret_from_env();
+    ureq::post(&pandaops_url)
         .set("Content-Type", "application/json")
         .set("CF-Access-Client-Id", client_id.as_str())
         .set("CF-Access-Client-Secret", client_secret.as_str())
+}
+
+fn build_custom_provider_http_client(node_url: Url) -> ureq::Request {
+    ureq::post(node_url.as_str()).set("Content-Type", "application/json")
 }


### PR DESCRIPTION
### What was wrong?

As noted in #509, Trin sometimes requires a connection to a trusted provider, however was no alternative to 
Infura. 

### How was it fixed?

Added:
- CLI flag `--trusted-provider`
    - New option `custom` 
    - Altered option `geth` -> `pandaops`
- `Url` library (see below)
- CLI flag `--trusted-provider-url` 
     - Accepts a url, such as `http://127.0.0.1:8545` that is parsed with `Url` library
     - Is required for the `custom` and `pandaops` trusted provider arguments
- Documentation in `./docs/getting_started.md`
- Flag testing for invalid combinations
- Requirement that `--trusted-provider custom` choice requires the `--trusted-provider-url`.
- ~~The ability to pass a either `http://127.0...` or `127.0...`~~. Urls are parsed for correctness, and must have a base otherwise the CLI parser will panic and return an appropriate parsing message.
- Url library is also used for `web3-http-address`
- Port clash detection for trusted provider (non-trin) and trin web3 ports.

### Validation
Started execution node on port 8545.

Started Trin with the following flags:
```sh
RUST_LOG=debug cargo run -- \
    --trusted-provider custom \
    --trusted-provider-url http://127.0.0.1:8545 \
    --web3-http-address http://127.0.0.1:8547 \
    --web3-transport http \
    --discovery-port 9009 \
    --bootnodes default \
    --kb 200000 \
    --no-stun
```
Called `eth_blockNumber` on port 8545 (Execution node's port) and received a response.

Called `eth_blockNumber` (requires trusted provider) on port 8547 (Trin's port) and received a response as follows:

```sh
curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_blockNumber", "params": [], "id":1}' localhost:8547

> {"jsonrpc":"2.0","id":1,"result":"0xfada96"} 
```
Which is block `16_439_958`.
### Interface
Running `cargo run -- --help`, the changed and new flag docs respectively are shown:
```sh
...
        --trusted-provider <trusted-provider>
            Trusted provider to use. (options: 'infura' (default), 'pandaops' (devops) or 'custom') [default: infura]

        --trusted-provider-url <trusted-provider-url>
            URL for a trusted http provider. Must include a base, host and port (e.g., '<base>://<host>:<port>').
...
```
## Panics
The following panic scenarios are introduced to enforce correct flag use:

With: `cargo run -- --trusted-provider-url http://127.0.0.1:8546`
```sh
thread 'main' panicked at '--trusted-provider-url flag is incompatible with infura as the trusted provider.', trin-core/src/cli.rs:194:48
```
With `cargo run -- --trusted-provider custom`
```sh
thread 'main' panicked at ''--trusted-provider custom' choice requires the --trusted-provider-url flag.', trin-core/src/cli.rs:202:48
```
With `cargo run -- --trusted-provider custom --trusted-provider-url http://127.0.0.1:8545 --web3-transport http`
```sh
thread 'main' panicked at '--trusted-provider-url and --web3-http-address cannot have the same localhost port.', trin-core/src/cli.rs:215:21
```
# To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
- [x] Run cargo clippy and cargo fmt 
- [x] Get unit tests passing 
- ~~[ ] Run peertest~~ (deprecated)
