### PR TITLE
Add vs-code config guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 .idea
 .python-version
+.vscode

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -52,7 +52,7 @@ cargo run
 Note: You may also pass environment variable values in the same command as the run command. This is especially useful for setting log levels.
 
 ```sh
-RUST_LOG=debug cargo run 
+RUST_LOG=debug cargo run
 ```
 
 View CLI options:
@@ -72,7 +72,7 @@ cargo run -- --bootnodes default
 To establish a connection with a specific peer, pass in one or more bootnode ENRs. Pass the ENR as the value for the `--bootnodes` CLI flag.
 
 ```sh
-cargo run -- --bootnodes <bootnode-enr> 
+cargo run -- --bootnodes <bootnode-enr>
 ```
 
 ## Default data directories
@@ -175,12 +175,12 @@ cargo run -p trin-cli -- json-rpc discv5_nodeInfo
 
 You can send a message from the local node to a bootnode using JSON-RPC, automatically adding the bootnode to your routing table.
 
-Find a [testnet bootnode ENR](https://github.com/ethereum/portal-network-specs/blob/master/testnet.md). 
+Find a [testnet bootnode ENR](https://github.com/ethereum/portal-network-specs/blob/master/testnet.md).
 
 Send a `PING` to the node on any of the Portal sub-networks (currently, only history and state are supported in Trin).
 
 ```sh
-cargo run -p trin-cli -- json-rpc portal_historyPing --params <enr> 
+cargo run -p trin-cli -- json-rpc portal_historyPing --params <enr>
 ```
 
 After pinging a bootnode, you should be able to see the messages being sent and received in your node's logs. Now you can check your routing table again, where you should see the pinged bootnode (along with other nodes the bootnode shared with you). Congrats! You're now connected to the Portal Network testnet.
@@ -194,7 +194,7 @@ The encoding for the content key depends on the kind of content that the key ref
 See available content keys (e.g. block header):
 
 ```sh
-cargo run -p trin-cli -- encode-key -h 
+cargo run -p trin-cli -- encode-key -h
 ```
 
 See arguments for a specific content key:
@@ -206,7 +206,7 @@ cargo run -p trin-cli -- encode-key block-header -h
 Example:
 
 ```sh
-$ cargo run -p trin-cli -- encode-key block-body --block-hash 59834fe81c78b1838745e4ac352e455ec23cb542658cbba91a4337759f5bf3fc 
+$ cargo run -p trin-cli -- encode-key block-body --block-hash 59834fe81c78b1838745e4ac352e455ec23cb542658cbba91a4337759f5bf3fc
 ```
 
 ### Request Content
@@ -223,15 +223,65 @@ cargo run -p trin-cli -- json-rpc portal_historyFindContent --params <enr>,<cont
 2. Run Prometheus: `docker run -d -p 9090:9090 -v /absolute/path/to/trin/docs/metrics_config:/etc/prometheus prom/prometheus`. Set the correct absolute path to your copy of Trin's `docs/metrics_config/`.
 3. Run Grafana: `docker run -d -p 3000:3000 -e "GF_INSTALL_PLUGINS=yesoreyeram-infinity-datasource" grafana/grafana:latest`.
 4. Start your Trin process with `--enable-metrics-with-url 127.0.0.1:9100 --web3-transport http`.
-	- The `--enable-metrics-with-url` parameter is the address that Trin exports metrics to, and should be equal to the port to which your Prometheus server is targeting at the bottom of `metrics_config/prometheus.yml`. 
+	- The `--enable-metrics-with-url` parameter is the address that Trin exports metrics to, and should be equal to the port to which your Prometheus server is targeting at the bottom of `metrics_config/prometheus.yml`.
     - The `--web-transport http` will allow Grafana to request routing table information from Trin via JSON-RPC over HTTP.
-5. From the root of the Trin repo, run `cargo run -p trin-cli -- create-dashboard`. If you used different ports than detailed in the above steps, or you are not using docker, then this command's defaults will not work. Run the command with the `-h` flag to see how to provide non-default addresses or credentials. 
+5. From the root of the Trin repo, run `cargo run -p trin-cli -- create-dashboard`. If you used different ports than detailed in the above steps, or you are not using docker, then this command's defaults will not work. Run the command with the `-h` flag to see how to provide non-default addresses or credentials.
 6. Upon successful dashboard creation, navigate to the dashboard URL that the `create-dashboard` outputs. Use `admin`/`admin` to login.
 
 ## Gotchas
 
-- If `create-dashboard` fails with an error, the most likely reason is that it has already been run. From within the Grafana UI, delete the "json-rpc" and    "prometheus" datasources and the "trin" dashboard and re-run the command. 
+- If `create-dashboard` fails with an error, the most likely reason is that it has already been run. From within the Grafana UI, delete the "json-rpc" and    "prometheus" datasources and the "trin" dashboard and re-run the command.
 
 - There is a limit on concurrent connections given by the threadpool. At last
   doc update, that number was 2, but will surely change. If you leave
   connections open, then new connections will block.
+
+## IDE Configuration
+
+### VS Code
+
+Set up a "Run and Debug" configuration to pass flags
+and environment variables. This enables the use of debug breakpoints.
+
+Below is an example `./.vscode/launch.json` file with custom flags (`"args"`)
+and environment variables (`"env"`). The commannd will be available in
+the "Run and Debug" drop down menu.
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug 'trin' with local provider",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=trin",
+                    "--package=trin"
+                ],
+                "filter": {
+                    "name": "trin",
+                    "kind": "bin"
+                }
+            },
+            "args": [
+                "--trusted-provider", "local",
+                "--local-provider-url", "127.0.0.1:8545",
+                "--web3-http-address", "127.0.0.1:8547",
+                "--web3-transport", "http",
+                "--discovery-port", "9009",
+                "--bootnodes", "default",
+                "--kb", "200000",
+                "--no-stun"
+            ],
+            "env": {
+                "RUST_BACKTRACE": "1",
+                "RUST_LOG": "info"
+            },
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}
+```

--- a/newsfragments/511.doc.md
+++ b/newsfragments/511.doc.md
@@ -1,0 +1,1 @@
+Added docs for debug configuration in VS Code.


### PR DESCRIPTION
### What was wrong?

Setting up debug breakpoints was tricky in VS Code (issue #511).

### How was it fixed?

Added:
- Example vs code configuration file at the bottom of `./docs/getting_started.md`.
    - Includes how to pass flags and set environment variables 
- To `.vscode` to `.gitignore` to prevent configs from being committed.

Now a config can be created once and run with a click. This means that debug breakpoints set will be triggered
when calling Trin from another program. This can be helpful to trigger/detect certain pathways and see values at runtime.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
