### PR TITLE
chore: bump rust from 1.62.0 to 1.66.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
     environment:
       IMAGE_NAME: ogenev/trin
     docker:
-      - image: cimg/rust:1.66.0
+      - image: cimg/rust:1.66.1
 jobs:
   docker-build:
     executor: docker-publisher
@@ -44,7 +44,7 @@ jobs:
         resource_class: xlarge
         executor:
             name: rust/default
-            tag: 1.66.0
+            tag: 1.66.1
         environment:
             RUSTFLAGS: '-D warnings'
             RUST_LOG: 'debug'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
     environment:
       IMAGE_NAME: ogenev/trin
     docker:
-      - image: cimg/rust:1.62.0
+      - image: cimg/rust:1.66.0
 jobs:
   docker-build:
     executor: docker-publisher
@@ -44,7 +44,7 @@ jobs:
         resource_class: xlarge
         executor:
             name: rust/default
-            tag: 1.62.0
+            tag: 1.66.0
         environment:
             RUSTFLAGS: '-D warnings'
             RUST_LOG: 'debug'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "trin"
 version = "0.1.0"
 authors = ["Jacob Kaufmann <jacobkaufmann18@gmail.com>", "Jason Carver <ut96caarrs@snkmail.com>"]
 edition = "2021"
-rust-version = "1.62.0"
+rust-version = "1.66.0"
 default-run = "trin"
 repository = "https://github.com/ethereum/trin"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "trin"
 version = "0.1.0"
 authors = ["Jacob Kaufmann <jacobkaufmann18@gmail.com>", "Jason Carver <ut96caarrs@snkmail.com>"]
 edition = "2021"
-rust-version = "1.66.0"
+rust-version = "1.66.1"
 default-run = "trin"
 repository = "https://github.com/ethereum/trin"
 


### PR DESCRIPTION
### What was wrong?

current rust version is `1.62.0`

### How was it fixed?

bump rust version to `1.66.1` in `Cargo.toml` and circle CI config

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
