### PR TITLE
fix: bump rust Docker image to 1.66.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # select build image
-FROM rust:1.62 AS builder
+FROM rust:1.66.1 AS builder
 
 # create a new empty shell project
 RUN USER=root cargo new --bin trin


### PR DESCRIPTION
### What was wrong?

#515 did not bump the rust Docker image version so the Docker image fails to build

### How was it fixed?

bump rust Docker image from `1.62` to `1.66.1`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
