### PR TITLE
`ethportal-api`: Add `bytes()` to `OverlayContentKey`

### DIFF
--- a/newsfragments/518.added.md
+++ b/newsfragments/518.added.md
@@ -1,0 +1,1 @@
+Added bytes() method to ethportal-api ContentKey. 


### PR DESCRIPTION
### What was wrong?

As noted in #518, there was no explicit way to access the bytes of an `OverlayContentKey`.

Closes #518 

### How was it fixed?

```rs
pub trait OverlayContentKey:
    Into<Vec<u8>> + TryFrom<Vec<u8>> + Clone + fmt::Debug + fmt::Display 
{
    /* snip */
    /// Returns the bytes of the content key.
    fn bytes(&self) -> [u8; 33]; // <-- New
}
```

With implementation:
```rs
fn bytes(&self) -> [u8; 33] {
    let mut bytes = [0u8; 33];
    let (selector, hash) = match self {
        HistoryContentKey::BlockHeader(k) => (0x00, k.block_hash),
        HistoryContentKey::BlockBody(k) => (0x01, k.block_hash),
        HistoryContentKey::BlockReceipts(k) => (0x02, k.block_hash),
        HistoryContentKey::EpochAccumulator(k) => (0x03, k.epoch_hash.0),
    };
    for (i, byte) in hash.into_iter().enumerate() {
        bytes[i] = byte
    }
    bytes.rotate_right(1);
    bytes[0] = selector;
    bytes
}
```

- Added `bytes()` method
- Updated `ethportal-api` tests to test/demonstrate use
### Usage
Before:
```rs
let key_bytes: Vec<u8> = key.clone().into();
do_thing(key_bytes);
```
After:
```rs
do_thing(key.bytes());
```
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
