### PR TITLE
bump minor ver for ethportal-api new method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,7 @@ checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
 
 [[package]]
 name = "ethportal-api"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "bytes 1.3.0",
  "enr 0.7.0",

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethportal-api"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 description = "Definitions for various Ethereum Portal Network JSONRPC APIs"
 license = "GPL-3.0"


### PR DESCRIPTION
### What was wrong?

New method was added, but neglected to bump `0.x.0` with the change

### How was it fixed?

`0.1.3` -> `0.2.0`

