### PR TITLE
Updates source node radius on `PING`/`PONG`

### DIFF
--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -1383,6 +1383,13 @@ where
                 self.request_node(&node.enr());
             }
         }
+
+        let data_radius: Distance = pong.custom_payload.into();
+        let updated_node = Node {
+            enr: source,
+            data_radius: data_radius,
+        };
+        self.kbuckets.write().update_node(&key, updated_node, None);
     }
 
     /// Processes a Nodes response.

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -1145,7 +1145,7 @@ where
     }
 
     /// Processes a ping request from some source node.
-    fn process_ping(&mut self, ping: Ping, source: NodeId) {
+    fn process_ping(&self, ping: Ping, source: NodeId) {
         // Look up the node in the routing table.
         let key = kbucket::Key::from(source);
         let optional_node = match self.kbuckets.write().entry(&key) {
@@ -1164,6 +1164,11 @@ where
             // table entry, then request the node.
             if node.enr().seq() < ping.enr_seq {
                 self.request_node(&node.enr());
+            }
+
+            let data_radius: Distance = ping.custom_payload.into();
+            if node.data_radius != data_radius {
+                self.update_node_radius(node.enr(), data_radius);
             }
         }
     }
@@ -1360,7 +1365,7 @@ where
     /// Processes a Pong response.
     ///
     /// Refreshes the node if necessary. Attempts to mark the node as connected.
-    fn process_pong(&mut self, pong: Pong, source: Enr) {
+    fn process_pong(&self, pong: Pong, source: Enr) {
         let node_id = source.node_id();
         trace!(
             protocol = %self.protocol,
@@ -1382,14 +1387,28 @@ where
             if node.enr().seq() < pong.enr_seq {
                 self.request_node(&node.enr());
             }
-        }
 
-        let data_radius: Distance = pong.custom_payload.into();
-        let updated_node = Node {
-            enr: source,
-            data_radius: data_radius,
+            let data_radius: Distance = pong.custom_payload.into();
+            if node.data_radius != data_radius {
+                self.update_node_radius(source, data_radius);
+            }
+        }
+    }
+
+    /// Update the recorded radius of a node in our routing table.
+    fn update_node_radius(&self, enr: Enr, data_radius: Distance) {
+        let node_id = enr.node_id();
+        let key = kbucket::Key::from(node_id);
+
+        let updated_node = Node { enr, data_radius };
+
+        if let UpdateResult::Failed(_) = self.kbuckets.write().update_node(&key, updated_node, None)
+        {
+            error!(
+                "Failed to update radius of node {}",
+                hex_encode_compact(node_id.raw())
+            );
         };
-        self.kbuckets.write().update_node(&key, updated_node, None);
     }
 
     /// Processes a Nodes response.

--- a/trin-core/src/portalnet/types/messages.rs
+++ b/trin-core/src/portalnet/types/messages.rs
@@ -59,6 +59,13 @@ impl From<Vec<u8>> for CustomPayload {
     }
 }
 
+impl Into<Distance> for CustomPayload {
+    fn into(self) -> Distance {
+        let bytes = self.payload;
+        U256::from_little_endian(bytes.deref()).into()
+    }
+}
+
 impl ssz::Decode for CustomPayload {
     fn is_ssz_fixed_len() -> bool {
         false


### PR DESCRIPTION
### What was wrong?

Trin's processing of `PING`/`PONG` messages is not updating the radius of the source node in the routing table. This results in Trin's gossip functionality sending `OFFER`s to nodes that are not interested in the data based on their radius. These nodes respond with `ACCEPT` messages, but they are empty implying no interest.

### How was it fixed?

Interpret `PING` and `PONG` custom payload field as a 32 byte, little endian representation of an unsigned 256 bit radius value and update the routing table entry.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
