### PR TITLE
Add purge db script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4982,15 +4982,19 @@ dependencies = [
 name = "trin"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "discv5",
  "enr 0.7.0",
+ "eth2_ssz",
  "ethereum-types 0.12.1",
+ "ethportal-api",
  "ethportal-peertest",
  "hex",
  "parking_lot 0.11.2",
  "prometheus_exporter",
  "rand 0.8.5",
  "rlp 0.5.2",
+ "rocksdb",
  "serde_json",
  "sha3 0.9.1",
  "structopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,18 @@ repository = "https://github.com/ethereum/trin"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.57"
 discv5 = { git = "https://github.com/sigp/discv5.git", branch = "master" }
 enr = { version = "=0.7.0", features = ["k256", "ed25519"] }
+eth2_ssz = "0.4.0"
 ethereum-types = "0.12.1"
+ethportal-api = { path = "ethportal-api" }
 hex = "0.4.3"
 parking_lot = "0.11.2"
 prometheus_exporter = "0.8.4"
 rand = "0.8.4"
 rlp = "0.5.0"
+rocksdb = "0.18.0"
 serde_json = {version = "1.0.59", features = ["preserve_order"]}
 sha3 = "0.9.1"
 structopt = "0.3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY --from=builder /trin/trin-core/src/assets/merge_macc.bin ./trin/trin-core/s
 # copy build artifacts from build stage
 COPY --from=builder /trin/target/release/trin /usr/bin/
 COPY --from=builder /trin/target/release/trin-cli /usr/bin/
+COPY --from=builder /trin/target/release/purge_db /usr/bin/
 
 ENV RUST_LOG=debug
 

--- a/newsfragments/526.added.md
+++ b/newsfragments/526.added.md
@@ -1,0 +1,1 @@
+Added util script to purge all / invalid data from storage.

--- a/src/bin/purge_db.rs
+++ b/src/bin/purge_db.rs
@@ -1,0 +1,140 @@
+use std::str::FromStr;
+
+use anyhow::anyhow;
+use discv5::enr::{CombinedKey, EnrBuilder};
+use rocksdb::IteratorMode;
+use ssz::Decode;
+use structopt::StructOpt;
+use tracing::{info, warn};
+
+use ethportal_api::types::accumulator::EpochAccumulator;
+use ethportal_api::types::block_body::BlockBody;
+use ethportal_api::types::block_header::BlockHeaderWithProof;
+use ethportal_api::types::content_key::HistoryContentKey;
+use ethportal_api::types::receipts::BlockReceipts;
+use trin_core::portalnet::storage::{PortalStorage, PortalStorageConfig};
+use trin_core::portalnet::types::messages::ProtocolId;
+use trin_core::utils::db::get_data_dir;
+
+///
+/// This script will iterate through all content id / key pairs in rocksd & meta db.
+/// However, if it is run in "invalid-only" mode, it will error if it encounters any
+/// non-history network content. Since we only support history network content, this
+/// shouldn't be a problem, but as we add support for more sub-networks this script will
+/// need to be updated to avoid panicking.
+///
+pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let purge_config = PurgeConfig::from_args();
+
+    let mut encoded = hex::decode(&purge_config.private_key).unwrap();
+    let enr_key = CombinedKey::secp256k1_from_bytes(&mut encoded).unwrap();
+    let enr = EnrBuilder::new("v4").build(&enr_key).unwrap();
+    let node_id = enr.node_id();
+    let data_dir_path = get_data_dir(node_id);
+    info!("Purging data for NodeID: {}", node_id);
+    info!("DB Path: {:?}", data_dir_path);
+
+    // Capacity is 0 since it (eg. for data radius calculation) is irrelevant when only removing data.
+    let capacity = 0;
+    let protocol = ProtocolId::History;
+    let config = PortalStorageConfig::new(capacity, node_id, false);
+    let storage = PortalStorage::new(config.clone(), protocol).unwrap();
+    let iter = config.db.iterator(IteratorMode::Start);
+    let mut item_count = 0;
+    let mut remove_count = 0;
+    for (id, value) in iter {
+        item_count += 1;
+        let mut content_id = [0u8; 32];
+        content_id.copy_from_slice(&id);
+        match purge_config.mode {
+            PurgeMode::All => match storage.evict(content_id) {
+                Ok(_) => remove_count += 1,
+                Err(err) => warn!(
+                    "Error occurred while evicting content id: {:?} - {:?}",
+                    content_id, err
+                ),
+            },
+            PurgeMode::Invalid => {
+                // naked unwrap since we shouldn't be storing any invalid content keys
+                let key = match storage.lookup_content_key(content_id).unwrap() {
+                    Some(val) => val,
+                    None => {
+                        warn!(
+                            "Couldn't find corresponding content key in meta db for content id: {:?}",
+                            content_id
+                        );
+                        continue;
+                    }
+                };
+                let content_key = HistoryContentKey::try_from(key).unwrap();
+                if !is_content_valid(&content_key, &value.into_vec()) {
+                    match storage.evict(content_id) {
+                        Ok(_) => remove_count += 1,
+                        Err(err) => warn!(
+                            "Error occurred while evicting content key: {:?} - {:?}",
+                            content_key, err
+                        ),
+                    }
+                }
+            }
+        }
+    }
+    info!(
+        "Found {:?} total items - Removed {:?} items",
+        item_count, remove_count
+    );
+    Ok(())
+}
+
+fn is_content_valid(content_key: &HistoryContentKey, value: &[u8]) -> bool {
+    match content_key {
+        HistoryContentKey::BlockHeaderWithProof(_) => {
+            BlockHeaderWithProof::from_ssz_bytes(value).is_ok()
+        }
+        HistoryContentKey::BlockBody(_) => BlockBody::from_ssz_bytes(value).is_ok(),
+        HistoryContentKey::BlockReceipts(_) => BlockReceipts::from_ssz_bytes(value).is_ok(),
+        HistoryContentKey::EpochAccumulator(_) => EpochAccumulator::from_ssz_bytes(value).is_ok(),
+    }
+}
+
+// CLI Parameter Handling
+#[derive(StructOpt, Debug, PartialEq)]
+#[structopt(
+    name = "Trin DB Purge Util",
+    about = "Remove undesired or invalid data from Trin DB"
+)]
+pub struct PurgeConfig {
+    #[structopt(
+        long,
+        help = "(unsafe) Hex private key to generate node id for database namespace"
+    )]
+    pub private_key: String,
+
+    #[structopt(
+        default_value = "all",
+        possible_values(&["all", "invalid-only"]),
+        long,
+        help = "Purge all content or only invalidly encoded content"
+    )]
+    pub mode: PurgeMode,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum PurgeMode {
+    All,
+    Invalid,
+}
+
+impl FromStr for PurgeMode {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        match s {
+            "all" => Ok(Self::All),
+            "invalid-only" => Ok(Self::Invalid),
+            _ => Err(anyhow!(
+                "Invalid purge mode provided. Possible values include `all` and `invalid-only`"
+            )),
+        }
+    }
+}


### PR DESCRIPTION
### What was wrong?
After #514 we will have testnet nodes that contain invalid / outdated data. Also following the discussion [here](https://github.com/ethereum/portal-network-specs/pull/177#discussion_r1068003004) it is now expected that we might have to occasionally purge the data from our testnet due to spec updates / etc.

### How was it fixed?
Add a script that can be easily run in our testnet deployment ansible playbook to either flush all data from a node's db - or iterate through and evict only incorrectly encoded data.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
