### PR TITLE
Do not gossip to disconnected nodes

### DIFF
--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -347,13 +347,14 @@ where
         kbuckets: Arc<RwLock<KBucketsTable<NodeId, Node>>>,
         command_tx: UnboundedSender<OverlayCommand<TContentKey>>,
     ) -> usize {
-        // Get all nodes from overlay routing table
+        // Get all connected nodes from overlay routing table
         let kbuckets = kbuckets.read();
         let all_nodes: Vec<&kbucket::Node<NodeId, Node>> = kbuckets
             .buckets_iter()
             .map(|kbucket| {
                 kbucket
                     .iter()
+                    .filter(|node| node.status.is_connected())
                     .collect::<Vec<&kbucket::Node<NodeId, Node>>>()
             })
             .flatten()


### PR DESCRIPTION
### What was wrong?

Trin currently gossips to nodes without regard for whether the routing table shows them as disconnected or not.

### How was it fixed

Nodes are filtered by connection status before gossiping.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Filter disconnected before gossiping
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
