### PR TITLE
add hex string method to overlaycontentkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,10 +1563,12 @@ dependencies = [
  "jsonrpsee 0.16.2",
  "reth-primitives",
  "reth-rlp",
+ "rstest 0.16.0",
  "serde",
  "serde-hex",
  "serde_json",
  "sha2 0.10.6",
+ "thiserror",
 ]
 
 [[package]]
@@ -4443,6 +4445,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f2d176c472198ec1e6551dc7da28f1c089652f66a7b722676c2238ebc0edf"
+dependencies = [
+ "futures 0.3.26",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.0",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
 name = "ruint"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5787,7 +5815,7 @@ dependencies = [
  "rlp 0.5.2",
  "rlp-derive",
  "rocksdb",
- "rstest",
+ "rstest 0.11.0",
  "rusqlite",
  "serde",
  "serde_json",

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -25,3 +25,7 @@ serde = { version = "1.0.150", features = ["derive"] }
 serde_json = "1.0.89"
 serde-hex = "0.1.0"
 sha2 = "0.10.1"
+thiserror = "1.0.38"
+
+[dev-dependencies]
+rstest = "0.16.0"

--- a/ethportal-api/src/lib.rs
+++ b/ethportal-api/src/lib.rs
@@ -6,6 +6,7 @@
 mod discv5;
 mod history;
 pub mod types;
+pub mod utils;
 mod web3;
 
 pub use discv5::{Discv5ApiClient, Discv5ApiServer};

--- a/ethportal-api/src/types/content_key.rs
+++ b/ethportal-api/src/types/content_key.rs
@@ -5,6 +5,8 @@ use ssz::{self, Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use std::fmt;
 
+use crate::utils::bytes::{hex_decode, hex_encode, hex_encode_compact};
+
 /// Types whose values represent keys to lookup content items in an overlay network.
 /// Keys are serializable.
 pub trait OverlayContentKey:
@@ -15,6 +17,10 @@ pub trait OverlayContentKey:
     fn content_id(&self) -> [u8; 32];
     /// Returns the bytes of the content key.
     fn to_bytes(&self) -> Vec<u8>;
+    /// Returns the content key as a hex encoded "0x"-prefixed string.
+    fn to_hex(&self) -> String {
+        hex_encode(self.to_bytes())
+    }
 }
 
 /// A content key in the history overlay network.
@@ -38,36 +44,7 @@ impl Serialize for HistoryContentKey {
     where
         S: Serializer,
     {
-        match self {
-            HistoryContentKey::BlockHeaderWithProof(block_header) => {
-                let ssz_bytes = block_header.as_ssz_bytes();
-                let hex_bytes = hex::encode(ssz_bytes);
-                let selector = "00";
-                serializer.serialize_str(&format!("0x{selector}{hex_bytes}"))
-            }
-            HistoryContentKey::BlockBody(block_body) => {
-                let ssz_bytes = block_body.as_ssz_bytes();
-                let hex_bytes = hex::encode(ssz_bytes);
-                let selector = "01";
-                serializer.serialize_str(&format!("0x{selector}{hex_bytes}"))
-            }
-            HistoryContentKey::BlockReceipts(block_receipt) => {
-                let ssz_bytes = block_receipt.as_ssz_bytes();
-                let hex_bytes = hex::encode(ssz_bytes);
-                let selector = "02";
-                serializer.serialize_str(&format!("0x{selector}{hex_bytes}"))
-            }
-            HistoryContentKey::EpochAccumulator(block_accumulator) => {
-                let ssz_bytes = block_accumulator.as_ssz_bytes();
-                let hex_bytes = hex::encode(ssz_bytes);
-                let selector = "03";
-                serializer.serialize_str(&format!("0x{selector}{hex_bytes}"))
-            }
-            HistoryContentKey::Unknown(value) => {
-                let hex_bytes = hex::encode(value.as_ssz_bytes());
-                serializer.serialize_str(&format!("0x{hex_bytes}"))
-            }
-        }
+        serializer.serialize_str(&self.to_hex())
     }
 }
 
@@ -85,7 +62,7 @@ impl<'de> Deserialize<'de> for HistoryContentKey {
             )));
         }
 
-        let ssz_bytes = hex::decode(&data[2..]).map_err(de::Error::custom)?;
+        let ssz_bytes = hex_decode(&data).map_err(de::Error::custom)?;
 
         match HistoryContentKey::from_ssz_bytes(&ssz_bytes) {
             Ok(content_key) => Ok(content_key),
@@ -211,22 +188,11 @@ impl OverlayContentKey for HistoryContentKey {
     }
 }
 
-/// Returns a compact hex-encoded `String` representation of `data`.
-pub fn hex_encode_compact<T: AsRef<[u8]>>(data: T) -> String {
-    if data.as_ref().len() <= 8 {
-        format!("0x{}", hex::encode(data))
-    } else {
-        let hex = hex::encode(data);
-        format!("0x{}..{}", &hex[0..4], &hex[hex.len() - 4..])
-    }
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
-
-    use hex;
+    use crate::utils::bytes::hex_decode;
 
     //
     // History Network Content Key Tests
@@ -240,9 +206,9 @@ mod test {
 
     #[test]
     fn block_header() {
-        let expected_content_key =
-            hex::decode("00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d")
-                .unwrap();
+        const KEY_STR: &str =
+            "0x00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d";
+        let expected_content_key = hex_decode(KEY_STR).unwrap();
         let expected_content_id: [u8; 32] = [
             0x3e, 0x86, 0xb3, 0x76, 0x7b, 0x57, 0x40, 0x2e, 0xa7, 0x2e, 0x36, 0x9a, 0xe0, 0x49,
             0x6c, 0xe4, 0x7c, 0xc1, 0x5b, 0xe6, 0x85, 0xbe, 0xc3, 0xb4, 0x72, 0x6b, 0x9f, 0x31,
@@ -257,13 +223,18 @@ mod test {
 
         assert_eq!(key.to_bytes(), expected_content_key);
         assert_eq!(key.content_id(), expected_content_id);
+        assert_eq!(
+            key.to_string(),
+            "BlockHeaderWithProof { block_hash: 0xd1c3..621d }"
+        );
+        assert_eq!(key.to_hex(), KEY_STR);
     }
 
     #[test]
     fn block_body() {
-        let expected_content_key =
-            hex::decode("01d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d")
-                .unwrap();
+        const KEY_STR: &str =
+            "0x01d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d";
+        let expected_content_key = hex_decode(KEY_STR).unwrap();
         let expected_content_id: [u8; 32] = [
             0xeb, 0xe4, 0x14, 0x85, 0x46, 0x29, 0xd6, 0x0c, 0x58, 0xdd, 0xd5, 0xbf, 0x60, 0xfd,
             0x72, 0xe4, 0x17, 0x60, 0xa5, 0xf7, 0xa4, 0x63, 0xfd, 0xcb, 0x16, 0x9f, 0x13, 0xee,
@@ -278,13 +249,15 @@ mod test {
 
         assert_eq!(key.to_bytes(), expected_content_key);
         assert_eq!(key.content_id(), expected_content_id);
+        assert_eq!(key.to_string(), "BlockBody { block_hash: 0xd1c3..621d }");
+        assert_eq!(key.to_hex(), KEY_STR);
     }
 
     #[test]
     fn block_receipts() {
-        let expected_content_key =
-            hex::decode("02d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d")
-                .unwrap();
+        const KEY_STR: &str =
+            "0x02d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d";
+        let expected_content_key = hex_decode(KEY_STR).unwrap();
         let expected_content_id: [u8; 32] = [
             0xa8, 0x88, 0xf4, 0xaa, 0xfe, 0x91, 0x09, 0xd4, 0x95, 0xac, 0x4d, 0x47, 0x74, 0xa6,
             0x27, 0x7c, 0x1a, 0xda, 0x42, 0x03, 0x5e, 0x3d, 0xa5, 0xe1, 0x0a, 0x04, 0xcc, 0x93,
@@ -299,32 +272,41 @@ mod test {
 
         assert_eq!(key.to_bytes(), expected_content_key);
         assert_eq!(key.content_id(), expected_content_id);
+        assert_eq!(
+            key.to_string(),
+            "BlockReceipts { block_hash: 0xd1c3..621d }"
+        );
+        assert_eq!(key.to_hex(), KEY_STR);
     }
 
     // test values sourced from: https://github.com/ethereum/portal-network-specs/blob/master/content-keys-test-vectors.md
     #[test]
     fn epoch_accumulator_key() {
         let epoch_hash =
-            hex::decode("e242814b90ed3950e13aac7e56ce116540c71b41d1516605aada26c6c07cc491")
+            hex_decode("0xe242814b90ed3950e13aac7e56ce116540c71b41d1516605aada26c6c07cc491")
                 .unwrap();
-        let expected_content_key_encoding =
-            hex::decode("03e242814b90ed3950e13aac7e56ce116540c71b41d1516605aada26c6c07cc491")
-                .unwrap();
+        const KEY_STR: &str =
+            "0x03e242814b90ed3950e13aac7e56ce116540c71b41d1516605aada26c6c07cc491";
+        let expected_content_key = hex_decode(KEY_STR).unwrap();
         let expected_content_id =
-            &hex::decode("9fb2175e76c6989e0fdac3ee10c40d2a81eb176af32e1c16193e3904fe56896e")
+            hex_decode("0x9fb2175e76c6989e0fdac3ee10c40d2a81eb176af32e1c16193e3904fe56896e")
                 .unwrap();
 
-        let content_key = HistoryContentKey::EpochAccumulator(EpochAccumulatorKey {
+        let key = HistoryContentKey::EpochAccumulator(EpochAccumulatorKey {
             epoch_hash: H256::from_slice(&epoch_hash),
         });
-        assert_eq!(&content_key.content_id().to_vec(), expected_content_id);
-
-        let encoded_content_key: Vec<u8> = content_key.clone().into();
-        assert_eq!(encoded_content_key, expected_content_key_encoding);
 
         // round trip
-        let decoded = HistoryContentKey::try_from(encoded_content_key).unwrap();
-        assert_eq!(decoded, content_key);
+        let decoded = HistoryContentKey::try_from(key.to_bytes().to_vec()).unwrap();
+        assert_eq!(decoded, key);
+
+        assert_eq!(key.to_bytes(), expected_content_key);
+        assert_eq!(key.content_id(), expected_content_id.as_ref());
+        assert_eq!(
+            key.to_string(),
+            "EpochAccumulator { epoch_hash: 0xe242..c491 }"
+        );
+        assert_eq!(key.to_hex(), KEY_STR);
     }
 
     #[test]
@@ -383,7 +365,7 @@ mod test {
         let content_key_json =
             "\"0x03e242814b90ed3950e13aac7e56ce116540c71b41d1516605aada26c6c07cc491\"";
         let epoch_hash =
-            hex::decode("e242814b90ed3950e13aac7e56ce116540c71b41d1516605aada26c6c07cc491")
+            hex_decode("0xe242814b90ed3950e13aac7e56ce116540c71b41d1516605aada26c6c07cc491")
                 .unwrap();
         let expected_content_key = HistoryContentKey::EpochAccumulator(EpochAccumulatorKey {
             epoch_hash: H256::from_slice(&epoch_hash),

--- a/ethportal-api/src/utils/bytes.rs
+++ b/ethportal-api/src/utils/bytes.rs
@@ -1,0 +1,70 @@
+use thiserror::Error;
+
+/// A error related to hexadecimal string encoding and decoding.
+#[derive(Error, Debug)]
+pub enum HexError {
+    /// A failure to convert a string into a byte vector.
+    #[error("Could not decode hex")]
+    DecodeError(#[from] hex::FromHexError),
+    /// A failure to adhere to the convention that a hex-encoded
+    /// string must include the "0x" prefix.
+    #[error("Hex strings must start with 0x, but found {0}")]
+    PrefixError(String),
+}
+
+/// Encode hex with 0x prefix
+pub fn hex_encode<T: AsRef<[u8]>>(data: T) -> String {
+    format!("0x{}", hex::encode(data))
+}
+
+/// Decode hex with 0x prefix
+pub fn hex_decode(data: &str) -> Result<Vec<u8>, HexError> {
+    let first_two = &data[..2];
+    match first_two {
+        "0x" => hex::decode(&data[2..]).map_err(|e| e.into()),
+        _ => Err(HexError::PrefixError(first_two.to_owned())),
+    }
+}
+
+/// Returns a compact hex-encoded `String` representation of `data`.
+pub fn hex_encode_compact<T: AsRef<[u8]>>(data: T) -> String {
+    if data.as_ref().len() <= 8 {
+        hex_encode(data)
+    } else {
+        let hex = hex::encode(data);
+        format!("0x{}..{}", &hex[0..4], &hex[hex.len() - 4..])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_hex_encode() {
+        let to_encode = vec![176, 15];
+        let encoded = hex_encode(to_encode);
+        assert_eq!(encoded, "0xb00f");
+    }
+
+    #[test]
+    fn test_hex_decode() {
+        let to_decode = "0xb00f";
+        let decoded = hex_decode(to_decode).unwrap();
+        assert_eq!(decoded, vec![176, 15]);
+    }
+
+    #[test]
+    fn test_hex_decode_invalid_start() {
+        let to_decode = "b00f";
+        let result = hex_decode(to_decode);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_hex_decode_invalid_char() {
+        let to_decode = "0xb00g";
+        let result = hex_decode(to_decode);
+        assert!(result.is_err());
+    }
+}

--- a/ethportal-api/src/utils/mod.rs
+++ b/ethportal-api/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod bytes;

--- a/newsfragments/528.added.md
+++ b/newsfragments/528.added.md
@@ -1,0 +1,1 @@
+Add .to_hex() method to OverlayContentKey.


### PR DESCRIPTION
### What was wrong?

Resolves #528. 

### How was it fixed?

Adds new default method to `OverlayContentKey` trait as follows:
```rust
/// Returns the content key as a hex encoded "0x"-prefixed string.
fn to_hex(&self) -> String {
    hex_encode(self.to_bytes())
}
```
Uses `to_*` naming convention for borrowed->owned methods according to [guidelines](https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv)

Trin-native `hex_encode`/`hex_decode` are used instead of external `hex::encode`/`hex::decode`. These utils
were copied from trin-core to `ethportal-api`. 

### Testing

Added test cases for `.to_hex()` and, for comparison, the existing `.to_string()` 
```sh
// Existing .to_string()
"EpochAccumulator { epoch_hash: 0xe242..c491 }"
// New .to_hex()
"0x03e242814b90ed3950e13aac7e56ce116540c71b41d1516605aada26c6c07cc491"
```

### Usage
Used in `self.serialize()` to replace/condense existing logic.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
