### PR TITLE
rename .bytes() to .to_bytes()

### DIFF
--- a/ethportal-api/src/types/content_key.rs
+++ b/ethportal-api/src/types/content_key.rs
@@ -14,7 +14,7 @@ pub trait OverlayContentKey:
     /// The identifier locates the content in the overlay.
     fn content_id(&self) -> [u8; 32];
     /// Returns the bytes of the content key.
-    fn bytes(&self) -> [u8; 33];
+    fn to_bytes(&self) -> [u8; 33];
 }
 
 /// A content key in the history overlay network.
@@ -177,7 +177,7 @@ impl OverlayContentKey for HistoryContentKey {
         sha256.finalize().into()
     }
 
-    fn bytes(&self) -> [u8; 33] {
+    fn to_bytes(&self) -> [u8; 33] {
         let mut bytes = [0u8; 33];
         let (selector, hash) = match self {
             HistoryContentKey::BlockHeaderWithProof(k) => (0x00, k.block_hash),
@@ -237,7 +237,7 @@ mod test {
 
         let key = HistoryContentKey::BlockHeaderWithProof(header);
 
-        assert_eq!(key.bytes(), expected_content_key.as_ref());
+        assert_eq!(key.to_bytes(), expected_content_key.as_ref());
         assert_eq!(key.content_id(), expected_content_id);
     }
 
@@ -258,7 +258,7 @@ mod test {
 
         let key = HistoryContentKey::BlockBody(body);
 
-        assert_eq!(key.bytes(), expected_content_key.as_ref());
+        assert_eq!(key.to_bytes(), expected_content_key.as_ref());
         assert_eq!(key.content_id(), expected_content_id);
     }
 
@@ -279,7 +279,7 @@ mod test {
 
         let key = HistoryContentKey::BlockReceipts(receipts);
 
-        assert_eq!(key.bytes(), expected_content_key.as_ref());
+        assert_eq!(key.to_bytes(), expected_content_key.as_ref());
         assert_eq!(key.content_id(), expected_content_id);
     }
 


### PR DESCRIPTION
### What was wrong?

The recently introduced `.bytes()` method is not explicit about resources used in conversion.

### How was it fixed?
For `OverlayContentKey`:
```rs
// Before
.bytes() 
// After
.to_bytes()
```
The method is `borrowed -> owned` and so follows the naming [guidelines](https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv) 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] ~~Add~~ Modified entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md). Given that the `.bytes()` method has not yet been included in a release, the existing newsfragment was updated.
- [x] Clean up commit history
