### PR TITLE
jsonrpc: Rename `Offer` endpoint to `Gossip` and add new `Offer` call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,7 +1273,7 @@ checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
 
 [[package]]
 name = "ethportal-api"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bytes 1.3.0",
  "enr 0.7.0",

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethportal-api"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Definitions for various Ethereum Portal Network JSONRPC APIs"
 license = "GPL-3.0"

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -82,21 +82,17 @@ pub trait HistoryNetworkApi {
 
     /// Send the provided content item to interested peers. Clients may choose to send to some or all peers.
     /// Return the number of peers that the content was gossiped to.
-    #[method(name = "historyOffer")]
-    async fn offer(
+    #[method(name = "historyGossip")]
+    async fn gossip(
         &self,
         content_key: HistoryContentKey,
         content_value: HistoryContentItem,
     ) -> RpcResult<u32>;
 
-    /// Send OFFER with a set og content keys that this node has content available for.
-    /// Return the ACCEPT response.
-    #[method(name = "historySendOffer")]
-    async fn send_offer(
-        &self,
-        enr: Enr,
-        content_keys: Vec<HistoryContentKey>,
-    ) -> RpcResult<AcceptInfo>;
+    /// Send an OFFER request with given ContentKey, to the designated peer and wait for a response.
+    /// Returns the content keys bitlist upon successful content transmission or empty bitlist receive.
+    #[method(name = "historyOffer")]
+    async fn offer(&self, enr: Enr, content_key: HistoryContentKey) -> RpcResult<AcceptInfo>;
 
     /// Store content key with a content data to the local database.
     #[method(name = "historyStore")]

--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -45,7 +45,6 @@ pub enum ContentInfo {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AcceptInfo {
-    pub connection_id: u16,
     pub content_keys: BitList<typenum::U8>,
 }
 

--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -247,14 +247,6 @@ fn validate_portal_routing_table_info(result: &Value, _peertest: &Peertest) {
 }
 
 pub fn validate_portal_offer(result: &Value, _peertest: &Peertest) {
-    // Expect u64 connection id
-    let connection_id = result
-        .get("connectionId")
-        .unwrap()
-        .as_u64()
-        .unwrap()
-        .to_string();
-    assert!(connection_id.parse::<u64>().is_ok());
     // Should accept the requested content
     assert_eq!(result.get("contentKeys").unwrap().as_str(), Some("0x03"))
 }

--- a/ethportal-peertest/src/scenarios/offer_accept.rs
+++ b/ethportal-peertest/src/scenarios/offer_accept.rs
@@ -1,6 +1,6 @@
 use std::{thread, time};
 
-use serde_json::{json, Value};
+use serde_json::Value;
 use tracing::{error, info};
 
 use crate::{
@@ -30,11 +30,11 @@ pub fn test_offer_accept(peertest_config: PeertestConfig, peertest: &Peertest) {
 
     // Send offer request from testnode to bootnode
     let offer_request = JsonRpcRequest {
-        method: "portal_historySendOffer".to_string(),
+        method: "portal_historyOffer".to_string(),
         id: 11,
         params: Params::Array(vec![
             Value::String(peertest.bootnode.enr.to_base64()),
-            Value::Array(vec![json!(HISTORY_CONTENT_KEY)]),
+            Value::String(HISTORY_CONTENT_KEY.to_string()),
         ]),
     };
 

--- a/newsfragments/499.fixed.md
+++ b/newsfragments/499.fixed.md
@@ -1,0 +1,1 @@
+JSON-RPC: rename `Offer` endpoint to `Gossip` and add new `Offer` call.

--- a/rpc/src/history.rs
+++ b/rpc/src/history.rs
@@ -154,25 +154,21 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
 
     /// Send the provided content item to interested peers. Clients may choose to send to some or all peers.
     /// Return the number of peers that the content was gossiped to.
-    async fn offer(
+    async fn gossip(
         &self,
         content_key: HistoryContentKey,
         content_value: HistoryContentItem,
     ) -> RpcResult<u32> {
-        let endpoint = HistoryEndpoint::Offer(content_key, content_value);
+        let endpoint = HistoryEndpoint::Gossip(content_key, content_value);
         let result = self.proxy_query_to_history_subnet(endpoint).await?;
         let result: u32 = from_value(result)?;
         Ok(result)
     }
 
-    /// Send OFFER with a set og content keys that this node has content available for.
-    /// Return the ACCEPT response.
-    async fn send_offer(
-        &self,
-        enr: Enr,
-        content_keys: Vec<HistoryContentKey>,
-    ) -> RpcResult<AcceptInfo> {
-        let endpoint = HistoryEndpoint::SendOffer(enr, content_keys);
+    /// Send an OFFER request with given ContentKey, to the designated peer and wait for a response.
+    /// Returns the content keys bitlist upon successful content transmission or empty bitlist receive.
+    async fn offer(&self, enr: Enr, content_key: HistoryContentKey) -> RpcResult<AcceptInfo> {
+        let endpoint = HistoryEndpoint::Offer(enr, content_key);
         let result = self.proxy_query_to_history_subnet(endpoint).await?;
         let result: AcceptInfo = from_value(result)?;
         Ok(result)

--- a/trin-core/src/jsonrpc/endpoints.rs
+++ b/trin-core/src/jsonrpc/endpoints.rs
@@ -34,10 +34,10 @@ pub enum HistoryEndpoint {
     FindNodes(Enr, Vec<u16>),
     /// params: content_key
     LocalContent(HistoryContentKey),
-    /// params: [content-key, content_value]
-    Offer(HistoryContentKey, HistoryContentItem),
-    /// params: [enr, content_keys]
-    SendOffer(Enr, Vec<HistoryContentKey>),
+    /// params: [content_key, content_value]
+    Gossip(HistoryContentKey, HistoryContentItem),
+    /// params: [enr, content_key]
+    Offer(Enr, HistoryContentKey),
     /// params: [enr, data_radius]
     Ping(Enr, Option<DataRadius>),
     /// params: content_key


### PR DESCRIPTION
### What was wrong?
We need to change Trin's offer endpoints to match recent [spec changes](https://github.com/ethereum/portal-network-specs/pull/179).

Closes #499 

### How was it fixed?
Rename the `Offer` endpoint to `Gossip` and add a new `Offer` call.

- `portal_*Offer` accepts now a single content key as a parameter, instead of a list of content keys.
- Do not return `connection_id` in the offer json-rpc result.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
