### PR TITLE
Use interpolated string formatting everywhere

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -253,3 +253,5 @@ Any datatype of significance **should** have an accompanying comment briefly des
 
 ## Code Style
 - Minimize the amount of `.clone()`s used. Cloning can be a useful mechanism, but should be used with discretion. When leaned upon excessively to [satisfy the borrow checker](https://rust-unofficial.github.io/patterns/anti_patterns/borrow_clone.html) it can lead to unintended consequences.
+- Use interpolated string formatting when possible.
+  - Do `format!("words: {var:?}")` not `format!("words: {:?}", var)`

--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -296,7 +296,7 @@ pub async fn make_http_request(
     let client = Client::new();
     let req = Request::builder()
         .method(Method::POST)
-        .uri(format!("http://{}", http_address))
+        .uri(format!("http://{http_address}"))
         .header("content-type", "application/json")
         .body(Body::from(request.to_jsonrpc()))
         .unwrap();

--- a/ethportal-peertest/src/lib.rs
+++ b/ethportal-peertest/src/lib.rs
@@ -133,7 +133,7 @@ fn generate_trin_config(id: u16, bootnode_enr: Option<&SszEnr>) -> TrinConfig {
         }
         None => {
             let ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-            let external_addr = format!("{}:{}", ip_addr, discovery_port);
+            let external_addr = format!("{ip_addr}:{discovery_port}");
             let trin_config_args = vec![
                 "trin",
                 "--networks",

--- a/ethportal-peertest/src/scenarios/offer_accept.rs
+++ b/ethportal-peertest/src/scenarios/offer_accept.rs
@@ -65,7 +65,6 @@ pub fn test_offer_accept(peertest_config: PeertestConfig, peertest: &Peertest) {
     let received_content_str = received_content_value.as_str().unwrap();
     assert_eq!(
         HISTORY_CONTENT_VALUE, received_content_str,
-        "The received content {}, must match the expected {}",
-        received_content_str, HISTORY_CONTENT_VALUE
+        "The received content {received_content_str}, must match the expected {HISTORY_CONTENT_VALUE}",
     );
 }

--- a/newsfragments/545.fixed.md
+++ b/newsfragments/545.fixed.md
@@ -1,0 +1,1 @@
+Use interpolated string formatting wherever possible.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,6 @@ async fn launch_jsonrpc_server(
             tokio::spawn(handle.stopped()); //FIXME: This runs the server forever
             info!("HTTP JSON-RPC server launched.");
         }
-        val => panic!("Unsupported web3 transport: {}", val),
+        val => panic!("Unsupported web3 transport: {val}"),
     }
 }

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -23,7 +23,7 @@ mod test {
 
         let test_ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
         let test_port = 9000;
-        let external_addr = format!("{}:{}", test_ip_addr, test_port);
+        let external_addr = format!("{test_ip_addr}:{test_port}");
 
         // Run a client, to be tested
         let trin_config = TrinConfig::new_from(

--- a/trin-cli/src/main.rs
+++ b/trin-cli/src/main.rs
@@ -163,7 +163,7 @@ fn create_dashboard(dashboard_config: DashboardConfig) -> Result<(), Box<dyn std
 
     let dashboard_url = grafana.create_dashboard(json_rpc_uid, prometheus_uid)?;
 
-    println!("Dashboard successfully created: {}", dashboard_url);
+    println!("Dashboard successfully created: {dashboard_url}");
     Ok(())
 }
 

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -186,7 +186,7 @@ impl TrinConfig {
                 DEFAULT_WEB3_HTTP_ADDRESS => {}
                 p => panic!("Must not supply an http address when using ipc protocol for json-rpc (received: {p})"),
             },
-            val => panic!("Unsupported json-rpc protocol: {}", val),
+            val => panic!("Unsupported json-rpc protocol: {val}"),
         }
 
         match config.trusted_provider_url {

--- a/trin-core/src/jsonrpc/service.rs
+++ b/trin-core/src/jsonrpc/service.rs
@@ -53,7 +53,7 @@ pub fn dispatch_trusted_http_request(
         Err(err) => Err(json!({
             "jsonrpc": "2.0",
             "id": obj.id,
-            "error": format!("Infura failure: {}", err),
+            "error": format!("Infura failure: {err}"),
         })
         .to_string()),
     }
@@ -65,16 +65,16 @@ fn proxy_to_url(request: &JsonRequest, trusted_http_client: Request) -> io::Resu
             Ok(val) => Ok(val.as_bytes().to_vec()),
             Err(msg) => Err(io::Error::new(
                 io::ErrorKind::Other,
-                format!("Error decoding response: {:?}", msg),
+                format!("Error decoding response: {msg:?}"),
             )),
         },
         Err(ureq::Error::Status(code, _response)) => Err(io::Error::new(
             io::ErrorKind::Other,
-            format!("Responded with status code: {:?}", code),
+            format!("Responded with status code: {code:?}"),
         )),
         Err(err) => Err(io::Error::new(
             io::ErrorKind::Other,
-            format!("Request failure: {:?}", err),
+            format!("Request failure: {err:?}"),
         )),
     }
 }

--- a/trin-core/src/jsonrpc/utils.rs
+++ b/trin-core/src/jsonrpc/utils.rs
@@ -35,7 +35,7 @@ pub fn bucket_entries_to_json(bucket_entries: BTreeMap<usize, Vec<NodeTuple>>) -
                         );
                         map.insert("enr".to_owned(), enr.to_base64());
                         map.insert("status".to_owned(), format!("{:?}", node_status.state));
-                        map.insert("radius".to_owned(), format!("{}", data_radius));
+                        map.insert("radius".to_owned(), format!("{data_radius}"));
                         if let Some(client_info) = client_info {
                             // Expand client name if possible, otherwise leave as-is.
                             match expand_client_name(client_info) {
@@ -50,7 +50,7 @@ pub fn bucket_entries_to_json(bucket_entries: BTreeMap<usize, Vec<NodeTuple>>) -
                             // Include address (IP:port) for convenience.
                             // TODO: Can be removed once a portal dashboard does UI-side ENR decoding.
                             let port = match enr.udp4_socket() {
-                                Some(port) => format!("{}", port),
+                                Some(port) => format!("{port}"),
                                 None => "None".to_string(),
                             };
                             map.insert("address".to_owned(), port);

--- a/trin-core/src/types/merkle/proof.rs
+++ b/trin-core/src/types/merkle/proof.rs
@@ -332,13 +332,13 @@ impl MerkleTree {
         const SPACES: u32 = 10;
         space += SPACES;
         let (pair, text) = match self {
-            MerkleTree::Node(hash, left, right) => (Some((left, right)), format!("Node({})", hash)),
-            MerkleTree::Leaf(hash) => (None, format!("Leaf({})", hash)),
+            MerkleTree::Node(hash, left, right) => (Some((left, right)), format!("Node({hash})")),
+            MerkleTree::Leaf(hash) => (None, format!("Leaf({hash})")),
             MerkleTree::Zero(depth) => (
                 None,
                 format!("Z[{}]({})", depth, H256::from_slice(&ZERO_HASHES[*depth])),
             ),
-            MerkleTree::Finalized(hash) => (None, format!("Finl({})", hash)),
+            MerkleTree::Finalized(hash) => (None, format!("Final({hash})")),
         };
         if let Some((_, right)) = pair {
             right.print_node(space);
@@ -347,7 +347,7 @@ impl MerkleTree {
         for _i in SPACES..space {
             print!(" ");
         }
-        println!("{}", text);
+        println!("{text}");
         if let Some((left, _)) = pair {
             left.print_node(space);
         }

--- a/trin-core/src/types/validation.rs
+++ b/trin-core/src/types/validation.rs
@@ -48,7 +48,7 @@ impl HeaderOracle {
     }
 
     pub fn get_header_by_hash(&self, block_hash: H256) -> anyhow::Result<Header> {
-        let block_hash = format!("0x{:02X}", block_hash);
+        let block_hash = format!("0x{block_hash:02X}");
         let method = "eth_getBlockByHash".to_string();
         let params = Params::Array(vec![json!(block_hash), json!(false)]);
         let response: Value = self

--- a/trin-core/src/utp/packets.rs
+++ b/trin-core/src/utp/packets.rs
@@ -834,7 +834,7 @@ mod tests {
         packet.set_seq_nr(11884);
         packet.set_ack_nr(0);
 
-        println!("packet: {:?}", packet);
+        println!("packet: {packet:?}");
         println!("packet raw: {:?}", packet.as_ref());
 
         assert_eq!(

--- a/trin-core/src/utp/stream.rs
+++ b/trin-core/src/utp/stream.rs
@@ -2262,7 +2262,7 @@ mod tests {
             match server.recv_from(&mut buf).await {
                 Ok((0, _src)) => break,
                 Ok((len, _src)) => received.extend(buf[..len].to_vec()),
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
 

--- a/trin-core/tests/overlay.rs
+++ b/trin-core/tests/overlay.rs
@@ -79,10 +79,10 @@ async fn spawn_overlay(
         while let Some(talk_req) = overlay_rx.recv().await {
             let talk_resp = match overlay.process_one_request(&talk_req).await {
                 Ok(response) => Message::from(response).into(),
-                Err(err) => panic!("Error processing request: {}", err),
+                Err(err) => panic!("Error processing request: {err}"),
             };
             if let Err(err) = talk_req.respond(talk_resp) {
-                panic!("Unable to respond to talk request: {}", err);
+                panic!("Unable to respond to talk request: {err}");
             }
         }
     });
@@ -149,7 +149,7 @@ async fn overlay() {
         Ok(pong) => {
             assert_eq!(1, pong.enr_seq);
         }
-        Err(err) => panic!("Unable to respond to ping: {}", err),
+        Err(err) => panic!("Unable to respond to ping: {err}"),
     }
     time::sleep(sleep_duration).await;
     let overlay_one_peers = overlay_one.table_entries_enr();
@@ -167,7 +167,7 @@ async fn overlay() {
             assert_eq!(1, nodes.enrs.len());
             assert!(nodes.enrs.contains(&SszEnr::new(overlay_three.local_enr())));
         }
-        Err(err) => panic!("Unable to respond to find nodes: {}", err),
+        Err(err) => panic!("Unable to respond to find nodes: {err}"),
     }
     time::sleep(sleep_duration).await;
     let overlay_one_peers = overlay_one.table_entries_enr();
@@ -189,7 +189,7 @@ async fn overlay() {
             assert!(nodes.enrs.contains(&SszEnr::new(overlay_two.local_enr())));
             assert!(nodes.enrs.contains(&SszEnr::new(overlay_three.local_enr())));
         }
-        Err(err) => panic!("Unable to respond to find nodes: {}", err),
+        Err(err) => panic!("Unable to respond to find nodes: {err}"),
     }
     time::sleep(sleep_duration).await;
     let overlay_three_peers = overlay_three.table_entries_enr();
@@ -208,9 +208,9 @@ async fn overlay() {
     {
         Ok(content) => match content {
             Content::Enrs(enrs) => enrs,
-            other => panic!("Unexpected response to find content: {:?}", other),
+            other => panic!("Unexpected response to find content: {other:?}"),
         },
-        Err(err) => panic!("Unable to respond to find content: {}", err),
+        Err(err) => panic!("Unable to respond to find content: {err}"),
     };
     time::sleep(sleep_duration).await;
     let overlay_two_peers = overlay_two.table_entries_enr();

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -50,9 +50,7 @@ impl HistoryRequestHandler {
                                         None => Ok(Value::String("0x0".to_string())),
                                     },
                                     Err(err) => Err(format!(
-                                        "Database error while looking for content key in local storage: {:?}, with error: {}",
-
-                                        content_key, err
+                                        "Database error while looking for content key in local storage: {content_key:?}, with error: {err}",
                                     )),
                                 };
                             let _ = request.resp.send(response);
@@ -70,8 +68,7 @@ impl HistoryRequestHandler {
                                 {
                                     Ok(val) => Ok(json!(val)),
                                     Err(err) => Err(format!(
-                                        "Database error while paginating local content keys with offset: {:?}, limit: {:?}. Error message: {}",
-                                        offset, limit, err
+                                        "Database error while paginating local content keys with offset: {offset:?}, limit: {limit:?}. Error message: {err}"
                                     )),
                                 };
                     let _ = request.resp.send(response);
@@ -142,7 +139,7 @@ impl HistoryRequestHandler {
                             Ok(val) => Ok(val),
                             Err(_) => Err("Content response decoding error".to_string()),
                         },
-                        Err(msg) => Err(format!("FindContent request timeout: {:?}", msg)),
+                        Err(msg) => Err(format!("FindContent request timeout: {msg:?}")),
                     };
                     let _ = request.resp.send(response);
                 }
@@ -159,7 +156,7 @@ impl HistoryRequestHandler {
                                 .map(|enr| EthEnr::from_str(&enr.to_base64()).unwrap())
                                 .collect::<Vec<EthEnr>>(),
                         })),
-                        Err(msg) => Err(format!("FindNodes request timeout: {:?}", msg)),
+                        Err(msg) => Err(format!("FindNodes request timeout: {msg:?}")),
                     };
                     let _ = request.resp.send(response);
                 }
@@ -186,7 +183,7 @@ impl HistoryRequestHandler {
                             connection_id: accept.connection_id,
                             content_keys: accept.content_keys,
                         })),
-                        Err(msg) => Err(format!("SendOffer request timeout: {:?}", msg)),
+                        Err(msg) => Err(format!("SendOffer request timeout: {msg:?}")),
                     };
                     let _ = request.resp.send(response);
                 }
@@ -197,7 +194,7 @@ impl HistoryRequestHandler {
                             enr_seq: pong.enr_seq as u32,
                             data_radius: *self.network.overlay.data_radius(),
                         })),
-                        Err(msg) => Err(format!("Ping request timeout: {:?}", msg)),
+                        Err(msg) => Err(format!("Ping request timeout: {msg:?}")),
                     };
 
                     let _ = request.resp.send(response);

--- a/utp-testing/src/bin/test_suite.rs
+++ b/utp-testing/src/bin/test_suite.rs
@@ -19,11 +19,11 @@ async fn main() -> anyhow::Result<()> {
 /// Send 10k bytes payload from client to server
 async fn send_10k_bytes() -> anyhow::Result<()> {
     println!("Sending 10k bytes uTP payload from client to server...");
-    let client_url = format!("http://{}", CLIENT_ADDR);
+    let client_url = format!("http://{CLIENT_ADDR}");
     let client_rpc = HttpClientBuilder::default().build(client_url)?;
     let client_enr: String = client_rpc.request("local_enr", None).await.unwrap();
 
-    let server_url = format!("http://{}", SERVER_ADDR);
+    let server_url = format!("http://{SERVER_ADDR}");
     let server_rpc = HttpClientBuilder::default().build(server_url)?;
     let server_enr: String = server_rpc.request("local_enr", None).await.unwrap();
 


### PR DESCRIPTION
### What was wrong?
As @perama-v pointed out in https://github.com/ethereum/trin/pull/510#issuecomment-1407260933- clippy nightly now checks for interpolated string formatting when possible. Assuming this will eventually make its way into stable, but in the meantime I don't see any problem with moving ahead and adopting this. I've added a line to the Style Guide, since I don't think it's worth updating our ci to nightly to catch this.

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
