### PR TITLE
Remove obsolete `JsonRpcExiter`

### DIFF
--- a/newsfragments/542.fixed.md
+++ b/newsfragments/542.fixed.md
@@ -1,0 +1,1 @@
+Remove the obsolete `JsonRpcExiter` struct and instead return jsonrpsee server handle from the `run_trin` method.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use ethportal_api::jsonrpsee::server::ServerHandle;
 use rpc::JsonRpcServer;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::RwLock;
@@ -8,7 +9,6 @@ use tracing::info;
 use trin_core::jsonrpc::types::HistoryJsonRpcRequest;
 use trin_core::{
     cli::{TrinConfig, HISTORY_NETWORK, STATE_NETWORK},
-    jsonrpc::service::JsonRpcExiter,
     portalnet::{
         discovery::Discovery, events::PortalnetEvents, storage::PortalStorageConfig,
         types::messages::PortalnetConfig,
@@ -23,7 +23,7 @@ use trin_state::initialize_state_network;
 pub async fn run_trin(
     trin_config: TrinConfig,
     trusted_provider: TrustedProvider,
-) -> Result<Arc<JsonRpcExiter>, Box<dyn std::error::Error>> {
+) -> Result<ServerHandle, Box<dyn std::error::Error>> {
     info!(config = %trin_config, "Launching trin");
 
     let bootnode_enrs = parse_bootnodes(&trin_config.bootnodes)?;
@@ -113,9 +113,9 @@ pub async fn run_trin(
 
     // Launch JSON-RPC server
     let jsonrpc_trin_config = trin_config.clone();
-    let json_exiter = Arc::new(JsonRpcExiter::new());
     let jsonrpc_discovery = Arc::clone(&discovery);
-    launch_jsonrpc_server(jsonrpc_trin_config, jsonrpc_discovery, history_jsonrpc_tx).await;
+    let rpc_handle =
+        launch_jsonrpc_server(jsonrpc_trin_config, jsonrpc_discovery, history_jsonrpc_tx).await;
 
     if let Some(handler) = state_handler {
         tokio::spawn(handler.handle_client_queries());
@@ -146,7 +146,7 @@ pub async fn run_trin(
         tokio::spawn(async { network.await });
     }
 
-    Ok(json_exiter)
+    Ok(rpc_handle)
 }
 
 // FIXME: Handle those unwraps in this method
@@ -154,28 +154,28 @@ async fn launch_jsonrpc_server(
     trin_config: TrinConfig,
     discv5: Arc<Discovery>,
     history_handler: Option<UnboundedSender<HistoryJsonRpcRequest>>,
-) {
+) -> ServerHandle {
     match trin_config.web3_transport.as_str() {
         "ipc" => {
             // Launch jsonrpsee server with http and WS transport
-            let handle =
+            let rpc_handle =
                 JsonRpcServer::run_ipc(trin_config.web3_ipc_path, discv5, history_handler.unwrap())
                     .await
                     .unwrap();
-            tokio::spawn(handle.stopped()); //FIXME: This runs the server forever
             info!("IPC JSON-RPC server launched.");
+            rpc_handle
         }
         "http" => {
             // Launch jsonrpsee server with http and WS transport
-            let handle = JsonRpcServer::run_http(
+            let rpc_handle = JsonRpcServer::run_http(
                 trin_config.web3_http_address,
                 discv5,
                 history_handler.unwrap(),
             )
             .await
             .unwrap();
-            tokio::spawn(handle.stopped()); //FIXME: This runs the server forever
             info!("HTTP JSON-RPC server launched.");
+            rpc_handle
         }
         val => panic!("Unsupported web3 transport: {}", val),
     }

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -46,7 +46,7 @@ mod test {
             http: ureq::post(&server.url("/")),
             ws: None,
         };
-        let test_client_exiter = trin::run_trin(trin_config, trusted_provider).await.unwrap();
+        let test_client_rpc_handle = trin::run_trin(trin_config, trusted_provider).await.unwrap();
 
         peertest::scenarios::paginate::test_paginate_local_storage(
             peertest_config.clone(),
@@ -70,6 +70,6 @@ mod test {
         );
 
         peertest.exit_all_nodes();
-        test_client_exiter.exit();
+        test_client_rpc_handle.stop().unwrap();
     }
 }

--- a/trin-core/src/jsonrpc/service.rs
+++ b/trin-core/src/jsonrpc/service.rs
@@ -1,41 +1,10 @@
-use std::{
-    io::{self},
-    sync::{Arc, RwLock},
-};
+use std::io::{self};
 
 use serde_json::json;
 use thiserror::Error;
 use ureq::{self, Request};
 
 use crate::jsonrpc::types::JsonRequest;
-
-pub struct JsonRpcExiter {
-    should_exit: Arc<RwLock<bool>>,
-}
-
-impl JsonRpcExiter {
-    pub fn new() -> Self {
-        JsonRpcExiter {
-            should_exit: Arc::new(RwLock::new(false)),
-        }
-    }
-
-    pub fn exit(&self) {
-        let mut flag = self.should_exit.write().unwrap();
-        *flag = true;
-    }
-
-    pub fn is_exiting(&self) -> bool {
-        let flag = self.should_exit.read().unwrap();
-        *flag
-    }
-}
-
-impl Default for JsonRpcExiter {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 #[derive(Error, Debug)]
 pub enum HttpParseError {


### PR DESCRIPTION
### What was wrong?

Closes #542 

### How was it fixed?
Remove the obsolete `JsonRpcExiter` struct and instead return jsonrpsee server handle from the `run_trin` method.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
