### PR TITLE
Move to stable discv5 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,7 +959,8 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.1.0"
-source = "git+https://github.com/sigp/discv5.git?branch=master#97a806ccf7817a420b5f43efa23e6127b475d839"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767c0e59b3e8d65222d95df723cc2ea1da92bb0f27c563607e6f0bde064f255"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/ethereum/trin"
 
 [dependencies]
 anyhow = "1.0.57"
-discv5 = { git = "https://github.com/sigp/discv5.git", branch = "master" }
+discv5 = "0.1.0"
 enr = { version = "=0.7.0", features = ["k256", "ed25519"] }
 eth2_ssz = "0.4.0"
 ethereum-types = "0.12.1"

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.62.0"
 [dependencies]
 anyhow = "1.0.57"
 clap = "2.33.3"
-discv5 = { git = "https://github.com/sigp/discv5.git", branch = "master" }
+discv5 = "0.1.0"
 eth2_ssz = "0.4.0"
 ethportal-api = { path="../ethportal-api"}
 futures = "0.3.21"

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -14,7 +14,7 @@ clap = "2.33.3"
 ctrlc = "3.1.8"
 delay_map = "0.1.1"
 directories = "3.0"
-discv5 = { git = "https://github.com/sigp/discv5.git", branch = "master" }
+discv5 = "0.1.0"
 enr = { version = "=0.7.0", features = ["k256", "ed25519"] }
 eth_trie = "0.1.0"
 eth2_hashing = "0.2.0"

--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -1841,7 +1841,7 @@ where
 
         match self.kbuckets.write().update_node_status(&key, state, None) {
             UpdateResult::Failed(reason) => match reason {
-                FailureReason::KeyNonExistent => Err(FailureReason::KeyNonExistent),
+                FailureReason::KeyNonExistant => Err(FailureReason::KeyNonExistant),
                 other => {
                     warn!(
                         protocol = %self.protocol,

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.62.0"
 anyhow = "1.0.57"
 async-trait = "0.1.53"
 bytes = "1.1.0"
-discv5 = { git = "https://github.com/sigp/discv5.git", branch = "master" }
+discv5 = "0.1.0"
 eth2_ssz = "0.4.0"
 eth2_ssz_types = "0.2.1"
 ethereum-types = "0.12.1"

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.62.0"
 [dependencies]
 anyhow = "1.0.57"
 async-trait = "0.1.53"
-discv5 = { git = "https://github.com/sigp/discv5.git", branch = "master" }
+discv5 = "0.1.0"
 ethereum-types = "0.12.0"
 eth_trie = "0.1.0"
 hex = "0.4.3"

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -12,7 +12,7 @@ tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 trin-core = { path = "../trin-core" }
 tokio = {version = "1.8.0", features = ["full"]}
-discv5 = { git = "https://github.com/sigp/discv5.git", branch = "master" }
+discv5 = "0.1.0"
 hex = "0.4.3"
 
 [[bin]]


### PR DESCRIPTION
### What was wrong?
Our discv5 dependency needs to be on a stable release, not a random git branch, to be able to publish a release since cargo requires that "all dependencies must have a version specified when publishing."

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
