### PR TITLE
Store content keys in meta db w/o 0x prefix

### DIFF
--- a/newsfragments/549.fixed.md
+++ b/newsfragments/549.fixed.md
@@ -1,0 +1,1 @@
+Update meta db to store content keys w/o 0x prefix.


### PR DESCRIPTION
### What was wrong?
We ran into an issue w/ our testnet databases where they were in a state of storing content keys both with and w/o a `0x` prefix. The naked unwraps inside the `paginate` function bricked the node when it tried to paginate over local content keys. The following changes are to help prevent this situation from repeating in the future - accompanied by a purge of the testnet databases.

### How was it fixed?
- store content keys w/o `0x` prefixes in our meta db
- added check to invalidate content keys w/ `0x` prefix before inserting them into the meta db
- removed some naked `unwrap`s & `expect`s

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
