### PR TITLE
Add check for valid ENR signature

### DIFF
--- a/trin-core/src/portalnet/overlay_service.rs
+++ b/trin-core/src/portalnet/overlay_service.rs
@@ -1543,6 +1543,11 @@ where
         for enr in enrs {
             let node_id = enr.node_id();
 
+            if !enr.verify() {
+                warn!("Received ENR with invalid signature: {}", enr);
+                continue;
+            }
+
             // Ignore ourself.
             if node_id == local_node_id {
                 continue;


### PR DESCRIPTION
### What was wrong?

I don't think the signatures of the ENRs that Trin (or discv5) receives are being checked anywhere. Correct me if I'm wrong. 

Discv5 uses a `verify_enr` method, but it doesn't check the signature, only that the ENR's stated address matches the observed address.

### How was it fixed?

Using the `Enr` crate's [verify](https://docs.rs/enr/latest/enr/struct.Enr.html#method.verify) method.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
