### PR TITLE
Use `jsonrpsee` features by removing `ethportal-api` features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,7 +1274,7 @@ checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
 
 [[package]]
 name = "ethportal-api"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bytes 1.3.0",
  "enr 0.7.0",

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethportal-api"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Definitions for various Ethereum Portal Network JSONRPC APIs"
 license = "GPL-3.0"
@@ -17,7 +17,7 @@ eth2_ssz_derive = "0.3.0"
 eth2_ssz_types = "0.2.1"
 hex = "0.4.3"
 hex-literal = "0.3.4"
-jsonrpsee = {version="0.16.2", features = ["macros"]}
+jsonrpsee = {version="0.16.2", features = ["async-client", "client", "macros", "server"]}
 rand = "0.8.1"
 rlp = "0.5.1"
 rlp-derive = "0.1.0"
@@ -30,8 +30,3 @@ sha2 = "0.10.1"
 
 [dev-dependencies]
 rstest = "0.16.0"
-
-[features]
-default = ["client"]
-client = ["jsonrpsee/client", "jsonrpsee/async-client"]
-server = ["jsonrpsee/server"]

--- a/ethportal-api/src/discv5.rs
+++ b/ethportal-api/src/discv5.rs
@@ -2,7 +2,6 @@ use crate::types::discv5::{Enr, NodeId, NodeInfo, RoutingTableInfo};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Discv5 JSON-RPC endpoints
-#[cfg(any(feature = "client", feature = "server"))]
 #[rpc(client, server, namespace = "discv5")]
 pub trait Discv5Api {
     /// Returns ENR and Node ID information of the local discv5 node.

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -10,7 +10,6 @@ use crate::types::{
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Portal History JSON-RPC endpoints
-#[cfg(any(feature = "client", feature = "server"))]
 #[rpc(client, server, namespace = "portal")]
 pub trait HistoryNetworkApi {
     /// Returns meta information about overlay routing table.

--- a/ethportal-api/src/lib.rs
+++ b/ethportal-api/src/lib.rs
@@ -7,28 +7,13 @@ mod history;
 pub mod types;
 mod web3;
 
-#[cfg(feature = "client")]
-pub use discv5::Discv5ApiClient;
-
-#[cfg(feature = "server")]
-pub use discv5::Discv5ApiServer;
-
-#[cfg(feature = "client")]
-pub use history::HistoryNetworkApiClient;
-
-#[cfg(feature = "server")]
-pub use history::HistoryNetworkApiServer;
-
-#[cfg(feature = "client")]
-pub use web3::Web3ApiClient;
-
-#[cfg(feature = "server")]
-pub use web3::Web3ApiServer;
-
+pub use discv5::{Discv5ApiClient, Discv5ApiServer};
+pub use history::{HistoryNetworkApiClient, HistoryNetworkApiServer};
 pub use types::{
     accumulator::EpochAccumulator, block_body::BlockBody, block_header::BlockHeaderWithProof,
     content_item::HistoryContentItem, content_key::HistoryContentKey, receipts::BlockReceipts,
 };
+pub use web3::{Web3ApiClient, Web3ApiServer};
 
 // Re-exports jsonrpsee crate
 pub use jsonrpsee;

--- a/ethportal-api/src/web3.rs
+++ b/ethportal-api/src/web3.rs
@@ -1,7 +1,6 @@
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Web3 JSON-RPC endpoints
-#[cfg(any(feature = "client", feature = "server"))]
 #[rpc(client, server, namespace = "web3")]
 pub trait Web3Api {
     #[method(name = "clientVersion")]

--- a/newsfragments/557.removed.md
+++ b/newsfragments/557.removed.md
@@ -1,0 +1,1 @@
+Removed ethportal-api client & server features to use jsonrpsee macro features directly.

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.68"
-ethportal-api = { path = "../ethportal-api", features=["server"]}
+ethportal-api = { path = "../ethportal-api"}
 trin-core = { path = "../trin-core"}
 tokio = { version = "1.8.0", features = ["full"] }
 reth-ipc = { version = "0.1.0", git = "https://github.com/paradigmxyz/reth.git"}


### PR DESCRIPTION
### What was wrong?

Build error preventing `ethportal-api` tests from running

Fixes: #557

### How was it fixed?
- Removed features from ethportal-api (see discussion in issue)
- Added jsonrpsee features required
- Minor version bump to `ethportal-api`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
