### PR TITLE
Add condition for clippy to warn on naked unwraps

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,3 @@
+# This feature is in Rust nightly, as of v1.62. The line is added in anticipation.
+# Once the feature stabilizes, remove the #[allow(clippy::unwrap_used)] lines in front of every `mod test`
+allow-unwrap-in-tests = true

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -245,7 +245,9 @@ Any datatype of significance **should** have an accompanying comment briefly des
 
 
 ## Error handling
-- Handle errors, avoid naked `.unwrap()`s, except for in unit tests. Write descriptive error messages that give context of the problem that occurred.
+- Handle errors. Naked `.unwrap()`s aren't allowed, except for in unit tests. Parsing a static value). Exceptions must be accompanied by a note justifying usage.
+  - In most cases where an exception can be made (eg. parsing a static value) `.expect()` with a relevant message should be used over a naked unwrap.
+- Write descriptive error messages that give context of the problem that occurred. Error messages should be unique, to aid with debugging.
 - Meaningful error types should be used in place of `Result< _, String>`.
 	- General errors should use the [anyhow](https://docs.rs/anyhow/latest/anyhow/) crate.
 	- Custom / typed errors should derive from the `std::error::Error` trait. The [`thiserror`](https://docs.rs/thiserror/1.0.30/thiserror/) crate provides a useful macro to simplify creating custom error types.

--- a/ethportal-api/src/lib.rs
+++ b/ethportal-api/src/lib.rs
@@ -1,6 +1,7 @@
 //! # ethportal-api
 //!
 //! `ethportal_api` is a collection of Portal Network APIs and types.
+#![warn(clippy::unwrap_used)]
 
 mod discv5;
 mod history;

--- a/ethportal-api/src/types/content_key.rs
+++ b/ethportal-api/src/types/content_key.rs
@@ -222,6 +222,7 @@ pub fn hex_encode_compact<T: AsRef<[u8]>>(data: T) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
 

--- a/ethportal-api/src/types/discv5.rs
+++ b/ethportal-api/src/types/discv5.rs
@@ -53,6 +53,7 @@ pub struct NodeInfo {
 pub type RoutingTableInfo = Value;
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use crate::types::discv5::{Enr, NodeId};
     use std::net::Ipv4Addr;

--- a/ethportal-peertest/src/main.rs
+++ b/ethportal-peertest/src/main.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::unwrap_used)]
+
 use std::{thread, time};
 use tracing::info;
 
@@ -30,8 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         peertest.exit_all_nodes();
     })
-    .await
-    .unwrap();
+    .await?;
 
     Ok(())
 }

--- a/newsfragments/562.fixed.md
+++ b/newsfragments/562.fixed.md
@@ -1,0 +1,1 @@
+Add clippy check to disallow naked unwraps.

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::unwrap_used)]
 #![allow(dead_code)]
 
 mod discv5;

--- a/src/bin/purge_db.rs
+++ b/src/bin/purge_db.rs
@@ -37,7 +37,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Capacity is 0 since it (eg. for data radius calculation) is irrelevant when only removing data.
     let capacity = 0;
     let protocol = ProtocolId::History;
-    let config = PortalStorageConfig::new(capacity, node_id, false);
+    let config = PortalStorageConfig::new(capacity, node_id, false)?;
     let storage =
         PortalStorage::new(config.clone(), protocol).expect("Failed to create portal storage");
     let iter = config.db.iterator(IteratorMode::Start);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,14 +54,14 @@ pub async fn run_trin(
 
     // Initialize Storage config
     if trin_config.ephemeral {
-        setup_temp_dir();
+        setup_temp_dir()?;
     }
 
     let storage_config = PortalStorageConfig::new(
         trin_config.kb.into(),
         discovery.local_enr().node_id(),
         trin_config.enable_metrics_with_url.is_some(),
-    );
+    )?;
 
     // Initialize validation oracle
     let master_accumulator = MasterAccumulator::try_from_file(trin_config.master_acc_path.clone())?;
@@ -82,7 +82,7 @@ pub async fn run_trin(
                 storage_config.clone(),
                 header_oracle.clone(),
             )
-            .await
+            .await?
         } else {
             (None, None, None, None, None)
         };
@@ -106,7 +106,7 @@ pub async fn run_trin(
             storage_config.clone(),
             header_oracle.clone(),
         )
-        .await
+        .await?
     } else {
         (None, None, None, None, None)
     };

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -144,10 +144,13 @@ impl Default for TrinConfig {
     fn default() -> Self {
         TrinConfig {
             web3_transport: "ipc".to_string(),
-            web3_http_address: Url::parse(DEFAULT_WEB3_HTTP_ADDRESS).unwrap(),
+            web3_http_address: Url::parse(DEFAULT_WEB3_HTTP_ADDRESS)
+                .expect("Parsing static DEFAULT_WEB3_HTTP_ADDRESS to work"),
             web3_ipc_path: DEFAULT_WEB3_IPC_PATH.to_string(),
             pool_size: 5,
-            discovery_port: DEFAULT_DISCOVERY_PORT.parse().unwrap(),
+            discovery_port: DEFAULT_DISCOVERY_PORT
+                .parse()
+                .expect("Parsing static DEFAULT_DISCOVERY_PORT to work"),
             bootnodes: vec![],
             external_addr: None,
             no_stun: false,
@@ -156,7 +159,9 @@ impl Default for TrinConfig {
                 .split(',')
                 .map(|n| n.to_string())
                 .collect(),
-            kb: DEFAULT_STORAGE_CAPACITY.parse().unwrap(),
+            kb: DEFAULT_STORAGE_CAPACITY
+                .parse()
+                .expect("Parsing static DEFAULT_STORAGE_CAPACITY to work"),
             enable_metrics_with_url: None,
             ephemeral: false,
             trusted_provider: TrustedProviderType::Infura,
@@ -256,6 +261,7 @@ impl fmt::Display for TrinConfig {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
     use crate::utils::provider::TrustedProvider;

--- a/trin-core/src/jsonrpc/service.rs
+++ b/trin-core/src/jsonrpc/service.rs
@@ -18,7 +18,9 @@ pub fn dispatch_trusted_http_request(
     trusted_http_client: Request,
 ) -> Result<String, String> {
     match proxy_to_url(&obj, trusted_http_client) {
-        Ok(result_body) => Ok(std::str::from_utf8(&result_body).unwrap().to_owned()),
+        Ok(result_body) => Ok(std::str::from_utf8(&result_body)
+            .map_err(|e| format!("When decoding utf8 from proxied provider: {e:?}"))?
+            .to_owned()),
         Err(err) => Err(json!({
             "jsonrpc": "2.0",
             "id": obj.id,

--- a/trin-core/src/jsonrpc/types.rs
+++ b/trin-core/src/jsonrpc/types.rs
@@ -103,6 +103,7 @@ impl TryFrom<&Value> for NodesParams {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
     use rstest::rstest;

--- a/trin-core/src/lib.rs
+++ b/trin-core/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::unwrap_used)]
+
 pub mod cli;
 pub mod jsonrpc;
 pub mod locks;

--- a/trin-core/src/portalnet/find/iterators/findcontent.rs
+++ b/trin-core/src/portalnet/find/iterators/findcontent.rs
@@ -395,6 +395,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use discv5::enr::NodeId;

--- a/trin-core/src/portalnet/find/iterators/findnodes.rs
+++ b/trin-core/src/portalnet/find/iterators/findnodes.rs
@@ -318,6 +318,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use discv5::enr::NodeId;

--- a/trin-core/src/portalnet/find/query_info.rs
+++ b/trin-core/src/portalnet/find/query_info.rs
@@ -113,6 +113,7 @@ fn findnode_log2distance(target: NodeId, peer: NodeId, size: usize) -> Option<Ve
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use test_log::test;

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -158,8 +158,7 @@ where
             config.query_num_results,
             config.findnodes_query_distances_per_peer,
         )
-        .await
-        .unwrap();
+        .await;
 
         Self {
             discovery,
@@ -848,6 +847,7 @@ fn validate_find_nodes_distances(distances: &Vec<u16>) -> Result<(), OverlayRequ
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
     use crate::utils::node_id::generate_random_remote_enr;

--- a/trin-core/src/portalnet/types/content_key.rs
+++ b/trin-core/src/portalnet/types/content_key.rs
@@ -380,6 +380,7 @@ impl OverlayContentKey for StateContentKey {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
 

--- a/trin-core/src/portalnet/types/messages.rs
+++ b/trin-core/src/portalnet/types/messages.rs
@@ -615,7 +615,9 @@ impl ssz::Decode for SszEnr {
 
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
         let string = base64::encode_config(&bytes, base64::URL_SAFE);
-        Ok(SszEnr(Enr::from_str(&string).unwrap()))
+        Ok(SszEnr(
+            Enr::from_str(&string).map_err(|e| DecodeError::BytesInvalid(e))?,
+        ))
     }
 }
 
@@ -645,6 +647,7 @@ impl FromStr for HexData {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
     use test_log::test;

--- a/trin-core/src/types/accumulator.rs
+++ b/trin-core/src/types/accumulator.rs
@@ -123,7 +123,7 @@ impl MasterAccumulator {
             endpoint,
             resp: resp_tx,
         };
-        history_jsonrpc_tx.send(request).unwrap();
+        history_jsonrpc_tx.send(request)?;
 
         let epoch_acc_ssz = match resp_rx.recv().await {
             Some(val) => {
@@ -235,6 +235,7 @@ fn calculate_generalized_index(header: &Header) -> usize {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
     use std::fs;

--- a/trin-core/src/types/block_body.rs
+++ b/trin-core/src/types/block_body.rs
@@ -410,11 +410,9 @@ pub struct AccessList {
 
 impl Decodable for AccessList {
     fn decode(rlp_obj: &Rlp) -> Result<Self, DecoderError> {
-        let list = rlp_obj
-            .iter()
-            .map(|v| rlp::decode(v.as_raw()).unwrap())
-            .collect();
-        Ok(Self { list })
+        let list: Result<Vec<AccessListItem>, DecoderError> =
+            rlp_obj.iter().map(|v| rlp::decode(v.as_raw())).collect();
+        Ok(Self { list: list? })
     }
 }
 
@@ -432,6 +430,7 @@ pub struct AccessListItem {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use rstest::rstest;

--- a/trin-core/src/types/header.rs
+++ b/trin-core/src/types/header.rs
@@ -114,13 +114,14 @@ impl Header {
             .append(&self.timestamp)
             .append(&self.extra_data);
 
+        // naked unwraps ok since we validate that properties exist before unwrapping
+        #[allow(clippy::unwrap_used)]
         if with_seal && self.mix_hash.is_some() && self.nonce.is_some() {
             s.append(&self.mix_hash.unwrap())
                 .append(self.nonce.as_ref().unwrap());
         }
-
-        if self.base_fee_per_gas.is_some() {
-            s.append(&self.base_fee_per_gas.unwrap());
+        if let Some(val) = self.base_fee_per_gas {
+            s.append(&val);
         }
     }
 }
@@ -378,6 +379,7 @@ impl ssz::Encode for SszNone {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use std::fs;

--- a/trin-core/src/types/merkle/proof.rs
+++ b/trin-core/src/types/merkle/proof.rs
@@ -305,6 +305,7 @@ impl MerkleTree {
                 return Err(MerkleTreeError::ProofEncounteredFinalizedNode);
             }
             // Note: unwrap is safe because leaves are only ever constructed at depth == 0.
+            #[allow(clippy::unwrap_used)]
             let (left, right) = current_node.left_and_right_branches().unwrap();
 
             // Go right, include the left branch in the proof.

--- a/trin-core/src/types/merkle/safe_arith.rs
+++ b/trin-core/src/types/merkle/safe_arith.rs
@@ -134,6 +134,7 @@ impl_safe_arith!(i64);
 impl_safe_arith!(isize);
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
 

--- a/trin-core/src/types/receipts.rs
+++ b/trin-core/src/types/receipts.rs
@@ -438,6 +438,7 @@ impl DerefMut for Receipt {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use std::str::FromStr;

--- a/trin-core/src/types/validation.rs
+++ b/trin-core/src/types/validation.rs
@@ -102,6 +102,7 @@ impl Validator<IdentityContentKey> for MockValidator {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
     use std::str::FromStr;

--- a/trin-core/src/utils/bootnodes.rs
+++ b/trin-core/src/utils/bootnodes.rs
@@ -5,10 +5,10 @@ use anyhow::anyhow;
 use crate::portalnet::Enr;
 
 lazy_static! {
-     pub static ref DEFAULT_BOOTNODES: Vec<Enr> = vec![
-        Enr::from_str("enr:-IS4QBISSFfBzsBrjq61iSIxPMfp5ShBTW6KQUglzH_tj8_SJaehXdlnZI-NAkTGeoclwnTB-pU544BQA44BiDZ2rkMBgmlkgnY0gmlwhKEjVaWJc2VjcDI1NmsxoQOSGugH1jSdiE_fRK1FIBe9oLxaWH8D_7xXSnaOVBe-SYN1ZHCCIyg").unwrap(),
-        Enr::from_str("enr:-IS4QPUT9hwV4YfNTxazR2ltch4qKzvX_HwxQBw8gUN3q1MDfNyaD1EHc1wQZRTUzQQD-RVYx3h4nA1Sqk0Wx9DwzNABgmlkgnY0gmlwhM69ZOyJc2VjcDI1NmsxoQLaI-m2CDIjpwcnUf1ESspvOctJLpIrLA8AZ4zbo_1bFIN1ZHCCIyg").unwrap(),
-        Enr::from_str("enr:-IS4QB77AROcGX-TSkY-U-SaZJ5ma9ICQj6ETO3FqUdCnTZeJ0mDrdCKUqd5AQ0jrHa7m9-mOLvFFKMV_-tBD8uDYZUBgmlkgnY0gmlwhJ_fCDaJc2VjcDI1NmsxoQN9rahqamBOJfj4u6yssJQJ1-EZoyAw-7HIgp1FwNUdnoN1ZHCCIyg").unwrap()
+    pub static ref DEFAULT_BOOTNODES: Vec<Enr> = vec![
+        Enr::from_str("enr:-IS4QBISSFfBzsBrjq61iSIxPMfp5ShBTW6KQUglzH_tj8_SJaehXdlnZI-NAkTGeoclwnTB-pU544BQA44BiDZ2rkMBgmlkgnY0gmlwhKEjVaWJc2VjcDI1NmsxoQOSGugH1jSdiE_fRK1FIBe9oLxaWH8D_7xXSnaOVBe-SYN1ZHCCIyg").expect("Parsing static bootnode enr to work"),
+        Enr::from_str("enr:-IS4QPUT9hwV4YfNTxazR2ltch4qKzvX_HwxQBw8gUN3q1MDfNyaD1EHc1wQZRTUzQQD-RVYx3h4nA1Sqk0Wx9DwzNABgmlkgnY0gmlwhM69ZOyJc2VjcDI1NmsxoQLaI-m2CDIjpwcnUf1ESspvOctJLpIrLA8AZ4zbo_1bFIN1ZHCCIyg").expect("Parsing static bootnode enr to work"),
+        Enr::from_str("enr:-IS4QB77AROcGX-TSkY-U-SaZJ5ma9ICQj6ETO3FqUdCnTZeJ0mDrdCKUqd5AQ0jrHa7m9-mOLvFFKMV_-tBD8uDYZUBgmlkgnY0gmlwhJ_fCDaJc2VjcDI1NmsxoQN9rahqamBOJfj4u6yssJQJ1-EZoyAw-7HIgp1FwNUdnoN1ZHCCIyg").expect("Parsing static bootnode enr to work"),
     ];
 }
 
@@ -29,6 +29,7 @@ pub fn parse_bootnodes(bootnodes: &[String]) -> anyhow::Result<Vec<Enr>> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
     use crate::cli::TrinConfig;

--- a/trin-core/src/utils/bytes.rs
+++ b/trin-core/src/utils/bytes.rs
@@ -56,6 +56,7 @@ pub fn hex_encode_compact<T: AsRef<[u8]>>(data: T) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
     use test_log::test;

--- a/trin-core/src/utils/db.rs
+++ b/trin-core/src/utils/db.rs
@@ -1,27 +1,28 @@
 use std::path::PathBuf;
 use std::{env, fs};
-use tracing::debug;
 
+use anyhow::anyhow;
 use directories::ProjectDirs;
 use discv5::enr::NodeId;
 use tempfile::TempDir;
+use tracing::debug;
 
 const TRIN_DATA_ENV_VAR: &str = "TRIN_DATA_PATH";
 
 /// Creates a directory on the file system that is deleted once it goes out of scope
-pub fn setup_temp_dir() -> TempDir {
+pub fn setup_temp_dir() -> anyhow::Result<TempDir> {
     let mut os_temp = env::temp_dir();
     os_temp.push("trin");
     debug!("Creating temp dir: {os_temp:?}");
-    fs::create_dir_all(&os_temp).unwrap();
+    fs::create_dir_all(&os_temp)?;
 
-    let temp_dir = TempDir::new_in(&os_temp).unwrap();
+    let temp_dir = TempDir::new_in(&os_temp)?;
     env::set_var(TRIN_DATA_ENV_VAR, temp_dir.path());
-    temp_dir
+    Ok(temp_dir)
 }
 
-pub fn get_data_dir(node_id: NodeId) -> PathBuf {
-    let mut trin_data_dir = get_root_path();
+pub fn get_data_dir(node_id: NodeId) -> anyhow::Result<PathBuf> {
+    let mut trin_data_dir = get_root_path()?;
 
     // Append first 8 characters of Node ID
     let mut application_string = "trin_".to_owned();
@@ -32,21 +33,27 @@ pub fn get_data_dir(node_id: NodeId) -> PathBuf {
     trin_data_dir.push(application_string);
 
     fs::create_dir_all(&trin_data_dir).expect("Unable to create data directory folder");
-    trin_data_dir
+    Ok(trin_data_dir)
 }
 
 /// Get root data path
-pub fn get_root_path() -> PathBuf {
-    let trin_data_dir = env::var(TRIN_DATA_ENV_VAR).unwrap_or_else(|_| get_default_data_dir());
-    PathBuf::from(&trin_data_dir)
+pub fn get_root_path() -> anyhow::Result<PathBuf> {
+    let trin_data_dir = match env::var(TRIN_DATA_ENV_VAR) {
+        Ok(val) => val,
+        Err(_) => get_default_data_dir()?,
+    };
+    Ok(PathBuf::from(&trin_data_dir))
 }
 
-pub fn get_default_data_dir() -> String {
+pub fn get_default_data_dir() -> anyhow::Result<String> {
     // Windows: C:\Users\Username\AppData\Roaming\trin
     // macOS: ~/Library/Application Support/trin
     // Unix-like: $HOME/.local/share/trin
     match ProjectDirs::from("", "", "trin") {
-        Some(proj_dirs) => proj_dirs.data_local_dir().to_str().unwrap().to_string(),
-        None => panic!("Unable to find data directory"),
+        Some(proj_dirs) => match proj_dirs.data_local_dir().to_str() {
+            Some(val) => Ok(val.to_string()),
+            None => Err(anyhow!("Unable to find default data directory")),
+        },
+        None => Err(anyhow!("Unable to find default data directory")),
     }
 }

--- a/trin-core/src/utils/node_id.rs
+++ b/trin-core/src/utils/node_id.rs
@@ -28,6 +28,7 @@ pub fn generate_random_node_id(target_bucket_idx: u8, local_node_id: NodeId) -> 
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 pub fn generate_random_remote_enr() -> (CombinedKey, Enr) {
     let key = CombinedKey::generate_secp256k1();
 

--- a/trin-core/src/utils/portal_wire.rs
+++ b/trin-core/src/utils/portal_wire.rs
@@ -69,6 +69,7 @@ pub fn read_varint(buf: &[u8]) -> anyhow::Result<(usize, u32)> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
     use rstest::rstest;

--- a/trin-core/src/utp/packets.rs
+++ b/trin-core/src/utp/packets.rs
@@ -106,7 +106,7 @@ pub(crate) fn check_extensions(data: &[u8]) -> anyhow::Result<()> {
 
     // Check for pending extensions (early exit of previous loop)
     if extension_type != ExtensionType::None {
-        return Err(anyhow!("Invalid packet length"));
+        return Err(anyhow!("Invalid packet length for extension type"));
     }
 
     Ok(())
@@ -142,7 +142,7 @@ impl PacketHeader {
 
     /// Returns the packet's type.
     pub fn get_type(&self) -> PacketType {
-        PacketType::try_from(self.type_ver >> 4).unwrap()
+        PacketType::try_from(self.type_ver >> 4).expect("Can't parse packet type")
     }
 
     /// Returns the type of the first extension
@@ -501,6 +501,7 @@ impl fmt::Debug for Packet {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::utp::{
         packets::{

--- a/trin-core/src/utp/stream.rs
+++ b/trin-core/src/utp/stream.rs
@@ -1662,6 +1662,7 @@ impl UtpStream {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::utp::packets::PacketType::State;
     use crate::{

--- a/trin-core/src/utp/trin_helpers.rs
+++ b/trin-core/src/utp/trin_helpers.rs
@@ -27,7 +27,10 @@ impl UtpMessage {
 
     pub fn decode(bytes: &[u8]) -> Result<UtpMessage, String> {
         if bytes.len() >= 4 {
-            let len = u32::from_be_bytes(bytes[0..4].try_into().unwrap());
+            let len: Result<[u8; 4], std::array::TryFromSliceError> = bytes[0..4].try_into();
+            let len = u32::from_be_bytes(
+                len.map_err(|e| format!("Unable to parse utp message length: {e:?}"))?,
+            );
             if len + 4 <= bytes.len() as u32 {
                 let mut payload_vec: Vec<u8> = vec![];
                 payload_vec.extend_from_slice(&bytes[4..(len as usize + 4)]);
@@ -65,6 +68,7 @@ pub enum UtpStreamId {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::utp::trin_helpers::UtpMessage;
     use test_log::test;

--- a/trin-core/src/utp/util.rs
+++ b/trin-core/src/utp/util.rs
@@ -4,6 +4,7 @@ use std::ops::Sub;
 
 /// Calculate the exponential weighted moving average for a vector of numbers, with a smoothing
 /// factor `alpha` between 0 and 1. A higher `alpha` discounts older observations faster.
+#[allow(clippy::unwrap_used)]
 pub fn ewma<'a, T, I>(mut samples: I, alpha: f64) -> f64
 where
     T: ToPrimitive + 'a,

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -281,8 +281,16 @@ impl HistoryRequestHandler {
             })
             .collect();
 
+        let content = match HistoryContentItem::decode(&content) {
+            Ok(val) => val,
+            Err(err) => {
+                return Err(format!(
+                    "Error decoding content item: {content:?} with error: {err:?}"
+                ))
+            }
+        };
         Ok(json!(TraceContentInfo {
-            content: HistoryContentItem::decode(&content).unwrap(),
+            content,
             route: closest_nodes,
         }))
     }

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::unwrap_used)]
+
 pub mod events;
 mod jsonrpc;
 pub mod network;
@@ -35,13 +37,13 @@ pub async fn initialize_history_network(
     portalnet_config: PortalnetConfig,
     storage_config: PortalStorageConfig,
     header_oracle: Arc<RwLock<HeaderOracle>>,
-) -> (
+) -> anyhow::Result<(
     HistoryHandler,
     HistoryNetworkTask,
     HistoryEventTx,
     HistoryUtpTx,
     HistoryJsonRpcTx,
-) {
+)> {
     let (history_jsonrpc_tx, history_jsonrpc_rx) =
         mpsc::unbounded_channel::<HistoryJsonRpcRequest>();
     header_oracle.write().await.history_jsonrpc_tx = Some(history_jsonrpc_tx.clone());
@@ -54,7 +56,7 @@ pub async fn initialize_history_network(
         portalnet_config.clone(),
         header_oracle,
     )
-    .await;
+    .await?;
     let history_network = Arc::new(history_network);
     let history_handler = HistoryRequestHandler {
         network: Arc::clone(&history_network),
@@ -66,13 +68,13 @@ pub async fn initialize_history_network(
         utp_history_rx,
         history_event_rx,
     );
-    (
+    Ok((
         Some(history_handler),
         Some(history_network_task),
         Some(history_event_tx),
         Some(utp_history_tx),
         Some(history_jsonrpc_tx),
-    )
+    ))
 }
 
 pub fn spawn_history_network(

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -34,15 +34,16 @@ impl HistoryNetwork {
         storage_config: PortalStorageConfig,
         portal_config: PortalnetConfig,
         header_oracle: Arc<RwLock<HeaderOracle>>,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         let config = OverlayConfig {
             bootnode_enrs: portal_config.bootnode_enrs.clone(),
             enable_metrics: portal_config.enable_metrics,
             ..Default::default()
         };
-        let storage = Arc::new(PLRwLock::new(
-            PortalStorage::new(storage_config, ProtocolId::History).unwrap(),
-        ));
+        let storage = Arc::new(PLRwLock::new(PortalStorage::new(
+            storage_config,
+            ProtocolId::History,
+        )?));
         let validator = Arc::new(ChainHistoryValidator { header_oracle });
         let overlay = OverlayProtocol::new(
             config,
@@ -55,8 +56,8 @@ impl HistoryNetwork {
         )
         .await;
 
-        Self {
+        Ok(Self {
             overlay: Arc::new(overlay),
-        }
+        })
     }
 }

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -115,6 +115,7 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use std::fs;

--- a/trin-state/src/utils.rs
+++ b/trin-state/src/utils.rs
@@ -53,11 +53,11 @@ impl ToU256 for BigInt {
 pub fn distance(node_id: U256, content_id: U256) -> Result<U256, String> {
     let node_id_int = BigInt::from_u256(node_id);
     let content_id_int = BigInt::from_u256(content_id);
-    let modulo = BigInt::parse_bytes(&MODULO, 10).unwrap();
-    let mid = BigInt::parse_bytes(&MID, 10).unwrap();
+    let modulo = BigInt::parse_bytes(&MODULO, 10).expect("Parse static MODULO always works");
+    let mid = BigInt::parse_bytes(&MID, 10).expect("Parse static MID always works");
     let negative_mid = mid
         .checked_mul(&BigInt::from_bytes_le(Sign::Minus, &[1u8]))
-        .unwrap();
+        .expect("Static multiplication always works");
 
     let first_phrase = node_id_int - content_id_int + &mid;
     // % returns the remainder, we want to return the modulus
@@ -70,6 +70,7 @@ pub fn distance(node_id: U256, content_id: U256) -> Result<U256, String> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
     use test_log::test;


### PR DESCRIPTION
### What was wrong?
Naked unwraps are bad, and have a tendency slip through the cracks. Case in point, I missed one in #555. Even though @ogenev spotted it, I think it's a good idea to add a check for unwraps to clippy so we don't have to rely on humans.

Furthermore, while working with the testnet nodes, I've experienced multiple instances where nodes are crashing / behaving incorrectly due to these unwraps. 
- eg. I spent a solid day once trying to figure out why a node was running but wouldn't respond to `portal_historyPaginate*` endpoints. Turns out the history thread was crashing due to a naked unwrap.

Our style guide also [dictates](https://github.com/ethereum/trin/blob/master/docs/contributing.md#error-handling) that naked unwraps are not allowed and if there is an exception (eg parsing a static value), the justification must be labeled.

In this pr, I added a clippy check for `unwrap_used`. I went through and fixed all of the simple cases. I plan to go through (before merging this pr) and revisit the more complex cases once I get :+1: on adopting this lint from the others

### How was it fixed?
- Added `#[warn(clippy::unwrap_used)]` to each workspace, except...
  - `trin-cli` - this library is no longer "maintained"
  - `utp-testing` - since it's a "testing" library
- Introduced a `clippy.toml` file to allow for `allow-unwrap-in-tests` configuration 
- Currently, the `allow-unwrap-in-tests` lint is [only available in rust nightly, not stable](https://github.com/rust-lang/rust-clippy/issues/9062). Which requires an explicit `#[allow(clippy::unwrap_used)]` for each test block that contains unwraps - since our ci environment uses stable. Imo, this is a bit wordy, but a fair trade-off since...
  - we'll be able to remove these explicit `allows` once the feature gets in stable
  - according to the [clippy docs](https://doc.rust-lang.org/clippy/usage.html?highlight=meant#lint-configuration)
    - `Clippy is meant to be used with a generous sprinkling of #[allow(..)]s through your code.`
  - in the meantime we get the benefit of automatically checking for naked unwraps

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
