### PR TITLE
Add optional `content_value` param in `portal_*Offer` rpc

### DIFF
--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -91,7 +91,12 @@ pub trait HistoryNetworkApi {
     /// Send an OFFER request with given ContentKey, to the designated peer and wait for a response.
     /// Returns the content keys bitlist upon successful content transmission or empty bitlist receive.
     #[method(name = "historyOffer")]
-    async fn offer(&self, enr: Enr, content_key: HistoryContentKey) -> RpcResult<AcceptInfo>;
+    async fn offer(
+        &self,
+        enr: Enr,
+        content_key: HistoryContentKey,
+        content_value: Option<HistoryContentItem>,
+    ) -> RpcResult<AcceptInfo>;
 
     /// Store content key with a content data to the local database.
     #[method(name = "historyStore")]

--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -3,6 +3,7 @@ use std::os::unix;
 use std::{io::prelude::*, panic, time::Duration};
 
 use anyhow::anyhow;
+use ethportal_api::types::portal::AcceptInfo;
 use hyper::{self, Body, Client, Method, Request};
 use serde_json::{self, json, Value};
 use ssz::Encode;
@@ -246,9 +247,9 @@ fn validate_portal_routing_table_info(result: &Value, _peertest: &Peertest) {
     assert!(result.get("numConnected").unwrap().is_u64());
 }
 
-pub fn validate_portal_offer(result: &Value, _peertest: &Peertest) {
+pub fn validate_portal_offer(result: AcceptInfo, _peertest: &Peertest) {
     // Should accept the requested content
-    assert_eq!(result.get("contentKeys").unwrap().as_str(), Some("0x03"))
+    assert_eq!(hex_encode(result.content_keys.into_bytes()), "0x03")
 }
 
 pub fn validate_portal_local_content(result: &Value, _peertest: &Peertest) {

--- a/newsfragments/563.fixed.md
+++ b/newsfragments/563.fixed.md
@@ -1,0 +1,1 @@
+Allow `content_value` param in `portal_*Offer` json-rpc endpoint.

--- a/rpc/src/history.rs
+++ b/rpc/src/history.rs
@@ -167,8 +167,13 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
 
     /// Send an OFFER request with given ContentKey, to the designated peer and wait for a response.
     /// Returns the content keys bitlist upon successful content transmission or empty bitlist receive.
-    async fn offer(&self, enr: Enr, content_key: HistoryContentKey) -> RpcResult<AcceptInfo> {
-        let endpoint = HistoryEndpoint::Offer(enr, content_key);
+    async fn offer(
+        &self,
+        enr: Enr,
+        content_key: HistoryContentKey,
+        content_value: Option<HistoryContentItem>,
+    ) -> RpcResult<AcceptInfo> {
+        let endpoint = HistoryEndpoint::Offer(enr, content_key, content_value);
         let result = self.proxy_query_to_history_subnet(endpoint).await?;
         let result: AcceptInfo = from_value(result)?;
         Ok(result)

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -55,7 +55,13 @@ mod test {
         .await;
         peertest::jsonrpc::test_jsonrpc_endpoints_over_ipc(peertest_config.clone(), &peertest)
             .await;
-        peertest::scenarios::offer_accept::test_offer_accept(peertest_config.clone(), &peertest);
+        peertest::scenarios::offer_accept::test_unpopulated_offer(
+            peertest_config.clone(),
+            &peertest,
+        )
+        .await;
+        peertest::scenarios::offer_accept::test_populated_offer(peertest_config.clone(), &peertest)
+            .await;
         peertest::scenarios::find::test_trace_recursive_find_content(
             peertest_config.clone(),
             &peertest,

--- a/trin-core/src/jsonrpc/endpoints.rs
+++ b/trin-core/src/jsonrpc/endpoints.rs
@@ -37,7 +37,7 @@ pub enum HistoryEndpoint {
     /// params: [content_key, content_value]
     Gossip(HistoryContentKey, HistoryContentItem),
     /// params: [enr, content_key]
-    Offer(Enr, HistoryContentKey),
+    Offer(Enr, HistoryContentKey, Option<HistoryContentItem>),
     /// params: [enr, data_radius]
     Ping(Enr, Option<DataRadius>),
     /// params: content_key

--- a/trin-core/src/portalnet/overlay.rs
+++ b/trin-core/src/portalnet/overlay.rs
@@ -676,6 +676,30 @@ where
         }
     }
 
+    /// Send Offer request without storing the content into db
+    pub async fn send_populated_offer(
+        &self,
+        enr: Enr,
+        content_key: RawContentKey,
+        content_value: Vec<u8>,
+    ) -> Result<Accept, OverlayRequestError> {
+        // Construct the request.
+        let request = Request::PopulatedOffer(PopulatedOffer {
+            content_items: vec![(content_key, content_value)],
+        });
+
+        let direction = RequestDirection::Outgoing {
+            destination: enr.clone(),
+        };
+
+        // Send the request and wait on the response.
+        match self.send_overlay_request(request, direction).await {
+            Ok(Response::Accept(accept)) => Ok(accept),
+            Ok(_) => Err(OverlayRequestError::InvalidResponse),
+            Err(error) => Err(error),
+        }
+    }
+
     /// Performs a content lookup for `target`.
     /// Returns the target content along with the peers traversed during content lookup.
     pub async fn lookup_content(&self, target: TContentKey) -> (Option<Vec<u8>>, Vec<NodeId>) {

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -188,10 +188,12 @@ impl HistoryRequestHandler {
                     let enr = convert_enr(enr);
 
                     let response = if let Some(content_value) = content_value {
+                        let mut content_item = vec![];
+                        content_value.encode(&mut content_item);
                         match self
                             .network
                             .overlay
-                            .send_populated_offer(enr, content_key.into(), content_value.into())
+                            .send_populated_offer(enr, content_key.into(), content_item)
                             .await
                         {
                             Ok(accept) => Ok(json!(AcceptInfo {


### PR DESCRIPTION
### What was wrong?
Portal json-rpc [specs](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/portal-network-specs/assembled-spec/jsonrpc/openrpc.json&uiSchema%5BappBar%5D%5Bui:splitView%5D=false&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false) require that a `content_value` param is accepted in `portal_*Offer` endpoint. 

Closes #559

### How was it fixed?

Add an optional `content_value` param to `Offer` rpc. If it is not provided, we look for the content in the database, otherwise, we keep the content value in memory and send it using the `PopulateOffer` overlay request.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
