### PR TITLE
Use zero radius if empty storage & 0kb config

### DIFF
--- a/newsfragments/564.fixed.md
+++ b/newsfragments/564.fixed.md
@@ -1,0 +1,1 @@
+Update storage to skip pruning db if 0kb selected.

--- a/trin-core/src/portalnet/types/distance.rs
+++ b/trin-core/src/portalnet/types/distance.rs
@@ -16,6 +16,8 @@ impl fmt::Display for Distance {
 impl Distance {
     /// The maximum value.
     pub const MAX: Self = Self(U256::MAX);
+    /// The minimum value.
+    pub const ZERO: Self = Self(U256::zero());
 
     /// Returns the integer base-2 logarithm of `self`.
     ///


### PR DESCRIPTION
### What was wrong?
`PortalStorage` has some inconsistency w/ respect to the `--kb` flag, which revealed itself while running bridge nodes w/ `--kb 0`. 

Scenario 1
- User runs a fresh `trin` node (eg. random private key) w/ `--kb 0`
  - Problem: Storage would be configured w/ `Distance::MAX` as it's radius instead of `0`
  - Solution: Set radius to `Distance::ZERO` in this scenario

Scenario 2
- User runs an old `trin` node w/ `--kb 1` (when `--kb` was set to a greater number in a previous run)
  - Problem: There was no pruning until the user tried to "store" a new piece of data
  - Solution: Prune db inside `PortalStorage::new()` if capacity is reached on startup, & set relevant fields

Scenario 3
- User runs an old `trin` node w/ `--kb 0`
  - Problem: There was no pruning until the user tried to "store" a new piece of data & storage would be configured with radius set to `Distance::MAX`
  - Solution: Same as Scenario 2 but also set radius to `Distance::ZERO`

### How was it fixed?
- Also removed `farthest_content_id` field from `PortalStorage` struct which served no apparent purpose

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
