### PR TITLE
Cleanup clippy's `allow(dead_code)` attributes

### DIFF
--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,5 +1,4 @@
 #![warn(clippy::unwrap_used)]
-#![allow(dead_code)]
 
 mod discv5;
 mod history;

--- a/trin-core/src/portalnet/find/query_info.rs
+++ b/trin-core/src/portalnet/find/query_info.rs
@@ -46,7 +46,6 @@ pub enum QueryType<TContentKey> {
 
 impl<TContentKey: OverlayContentKey> QueryInfo<TContentKey> {
     /// Builds an RPC Request, given the QueryInfo
-    #[allow(dead_code)]
     pub(crate) fn rpc_request(&self, peer: NodeId) -> Result<Request, &'static str> {
         let request = match self.query_type {
             QueryType::FindNode {

--- a/trin-core/src/utp/trin_helpers.rs
+++ b/trin-core/src/utp/trin_helpers.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 // These are just some Trin helper functions
 
 use crate::portalnet::types::content_key::RawContentKey;
@@ -42,10 +41,6 @@ impl UtpMessage {
             }
         }
         Err("Invalid message".to_owned())
-    }
-
-    pub(crate) fn len(self) -> usize {
-        4 + self.payload.len()
     }
 }
 


### PR DESCRIPTION
### What was wrong?

Some `![allow(dead_code)]` attributes are sneaking into our codebase.

### How was it fixed?

Removes all `![allow(dead_code)]` occurrences.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
