### PR TITLE
Replace r2d2 connection pool with rusqlite connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3943,27 +3943,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "r2d2"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
-dependencies = [
- "log 0.4.17",
- "parking_lot 0.12.1",
- "scheduled-thread-pool",
-]
-
-[[package]]
-name = "r2d2_sqlite"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ca3c9468a76fc2ad724c486a59682fc362efeac7b18d1c012958bc19f34800"
-dependencies = [
- "r2d2",
- "rusqlite",
-]
-
-[[package]]
 name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4624,15 +4603,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
  "windows-sys",
-]
-
-[[package]]
-name = "scheduled-thread-pool"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977a7519bff143a44f842fd07e80ad1329295bd71686457f18e496736f4bf9bf"
-dependencies = [
- "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -5812,8 +5782,6 @@ dependencies = [
  "prometheus_exporter",
  "quickcheck",
  "quickcheck_macros",
- "r2d2",
- "r2d2_sqlite",
  "rand 0.8.5",
  "rlp 0.5.2",
  "rlp-derive",

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -37,8 +37,6 @@ rand = "0.8.4"
 rlp = "0.5.0"
 rlp-derive = "0.1.0"
 rocksdb = "0.18.0"
-r2d2 = "0.8.9"
-r2d2_sqlite = "0.19.0"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.59"
 sha2 = "0.10.1"


### PR DESCRIPTION
### What was wrong?
<s>`r2d2_sqlite` is heavy. When building a docker image, compilation for `r2d2_sqlite` alone accounts for ~45% of the compilation time</s>. We don't require the connection pool, and can use `rusqlite`'s `Connection` instead. Wrapped in a `Mutex` because [Connection is not Send + Sync](https://github.com/rusqlite/rusqlite/issues/342). It seems to me like this change should have no impact on performance as we start supporting multiple sub-networks.

### How was it fixed?
- Switch out `Pool<SqliteConnectionManager>` in favor of `Arc<Mutex<Connection>>`
- Remove dependency on `r2d2_sqlite`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
