### PR TITLE
Transfer from ogenev docker registry to portalnetwork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   docker-publisher:
     environment:
-      IMAGE_NAME: ogenev/trin
+      IMAGE_NAME: portalnetwork/trin
     docker:
       - image: cimg/rust:1.66.1
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,3 @@ members = [
     "rpc",
     "utp-testing",
 ]
-
-[[bin]]
-name = "purge-db"
-path = "src/bin/purge_db.rs"


### PR DESCRIPTION
### What was wrong?
We have two docker hub registries that need consolidation. 
- `portalnetwork/trin:latest` will be updated automatically with every merge into `master`. 
- `portalnetwork/trin:testnet` will be updated manually, and a tag `testnet` will be pushed to github to track testnet releases
- `portalnetwork/trin:bridge` will be updated manually

### How was it fixed?

Requires
- [x] Updating CircleCI env vars (will do after approval, before merging)
- [ ] Updating `portal-hive` to use new registry (delegating to @ogenev)

Also...
Includes a hotfix for failing `docker-build` step on `master`'s CI. The `[[bin]]` definition causes the output executable to be under a different name (`purge-db`). Since our testnet config is already tied to `purge_db`, I just removed the superfluous definition

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
