### PR TITLE
Update Github action for mdbook

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,61 +1,74 @@
 name: book
 on:
   push:
-    branches: [main]
+    branches: 
+      - master
     paths:
       - 'book/**'
       - 'book.toml'
+      - '.github/workflows/book.yml'
   pull_request:
-    branches: [main]
+    branches: 
+      - master
     paths:
       - 'book/**'
       - 'book.toml'
+      - '.github/workflows/book.yml'
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: test
-
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        run: |
+          rustup set profile minimal
+          rustup toolchain install stable
+          rustup default stable
 
       - name: Install mdbook
         run: |
-          mkdir mdbook
-          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-          echo `pwd`/mdbook >> $GITHUB_PATH
+          mkdir bin
+          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
+          echo "$(pwd)/bin" >> $GITHUB_PATH
 
       - name: Run tests
+        working-directory: book
         run: mdbook test
 
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install mdbook
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Install dependencies
+        run: cargo install mdbook
+      
+      - name: Install mdbook-mermaid
+        working-directory: book
         run: |
-          mkdir mdbook
-          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-          echo `pwd`/mdbook >> $GITHUB_PATH
+          cargo install mdbook-mermaid
+          mdbook-mermaid install
 
       - name: Build
+        working-directory: book
         run: mdbook build
 
-      - name: Save pages artifact
+      - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: target/book
+          path: ./book/book
 
   deploy:
-    # Only deploy if a push to main
-    if: github.ref_name == 'main' && github.event_name == 'push'
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
-    needs: [test, build]
+    needs:
+      - test
+      - build
 
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
       pages: write
       id-token: write

--- a/newsfragments/590.fixed.md
+++ b/newsfragments/590.fixed.md
@@ -1,0 +1,1 @@
+Update Github action for mdbook


### PR DESCRIPTION
### What was wrong?

`book.yml` didn't trigger a Github action, and the mdbook didn't deploy to Github pages.

### How was it fixed?

Update `book.yml` to test/build/deploy the mdbook. It will run test/build when PR are for the master branch, and it will deploy a page only when commits push to the master branch. [Deployed page](https://e3243eric.github.io/trin/).

- Rename branches from `main` to `master`.
- Add `book.yml` to paths.
- Update some steps in jobs. Reference: [running-rust-tests](https://github.com/rust-lang/mdBook/wiki/Automated-Deployment%3A-GitHub-Actions#running-rust-tests), [starter-workflows](https://github.com/actions/starter-workflows/blob/main/pages/mdbook.yml), [workflow to publish your site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#creating-a-custom-github-actions-workflow-to-publish-your-site).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
