### PR TITLE
Remove websocket from trusted provider

### DIFF
--- a/ethportal-peertest/src/lib.rs
+++ b/ethportal-peertest/src/lib.rs
@@ -82,7 +82,6 @@ pub async fn launch_node(trin_config: TrinConfig) -> anyhow::Result<PeertestNode
     let server = setup_mock_trusted_http_server();
     let mock_trusted_provider = TrustedProvider {
         http: ureq::post(&server.url("/")),
-        ws: None,
     };
     let rpc_handle = trin::run_trin(trin_config, mock_trusted_provider)
         .await

--- a/newsfragments/591.fixed.md
+++ b/newsfragments/591.fixed.md
@@ -1,0 +1,1 @@
+Remove ws option from Trusted Provider.

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -44,7 +44,6 @@ mod test {
         let server = peertest::setup_mock_trusted_http_server();
         let trusted_provider = TrustedProvider {
             http: ureq::post(&server.url("/")),
-            ws: None,
         };
         let test_client_rpc_handle = trin::run_trin(trin_config, trusted_provider).await.unwrap();
 

--- a/trin-core/src/utils/provider.rs
+++ b/trin-core/src/utils/provider.rs
@@ -12,7 +12,6 @@ use crate::jsonrpc::service::dispatch_trusted_http_request;
 use crate::jsonrpc::types::{JsonRequest, Params};
 
 pub const INFURA_BASE_HTTP_URL: &str = "https://mainnet.infura.io:443/v3/";
-pub const INFURA_BASE_WS_URL: &str = "wss://mainnet.infura.io:443/ws/v3/";
 pub const DEFAULT_LOCAL_PROVIDER: &str = "http://127.0.0.1:8545";
 
 // Type used for parsing cli args
@@ -54,7 +53,6 @@ impl FromStr for TrustedProviderType {
 #[derive(Clone, Debug)]
 pub struct TrustedProvider {
     pub http: Request,
-    pub ws: Option<String>,
 }
 
 impl TrustedProvider {
@@ -75,16 +73,8 @@ impl TrustedProvider {
                 ),
             },
         };
-        let trusted_ws_url = match trin_config.trusted_provider {
-            TrustedProviderType::Infura => Some(build_infura_ws_url_from_env()),
-            TrustedProviderType::Pandaops => {
-                panic!("Pandaops connection is not currently supported over websockets.")
-            }
-            TrustedProviderType::Custom => None,
-        };
         Self {
             http: trusted_http_client,
-            ws: trusted_ws_url,
         }
     }
 
@@ -118,11 +108,6 @@ fn build_infura_http_client_from_env() -> ureq::Request {
     let infura_project_id = get_infura_project_id_from_env();
     let infura_url = format!("{INFURA_BASE_HTTP_URL}{infura_project_id}");
     ureq::post(&infura_url)
-}
-
-fn build_infura_ws_url_from_env() -> String {
-    let infura_project_id = get_infura_project_id_from_env();
-    format!("{INFURA_BASE_WS_URL}{infura_project_id}")
 }
 
 fn get_pandaops_client_id_from_env() -> String {

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -447,7 +447,6 @@ mod tests {
     fn default_header_oracle(infura_url: String) -> Arc<RwLock<HeaderOracle>> {
         let trusted_provider = TrustedProvider {
             http: ureq::post(&infura_url),
-            ws: None,
         };
         let master_acc =
             MasterAccumulator::try_from_file(PathBuf::from(DEFAULT_MASTER_ACC_PATH.to_string()))


### PR DESCRIPTION
### What was wrong?
The logic for generating `TrustedProvider` when using panda ops caused a panic, which occurred when deploying the bridge nodes to the testnet. Imo, it's worth removing the `ws` attribute entirely from `TrustedProvider`
- The pandaops nodes don't support ws
- The decision to have a ws option was back when we were targeting wallet users - and expected to proxy to infura quite frequently. Now, we're targeting research and expect to remove any infura relience in the near future.

If we want to leave in the `ws` attribute, it's fairly simple bugfix to avoid the panic. But, imo since we don't need `ws` we might as well remove it entirely

### How was it fixed?
Removed `ws` attribute from `TrustedProvider`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
