### PR TITLE
Add trin-types copy step to dockerfile (hotfix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY ./trin-cli ./trin-cli
 COPY ./trin-core ./trin-core 
 COPY ./trin-history ./trin-history 
 COPY ./trin-state ./trin-state 
+COPY ./trin-types ./trin-types
 COPY ./trin-utils ./trin-utils 
 COPY ./ethportal-peertest ./ethportal-peertest 
 COPY ./utp-testing ./utp-testing


### PR DESCRIPTION
### What was wrong?
Eww, sorry for the second hotfix in one day. I forgot to add the step to the dockerfile to copy over the newly created workspace: `trin-types` in #588 

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
