### PR TITLE
Add 'clippy::cargo' and 'unused_crate_dependencies' lints to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 help:
 		@echo "lint - run clippy and rustfmt"
+		@echo "lint-unstable - run clippy, rustfmt and rustc lints with unstable features. expect errors, which cannot be resolved, so the user must step through and evaluate each one manually."
 		@echo "notes - generate release notes"
 		@echo "release - publish a new release"
 		@echo "create-docker-image - create docker image"
@@ -8,6 +9,11 @@ help:
 lint:	
 		cargo clippy --all --all-targets --all-features --no-deps -- --deny warnings
 		cargo fmt --all -- --check
+
+lint-unstable:
+		cargo clippy --all --all-targets --all-features --no-deps -- -Wclippy::cargo
+		cargo fmt --all -- --check
+		RUSTFLAGS="-W unused_crate_dependencies" cargo build
 
 notes:
 		towncrier --yes --version $(version)

--- a/newsfragments/601.added.md
+++ b/newsfragments/601.added.md
@@ -1,0 +1,1 @@
+Add ``clippy::cargo`` and ``unused_crate_dependencies`` to Makefile ``lint-unstable``.


### PR DESCRIPTION
### What was wrong?

Related to Issue #599.

### How was it fixed?

Add a new Makefile `lint-optional` command. This command includes the original lint checks, and adds the `clippy::cargo` and the rustc lint `unused_crate_dependencies`. It will bump up warnings and includes some false positives as #599 said.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
