### PR TITLE
Build docker image with git hash env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Build Docker image
           no_output_timeout: 30m
-          command: docker build -t $IMAGE_NAME:latest .
+          command: docker build -t $IMAGE_NAME:latest --build-arg GIT_HASH=$CIRCLE_SHA1 .
       - run:
           name: Archive Docker image
           command: docker save -o image.tar $IMAGE_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ FROM rust:1.66.1 AS builder
 RUN USER=root cargo new --bin trin
 WORKDIR /trin
 
+# Docker build command *SHOULD* include --build-arg GIT_HASH=...
+# eg. --build-arg GIT_HASH=$(git rev-parse HEAD)
+ARG GIT_HASH=unknown
+ENV GIT_HASH=$GIT_HASH
+
 RUN apt-get update && apt-get install clang -y
 
 # copy over manifests and source to build image

--- a/newsfragments/604.fixed.md
+++ b/newsfragments/604.fixed.md
@@ -1,0 +1,1 @@
+Fix build script setting GIT_HASH env var so it is compatible with docker build environment.

--- a/trin-utils/build.rs
+++ b/trin-utils/build.rs
@@ -1,11 +1,29 @@
+use std::env;
 use std::process::Command;
+
 fn main() {
     let output = Command::new("git")
         .args(["rev-parse", "HEAD"])
         .output()
         .expect("Unable to get git hash");
-    let git_hash = String::from_utf8(output.stdout)
-        .expect("git rev-parse output must be a valid utf8 encoding");
+    let output = String::from_utf8(output.stdout)
+        .expect("git rev-parse output must be a valid utf8 encoding")
+        .replace('\n', "");
+    let git_hash = match output.len() {
+        40 => output,
+        _ => {
+            // If the git hash is not 40 characters, then we are probably in a
+            // docker build context, in which case we access the git hash via the
+            // environment variable set in the Docker build command
+            match env::var("GIT_HASH") {
+                Ok(val) => match val.len() {
+                    40 => val,
+                    _ => "".to_string(),
+                },
+                Err(_) => "".to_string(),
+            }
+        }
+    };
     // Printing to stdout is how build scripts communicate with cargo
     // https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);


### PR DESCRIPTION
### What was wrong?
`git` is not available from within the docker build context. Which means that all of our docker-based nodes (eg. hive & testnet) are built w/o the git hash in their enr (`trin v0.1.0-unknown`). The latest commit hash must be passed in manually using the `--build-arg` flag. 

### How was it fixed?
Added logic to check for the docker build argument if git is not available to produce the git hash.

[This docker image](https://hub.docker.com/layers/portalnetwork/trin/latest/images/sha256-13fbae2c1ebedfebc8d989d5e7f5ff338bb01377aff7d8e4fbe60f64048a0295?context=explore) contains the build of this pr. If you pull it down locally and run it, you can see the git hash in the displayed version when you launch trin.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
