### PR TITLE
bump utp-rs dependency version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6395,9 +6395,9 @@ checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utp-rs"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2189fee3a270a59241c510089f98a6e6c25e3e0e7d36db7344ff0526806c7df4"
+checksum = "7e60a53f80566700de23c22873f36c3974ab60193fcbcca7c0b12bde315994ff"
 dependencies = [
  "async-trait",
  "delay_map 0.1.2",

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -55,7 +55,7 @@ trin-utils = { path="../trin-utils" }
 trin-validation = { path="../trin-validation" }
 validator = { version = "0.13.0", features = ["derive"] }
 url = "2.3.1"
-utp-rs = "0.1.0-alpha.2"
+utp-rs = "0.1.0-alpha.3"
 
 [target.'cfg(windows)'.dependencies]
 ipconfig = "0.2.2"

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -27,7 +27,7 @@ trin-core = { path = "../trin-core" }
 trin-types = { path = "../trin-types" }
 trin-utils = { path = "../trin-utils" }
 trin-validation = { path = "../trin-validation" }
-utp-rs = "0.1.0-alpha.2"
+utp-rs = "0.1.0-alpha.3"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -25,7 +25,7 @@ tokio = {version = "1.14.0", features = ["full"]}
 trin-core = { path = "../trin-core" }
 trin-types = { path = "../trin-types" }
 trin-validation = { path = "../trin-validation" }
-utp-rs = "0.1.0-alpha.2"
+utp-rs = "0.1.0-alpha.3"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -22,7 +22,7 @@ trin-core = { path = "../trin-core" }
 trin-types = { path = "../trin-types" }
 trin-utils = { path = "../trin-utils" }
 tokio = {version = "1.14.0", features = ["full"]}
-utp-rs = "0.1.0-alpha.2"
+utp-rs = "0.1.0-alpha.3"
 
 [[bin]]
 name = "utp-test-app"


### PR DESCRIPTION
### What was wrong?

#610 

### How was it fixed?

bump `utp-rs` version to [`0.1.0-alpha.3`](https://github.com/jacobkaufmann/utp/pull/42), which includes changes to address verbosity issue above

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
