### PR TITLE
Remove history content key/item `Unknown` variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,6 +3882,7 @@ dependencies = [
  "ethportal-api",
  "portalnet",
  "reth-ipc",
+ "serde_json",
  "tokio",
  "trin-types",
  "trin-utils",
@@ -5196,6 +5197,7 @@ dependencies = [
  "snap",
  "structopt",
  "test-log",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5211,8 +5213,8 @@ dependencies = [
 name = "trin-utils"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "hex",
+ "thiserror",
 ]
 
 [[package]]

--- a/ethportal-api/README.md
+++ b/ethportal-api/README.md
@@ -11,7 +11,7 @@ Enable `client` feature of `ethportal-api` crate.
 ```rust,no_run
 use ethportal_api::jsonrpsee::http_client::HttpClientBuilder;
 use ethportal_api::{
-    HistoryContentItem, HistoryContentKey, HistoryNetworkApiClient, Web3ApiClient,
+    HistoryContentValue, HistoryContentKey, HistoryNetworkApiClient, Web3ApiClient,
 };
 
 #[tokio::main]
@@ -31,7 +31,7 @@ async fn main() {
 
     // Deserialise to a portal history content key type from a hex string
     let content_key: HistoryContentKey = serde_json::from_str(content_key_json).unwrap();
-    let content_item: HistoryContentItem = serde_json::from_str(content_item_json).unwrap();
+    let content_item: HistoryContentValue = serde_json::from_str(content_item_json).unwrap();
 
     // Store content to remote node, call portal_historyStore endpoint
     let result: bool = client
@@ -40,8 +40,8 @@ async fn main() {
         .unwrap();
     assert!(result);
 
-    // Call portal_historyLocalContent endpoint and deserialize to `HistoryContentItem::BlockHeaderWithProof` type
-    let result: HistoryContentItem = client.local_content(content_key).await.unwrap();
+    // Call portal_historyLocalContent endpoint and deserialize to `HistoryContentValue::BlockHeaderWithProof` type
+    let result: HistoryContentValue = client.local_content(content_key).await.unwrap();
     assert_eq!(result, content_item);
 }
 ```

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -8,7 +8,7 @@ use crate::types::{
 };
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use trin_types::content_key::HistoryContentKey;
-use trin_types::content_value::HistoryContentValue;
+use trin_types::content_value::{HistoryContentValue, PossibleHistoryContentValue};
 
 /// Portal History JSON-RPC endpoints
 #[rpc(client, server, namespace = "portal")]
@@ -63,7 +63,7 @@ pub trait HistoryNetworkApi {
     async fn recursive_find_content(
         &self,
         content_key: HistoryContentKey,
-    ) -> RpcResult<HistoryContentValue>;
+    ) -> RpcResult<PossibleHistoryContentValue>;
 
     /// Lookup a target content key in the network. Return tracing info.
     #[method(name = "historyTraceRecursiveFindContent")]
@@ -109,6 +109,8 @@ pub trait HistoryNetworkApi {
 
     /// Get a content from the local database
     #[method(name = "historyLocalContent")]
-    async fn local_content(&self, content_key: HistoryContentKey)
-        -> RpcResult<HistoryContentValue>;
+    async fn local_content(
+        &self,
+        content_key: HistoryContentKey,
+    ) -> RpcResult<PossibleHistoryContentValue>;
 }

--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -2,7 +2,7 @@ use crate::types::enr::Enr;
 use serde::{Deserialize, Serialize};
 use ssz_types::{typenum, BitList};
 use trin_types::content_key::HistoryContentKey;
-use trin_types::content_value::HistoryContentValue;
+use trin_types::content_value::{HistoryContentValue, PossibleHistoryContentValue};
 
 pub type DataRadius = ethereum_types::U256;
 pub type Distance = ethereum_types::U256;
@@ -50,11 +50,14 @@ pub struct AcceptInfo {
     pub content_keys: BitList<typenum::U8>,
 }
 
-/// Response for TraceRecursiveFindContent endpoint
+/// Parsed response for TraceRecursiveFindContent endpoint
+///
+/// The RPC response encodes absent content as "0x". This struct
+/// represents the content info, using None for absent content.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TraceContentInfo {
-    pub content: HistoryContentValue,
+    pub content: PossibleHistoryContentValue,
     pub route: Vec<NodeInfo>,
 }
 

--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -8,6 +8,7 @@ use hyper::{self, Body, Client, Method, Request};
 use serde_json::{self, json, Value};
 use ssz::Encode;
 use tracing::{error, info};
+use trin_types::constants::CONTENT_ABSENT;
 
 use crate::{cli::PeertestConfig, Peertest};
 use trin_types::distance::Distance;
@@ -203,7 +204,7 @@ fn validate_discv5_node_info(val: &Value, _peertest: &Peertest) {
 fn validate_discv5_routing_table_info(val: &Value, _peertest: &Peertest) {
     let local_key = val.get("localNodeId").unwrap();
     assert!(local_key.is_string());
-    assert!(local_key.as_str().unwrap().contains("0x"));
+    assert!(local_key.as_str().unwrap().starts_with("0x"));
     assert!(val.get("buckets").unwrap().is_array());
 }
 
@@ -254,7 +255,7 @@ pub fn validate_portal_offer(result: AcceptInfo, _peertest: &Peertest) {
 }
 
 pub fn validate_portal_local_content(result: &Value, _peertest: &Peertest) {
-    assert_eq!(result.as_str().unwrap(), "0x0");
+    assert_eq!(result.as_str().unwrap(), CONTENT_ABSENT);
 }
 
 #[cfg(unix)]

--- a/ethportal-peertest/src/scenarios/paginate.rs
+++ b/ethportal-peertest/src/scenarios/paginate.rs
@@ -1,7 +1,9 @@
 use ethportal_api::HistoryContentValue;
 use ethportal_api::HistoryNetworkApiClient;
 use ethportal_api::{BlockHeaderKey, HistoryContentKey};
+use serde_json::json;
 
+use crate::jsonrpc::HISTORY_CONTENT_VALUE;
 use crate::{Peertest, PeertestConfig};
 
 pub async fn test_paginate_local_storage(peertest_config: PeertestConfig, _peertest: &Peertest) {
@@ -25,10 +27,12 @@ pub async fn test_paginate_local_storage(peertest_config: PeertestConfig, _peert
 
     for content_key in content_keys.clone().into_iter() {
         // Store content to offer in the testnode db
+        let dummy_content_value: HistoryContentValue =
+            serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).unwrap();
         let store_result = ipc_client
             .store(
                 serde_json::from_str(&content_key).unwrap(),
-                HistoryContentValue::Unknown("0x00".to_owned()),
+                dummy_content_value,
             )
             .await
             .unwrap();

--- a/newsfragments/538.changed.md
+++ b/newsfragments/538.changed.md
@@ -1,0 +1,1 @@
+Change HistoryContentValue to remove Unknown variant.

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -1471,9 +1471,11 @@ where
         let content_values = portal_wire::decode_content_payload(payload)?;
 
         // Accepted content keys len should match content value len
-        if content_keys.len() != content_values.len() {
+        let keys_len = content_keys.len();
+        let vals_len = content_values.len();
+        if keys_len != vals_len {
             return Err(anyhow!(
-                "Content keys len doesn't match content values len."
+                "Content keys len {keys_len} doesn't match content values len {vals_len}."
             ));
         }
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -19,3 +19,4 @@ trin-utils = { path = "../trin-utils"}
 tokio = { version = "1.14.0", features = ["full"] }
 reth-ipc = { version = "0.1.0", git = "https://github.com/paradigmxyz/reth.git"}
 url = "2.3.1"
+serde_json = "1.0.95"

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -21,8 +21,9 @@ mod test {
 
         let peertest_config = peertest::PeertestConfig::default();
         let test_ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-        let test_port = 9000;
-        let external_addr = format!("{test_ip_addr}:{test_port}");
+        // Use an uncommon port for the peertest to avoid clashes.
+        let test_discovery_port = 8999;
+        let external_addr = format!("{test_ip_addr}:{test_discovery_port}");
 
         // Run a client, to be tested
         let trin_config = TrinConfig::new_from(
@@ -35,6 +36,8 @@ mod test {
                 "--web3-ipc-path",
                 &peertest_config.target_ipc_path,
                 "--ephemeral",
+                "--discovery-port",
+                test_discovery_port.to_string().as_ref(),
             ]
             .iter(),
         )
@@ -61,6 +64,10 @@ mod test {
         peertest::scenarios::offer_accept::test_populated_offer(peertest_config.clone(), &peertest)
             .await;
         peertest::scenarios::find::test_trace_recursive_find_content(
+            peertest_config.clone(),
+            &peertest,
+        );
+        peertest::scenarios::find::test_trace_recursive_find_content_for_absent_content(
             peertest_config.clone(),
             &peertest,
         );

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -110,7 +110,6 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
                 }
                 Ok(())
             }
-            &ethportal_api::HistoryContentKey::Unknown(_) => todo!(),
         }
     }
 }

--- a/trin-types/Cargo.toml
+++ b/trin-types/Cargo.toml
@@ -40,6 +40,7 @@ trin-utils = { path = "../trin-utils" }
 ureq = { version = "2.5.0", features = ["json"] }
 url = "2.3.1"
 validator = { version = "0.13.0", features = ["derive"] }
+thiserror = "1.0.40"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/trin-types/src/constants.rs
+++ b/trin-types/src/constants.rs
@@ -1,0 +1,2 @@
+/// Portal network defines "content absent" response as "0x".
+pub const CONTENT_ABSENT: &str = "0x";

--- a/trin-types/src/content_value.rs
+++ b/trin-types/src/content_value.rs
@@ -1,9 +1,11 @@
+use crate::constants::CONTENT_ABSENT;
 use crate::execution::accumulator::EpochAccumulator;
 use crate::execution::block_body::BlockBody;
 use crate::execution::header::HeaderWithProof;
 use crate::execution::receipts::Receipts;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ssz::{Decode, Encode};
+use thiserror::Error;
 use trin_utils::bytes::{hex_decode, hex_encode};
 
 /// An encodable portal network content value.
@@ -11,7 +13,7 @@ pub trait ContentValue: Sized {
     /// Encodes the content value into a byte vector.
     fn encode(&self) -> Vec<u8>;
     /// Decodes `buf` into a content value.
-    fn decode(buf: &[u8]) -> anyhow::Result<Self>;
+    fn decode(buf: &[u8]) -> Result<Self, ContentValueError>;
 }
 
 /// The length of the Merkle proof for the inclusion of a block header in a particular epoch
@@ -26,8 +28,93 @@ pub enum HistoryContentValue {
     BlockBody(BlockBody),
     Receipts(Receipts),
     EpochAccumulator(EpochAccumulator),
-    /// A placeholder for data that could not be interpreted as any of the valid content types.
-    Unknown(String),
+}
+
+/// A content response from the RPC server.
+///
+/// This type allows the RPC response to be non-error,
+/// functioning as an Option, but with None serializing to "0x"
+/// rather than 'null'.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PossibleHistoryContentValue {
+    ContentPresent(HistoryContentValue),
+    ContentAbsent,
+}
+
+impl Serialize for PossibleHistoryContentValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            PossibleHistoryContentValue::ContentPresent(content) => content.serialize(serializer),
+            PossibleHistoryContentValue::ContentAbsent => serializer.serialize_str(CONTENT_ABSENT),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PossibleHistoryContentValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+
+        if s.as_str() == CONTENT_ABSENT {
+            return Ok(PossibleHistoryContentValue::ContentAbsent);
+        }
+
+        let content_bytes = hex_decode(&s).map_err(serde::de::Error::custom)?;
+
+        if let Ok(value) = HeaderWithProof::from_ssz_bytes(&content_bytes) {
+            return Ok(Self::ContentPresent(
+                HistoryContentValue::BlockHeaderWithProof(value),
+            ));
+        }
+
+        if let Ok(value) = BlockBody::from_ssz_bytes(&content_bytes) {
+            return Ok(Self::ContentPresent(HistoryContentValue::BlockBody(value)));
+        }
+
+        if let Ok(value) = Receipts::from_ssz_bytes(&content_bytes) {
+            return Ok(Self::ContentPresent(HistoryContentValue::Receipts(value)));
+        }
+
+        if let Ok(value) = EpochAccumulator::from_ssz_bytes(&content_bytes) {
+            return Ok(Self::ContentPresent(HistoryContentValue::EpochAccumulator(
+                value,
+            )));
+        }
+
+        Err(ContentValueError::UnknownContent {
+            bytes: s,
+            network: "history".to_string(),
+        })
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+/// An error decoding a portal network content value.
+#[derive(Clone, Debug, Error, PartialEq)]
+pub enum ContentValueError {
+    #[error("unable to decode value SSZ bytes {input} due to {decode_error:?}")]
+    DecodeSsz {
+        decode_error: ssz::DecodeError,
+        input: String,
+    },
+    #[error("could not determine content type of {bytes} from {network} network")]
+    UnknownContent { bytes: String, network: String },
+    /// The content value is the "0x" absent content message rather than data.
+    ///
+    /// This error implies that handling of the "content absent" response was skipped.
+    #[error("attempted to deserialize the '0x' absent content message")]
+    DeserializeAbsentContent,
+
+    /// The content value is the "0x" absent content message rather than data.
+    ///
+    /// This error implies that handling of the "content absent" response was skipped.
+    #[error("attempted to decode the '0x' absent content message")]
+    DecodeAbsentContent,
 }
 
 impl ContentValue for HistoryContentValue {
@@ -37,11 +124,15 @@ impl ContentValue for HistoryContentValue {
             Self::BlockBody(value) => value.as_ssz_bytes(),
             Self::Receipts(value) => value.as_ssz_bytes(),
             Self::EpochAccumulator(value) => value.as_ssz_bytes(),
-            Self::Unknown(value) => hex_decode(value).unwrap_or_default(),
         }
     }
 
-    fn decode(buf: &[u8]) -> anyhow::Result<Self> {
+    fn decode(buf: &[u8]) -> Result<Self, ContentValueError> {
+        // Catch any attempt to construct a content value from "0x" improperly.
+        if buf == CONTENT_ABSENT.to_string().as_bytes() {
+            return Err(ContentValueError::DecodeAbsentContent);
+        }
+
         if let Ok(value) = HeaderWithProof::from_ssz_bytes(buf) {
             return Ok(Self::BlockHeaderWithProof(value));
         }
@@ -57,8 +148,10 @@ impl ContentValue for HistoryContentValue {
         if let Ok(value) = EpochAccumulator::from_ssz_bytes(buf) {
             return Ok(Self::EpochAccumulator(value));
         }
-
-        Ok(Self::Unknown(hex_encode(buf)))
+        Err(ContentValueError::UnknownContent {
+            bytes: hex_encode(buf),
+            network: "history".to_string(),
+        })
     }
 }
 
@@ -72,12 +165,6 @@ impl Serialize for HistoryContentValue {
             Self::BlockBody(value) => value.as_ssz_bytes(),
             Self::Receipts(value) => value.as_ssz_bytes(),
             Self::EpochAccumulator(value) => value.as_ssz_bytes(),
-            Self::Unknown(value) => {
-                if value.is_empty() {
-                    return serializer.serialize_str("0x0");
-                }
-                value.clone().into_bytes()
-            }
         };
         serializer.serialize_str(&hex_encode(encoded))
     }
@@ -90,8 +177,9 @@ impl<'de> Deserialize<'de> for HistoryContentValue {
     {
         let s = String::deserialize(deserializer)?;
 
-        if s.as_str() == "0x0" {
-            return Ok(Self::Unknown(String::from("")));
+        if s.as_str() == CONTENT_ABSENT {
+            return Err(ContentValueError::DeserializeAbsentContent)
+                .map_err(serde::de::Error::custom);
         }
         let content_bytes = hex_decode(&s).map_err(serde::de::Error::custom)?;
 
@@ -111,7 +199,11 @@ impl<'de> Deserialize<'de> for HistoryContentValue {
             return Ok(Self::EpochAccumulator(value));
         }
 
-        Ok(Self::Unknown(s))
+        Err(ContentValueError::UnknownContent {
+            bytes: s,
+            network: "history".to_string(),
+        })
+        .map_err(serde::de::Error::custom)
     }
 }
 
@@ -154,5 +246,39 @@ mod test {
         let epoch_acc = EpochAccumulator::from_ssz_bytes(&epoch_acc_ssz).unwrap();
         assert_eq!(epoch_acc.len(), EPOCH_SIZE);
         assert_eq!(epoch_acc.as_ssz_bytes(), epoch_acc_ssz);
+    }
+
+    #[test]
+    fn content_value_deserialization_failure_displays_debuggable_data() {
+        let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let item_result = HistoryContentValue::decode(&data);
+        let error = item_result.unwrap_err();
+        // Test the error Debug representation
+        assert_eq!(
+            error,
+            ContentValueError::UnknownContent {
+                bytes: "0x010203040506070809".to_string(),
+                network: "history".to_string()
+            }
+        );
+        // Test the error Display representation.
+        assert_eq!(
+            error.to_string(),
+            "could not determine content type of 0x010203040506070809 from history network"
+        );
+    }
+
+    #[test]
+    fn content_value_absent_raises_error_on_deserialization() {
+        let data = CONTENT_ABSENT.to_string();
+        let item_result = HistoryContentValue::decode(data.as_bytes());
+        let error = item_result.unwrap_err();
+        // Test the error Debug representation
+        assert_eq!(error, ContentValueError::DecodeAbsentContent);
+        // Test the error Display representation.
+        assert_eq!(
+            error.to_string(),
+            "attempted to decode the '0x' absent content message"
+        );
     }
 }

--- a/trin-types/src/lib.rs
+++ b/trin-types/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bytes;
 pub mod cli;
 pub mod consensus;
+pub mod constants;
 pub mod content_key;
 pub mod content_value;
 pub mod distance;

--- a/trin-utils/Cargo.toml
+++ b/trin-utils/Cargo.toml
@@ -12,5 +12,5 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 build = "build.rs"
 
 [dependencies]
-anyhow = "1.0.68"
 hex = "0.4.3"
+thiserror = "1.0.40"


### PR DESCRIPTION
## What was wrong?

- Resolves #538
- Fixes #540

## How was it fixed?

- `thiserror` is used to capture errors 
- Problematic bytes are stored in an error variant:
    - Where decoding fails to produce a known content type (item/key), represent the input as an error variant rather than a content variant.
- `From` replace with `TryFrom`:
    - When a content key decode failure was encountered via `From`, the `Unknown` variant was used. Now, `From` is replaced with `TryFrom`.
- RPC responses are wrapped in an Option-like enum for `HistoryContentValue `called `PossibleHistoryContentValue`. This allows the None variant to be represented as `0x`. The serialization and deserializeation of this new enum could be probably be shortened by pointing to the implementations for `HistoryContentValue`.

```rs
// ethportal-api/src/types/content_item.rs

/// An error decoding a portal network content item.
#[derive(Clone, Debug, Error, PartialEq)]
pub enum ContentValueError {
    #[error("unable to decode value SSZ bytes {input} due to {decode_error:?}")]
    DecodeSsz {
        decode_error: ssz::DecodeError,
        input: String,
    },
    #[error("could not determine content type of {bytes} from {network} network")]
    UnknownContent { bytes: String, network: String },
    /// The content value is the "0x" absent content message rather than data.
    ///
    /// This error implies that handling of the "content absent" response was skipped.
    #[error("attempted to deserialize the '0x' absent content message")]
    DeserializeAbsentContent,

    /// The content value is the "0x" absent content message rather than data.
    ///
    /// This error implies that handling of the "content absent" response was skipped.
    #[error("attempted to decode the '0x' absent content message")]
    DecodeAbsentContent,
}
```
Errors have two representations and a test is introduced to check both kinds:
- Debug: `UnknownContent { bytes: "0x010203040506070809", network: "history" }`
- Display: `"could not determine content type of 0x010203040506070809 from history network"`

## Other notes

### co-resolution of rusqlite mixed error handling
Handling of the `TryFrom` code touched some previously unresolved `rusqlite` error workaround where multiple error
kinds were occurring within closure that had to return a rusqlite error. This was fixed by dividing the closure into two and mapping the rusqlite error to a native error
```rs
 #[error("rusqlite error")]
 Rusqlite(#[from] rusqlite::Error),
```

### Automatic implementation of existing error traits

The existing errors (`ContentKeyError`, `ContentItemError`) had manual implementations of `From` and `Display`. These
have been moved to the error enum via the derive syntax that `thiserror` provides.

### Replaced anyhow use in trin-utils with custom error types

The hex utils had opaque anyhow errors, which were changed to specific error kinds for greater transparency upon failure.
This is accompanied by additional unit tests and handling of cases where the `hex_decode()` function could panic.

This could be pulled out as a separate PR. I included it because a) handling no content responses with hex_decode induced a panic that was unhandled due to string slice indexing and b) newly created error variants elsewhere would have been created with opaque internal anyhow that would later need to be undone.

### Treat invalid keys in requests as error

Peertest was responding with `0x` when passed an invalid key (odd length, too short, etc). Now it responds with invalid parameter jsonrpc response and includes a message with an explanation of the reason.
```console
{"code": Number(-32602), "message": String("unable to decode key SSZ bytes 0x0055b11b918355b1ef9c5db810302ebad0bf2544255b530cdce9 due to InvalidByteLength { len: 25, expected: 32 }")}
```

### Check content tracing of absent-content response

Previously there was no peertest to check the peers involved when a particular content value was absent. A test is
added, with a check that the ENR list has at least one peer (the specific peer ENR is not asserted as the content is
not posted to a particular peer.)

## To-Do

- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
- [x] Resolve remaining issues related to replacing `From` with `TryFrom` for the `HistoryContentKey`
- [x] Testing