### PR TITLE
Storage metrics for log report

### DIFF
--- a/trin-core/src/portalnet/storage.rs
+++ b/trin-core/src/portalnet/storage.rs
@@ -732,7 +732,7 @@ impl StorageMetrics {
     pub fn new(protocol: &ProtocolId) -> Self {
         let content_storage_usage_kb_options = opts!(
             format!("trin_content_storage_usage_kb_{protocol:?}"),
-            "help"
+            "sum of size of individual content stored, in kb"
         );
         let (content_storage_usage_kb, registry) = match register_gauge!(
             content_storage_usage_kb_options.clone()
@@ -753,13 +753,13 @@ impl StorageMetrics {
 
         let total_storage_usage_kb = register_gauge_with_registry!(
             format!("trin_total_storage_usage_kb_{protocol:?}"),
-            "help",
+            "full on-disk database size, in kb",
             registry,
         )
         .unwrap();
         let storage_capacity_kb = register_gauge_with_registry!(
             format!("trin_storage_capacity_kb_{protocol:?}"),
-            "help",
+            "user-defined limit on storage usage, in kb",
             registry
         )
         .unwrap();

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -115,10 +115,8 @@ pub fn spawn_history_heartbeat(network: Arc<HistoryNetwork>) {
         let mut heart_interval = interval(Duration::from_millis(30000));
 
         loop {
-            let radius = network.overlay.store.read().radius();
-            // calculate the percentage of the whole data ring covered by the data radius
-            let coverage_percent = radius.byte(31) as f32 * 100.0 / 255.0;
-            info!("report: radius={coverage_percent:.1}%");
+            let storage_log = network.overlay.store.read().get_summary_info();
+            info!("storage-report: {storage_log}");
             heart_interval.tick().await;
         }
     });

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -115,9 +115,12 @@ pub fn spawn_history_heartbeat(network: Arc<HistoryNetwork>) {
         let mut heart_interval = interval(Duration::from_millis(30000));
 
         loop {
+            // Don't want to wait to display 1st log, but a bug seems to skip the first wait, so put
+            // this wait at the top. Otherwise, we get two log lines immediately on startup.
+            heart_interval.tick().await;
+
             let storage_log = network.overlay.store.read().get_summary_info();
             info!("storage-report: {storage_log}");
-            heart_interval.tick().await;
         }
     });
 }


### PR DESCRIPTION
### What was wrong?

Progress on #530 

Want to report more storage usage metrics in the logs

Bonus issue: There was going to be some duplication of effort, to build the metrics for logs. So we combine the collection/calculation to one spot.

### How was it fixed?

Changes are small, but there are several of them. I recommend reviewing commit-by-commit.

1. Always track the database statistics, whether or not we report them online (since we always report them to log now)
2. Combine all storage metrics into a single loggable string
3. Internally track whenever the radius changes (both, setting `storage.radius` and updating `storage.metrics.report_radius()`)
4. Correctly generate the starting radius, when reusing an existing database
5. Bonus fix: the first log was getting double-reported for unknown reasons, this went away in local testing.

Example report:
```
2023-03-28T01:17:43.692962Z  INFO trin_history: storage-report: radius=22.7% content=9.8/10kb disk=147.1kb
```

Low urgency follow-up work: convert large storage values to MB or GB

### To-Do

- [ ] Clean up commit history
