### PR TITLE
Panicking during: trin --help

### DIFF
--- a/trin-types/src/cli.rs
+++ b/trin-types/src/cli.rs
@@ -205,14 +205,14 @@ impl Default for TrinConfig {
 
 impl TrinConfig {
     pub fn from_cli() -> Self {
-        Self::new_from(env::args_os()).expect("Could not parse trin arguments")
+        Self::new_from(env::args_os()).unwrap_or_else(|e| e.exit())
     }
     pub fn new_from<I, T>(args: I) -> Result<Self, clap::Error>
     where
         I: Iterator<Item = T>,
         T: Into<OsString> + Clone,
     {
-        let config = Self::from_iter_safe(args).unwrap_or_else(|e| panic!("{e}"));
+        let config = Self::from_iter_safe(args)?;
 
         match config.web3_transport {
             Web3TransportType::HTTP => match &config.web3_ipc_path[..] {

--- a/trin-types/src/cli.rs
+++ b/trin-types/src/cli.rs
@@ -326,6 +326,11 @@ mod test {
     }
 
     #[test]
+    fn test_help() {
+        TrinConfig::new_from(["trin", "-h"].iter()).expect_err("Should be an error to exit early");
+    }
+
+    #[test]
     fn test_custom_http_args() {
         let expected_config = TrinConfig {
             web3_http_address: Url::parse("http://0.0.0.0:8080/").unwrap(),


### PR DESCRIPTION
### What was wrong?

trin was panicking when being called with `--help` or `--version`. This was introduced by #578 

### How was it fixed?

Add a test that `-h` doesn't panic. Return the error instead of panicking. Then, when parsing args for CLI, use `Clap::Error`'s built-in `.exit()`, which prints the appropriate message and exits immediately.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history
- [x] Add GFI to switch all the cli arg panics to custom `clap:Error` messages #618 