### PR TITLE
Pass real radius during ping/pong

### DIFF
--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -248,8 +248,6 @@ pub struct OverlayService<TContentKey, TMetric, TValidator, TStore> {
     store: Arc<RwLock<TStore>>,
     /// The routing table of the local node.
     kbuckets: Arc<RwLock<KBucketsTable<NodeId, Node>>>,
-    /// The data radius of the local node.
-    data_radius: Arc<Distance>,
     /// The protocol identifier.
     protocol: ProtocolId,
     /// A queue of peers that require regular ping to check connectivity.
@@ -314,7 +312,6 @@ where
         kbuckets: Arc<RwLock<KBucketsTable<NodeId, Node>>>,
         bootnode_enrs: Vec<Enr>,
         ping_queue_interval: Option<Duration>,
-        data_radius: Arc<Distance>,
         protocol: ProtocolId,
         utp_socket: Arc<UtpSocket<crate::discovery::UtpEnr>>,
         enable_metrics: bool,
@@ -349,7 +346,6 @@ where
                 discovery,
                 store,
                 kbuckets,
-                data_radius,
                 protocol,
                 peers_to_ping,
                 command_rx,
@@ -558,7 +554,7 @@ where
 
     /// Returns the data radius of the node.
     fn data_radius(&self) -> Distance {
-        *self.data_radius
+        self.store.read().radius()
     }
 
     /// Maintains the routing table.
@@ -2471,7 +2467,6 @@ mod tests {
             overlay_config.bucket_filter,
         )));
 
-        let data_radius = Arc::new(Distance::MAX);
         let protocol = ProtocolId::History;
         let active_outgoing_requests = Arc::new(RwLock::new(HashMap::new()));
         let peers_to_ping = HashSetDelay::default();
@@ -2485,7 +2480,6 @@ mod tests {
             utp_socket,
             store,
             kbuckets,
-            data_radius,
             protocol,
             peers_to_ping,
             command_tx,

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -8,7 +8,7 @@ use portalnet::{
     types::messages::{Content, Message, PortalnetConfig, ProtocolId},
 };
 use trin_types::content_key::IdentityContentKey;
-use trin_types::distance::{Distance, XorMetric};
+use trin_types::distance::XorMetric;
 use trin_types::enr::{Enr, SszEnr};
 use trin_validation::validator::MockValidator;
 
@@ -44,7 +44,6 @@ async fn init_overlay(
         discovery,
         utp_socket,
         store,
-        Distance::MAX,
         protocol,
         validator,
     )

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -46,7 +46,6 @@ impl HistoryNetwork {
             discovery,
             utp_socket,
             storage,
-            portal_config.data_radius,
             ProtocolId::History,
             validator,
         )

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -53,7 +53,6 @@ impl StateNetwork {
             discovery,
             utp_socket,
             storage,
-            portal_config.data_radius,
             ProtocolId::State,
             validator,
         )


### PR DESCRIPTION
### What was wrong?

Fix #619 

### How was it fixed?

Rremove any duplicate values of `data_radius` and pass all reads through to storage. Then pings/pongs should use the real value from our data store.

### To-Do

- [x] Clean up commit history
