### PR TITLE
Remove unused cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,17 +225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.11",
-]
-
-[[package]]
 name = "async-std"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,10 +1279,8 @@ dependencies = [
  "serde_json",
  "sha2 0.10.6",
  "sha3 0.9.1",
- "test-log",
  "thiserror",
  "tracing",
- "tracing-subscriber",
  "trin-types",
  "trin-utils",
 ]
@@ -2900,47 +2887,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e865500b46e35210765d62d549178c520badc018b2a71a827c29b305d680d1fb"
-dependencies = [
- "ntest_proc_macro_helper",
- "ntest_test_cases",
- "ntest_timeout",
-]
-
-[[package]]
-name = "ntest_proc_macro_helper"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e328d267a679d683b55222b3d06c2fb7358220857945bfc4e65a6b531e9994"
-
-[[package]]
-name = "ntest_test_cases"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f7caf063242bb66721e74515dc01a915901063fa1f994bee7a2b9136f13370e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ntest_timeout"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca6eaadc7c104fb2eb0c6d14782b9e33775aaf5584c3bcb0f87c89e3e6d6c07"
-dependencies = [
- "ntest_proc_macro_helper",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3344,7 +3290,6 @@ name = "portalnet"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-recursion",
  "async-trait",
  "base64 0.13.1",
  "bytes 1.4.0",
@@ -3365,12 +3310,9 @@ dependencies = [
  "lazy_static 1.4.0",
  "leb128",
  "lru",
- "ntest",
- "num",
  "parking_lot 0.11.2",
  "prometheus_exporter",
  "quickcheck",
- "quickcheck_macros",
  "r2d2",
  "r2d2_sqlite",
  "rand 0.8.5",
@@ -5187,7 +5129,6 @@ dependencies = [
  "httpmock",
  "parking_lot 0.11.2",
  "portalnet",
- "rpc",
  "rstest 0.11.0",
  "serde_json",
  "test-log",
@@ -5244,7 +5185,6 @@ dependencies = [
  "ethnum",
  "keccak-hash",
  "quickcheck",
- "quickcheck_macros",
  "rlp 0.5.2",
  "rlp-derive",
  "rstest 0.16.0",
@@ -5272,9 +5212,7 @@ name = "trin-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "discv5",
  "hex",
- "rstest 0.11.0",
 ]
 
 [[package]]
@@ -5288,7 +5226,6 @@ dependencies = [
  "eth2_ssz_derive",
  "eth2_ssz_types",
  "ethereum-types 0.12.1",
- "ethportal-api",
  "lazy_static 1.4.0",
  "quickcheck",
  "quickcheck_macros",

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -29,6 +29,4 @@ trin-utils = { path = "../trin-utils" }
 
 [dev-dependencies]
 env_logger = "0.9.0"
-test-log = { version = "0.2.11", features = ["trace"] }
 tracing = "0.1.36"
-tracing-subscriber = "0.3.15"

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -12,7 +12,6 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
-async-recursion = "1.0.0"
 async-trait = "0.1.64"
 base64 = "0.13.0"
 bytes = "1.3.0"
@@ -30,7 +29,6 @@ futures = "0.3.21"
 lazy_static = "1.4.0"
 leb128 = "0.2.1"
 lru = "0.7.8"
-num = "0.4.0"
 parking_lot = "0.11.2"
 prometheus_exporter = "0.8.4"
 rand = "0.8.4"
@@ -67,9 +65,7 @@ interfaces = "0.0.7"
 
 [dev-dependencies]
 env_logger = "0.9.0"
-ntest = "0.8.0"
 quickcheck = "1.0.3"
-quickcheck_macros = "1.0.0"
 rstest = "0.11.0"
 serial_test = "0.5.1"
 test-log = { version = "0.2.11", features = ["trace"] }

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -19,7 +19,6 @@ ethereum-types = "0.12.1"
 ethportal-api = {path = "../ethportal-api"}
 parking_lot = "0.11.2"
 portalnet = { path = "../portalnet" }
-rpc = { path = "../rpc" }
 serde_json = "1.0.89"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"

--- a/trin-types/Cargo.toml
+++ b/trin-types/Cargo.toml
@@ -44,7 +44,6 @@ validator = { version = "0.13.0", features = ["derive"] }
 [dev-dependencies]
 env_logger = "0.9.0"
 quickcheck = "1.0.3"
-quickcheck_macros = "1.0.0"
 rstest = "0.16.0"
 test-log = { version = "0.2.11", features = ["trace"] }
 tracing = "0.1.36"

--- a/trin-utils/Cargo.toml
+++ b/trin-utils/Cargo.toml
@@ -13,8 +13,4 @@ build = "build.rs"
 
 [dependencies]
 anyhow = "1.0.68"
-discv5 = { version = "0.2.1", features = ["serde"] }
 hex = "0.4.3"
-
-[dev-dependencies]
-rstest = "0.11.0"

--- a/trin-validation/Cargo.toml
+++ b/trin-validation/Cargo.toml
@@ -18,7 +18,6 @@ eth2_ssz = "0.4.0"
 eth2_ssz_derive = "0.3.0"
 eth2_ssz_types = "0.2.1"
 ethereum-types = "0.12.1"
-ethportal-api = { path = "../ethportal-api" }
 lazy_static = "1.4.0"
 serde = { version = "1.0.150", features = ["derive"] }
 serde_json = "1.0.89"


### PR DESCRIPTION
### What was wrong?
Unused dependencies in some workspace crates.

### How was it fixed?
Ran [cargo-udeps](https://github.com/est31/cargo-udeps) to remove unused dependencies.


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
