### PR TITLE
bump utp-rs to 0.1.0-alpha.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5399,9 +5399,9 @@ checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utp-rs"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e60a53f80566700de23c22873f36c3974ab60193fcbcca7c0b12bde315994ff"
+checksum = "c3898e5333068df43ac19f92e282fcc5962bfd2c36987b1dd4f18094546eb343"
 dependencies = [
  "async-trait",
  "delay_map 0.1.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ trin-state = { path = "trin-state" }
 trin-types = { path = "trin-types" }
 trin-utils = { path = "trin-utils" }
 trin-validation = { path = "trin-validation" }
-utp-rs = "0.1.0-alpha.2"
+utp-rs = "0.1.0-alpha.4"
 
 [dev-dependencies]
 ethportal-peertest = { path = "ethportal-peertest" }

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -54,7 +54,7 @@ trin-utils = { path="../trin-utils" }
 trin-validation = { path="../trin-validation" }
 validator = { version = "0.13.0", features = ["derive"] }
 url = "2.3.1"
-utp-rs = "0.1.0-alpha.3"
+utp-rs = "0.1.0-alpha.4"
 
 [target.'cfg(windows)'.dependencies]
 ipconfig = "0.2.2"

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -26,7 +26,7 @@ tree_hash = "0.4.0"
 trin-types = { path = "../trin-types" }
 trin-utils = { path = "../trin-utils" }
 trin-validation = { path = "../trin-validation" }
-utp-rs = "0.1.0-alpha.3"
+utp-rs = "0.1.0-alpha.4"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -25,7 +25,7 @@ tracing = "0.1.36"
 tokio = {version = "1.14.0", features = ["full"]}
 trin-types = { path = "../trin-types" }
 trin-validation = { path = "../trin-validation" }
-utp-rs = "0.1.0-alpha.3"
+utp-rs = "0.1.0-alpha.4"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = "0.3.15"
 trin-types = { path = "../trin-types" }
 trin-utils = { path = "../trin-utils" }
 tokio = {version = "1.14.0", features = ["full"]}
-utp-rs = "0.1.0-alpha.3"
+utp-rs = "0.1.0-alpha.4"
 
 [[bin]]
 name = "utp-test-app"


### PR DESCRIPTION
### What was wrong?

* incorrect uTP ACK num initialization upon SYN-ACK
* unexpected sequence number in uTP `STATE` packets

### How was it fixed?

bump `utp-rs` to `0.1.0-alpha.4` to include [fix](https://github.com/jacobkaufmann/utp/pull/43)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
