### PR TITLE
Wrap NodeId over Enr::NodeId

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ description = "A Rust implementation of the Ethereum Portal Network"
 [dependencies]
 anyhow = "1.0.68"
 discv5 = { version = "0.2.1", features = ["serde"] }
-enr = { version = "=0.7.0", features = ["k256", "ed25519"] }
+enr = { git = "https://github.com/sigp/enr.git", features = ["k256", "ed25519"], rev = "220daa0" }
 eth2_ssz = "0.4.0"
 ethereum-types = "0.12.1"
 ethportal-api = { path = "ethportal-api" }

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -18,6 +18,7 @@ eth2_ssz = "0.4.0"
 eth2_ssz_derive = "0.3.0"
 eth2_ssz_types = "0.2.1"
 jsonrpsee = {version="0.16.2", features = ["async-client", "client", "macros", "server"]}
+enr = { git = "https://github.com/sigp/enr.git", features = ["k256", "ed25519"], rev = "220daa0" }
 serde = { version = "1.0.150", features = ["derive"] }
 serde_json = "1.0.89"
 serde-hex = "0.1.0"

--- a/ethportal-api/src/types/discv5.rs
+++ b/ethportal-api/src/types/discv5.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 /// Discv5 NodeId
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NodeId(EnrNodeId);
+pub struct NodeId(pub EnrNodeId);
 
 /// Discv5 bucket
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/ethportal-api/src/types/discv5.rs
+++ b/ethportal-api/src/types/discv5.rs
@@ -69,4 +69,15 @@ mod test {
 
         assert_eq!(node_id, serde_json::from_str(&node_id_string).unwrap());
     }
+
+    #[test]
+    fn test_same_with_enr_node_id() {
+        let enr_node_id = EnrNodeId::random();
+        let portal_node_id = NodeId(enr_node_id);
+        assert_eq!(
+            serde_json::to_string(&enr_node_id).unwrap(),
+            serde_json::to_string(&portal_node_id).unwrap()
+        );
+        assert_eq!(enr_node_id, portal_node_id.0);
+    }
 }

--- a/ethportal-api/src/types/discv5.rs
+++ b/ethportal-api/src/types/discv5.rs
@@ -1,29 +1,11 @@
 use crate::types::enr::Enr;
+use enr::NodeId as EnrNodeId;
 use serde::{Deserialize, Serialize};
-use serde_hex::{SerHex, StrictPfx};
 use serde_json::Value;
-use std::ops::Deref;
-
-type RawNodeId = [u8; 32];
 
 /// Discv5 NodeId
-// TODO: Wrap this type over discv5::NodeId type
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NodeId(#[serde(with = "SerHex::<StrictPfx>")] pub RawNodeId);
-
-impl From<RawNodeId> for NodeId {
-    fn from(item: RawNodeId) -> Self {
-        NodeId(item)
-    }
-}
-
-impl Deref for NodeId {
-    type Target = RawNodeId;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub struct NodeId(EnrNodeId);
 
 /// Discv5 bucket
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -53,7 +35,7 @@ pub type RoutingTableInfo = Value;
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use crate::types::discv5::{Enr, NodeId};
+    use super::*;
     use std::net::Ipv4Addr;
 
     #[test]
@@ -75,10 +57,13 @@ mod test {
 
     #[test]
     fn test_node_id_ser_de() {
-        let node_id = NodeId([
-            176, 202, 35, 254, 68, 245, 224, 61, 174, 106, 81, 237, 41, 88, 144, 15, 55, 58, 125,
-            119, 228, 39, 201, 211, 154, 95, 148, 198, 212, 185, 175, 219,
-        ]);
+        let node_id = NodeId(
+            [
+                176, 202, 35, 254, 68, 245, 224, 61, 174, 106, 81, 237, 41, 88, 144, 15, 55, 58,
+                125, 119, 228, 39, 201, 211, 154, 95, 148, 198, 212, 185, 175, 219,
+            ]
+            .into(),
+        );
 
         let node_id_string = serde_json::to_string(&node_id).unwrap();
 

--- a/ethportal-peertest/src/jsonrpc.rs
+++ b/ethportal-peertest/src/jsonrpc.rs
@@ -197,7 +197,12 @@ fn validate_discv5_node_info(val: &Value, _peertest: &Peertest) {
     let enr = val.get("enr").unwrap();
     assert!(enr.is_string());
     assert!(enr.as_str().unwrap().contains("enr:"));
-    assert!(val.get("nodeId").unwrap().is_string());
+    assert!(val
+        .get("nodeId")
+        .unwrap()
+        .as_object()
+        .unwrap()
+        .contains_key("raw"));
 }
 
 fn validate_discv5_routing_table_info(val: &Value, _peertest: &Peertest) {

--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -232,7 +232,7 @@ impl Discovery {
         Ok(NodeInfo {
             enr: Enr::from_str(&self.discv5.local_enr().to_base64())
                 .map_err(|err| anyhow!("{err}"))?,
-            node_id: EthportalNodeId::from(self.discv5.local_enr().node_id().raw()),
+            node_id: EthportalNodeId(self.discv5.local_enr().node_id().raw().into()),
             ip: self
                 .discv5
                 .local_enr()


### PR DESCRIPTION
### What was wrong?
https://github.com/ethereum/trin/blob/0b1ed5b4ce9837160b74308c027ef74520d70ef0/ethportal-api/src/types/discv5.rs#L9-L12
NodeId is implemented from scratch because Enr::NodeId did not support Serialize/Deserialize traits.

### How was it fixed?

- Enr::NodeId support Serialize/Deserialize in https://github.com/sigp/enr/pull/27.
- Wrap NodeId over Enr::NodeId, like https://github.com/ethereum/trin/blob/0b1ed5b4ce9837160b74308c027ef74520d70ef0/trin-types/src/wrapped/bloom.rs.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
