### PR TITLE
ethportal-api: Re-export `PossibleHistoryContentValue` and `ContentValueError`

### DIFF
--- a/ethportal-api/src/lib.rs
+++ b/ethportal-api/src/lib.rs
@@ -17,7 +17,9 @@ pub use trin_types::content_key::{
     BlockBodyKey, BlockHeaderKey, BlockReceiptsKey, EpochAccumulatorKey, HistoryContentKey,
     OverlayContentKey, StateContentKey,
 };
-pub use trin_types::content_value::{ContentValue, HistoryContentValue};
+pub use trin_types::content_value::{
+    ContentValue, ContentValueError, HistoryContentValue, PossibleHistoryContentValue,
+};
 pub use trin_types::execution::block_body::*;
 pub use trin_types::execution::header::*;
 pub use trin_types::execution::receipts::*;


### PR DESCRIPTION
### What was wrong?
`Portal-hive` tests want to match on `PossibleHistoryContentValue` which is not exported via `ethportal-api`.

### How was it fixed?
Re-export `PossibleHistoryContentValue` and `ContentValueError` from `trin-types`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
