### PR TITLE
Copy trin-bridge in main dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,7 @@ COPY ./ethportal-peertest ./ethportal-peertest
 COPY ./portalnet ./portalnet
 COPY ./rpc ./rpc
 COPY ./src ./src 
+COPY ./trin-bridge ./trin-bridge
 COPY ./trin-cli ./trin-cli
 COPY ./trin-history ./trin-history 
 COPY ./trin-state ./trin-state 


### PR DESCRIPTION
### What was wrong?
Quick hotfix to fix failing `docker` builds on master CI

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
