### PR TITLE
Only use ANSI colors if output to colored terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5661,8 +5661,12 @@ dependencies = [
 name = "trin-utils"
 version = "0.1.0"
 dependencies = [
+ "ansi_term",
+ "atty",
  "hex",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/ethportal-peertest/src/main.rs
+++ b/ethportal-peertest/src/main.rs
@@ -2,6 +2,7 @@
 
 use std::{thread, time};
 use tracing::info;
+use trin_utils::log::init_tracing_logger;
 
 use ethportal_peertest::{
     cli::PeertestConfig,
@@ -11,7 +12,7 @@ use ethportal_peertest::{
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+    init_tracing_logger();
 
     let peertest = launch_peertest_nodes(2).await;
     // Short sleep to make sure all peertest nodes can connect

--- a/src/bin/purge_db.rs
+++ b/src/bin/purge_db.rs
@@ -17,6 +17,7 @@ use trin_types::execution::block_body::BlockBody;
 use trin_types::execution::header::HeaderWithProof;
 use trin_types::execution::receipts::Receipts;
 use trin_utils::bytes::hex_encode;
+use trin_utils::log::init_tracing_logger;
 
 ///
 /// This script will iterate through all content id / key pairs in rocksd & meta db.
@@ -26,7 +27,7 @@ use trin_utils::bytes::hex_encode;
 /// need to be updated to avoid panicking.
 ///
 pub fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
+    init_tracing_logger();
     let purge_config = PurgeConfig::from_args();
 
     let enr_key =

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,13 @@
 
 use tracing::error;
 use trin_types::{cli::TrinConfig, provider::TrustedProvider};
+use trin_utils::log::init_tracing_logger;
 
 use trin::run_trin;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+    init_tracing_logger();
     let trin_config = TrinConfig::from_cli();
     let trusted_provider = TrustedProvider::from_trin_config(&trin_config);
     let rpc_handle = run_trin(trin_config, trusted_provider).await?;

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -8,11 +8,12 @@ mod test {
     use ethportal_peertest as peertest;
     use trin_types::cli::TrinConfig;
     use trin_types::provider::TrustedProvider;
+    use trin_utils::log::init_tracing_logger;
 
     // Logs don't show up when trying to use test_log here, maybe because of multi_thread
     #[tokio::test(flavor = "multi_thread")]
     async fn test_launches() {
-        tracing_subscriber::fmt::init();
+        init_tracing_logger();
 
         // Run a client, as a buddy peer for ping tests, etc.
         let peertest = peertest::launch_peertest_nodes(2).await;

--- a/trin-bridge/src/main.rs
+++ b/trin-bridge/src/main.rs
@@ -8,12 +8,13 @@ use trin_bridge::cli::{BridgeConfig, BridgeMode};
 use trin_bridge::constants::PANDAOPS_URL;
 use trin_bridge::utils::generate_spaced_private_keys;
 use trin_types::provider::{build_pandaops_http_client_from_env, TrustedProvider};
+use trin_utils::log::init_tracing_logger;
 use trin_validation::accumulator::MasterAccumulator;
 use trin_validation::oracle::HeaderOracle;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+    init_tracing_logger();
 
     let bridge_config = BridgeConfig::from_args();
     let private_keys = generate_spaced_private_keys(bridge_config.node_count);

--- a/trin-utils/Cargo.toml
+++ b/trin-utils/Cargo.toml
@@ -14,3 +14,13 @@ build = "build.rs"
 [dependencies]
 hex = "0.4.3"
 thiserror = "1.0.40"
+tracing = "0.1.36"
+tracing-subscriber = "0.3.15"
+
+[target.'cfg(windows)'.dependencies]
+# The crates for detecting whether the terminal supports colors are OS-specific.
+ansi_term = "0.12"
+
+[target.'cfg(not(windows))'.dependencies]
+# The crates for detecting whether the terminal supports colors are OS-specific.
+atty = "0.2.14"

--- a/trin-utils/src/lib.rs
+++ b/trin-utils/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod bytes;
+pub mod log;
 pub mod version;

--- a/trin-utils/src/log.rs
+++ b/trin-utils/src/log.rs
@@ -1,0 +1,33 @@
+use std::env;
+
+#[cfg(windows)]
+use ansi_term;
+#[cfg(not(windows))]
+use atty;
+
+pub fn init_tracing_logger() {
+    tracing_subscriber::fmt()
+        .with_ansi(detect_ansi_support())
+        .init();
+}
+
+fn detect_ansi_support() -> bool {
+    #[cfg(windows)]
+    {
+        use ansi_term::enable_ansi_support;
+        enable_ansi_support().is_ok()
+    }
+    #[cfg(not(windows))]
+    {
+        // Detect whether our log output (which goes to stdout) is going to a terminal.
+        // For example, instead of the terminal, it might be getting piped into another file, which
+        // probably ought to be plain text.
+        let is_terminal = atty::is(atty::Stream::Stdout);
+        if !is_terminal {
+            return false;
+        }
+
+        // Return whether terminal defined in TERM supports ANSI
+        env::var("TERM").map(|term| term != "dumb").unwrap_or(false)
+    }
+}

--- a/utp-testing/src/bin/test_app.rs
+++ b/utp-testing/src/bin/test_app.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 use std::str::FromStr;
 use tracing::info;
+use trin_utils::log::init_tracing_logger;
 use utp_testing::run_test_app;
 
 use structopt::StructOpt;
@@ -9,7 +10,7 @@ use utp_testing::cli::TestAppConfig;
 /// uTP test app, used for creation of a `test-app` docker image
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    init_tracing_logger();
 
     let config = TestAppConfig::from_args();
 


### PR DESCRIPTION

### What was wrong?

Fix #638 

### How was it fixed?

Only import the libraries as needed, per OS.

Unfortunately, increases the size of trin-utlis a bit, to add log tracing.

On *nix, check if output is going to terminal (or for example, piped to a file). Also, if going to a terminal, make sure the terminal supports color (ie~ the environment variable TERM is not "dumb").

### To-Do

- [ ] Clean up commit history
