### PR TITLE
Update accumulators repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Clone portal-accumulators
-          command: git clone https://github.com/njgheorghita/portal-accumulators
+          command: git clone https://github.com/ethereum/portal-accumulators
       - run:
           name: Build Docker bridge image
           no_output_timeout: 30m


### PR DESCRIPTION
### What was wrong?
Minor update to take into account moving the location of `portal-accumulator` repo

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
