### PR TITLE
Display content key rather than id

### DIFF
--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -1495,7 +1495,7 @@ where
                         // Skip storing & propagating content if it's not valid
                         warn!(
                             error = %err,
-                            content.id = %hex_encode(key.content_id()),
+                            content.key = %key.to_hex(),
                             "Error validating accepted content"
                         );
                         return None;
@@ -1508,21 +1508,21 @@ where
                             if let Err(err) = store.write().put(key.clone(), &content_value) {
                                 warn!(
                                     error = %err,
-                                    content.id = %hex_encode(key.content_id()),
+                                    content.key = %key.to_hex(),
                                     "Error storing accepted content"
                                 );
                             }
                         }
                         Ok(false) => {
                             warn!(
-                                content.id = %hex_encode(key.content_id()),
+                                content.key = %key.to_hex(),
                                 "Accepted content outside radius or already stored"
                             );
                         }
                         Err(err) => {
                             warn!(
                                 error = %err,
-                                content.id = %hex_encode(key.content_id()),
+                                content.key = %key.to_hex(),
                                 "Error checking data store for content key"
                             );
                         }


### PR DESCRIPTION
### What was wrong?
Imo - content keys are far more useful to display - especially for debugging purposes.

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
