### PR TITLE
Add a SQL index to speed up data size checks

### DIFF
--- a/portalnet/src/storage.rs
+++ b/portalnet/src/storage.rs
@@ -868,7 +868,8 @@ const CREATE_QUERY: &str = "create table if not exists content_metadata (
                                 content_id_short INTEGER NOT NULL,
                                 content_key TEXT NOT NULL,
                                 content_size INTEGER
-                            )";
+                            );
+                            create index content_size_idx on content_metadata(content_size);";
 
 const INSERT_QUERY: &str =
     "INSERT OR IGNORE INTO content_metadata (content_id_long, content_id_short, content_key, content_size)

--- a/portalnet/src/storage.rs
+++ b/portalnet/src/storage.rs
@@ -863,13 +863,15 @@ impl StorageMetrics {
 }
 
 // SQLite Statements
-const CREATE_QUERY: &str = "create table if not exists content_metadata (
+const CREATE_QUERY: &str = "CREATE TABLE IF NOT EXISTS content_metadata (
                                 content_id_long TEXT PRIMARY KEY,
                                 content_id_short INTEGER NOT NULL,
                                 content_key TEXT NOT NULL,
                                 content_size INTEGER
                             );
-                            create index content_size_idx on content_metadata(content_size);";
+                            CREATE INDEX content_size_idx ON content_metadata(content_size);
+                            CREATE INDEX content_id_short_idx ON content_metadata(content_id_short);
+                            CREATE INDEX content_id_long_idx ON content_metadata(content_id_long);";
 
 const INSERT_QUERY: &str =
     "INSERT OR IGNORE INTO content_metadata (content_id_long, content_id_short, content_key, content_size)


### PR DESCRIPTION
In a local test with 2M rows, adding this index sped up a SELECT TOTAL(content_size) query time from 125ms to 75ms.

### What was wrong?

Fix #649 

### How was it fixed?

Add an index and shelve the issue, for now.
