### PR TITLE
Track and display network message stats

### DIFF
--- a/portalnet/src/metrics.rs
+++ b/portalnet/src/metrics.rs
@@ -1,9 +1,13 @@
 use prometheus_exporter::{
     self,
-    prometheus::{register_counter, Counter},
+    prometheus::{
+        opts, register_int_counter_vec, register_int_counter_vec_with_registry, IntCounterVec,
+        Registry,
+    },
 };
+use tracing::error;
 
-use crate::types::messages::ProtocolId;
+use crate::types::messages::{ProtocolId, Request, Response};
 
 /// General Metrics Strategy (wip)
 /// - Each module should maintain its own metrics reporter
@@ -11,82 +15,196 @@ use crate::types::messages::ProtocolId;
 /// - - https://romankudryashov.com/blog/2021/11/monitoring-rust-web-application/
 /// - - https://github.com/sigp/lighthouse/blob/c3a793fd73a3b11b130b82032904d39c952869e4/beacon_node/lighthouse_network/src/metrics.rs
 
+/// Protocol Labels
+/// - These label values identify the protocol in the metrics
+pub enum ProtocolLabel {
+    State,
+    History,
+    TransactionGossip,
+    HeaderGossip,
+    CanonicalIndices,
+    Utp,
+}
+
+/// Message Direction Labels
+pub enum MessageDirectionLabel {
+    /// Messages sent to the network
+    Sent,
+    /// Messages received from the network
+    Received,
+}
+
+/// Message Labels
+/// - These label values identify the type of message in the metrics
+pub enum MessageLabel {
+    Ping,
+    FindNodes,
+    FindContent,
+    Offer,
+    Pong,
+    Nodes,
+    Content,
+    Accept,
+}
+
 /// Overlay Service Metrics Reporter
 #[derive(Clone, Debug)]
 pub struct OverlayMetrics {
-    inbound_ping: Counter,
-    inbound_find_nodes: Counter,
-    inbound_find_content: Counter,
-    inbound_offer: Counter,
-    outbound_ping: Counter,
-    outbound_find_nodes: Counter,
-    outbound_find_content: Counter,
-    outbound_offer: Counter,
+    message_count: IntCounterVec,
 }
 
 impl OverlayMetrics {
-    pub fn new(protocol: &ProtocolId) -> Self {
-        let inbound_ping =
-            register_counter!(format!("trin_inbound_ping_{:?}", protocol), "help").unwrap();
-        let inbound_find_nodes =
-            register_counter!(format!("trin_inbound_find_nodes_{:?}", protocol), "help").unwrap();
-        let inbound_find_content =
-            register_counter!(format!("trin_inbound_find_content_{:?}", protocol), "help").unwrap();
-        let inbound_offer =
-            register_counter!(format!("trin_inbound_offer_{:?}", protocol), "help").unwrap();
-        let outbound_ping =
-            register_counter!(format!("trin_outbound_ping_{:?}", protocol), "help").unwrap();
-        let outbound_find_nodes =
-            register_counter!(format!("trin_outbound_find_nodes_{:?}", protocol), "help").unwrap();
-        let outbound_find_content =
-            register_counter!(format!("trin_outbound_find_content_{:?}", protocol), "help")
-                .unwrap();
-        let outbound_offer =
-            register_counter!(format!("trin_outbound_offer_{:?}", protocol), "help").unwrap();
+    pub fn new() -> Self {
+        let message_count_options = opts!(
+            "trin_message_total",
+            "count all network messages sent and received"
+        );
+        let message_count_labels = &["protocol", "direction", "type"];
 
-        Self {
-            inbound_ping,
-            inbound_find_nodes,
-            inbound_find_content,
-            inbound_offer,
-            outbound_ping,
-            outbound_find_nodes,
-            outbound_find_content,
-            outbound_offer,
+        // Register the metric with the default registry, or if that fails, register with a
+        // newly-created registry.
+        let message_count = register_int_counter_vec!(message_count_options.clone(), message_count_labels).unwrap_or_else(|_| {
+            // Trying to register the same metric multiple times in the process should only happen
+            // in testing situations. In regular usage, it should be reported as an error:
+            error!("Failed to register prometheus messaging metrics with default registry, creating new");
+
+            let custom_registry = Registry::new_custom(None, None)
+                .expect("Prometheus docs don't explain when it might fail to create a custom registry, so... hopefully never");
+            register_int_counter_vec_with_registry!(message_count_options, message_count_labels, custom_registry)
+                .expect("a gauge can always be added to a new custom registry, without conflict")
+        });
+
+        Self { message_count }
+    }
+
+    /// Returns the value of the given metric with the specified labels.
+    pub fn message_count_by_labels(
+        &self,
+        network: ProtocolLabel,
+        direction: MessageDirectionLabel,
+        message_name: MessageLabel,
+    ) -> u64 {
+        let labels = [network.into(), direction.into(), message_name.into()];
+        self.message_count.with_label_values(&labels).get()
+    }
+
+    pub fn report_outbound_request(&self, protocol: &ProtocolId, request: &Request) {
+        self.increment_message_count(protocol.into(), MessageDirectionLabel::Sent, request.into());
+    }
+
+    pub fn report_inbound_request(&self, protocol: &ProtocolId, request: &Request) {
+        self.increment_message_count(
+            protocol.into(),
+            MessageDirectionLabel::Received,
+            request.into(),
+        );
+    }
+
+    pub fn report_outbound_response(&self, protocol: &ProtocolId, response: &Response) {
+        self.increment_message_count(
+            protocol.into(),
+            MessageDirectionLabel::Sent,
+            response.into(),
+        );
+    }
+
+    pub fn report_inbound_response(&self, protocol: &ProtocolId, response: &Response) {
+        self.increment_message_count(
+            protocol.into(),
+            MessageDirectionLabel::Received,
+            response.into(),
+        );
+    }
+
+    fn increment_message_count(
+        &self,
+        protocol: ProtocolLabel,
+        direction: MessageDirectionLabel,
+        message: MessageLabel,
+    ) {
+        let labels = [protocol.into(), direction.into(), message.into()];
+        self.message_count.with_label_values(&labels).inc();
+    }
+}
+
+type MetricLabel = &'static str;
+
+impl From<ProtocolLabel> for MetricLabel {
+    fn from(label: ProtocolLabel) -> Self {
+        match label {
+            ProtocolLabel::State => "state",
+            ProtocolLabel::History => "history",
+            ProtocolLabel::TransactionGossip => "transaction_gossip",
+            ProtocolLabel::HeaderGossip => "header_gossip",
+            ProtocolLabel::CanonicalIndices => "canonical_indices",
+            ProtocolLabel::Utp => "utp",
         }
     }
 }
 
-impl OverlayMetrics {
-    pub fn report_inbound_ping(&self) {
-        self.inbound_ping.inc();
+impl From<MessageDirectionLabel> for MetricLabel {
+    fn from(label: MessageDirectionLabel) -> Self {
+        match label {
+            MessageDirectionLabel::Sent => "sent",
+            MessageDirectionLabel::Received => "received",
+        }
     }
+}
 
-    pub fn report_inbound_find_nodes(&self) {
-        self.inbound_find_nodes.inc();
+impl From<MessageLabel> for MetricLabel {
+    fn from(label: MessageLabel) -> Self {
+        match label {
+            MessageLabel::Ping => "ping",
+            MessageLabel::FindNodes => "find_nodes",
+            MessageLabel::FindContent => "find_content",
+            MessageLabel::Offer => "offer",
+            MessageLabel::Pong => "pong",
+            MessageLabel::Nodes => "nodes",
+            MessageLabel::Content => "content",
+            MessageLabel::Accept => "accept",
+        }
     }
+}
 
-    pub fn report_inbound_find_content(&self) {
-        self.inbound_find_content.inc();
+impl From<&ProtocolId> for ProtocolLabel {
+    fn from(protocol: &ProtocolId) -> Self {
+        match protocol {
+            ProtocolId::State => Self::State,
+            ProtocolId::History => Self::History,
+            ProtocolId::TransactionGossip => Self::TransactionGossip,
+            ProtocolId::HeaderGossip => Self::HeaderGossip,
+            ProtocolId::CanonicalIndices => Self::CanonicalIndices,
+            ProtocolId::Utp => Self::Utp,
+        }
     }
+}
 
-    pub fn report_inbound_offer(&self) {
-        self.inbound_offer.inc();
+impl From<&Request> for MessageLabel {
+    fn from(request: &Request) -> Self {
+        match request {
+            Request::Ping(_) => MessageLabel::Ping,
+            Request::FindNodes(_) => MessageLabel::FindNodes,
+            Request::FindContent(_) => MessageLabel::FindContent,
+            Request::Offer(_) => MessageLabel::Offer,
+            // Populated offers are the same as regular offers, from a metrics point of view
+            Request::PopulatedOffer(_) => MessageLabel::Offer,
+        }
     }
+}
 
-    pub fn report_outbound_ping(&self) {
-        self.outbound_ping.inc();
+impl From<&Response> for MessageLabel {
+    fn from(response: &Response) -> Self {
+        match response {
+            Response::Pong(_) => MessageLabel::Pong,
+            Response::Nodes(_) => MessageLabel::Nodes,
+            Response::Content(_) => MessageLabel::Content,
+            Response::Accept(_) => MessageLabel::Accept,
+        }
     }
+}
 
-    pub fn report_outbound_find_nodes(&self) {
-        self.outbound_find_nodes.inc();
-    }
-
-    pub fn report_outbound_find_content(&self) {
-        self.outbound_find_content.inc();
-    }
-
-    pub fn report_outbound_offer(&self) {
-        self.outbound_offer.inc();
+impl Default for OverlayMetrics {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -20,6 +20,7 @@ use utp_rs::socket::UtpSocket;
 
 use crate::{
     discovery::{Discovery, UtpEnr},
+    metrics::{MessageDirectionLabel, MessageLabel, OverlayMetrics, ProtocolLabel},
     overlay_service::{
         OverlayCommand, OverlayRequest, OverlayRequestError, OverlayService, RequestDirection,
         UTP_CONN_CFG,
@@ -49,7 +50,6 @@ pub struct OverlayConfig {
     pub table_filter: Option<Box<dyn Filter<Node>>>,
     pub bucket_filter: Option<Box<dyn Filter<Node>>>,
     pub ping_queue_interval: Option<Duration>,
-    pub enable_metrics: bool,
     pub query_parallelism: usize,
     pub query_timeout: Duration,
     pub query_peer_timeout: Duration,
@@ -66,7 +66,6 @@ impl Default for OverlayConfig {
             table_filter: None,
             bucket_filter: None,
             ping_queue_interval: None,
-            enable_metrics: false,
             query_parallelism: 3, // (recommended α from kademlia paper)
             query_peer_timeout: Duration::from_secs(10),
             query_timeout: Duration::from_secs(60),
@@ -100,11 +99,13 @@ pub struct OverlayProtocol<TContentKey, TMetric, TValidator, TStore> {
     /// Use a phantom, because we don't store any keys in this struct.
     /// For example, this type is used when decoding a content key received over the network.
     phantom_content_key: PhantomData<TContentKey>,
-    /// Associate a metric with the overlay network.
+    /// Associate a distance metric with the overlay network.
     phantom_metric: PhantomData<TMetric>,
     /// Accepted content validator that makes requests to this/other overlay networks (or trusted
     /// http server)
     validator: Arc<TValidator>,
+    /// Runtime telemetry metrics for the overlay network.
+    metrics: Arc<OverlayMetrics>,
 }
 
 impl<
@@ -132,6 +133,9 @@ where
             config.bucket_filter,
         )));
 
+        // Initialize metrics, keep a reference in order to build metrics summaries for logging
+        let metrics = Arc::new(OverlayMetrics::new());
+
         let command_tx = OverlayService::<TContentKey, TMetric, TValidator, TStore>::spawn(
             Arc::clone(&discovery),
             Arc::clone(&store),
@@ -140,7 +144,7 @@ where
             config.ping_queue_interval,
             protocol.clone(),
             Arc::clone(&utp_socket),
-            config.enable_metrics,
+            Arc::clone(&metrics),
             Arc::clone(&validator),
             config.query_timeout,
             config.query_peer_timeout,
@@ -160,6 +164,7 @@ where
             phantom_content_key: PhantomData,
             phantom_metric: PhantomData,
             validator,
+            metrics,
         }
     }
 
@@ -539,6 +544,32 @@ where
                 "Failed to bond with any bootnodes",
             );
         }
+    }
+
+    pub fn get_summary_info(&self) -> String {
+        format!(
+            "offers={}/{}, accepts={}/{}",
+            self.metrics.message_count_by_labels(
+                ProtocolLabel::History,
+                MessageDirectionLabel::Received,
+                MessageLabel::Accept
+            ),
+            self.metrics.message_count_by_labels(
+                ProtocolLabel::History,
+                MessageDirectionLabel::Sent,
+                MessageLabel::Offer
+            ),
+            self.metrics.message_count_by_labels(
+                ProtocolLabel::History,
+                MessageDirectionLabel::Sent,
+                MessageLabel::Accept
+            ),
+            self.metrics.message_count_by_labels(
+                ProtocolLabel::History,
+                MessageDirectionLabel::Received,
+                MessageLabel::Offer
+            ),
+        )
     }
 }
 

--- a/portalnet/src/storage.rs
+++ b/portalnet/src/storage.rs
@@ -176,15 +176,10 @@ pub struct PortalStorageConfig {
     pub distance_fn: DistanceFunction,
     pub db: Arc<rocksdb::DB>,
     pub sql_connection_pool: Pool<SqliteConnectionManager>,
-    pub metrics_enabled: bool,
 }
 
 impl PortalStorageConfig {
-    pub fn new(
-        storage_capacity_kb: u64,
-        node_id: NodeId,
-        metrics_enabled: bool,
-    ) -> anyhow::Result<Self> {
+    pub fn new(storage_capacity_kb: u64, node_id: NodeId) -> anyhow::Result<Self> {
         let db = Arc::new(PortalStorage::setup_rocksdb(node_id)?);
         let sql_connection_pool = PortalStorage::setup_sql(node_id)?;
         Ok(Self {
@@ -193,7 +188,6 @@ impl PortalStorageConfig {
             distance_fn: DistanceFunction::Xor,
             db,
             sql_connection_pool,
-            metrics_enabled,
         })
     }
 }
@@ -937,7 +931,7 @@ pub mod test {
 
         let node_id = NodeId::random();
 
-        let storage_config = PortalStorageConfig::new(CAPACITY, node_id, false).unwrap();
+        let storage_config = PortalStorageConfig::new(CAPACITY, node_id).unwrap();
         let storage = PortalStorage::new(storage_config, ProtocolId::History)?;
 
         // Assert that configs match the storage object's fields
@@ -957,7 +951,7 @@ pub mod test {
             let temp_dir = setup_temp_dir().unwrap();
 
             let node_id = NodeId::random();
-            let storage_config = PortalStorageConfig::new(CAPACITY, node_id, false).unwrap();
+            let storage_config = PortalStorageConfig::new(CAPACITY, node_id).unwrap();
             let mut storage = PortalStorage::new(storage_config, ProtocolId::History).unwrap();
             let content_key = generate_random_content_key();
             let mut value = [0u8; 32];
@@ -980,7 +974,7 @@ pub mod test {
         let temp_dir = setup_temp_dir().unwrap();
 
         let node_id = NodeId::random();
-        let storage_config = PortalStorageConfig::new(CAPACITY, node_id, false).unwrap();
+        let storage_config = PortalStorageConfig::new(CAPACITY, node_id).unwrap();
         let mut storage = PortalStorage::new(storage_config, ProtocolId::History)?;
         let content_key = generate_random_content_key();
         let value: Vec<u8> = "OGFWs179fWnqmjvHQFGHszXloc3Wzdb4".into();
@@ -1001,7 +995,7 @@ pub mod test {
         let temp_dir = setup_temp_dir().unwrap();
 
         let node_id = NodeId::random();
-        let storage_config = PortalStorageConfig::new(CAPACITY, node_id, false).unwrap();
+        let storage_config = PortalStorageConfig::new(CAPACITY, node_id).unwrap();
         let mut storage = PortalStorage::new(storage_config, ProtocolId::History)?;
 
         let content_key = generate_random_content_key();
@@ -1023,7 +1017,7 @@ pub mod test {
         let temp_dir = setup_temp_dir().unwrap();
 
         let node_id = NodeId::random();
-        let storage_config = PortalStorageConfig::new(CAPACITY, node_id, false).unwrap();
+        let storage_config = PortalStorageConfig::new(CAPACITY, node_id).unwrap();
         let mut storage = PortalStorage::new(storage_config, ProtocolId::History)?;
 
         for _ in 0..50 {
@@ -1038,7 +1032,7 @@ pub mod test {
         std::mem::drop(storage);
 
         // test with 1kb capacity
-        let new_storage_config = PortalStorageConfig::new(1, node_id, false).unwrap();
+        let new_storage_config = PortalStorageConfig::new(1, node_id).unwrap();
         let new_storage = PortalStorage::new(new_storage_config, ProtocolId::History)?;
 
         // test that previously set value has been pruned
@@ -1051,7 +1045,7 @@ pub mod test {
         std::mem::drop(new_storage);
 
         // test with 0kb capacity
-        let new_storage_config = PortalStorageConfig::new(0, node_id, false).unwrap();
+        let new_storage_config = PortalStorageConfig::new(0, node_id).unwrap();
         let new_storage = PortalStorage::new(new_storage_config, ProtocolId::History)?;
 
         // test that previously set value has been pruned
@@ -1073,7 +1067,7 @@ pub mod test {
         let node_id = NodeId::random();
         let min_capacity = 1;
         // Use a tiny storage capacity, to fill up as quickly as possible
-        let storage_config = PortalStorageConfig::new(min_capacity, node_id, false).unwrap();
+        let storage_config = PortalStorageConfig::new(min_capacity, node_id).unwrap();
         let mut storage = PortalStorage::new(storage_config.clone(), ProtocolId::History)?;
 
         // Fill up the storage. This is overkill for the 1kb capacity, but an upcoming
@@ -1117,7 +1111,7 @@ pub mod test {
         let temp_dir = setup_temp_dir().unwrap();
 
         let node_id = NodeId::random();
-        let storage_config = PortalStorageConfig::new(0, node_id, false).unwrap();
+        let storage_config = PortalStorageConfig::new(0, node_id).unwrap();
         let mut storage = PortalStorage::new(storage_config, ProtocolId::History)?;
 
         let content_key = generate_random_content_key();
@@ -1140,7 +1134,7 @@ pub mod test {
         let temp_dir = setup_temp_dir().unwrap();
 
         let node_id = NodeId::random();
-        let storage_config = PortalStorageConfig::new(CAPACITY, node_id, false).unwrap();
+        let storage_config = PortalStorageConfig::new(CAPACITY, node_id).unwrap();
         let storage = PortalStorage::new(storage_config, ProtocolId::History)?;
 
         let result = storage.find_farthest_content_id()?;
@@ -1159,7 +1153,7 @@ pub mod test {
 
             let node_id = NodeId::random();
             let val = vec![0x00, 0x01, 0x02, 0x03, 0x04];
-            let storage_config = PortalStorageConfig::new(CAPACITY, node_id, false).unwrap();
+            let storage_config = PortalStorageConfig::new(CAPACITY, node_id).unwrap();
             let mut storage = PortalStorage::new(storage_config, ProtocolId::History).unwrap();
             storage.store(&x, &val).unwrap();
             storage.store(&y, &val).unwrap();

--- a/portalnet/src/types/messages.rs
+++ b/portalnet/src/types/messages.rs
@@ -166,7 +166,6 @@ pub struct PortalnetConfig {
     pub data_radius: Distance,
     pub internal_ip: bool,
     pub no_stun: bool,
-    pub enable_metrics: bool,
     pub node_addr_cache_capacity: usize,
 }
 
@@ -180,7 +179,6 @@ impl Default for PortalnetConfig {
             data_radius: Distance::MAX,
             internal_ip: false,
             no_stun: false,
-            enable_metrics: false,
             node_addr_cache_capacity: NODE_ADDR_CACHE_CAPACITY,
         }
     }

--- a/src/bin/purge_db.rs
+++ b/src/bin/purge_db.rs
@@ -41,7 +41,7 @@ pub fn main() -> Result<()> {
     // Capacity is 0 since it (eg. for data radius calculation) is irrelevant when only removing data.
     let capacity = 0;
     let protocol = ProtocolId::History;
-    let config = PortalStorageConfig::new(capacity, node_id, false)?;
+    let config = PortalStorageConfig::new(capacity, node_id)?;
     let storage =
         PortalStorage::new(config.clone(), protocol).expect("Failed to create portal storage");
     let iter = config.db.iterator(IteratorMode::Start);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@ pub async fn run_trin(
         private_key: trin_config.private_key,
         listen_port: trin_config.discovery_port,
         no_stun: trin_config.no_stun,
-        enable_metrics: trin_config.enable_metrics_with_url.is_some(),
         bootnode_enrs: trin_config.bootnodes.clone().into(),
         ..Default::default()
     };
@@ -63,11 +62,8 @@ pub async fn run_trin(
         setup_temp_dir()?;
     }
 
-    let storage_config = PortalStorageConfig::new(
-        trin_config.kb.into(),
-        discovery.local_enr().node_id(),
-        trin_config.enable_metrics_with_url.is_some(),
-    )?;
+    let storage_config =
+        PortalStorageConfig::new(trin_config.kb.into(), discovery.local_enr().node_id())?;
 
     // Initialize validation oracle
     let master_accumulator = MasterAccumulator::try_from_file(trin_config.master_acc_path.clone())?;

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -120,7 +120,8 @@ pub fn spawn_history_heartbeat(network: Arc<HistoryNetwork>) {
             heart_interval.tick().await;
 
             let storage_log = network.overlay.store.read().get_summary_info();
-            info!("storage-report: {storage_log}");
+            let message_log = network.overlay.get_summary_info();
+            info!("reports~ data: {storage_log}; msgs: {message_log}");
         }
     });
 }

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -33,7 +33,6 @@ impl HistoryNetwork {
     ) -> anyhow::Result<Self> {
         let config = OverlayConfig {
             bootnode_enrs: portal_config.bootnode_enrs.clone(),
-            enable_metrics: portal_config.enable_metrics,
             ..Default::default()
         };
         let storage = Arc::new(PLRwLock::new(PortalStorage::new(

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -45,7 +45,6 @@ impl StateNetwork {
         let validator = Arc::new(StateValidator { header_oracle });
         let config = OverlayConfig {
             bootnode_enrs: portal_config.bootnode_enrs.clone(),
-            enable_metrics: portal_config.enable_metrics,
             ..Default::default()
         };
         let overlay = OverlayProtocol::new(


### PR DESCRIPTION
### What was wrong?

Fix #655 

### How was it fixed?

Combine metrics into one, using labels to differentiate. Display offers and accepts in the heartbeat log. Other things are being tracked, this is shown just to give you a flavor of what's going on.

The heartbeat log now looks like:
```
2023-04-13T04:09:28.335984Z  INFO trin_history: reports~ data: radius=0.4% content=2086.4/2000kb #=27 disk=2509.3kb; msgs: offers=7/8, accepts=3/4
```


### To-Do

- [x] Clean up commit history
- [x] Add the custom registry trick to pass tests.
