### PR TITLE
Radius metric: higher precision, switch to ratio, log approprate number of digits

### DIFF
--- a/portalnet/src/storage.rs
+++ b/portalnet/src/storage.rs
@@ -852,14 +852,26 @@ impl StorageMetrics {
     }
 
     pub fn get_summary(&self) -> String {
+        let radius_percent = self.radius_ratio.get() * 100.0;
         format!(
-            "radius={:.1}% content={:.1}/{}kb #={} disk={:.1}kb",
-            self.radius_ratio.get() * 100.0,
+            "radius={:.*}% content={:.1}/{}kb #={} disk={:.1}kb",
+            Self::precision_for_percentage(radius_percent),
+            radius_percent,
             self.content_storage_usage_kb.get(),
             self.storage_capacity_kb.get(),
             self.entry_count.get(),
             self.total_storage_usage_kb.get(),
         )
+    }
+
+    fn precision_for_percentage(percent: f64) -> usize {
+        match percent {
+            x if x >= 10.0 => 0,
+            x if x >= 1.0 => 1,
+            x if x >= 0.1 => 2,
+            x if x >= 0.01 => 3,
+            _ => 4,
+        }
     }
 }
 
@@ -1247,5 +1259,50 @@ pub mod test {
         assert!(!store
             .is_key_within_radius_and_unavailable(&arb_key)
             .unwrap());
+    }
+
+    #[test]
+    fn test_precision_for_percentage() {
+        fn formatted_percent(ratio: f64) -> String {
+            let precision = StorageMetrics::precision_for_percentage(ratio * 100.0);
+            format!("{:.*}%", precision, ratio * 100.0)
+        }
+        assert_eq!(formatted_percent(1.0), "100%");
+        assert_eq!(formatted_percent(0.9999), "100%");
+        assert_eq!(formatted_percent(0.9949), "99%");
+
+        assert_eq!(formatted_percent(0.10001), "10%");
+        assert_eq!(formatted_percent(0.1), "10%");
+        assert_eq!(formatted_percent(0.09949), "9.9%");
+
+        assert_eq!(formatted_percent(0.010001), "1.0%");
+        assert_eq!(formatted_percent(0.01), "1.0%");
+        assert_eq!(formatted_percent(0.009949), "0.99%");
+
+        assert_eq!(formatted_percent(0.0010001), "0.10%");
+        assert_eq!(formatted_percent(0.001), "0.10%");
+        assert_eq!(formatted_percent(0.0009949), "0.099%");
+
+        assert_eq!(formatted_percent(0.00010001), "0.010%");
+        assert_eq!(formatted_percent(0.0001), "0.010%");
+        assert_eq!(formatted_percent(0.00009949), "0.0099%");
+
+        assert_eq!(formatted_percent(0.000010001), "0.0010%");
+        assert_eq!(formatted_percent(0.00001), "0.0010%");
+        assert_eq!(formatted_percent(0.0000095), "0.0010%");
+        assert_eq!(formatted_percent(0.00000949), "0.0009%");
+
+        assert_eq!(formatted_percent(0.0000010001), "0.0001%");
+        assert_eq!(formatted_percent(0.000001), "0.0001%");
+        assert_eq!(formatted_percent(0.0000009949), "0.0001%");
+        assert_eq!(formatted_percent(0.0000005001), "0.0001%");
+        assert_eq!(formatted_percent(0.0000004999), "0.0000%");
+        assert_eq!(formatted_percent(0.0), "0.0000%");
+
+        // We mostly care that values outside of [0.0, 1.0] do not crash, but
+        // for now we also check that they pin to 0 or 4.
+        assert_eq!(StorageMetrics::precision_for_percentage(101.0), 0);
+        assert_eq!(StorageMetrics::precision_for_percentage(-0.001), 4);
+        assert_eq!(StorageMetrics::precision_for_percentage(-1000.0), 4);
     }
 }


### PR DESCRIPTION
### What was wrong?

Fix #659 

It won't take long for 1 digit of percentage to be rounded down to 0, for even moderately sized nodes. So we need to generate and display more precision for the logs.

### How was it fixed?

Get more bytes of the radius, to get a higher precision estimate. We don't expect to display a higher precision than 1 in a million, so 3 bytes would be sufficient. The nearest supported integer is at u32 with 4 bytes.

Ratio (0-1) is favored over % (0-100) in the prometheus system. Switch to saving that value, plus the corresponding metric name change.

Depending on the size of the radius, grow or shrink the number of displayed digits in the heartbeat log.

### To-Do

- [ ] Clean up commit history
- [x] Show more digits in the log, maybe even dynamically as the number changes?
