### PR TITLE
Refactor DB utils to decrease side effects

### DIFF
--- a/portalnet/src/storage.rs
+++ b/portalnet/src/storage.rs
@@ -718,6 +718,7 @@ impl PortalStorage {
         let mut data_path: PathBuf = get_data_dir(node_id).map_err(|err| {
             ContentStoreError::Database(format!("Unable to get data dir for rocksdb: {err:?}"))
         })?;
+        fs::create_dir_all(&data_path).expect("Unable to create data directory folder");
         data_path.push("rocksdb");
         info!(path = %data_path.display(), "Setting up RocksDB");
 
@@ -731,6 +732,7 @@ impl PortalStorage {
         let mut data_path: PathBuf = get_data_dir(node_id).map_err(|err| {
             ContentStoreError::Database(format!("Unable to get data dir for sql: {err:?}"))
         })?;
+        fs::create_dir_all(&data_path).expect("Unable to create data directory folder");
         data_path.push("trin.sqlite");
         info!(path = %data_path.display(), "Setting up SqliteDB");
 

--- a/portalnet/src/utils/db.rs
+++ b/portalnet/src/utils/db.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 use trin_utils::bytes::hex_encode;
 
-const TRIN_DATA_ENV_VAR: &str = "TRIN_DATA_PATH";
+pub const TRIN_DATA_ENV_VAR: &str = "TRIN_DATA_PATH";
 
 /// Creates a directory on the file system that is deleted once it goes out of scope
 pub fn setup_temp_dir() -> anyhow::Result<TempDir> {
@@ -19,7 +19,6 @@ pub fn setup_temp_dir() -> anyhow::Result<TempDir> {
     fs::create_dir_all(&os_temp)?;
 
     let temp_dir = TempDir::new_in(&os_temp)?;
-    env::set_var(TRIN_DATA_ENV_VAR, temp_dir.path());
     Ok(temp_dir)
 }
 
@@ -33,8 +32,6 @@ pub fn get_data_dir(node_id: NodeId) -> anyhow::Result<PathBuf> {
     application_string.push_str(suffix);
 
     trin_data_dir.push(application_string);
-
-    fs::create_dir_all(&trin_data_dir).expect("Unable to create data directory folder");
     Ok(trin_data_dir)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use portalnet::{
     events::PortalnetEvents,
     storage::PortalStorageConfig,
     types::messages::PortalnetConfig,
-    utils::db::setup_temp_dir,
+    utils::db::{setup_temp_dir, TRIN_DATA_ENV_VAR},
 };
 use trin_history::initialize_history_network;
 use trin_state::initialize_state_network;
@@ -59,7 +59,8 @@ pub async fn run_trin(
 
     // Initialize Storage config
     if trin_config.ephemeral {
-        setup_temp_dir()?;
+        let temp_dir = setup_temp_dir()?;
+        std::env::set_var(TRIN_DATA_ENV_VAR, temp_dir.path());
     }
 
     let storage_config =


### PR DESCRIPTION
### What was wrong?
Jacob made this issue https://github.com/ethereum/trin/issues/407 and I thought I would take a jab at it. After I clicked "New Pull Request" I seen he made a draft PR for it roughly 8 months ago. I found it after looking through the other PR's to see what the report format looked like. So if there is no need for this PR that is fine I will close it, I wish the issue was marked cause I don't want to step on anybody's toes. But since that PR had not been touched for so long I thought I would create my pull request anyways and see how it goes.

### How was it fixed?
I refactored ``create_dir_all`` out of ``get_data_dir`` and placed it after ``setup_rocksdb`` and ``setup_sql`` since that is where it seemed best suited looking to remove side effects in mind. It being best suited in those places since it would only need to create them possibly in setup was my assumption.

Then for removing the side effect list in the issue from ``setup_temp_dir``. I noticed that setup_temp_dir is only used in 2 places in storage tests, and ``trin/src/lib.rs`` so since the storage tests didn't need ``get_root_path()`` which used the environment variable ``TRIN_DATA_ENV_VAR`` it only made set to set the variable in ``trin/src/lib.rs``. Which eliminates the side effect.
