### PR TITLE
Switch from StructOpt to Clap in ethportal-peertest

### DIFF
--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
-clap = "2.33.3"
+clap = { version = "4.2.1", features = ["derive"] }
 discv5 = { version = "0.2.1", features = ["serde"]}
 eth2_ssz = "0.4.0"
 ethportal-api = { path="../ethportal-api"}
@@ -23,7 +23,6 @@ rand = "0.8.4"
 reth-ipc = { version = "0.1.0", git = "https://github.com/paradigmxyz/reth.git"}
 rocksdb = "0.18.0"
 serde_json = "1.0.89"
-structopt = "0.3.26"
 tokio = {version = "1.14.0", features = ["full"]}
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"

--- a/ethportal-peertest/src/cli.rs
+++ b/ethportal-peertest/src/cli.rs
@@ -1,5 +1,4 @@
-use std::{env, ffi::OsString};
-use structopt::StructOpt;
+use clap::{Parser, ValueEnum};
 use trin_types::cli::{
     DEFAULT_WEB3_HTTP_ADDRESS as DEFAULT_TARGET_HTTP_ADDRESS,
     DEFAULT_WEB3_IPC_PATH as DEFAULT_TARGET_IPC_PATH,
@@ -7,37 +6,36 @@ use trin_types::cli::{
 
 const DEFAULT_LISTEN_PORT: &str = "9876";
 
-#[derive(StructOpt, Debug, PartialEq, Eq, Clone)]
-#[structopt(
+#[derive(Parser, Debug, PartialEq, Eq, Clone)]
+#[command(
     name = "ethportal-peertest",
     version = "0.0.1",
     about = "Testing framework for portal network peer-to-peer network calls"
 )]
 pub struct PeertestConfig {
-    #[structopt(
-        default_value(DEFAULT_LISTEN_PORT),
-        short = "p",
+    #[arg(
+        default_value = DEFAULT_LISTEN_PORT,
+        short = 'p',
         long = "listen-port",
         help = "The UDP port to listen on."
     )]
     pub listen_port: u16,
 
-    #[structopt(
+    #[arg(
         default_value = "ipc",
-        possible_values(&["http", "ipc"]),
         long = "target-transport",
         help = "Transport type of the node under test"
     )]
-    pub target_transport: String,
+    pub target_transport: PeertestTransport,
 
-    #[structopt(
+    #[arg(
         default_value = DEFAULT_TARGET_IPC_PATH,
         long = "target-ipc-path",
         help = "IPC path of target node under test"
     )]
     pub target_ipc_path: String,
 
-    #[structopt(
+    #[arg(
         default_value = DEFAULT_TARGET_HTTP_ADDRESS,
         long = "target-http-address",
         help = "HTTP address of target node under test"
@@ -45,24 +43,66 @@ pub struct PeertestConfig {
     pub target_http_address: String,
 }
 
-impl PeertestConfig {
-    pub fn from_cli() -> Self {
-        Self::new_from(env::args_os()).expect("Could not parse ethportal-peertest arguments")
-    }
-
-    pub fn new_from<I, T>(args: I) -> Result<Self, String>
-    where
-        I: Iterator<Item = T>,
-        T: Into<OsString> + Clone,
-    {
-        let config = Self::from_iter(args);
-
-        Ok(config)
-    }
+#[derive(ValueEnum, Debug, PartialEq, Eq, Clone)]
+pub enum PeertestTransport {
+    Ipc,
+    Http,
 }
 
 impl Default for PeertestConfig {
     fn default() -> Self {
-        Self::new_from(["."].iter()).unwrap()
+        Self::parse_from([""])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::cli::PeertestConfig;
+    use crate::cli::PeertestTransport;
+    use clap::Parser;
+
+    #[test]
+    fn test_default_pasre_config() {
+        let config = PeertestConfig::default();
+        assert_eq!(config.listen_port, 9876);
+        assert_eq!(config.target_transport, PeertestTransport::Ipc);
+        assert_eq!(config.target_ipc_path, "/tmp/trin-jsonrpc.ipc");
+        assert_eq!(config.target_http_address, "http://127.0.0.1:8545/");
+    }
+
+    #[test]
+    fn test_parse_config_with_http() {
+        let config = PeertestConfig::parse_from([
+            "test",
+            "--target-transport",
+            "http",
+            "--target-http-address",
+            "http://127.0.0.1:5555/",
+        ]);
+        assert_eq!(config.listen_port, 9876);
+        assert_eq!(config.target_transport, PeertestTransport::Http);
+        assert_eq!(config.target_http_address, "http://127.0.0.1:5555/");
+    }
+
+    #[test]
+    fn test_parse_config_with_ipc() {
+        let config = PeertestConfig::parse_from([
+            "test",
+            "--target-transport",
+            "ipc",
+            "--target-ipc-path",
+            "/tmp/test.ipc",
+        ]);
+        assert_eq!(config.listen_port, 9876);
+        assert_eq!(config.target_transport, PeertestTransport::Ipc);
+        assert_eq!(config.target_ipc_path, "/tmp/test.ipc");
+    }
+
+    #[test]
+    fn test_parse_config_with_listen_port() {
+        let config = PeertestConfig::parse_from(["test", "--listen-port", "5555"]);
+        assert_eq!(config.listen_port, 5555);
+        assert_eq!(config.target_transport, PeertestTransport::Ipc);
+        assert_eq!(config.target_ipc_path, "/tmp/trin-jsonrpc.ipc");
     }
 }

--- a/newsfragments/667.changed.md
+++ b/newsfragments/667.changed.md
@@ -1,0 +1,1 @@
+Switch from StructOpt to Clap in ethportal-peertest.


### PR DESCRIPTION
### What was wrong?

Related to #627. A tiny PR of #651.

### How was it fixed?

Switched from StructOpt to Clap in `ethportal-peertest`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
