### PR TITLE
Switch from StructOpt to Clap in purge_db

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ description = "A Rust implementation of the Ethereum Portal Network"
 
 [dependencies]
 anyhow = "1.0.68"
+clap = { version = "4.2.1", features = ["derive"] }
 discv5 = { version = "0.2.1", features = ["serde"] }
 enr = { version = "=0.7.0", features = ["k256", "ed25519"] }
 eth2_ssz = "0.4.0"
@@ -28,7 +29,6 @@ rocksdb = "0.18.0"
 rpc = { path = "rpc"}
 serde_json = {version = "1.0.89", features = ["preserve_order"]}
 sha3 = "0.9.1"
-structopt = "0.3.26"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"

--- a/newsfragments/668.changed.md
+++ b/newsfragments/668.changed.md
@@ -1,0 +1,1 @@
+Switch from StructOpt to Clap in purge_db.


### PR DESCRIPTION
### What was wrong?

Related to #627. A tiny PR of #651.

How was it fixed?

Switched from StructOpt to Clap in purge_db.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
