### PR TITLE
replace wrapped NodeId with native discv5 type (except for caveat in description)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5541,6 +5541,7 @@ name = "rpc"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "discv5",
  "ethportal-api",
  "hyper",
  "portalnet",

--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -5,7 +5,8 @@ use crate::types::portal::FindNodesInfo;
 use crate::types::portal::{
     AcceptInfo, ContentInfo, DataRadius, PaginateLocalContentInfo, PongInfo, TraceContentInfo,
 };
-use crate::{NodeId, RoutingTableInfo};
+use crate::RoutingTableInfo;
+use discv5::enr::NodeId;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Portal Beacon JSON-RPC endpoints

--- a/ethportal-api/src/discv5.rs
+++ b/ethportal-api/src/discv5.rs
@@ -1,6 +1,6 @@
 use crate::types::discv5::{NodeInfo, RoutingTableInfo};
 use crate::types::enr::Enr;
-use crate::types::node_id::NodeId;
+use discv5::enr::NodeId;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Discv5 JSON-RPC endpoints

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -5,7 +5,8 @@ use crate::types::portal::FindNodesInfo;
 use crate::types::portal::{
     AcceptInfo, ContentInfo, DataRadius, PaginateLocalContentInfo, PongInfo, TraceContentInfo,
 };
-use crate::{NodeId, RoutingTableInfo};
+use crate::RoutingTableInfo;
+use discv5::enr::NodeId;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Portal History JSON-RPC endpoints

--- a/ethportal-api/src/types/discv5.rs
+++ b/ethportal-api/src/types/discv5.rs
@@ -2,7 +2,7 @@ use super::enr::Enr;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::node_id::NodeId;
+use discv5::enr::NodeId;
 
 /// Discv5 bucket
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/ethportal-api/src/types/enr.rs
+++ b/ethportal-api/src/types/enr.rs
@@ -98,15 +98,16 @@ pub fn generate_random_remote_enr() -> (CombinedKey, Enr) {
 
 #[cfg(test)]
 mod test {
+    use crate::generate_random_node_id;
     use crate::types::distance::{Metric, XorMetric};
-    use crate::types::node_id::NodeId;
+    use discv5::enr::NodeId;
     use test_log::test;
 
     #[test]
     fn test_generate_random_node_id_1() {
         let target_bucket_idx: u8 = 5;
         let local_node_id = NodeId::random();
-        let random_node_id = NodeId::generate_random_node_id(target_bucket_idx, local_node_id);
+        let random_node_id = generate_random_node_id(target_bucket_idx, local_node_id);
         let distance = XorMetric::distance(&random_node_id.raw(), &local_node_id.raw());
         let distance = distance.big_endian();
 
@@ -118,7 +119,7 @@ mod test {
     fn test_generate_random_node_id_2() {
         let target_bucket_idx: u8 = 0;
         let local_node_id = NodeId::random();
-        let random_node_id = NodeId::generate_random_node_id(target_bucket_idx, local_node_id);
+        let random_node_id = generate_random_node_id(target_bucket_idx, local_node_id);
         let distance = XorMetric::distance(&random_node_id.raw(), &local_node_id.raw());
         let distance = distance.big_endian();
 
@@ -130,7 +131,7 @@ mod test {
     fn test_generate_random_node_id_3() {
         let target_bucket_idx: u8 = 255;
         let local_node_id = NodeId::random();
-        let random_node_id = NodeId::generate_random_node_id(target_bucket_idx, local_node_id);
+        let random_node_id = generate_random_node_id(target_bucket_idx, local_node_id);
         let distance = XorMetric::distance(&random_node_id.raw(), &local_node_id.raw());
         let distance = distance.big_endian();
 

--- a/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -1,7 +1,7 @@
 use crate::types::content_key::{BeaconContentKey, HistoryContentKey};
 use crate::types::content_value::{BeaconContentValue, HistoryContentValue};
 use crate::types::enr::Enr;
-use crate::types::node_id::NodeId;
+use discv5::enr::NodeId;
 
 /// Discv5 JSON-RPC endpoints. Start with "discv5_" prefix
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/ethportal-api/src/types/node_id.rs
+++ b/ethportal-api/src/types/node_id.rs
@@ -1,7 +1,18 @@
-use crate::types::distance::{Metric, XorMetric};
-use discv5::enr::NodeId;
+use super::enr::Enr;
+use serde::{Deserialize, Serialize};
+use stremio_serde_hex::{SerHex, StrictPfx};
 
-pub fn generate_random_node_id(target_bucket_idx: u8, local_node_id: NodeId) -> NodeId {
+use discv5::enr::NodeId as EnrNodeId;
+
+use super::distance::{Metric, XorMetric};
+
+type RawNodeId = [u8; 32];
+
+/// Generate random NodeId based on bucket index target and a local node id.
+/// First we generate a random distance metric with leading zeroes based on the target bucket.
+/// Then we XOR the result distance with the local NodeId to get the random target NodeId
+// TODO: We should be able to make this generic over a `Metric`.
+pub fn generate_random_node_id(target_bucket_idx: u8, local_node_id: EnrNodeId) -> EnrNodeId {
     let distance_leading_zeroes = 255 - target_bucket_idx;
     let random_distance = crate::utils::bytes::random_32byte_array(distance_leading_zeroes);
 
@@ -10,4 +21,27 @@ pub fn generate_random_node_id(target_bucket_idx: u8, local_node_id: NodeId) -> 
     let raw_bytes = raw_node_id.big_endian();
 
     raw_bytes.into()
+}
+
+/// Discv5 NodeId
+// TODO: Wrap this type over discv5::NodeId type
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct NodeId(#[serde(with = "SerHex::<StrictPfx>")] pub RawNodeId);
+
+impl From<&Enr> for NodeId {
+    fn from(enr: &Enr) -> Self {
+        NodeId(enr.node_id().raw())
+    }
+}
+
+impl From<Enr> for NodeId {
+    fn from(enr: Enr) -> Self {
+        NodeId(enr.node_id().raw())
+    }
+}
+
+impl From<EnrNodeId> for NodeId {
+    fn from(value: EnrNodeId) -> Self {
+        NodeId(value.raw())
+    }
 }

--- a/ethportal-api/src/types/node_id.rs
+++ b/ethportal-api/src/types/node_id.rs
@@ -1,115 +1,13 @@
-use super::enr::Enr;
-use serde::{Deserialize, Serialize};
-use std::ops::Deref;
-use stremio_serde_hex::{SerHex, StrictPfx};
+use crate::types::distance::{Metric, XorMetric};
+use discv5::enr::NodeId;
 
-use discv5::enr::NodeId as EnrNodeId;
+pub fn generate_random_node_id(target_bucket_idx: u8, local_node_id: NodeId) -> NodeId {
+    let distance_leading_zeroes = 255 - target_bucket_idx;
+    let random_distance = crate::utils::bytes::random_32byte_array(distance_leading_zeroes);
 
-use super::distance::{Metric, XorMetric};
+    let raw_node_id = XorMetric::distance(&local_node_id.raw(), &random_distance);
 
-type RawNodeId = [u8; 32];
+    let raw_bytes = raw_node_id.big_endian();
 
-/// Discv5 NodeId
-// TODO: Wrap this type over discv5::NodeId type
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub struct NodeId(#[serde(with = "SerHex::<StrictPfx>")] pub RawNodeId);
-
-impl NodeId {
-    pub fn random() -> Self {
-        Self(rand::random())
-    }
-
-    pub fn raw(self) -> RawNodeId {
-        *self.deref()
-    }
-
-    /// Generate random NodeId based on bucket index target and a local node id.
-    /// First we generate a random distance metric with leading zeroes based on the target bucket.
-    /// Then we XOR the result distance with the local NodeId to get the random target NodeId
-    // TODO: We should be able to make this generic over a `Metric`.
-    pub fn generate_random_node_id(target_bucket_idx: u8, local_node_id: NodeId) -> NodeId {
-        let distance_leading_zeroes = 255 - target_bucket_idx;
-        let random_distance = crate::utils::bytes::random_32byte_array(distance_leading_zeroes);
-
-        let raw_node_id = XorMetric::distance(&local_node_id.raw(), &random_distance);
-
-        let raw_bytes = raw_node_id.big_endian();
-
-        raw_bytes.into()
-    }
-}
-
-impl From<RawNodeId> for NodeId {
-    fn from(item: RawNodeId) -> Self {
-        NodeId(item)
-    }
-}
-
-impl From<EnrNodeId> for NodeId {
-    fn from(value: EnrNodeId) -> Self {
-        NodeId(value.raw())
-    }
-}
-
-impl From<NodeId> for EnrNodeId {
-    fn from(val: NodeId) -> Self {
-        EnrNodeId::new(val.deref())
-    }
-}
-
-impl From<&Enr> for NodeId {
-    fn from(enr: &Enr) -> Self {
-        NodeId(enr.node_id().raw())
-    }
-}
-
-impl From<Enr> for NodeId {
-    fn from(enr: Enr) -> Self {
-        NodeId(enr.node_id().raw())
-    }
-}
-
-impl Deref for NodeId {
-    type Target = RawNodeId;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-#[cfg(test)]
-#[allow(clippy::unwrap_used)]
-mod test {
-    use crate::types::enr::Enr;
-    use crate::types::node_id::NodeId;
-    use std::net::Ipv4Addr;
-
-    #[test]
-    fn test_enr_ser_de() {
-        let enr_base64 = r#""enr:-I24QAnHRBtPxxqnrZ0A9Xw1GV0cr3g178FcLutgd1DcG8a1FjOoRooOleI79K2NvTXYpOpkbe_NN-VqNZqS2a_Bo40BY4d0IDAuMS4wgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQIJSs6oF8rPca9GjRV6tNaJ2YfZb5nNQjui2VUloBleH4N1ZHCCIyo""#;
-        let expected_node_id = [
-            176, 202, 35, 254, 68, 245, 224, 61, 174, 106, 81, 237, 41, 88, 144, 15, 55, 58, 125,
-            119, 228, 39, 201, 211, 154, 95, 148, 198, 212, 185, 175, 219,
-        ];
-        let expected_ip4 = Some(Ipv4Addr::from([127, 0, 0, 1]));
-
-        let enr: Enr = serde_json::from_str(enr_base64).unwrap();
-        assert_eq!(enr.node_id(), expected_node_id);
-        assert_eq!(enr.ip4(), expected_ip4);
-
-        let decoded_enr = serde_json::to_string(&enr).unwrap();
-        assert_eq!(decoded_enr, enr_base64);
-    }
-
-    #[test]
-    fn test_node_id_ser_de() {
-        let node_id = NodeId([
-            176, 202, 35, 254, 68, 245, 224, 61, 174, 106, 81, 237, 41, 88, 144, 15, 55, 58, 125,
-            119, 228, 39, 201, 211, 154, 95, 148, 198, 212, 185, 175, 219,
-        ]);
-
-        let node_id_string = serde_json::to_string(&node_id).unwrap();
-
-        assert_eq!(node_id, serde_json::from_str(&node_id_string).unwrap());
-    }
+    raw_bytes.into()
 }

--- a/ethportal-api/src/types/query_trace.rs
+++ b/ethportal-api/src/types/query_trace.rs
@@ -1,5 +1,5 @@
 use super::enr::Enr;
-use super::node_id::NodeId;
+use discv5::enr::NodeId;
 use std::collections::HashMap;
 use std::time::SystemTime;
 
@@ -158,9 +158,9 @@ mod tests {
     #[test]
     fn test_query_trace() {
         let (_, local_enr) = generate_random_remote_enr();
-        let local_node_id = &local_enr.node_id().into();
+        let local_node_id = &local_enr.node_id();
 
-        let mut tracer = QueryTrace::new(&local_enr, local_enr.node_id().into());
+        let mut tracer = QueryTrace::new(&local_enr, local_enr.node_id());
         let (_, enr_a) = generate_random_remote_enr();
         let node_id_a: &NodeId = &enr_a.clone().into();
         let (_, enr_b) = generate_random_remote_enr();
@@ -173,7 +173,7 @@ mod tests {
         tracer.node_responded_with(&local_enr, vec![&enr_c]);
 
         let (_, enr_d) = generate_random_remote_enr();
-        let node_id_d = &enr_d.node_id().into();
+        let node_id_d = &enr_d.node_id();
 
         tracer.node_responded_with(&enr_a, vec![]);
         tracer.node_responded_with(&enr_b, vec![&enr_d]);

--- a/ethportal-api/src/types/query_trace.rs
+++ b/ethportal-api/src/types/query_trace.rs
@@ -1,5 +1,5 @@
 use super::enr::Enr;
-use discv5::enr::NodeId;
+use super::node_id::NodeId;
 use std::collections::HashMap;
 use std::time::SystemTime;
 
@@ -115,7 +115,7 @@ impl QueryTrace {
             None => "".to_owned(),
         };
         let port = enr.udp4().unwrap_or(0).to_string();
-        let distance = XorMetric::distance(&node_id_raw, &target.raw());
+        let distance = XorMetric::distance(&node_id_raw, &target.0);
         let distance_log2 = distance.log2().unwrap_or(0);
         let distance: u64 = distance.0[3];
         let distance = (distance >> 32) as u32;
@@ -158,9 +158,9 @@ mod tests {
     #[test]
     fn test_query_trace() {
         let (_, local_enr) = generate_random_remote_enr();
-        let local_node_id = &local_enr.node_id();
+        let local_node_id = &local_enr.node_id().into();
 
-        let mut tracer = QueryTrace::new(&local_enr, local_enr.node_id());
+        let mut tracer = QueryTrace::new(&local_enr, local_enr.node_id().into());
         let (_, enr_a) = generate_random_remote_enr();
         let node_id_a: &NodeId = &enr_a.clone().into();
         let (_, enr_b) = generate_random_remote_enr();
@@ -173,7 +173,7 @@ mod tests {
         tracer.node_responded_with(&local_enr, vec![&enr_c]);
 
         let (_, enr_d) = generate_random_remote_enr();
-        let node_id_d = &enr_d.node_id();
+        let node_id_d = &enr_d.node_id().into();
 
         tracer.node_responded_with(&enr_a, vec![]);
         tracer.node_responded_with(&enr_b, vec![&enr_d]);

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -52,7 +52,7 @@ pub async fn test_history_add_enr(target: &Client, peertest: &Peertest) {
 
 pub async fn test_history_get_enr(target: &Client, peertest: &Peertest) {
     info!("Testing portal_historyGetEnr");
-    let result = HistoryNetworkApiClient::get_enr(target, peertest.bootnode.enr.node_id().into())
+    let result = HistoryNetworkApiClient::get_enr(target, peertest.bootnode.enr.node_id())
         .await
         .unwrap();
     assert_eq!(result, peertest.bootnode.enr);
@@ -60,10 +60,9 @@ pub async fn test_history_get_enr(target: &Client, peertest: &Peertest) {
 
 pub async fn test_history_delete_enr(target: &Client, peertest: &Peertest) {
     info!("Testing portal_historyDeleteEnr");
-    let result =
-        HistoryNetworkApiClient::delete_enr(target, peertest.bootnode.enr.node_id().into())
-            .await
-            .unwrap();
+    let result = HistoryNetworkApiClient::delete_enr(target, peertest.bootnode.enr.node_id())
+        .await
+        .unwrap();
     assert!(result);
 }
 
@@ -71,7 +70,7 @@ pub async fn test_history_lookup_enr(peertest: &Peertest) {
     info!("Testing portal_historyLookupEnr");
     let result = HistoryNetworkApiClient::lookup_enr(
         &peertest.bootnode.ipc_client,
-        peertest.nodes[0].enr.node_id().into(),
+        peertest.nodes[0].enr.node_id(),
     )
     .await
     .unwrap();

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -86,11 +86,14 @@ pub async fn test_trace_recursive_find_content(peertest: &Peertest) {
 
     // Test that `origin` is set correctly
     let origin = trace.origin;
-    assert_eq!(origin, query_origin_node);
+    assert_eq!(origin, ethportal_api::NodeId::from(query_origin_node));
 
     // Test that `received_content_from_node` is set correctly
     let received_content_from_node = trace.received_content_from_node.unwrap();
-    assert_eq!(node_with_content, received_content_from_node);
+    assert_eq!(
+        ethportal_api::NodeId::from(node_with_content),
+        received_content_from_node
+    );
 
     let responses = trace.responses;
 
@@ -159,5 +162,5 @@ pub async fn test_trace_recursive_find_content_local_db(peertest: &Peertest) {
     );
 
     let expected_origin_id: NodeId = peertest.bootnode.enr.node_id();
-    assert_eq!(expected_origin_id, origin);
+    assert_eq!(ethportal_api::NodeId::from(expected_origin_id), origin);
 }

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -1,7 +1,7 @@
 use crate::{constants::HISTORY_CONTENT_VALUE, Peertest};
+use discv5::enr::NodeId;
 use ethportal_api::types::content_key::HistoryContentKey;
 use ethportal_api::types::content_value::{HistoryContentValue, PossibleHistoryContentValue};
-use ethportal_api::types::node_id::NodeId;
 use ethportal_api::types::portal::TraceContentInfo;
 use ethportal_api::utils::bytes::hex_decode;
 use ethportal_api::{ContentValue, HistoryNetworkApiClient};
@@ -81,8 +81,8 @@ pub async fn test_trace_recursive_find_content(peertest: &Peertest) {
         PossibleHistoryContentValue::ContentPresent(history_content_value)
     );
 
-    let query_origin_node: NodeId = peertest.nodes[0].enr.node_id().into();
-    let node_with_content: NodeId = peertest.bootnode.enr.node_id().into();
+    let query_origin_node: NodeId = peertest.nodes[0].enr.node_id();
+    let node_with_content: NodeId = peertest.bootnode.enr.node_id();
 
     // Test that `origin` is set correctly
     let origin = trace.origin;
@@ -158,6 +158,6 @@ pub async fn test_trace_recursive_find_content_local_db(peertest: &Peertest) {
         origin
     );
 
-    let expected_origin_id: NodeId = peertest.bootnode.enr.node_id().into();
+    let expected_origin_id: NodeId = peertest.bootnode.enr.node_id();
     assert_eq!(expected_origin_id, origin);
 }

--- a/newsfragments/669.fixed.md
+++ b/newsfragments/669.fixed.md
@@ -1,0 +1,1 @@
+replace wrapped NodeId with native discv5 type

--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -15,7 +15,7 @@ use super::types::messages::{PortalnetConfig, ProtocolId};
 use crate::socket;
 use ethportal_api::types::enr::Enr;
 use ethportal_api::utils::bytes::hex_encode;
-use ethportal_api::{NodeId as EthportalNodeId, NodeInfo};
+use ethportal_api::NodeInfo;
 use std::net::Ipv4Addr;
 use std::str::FromStr;
 use std::{convert::TryFrom, fmt, io, net::SocketAddr, sync::Arc};
@@ -201,7 +201,7 @@ impl Discovery {
         Ok(NodeInfo {
             enr: Enr::from_str(&self.discv5.local_enr().to_base64())
                 .map_err(|err| anyhow!("{err}"))?,
-            node_id: EthportalNodeId::from(self.discv5.local_enr().node_id().raw()),
+            node_id: self.discv5.local_enr().node_id(),
             ip: self
                 .discv5
                 .local_enr()

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -59,10 +59,9 @@ use crate::{
 use ethportal_api::types::content_key::RawContentKey;
 use ethportal_api::types::distance::{Distance, Metric, XorMetric};
 use ethportal_api::types::enr::{Enr, SszEnr};
-use ethportal_api::types::node_id::NodeId as TrinNodeId;
 use ethportal_api::types::query_trace::QueryTrace;
 use ethportal_api::utils::bytes::{hex_encode, hex_encode_compact};
-use ethportal_api::OverlayContentKey;
+use ethportal_api::{generate_random_node_id, OverlayContentKey};
 use trin_validation::validator::Validator;
 
 pub const FIND_NODES_MAX_NODES: usize = 32;
@@ -438,9 +437,8 @@ where
         self.init_find_nodes_query(&local_node_id, None);
 
         for bucket_index in (255 - EXPECTED_NON_EMPTY_BUCKETS as u8)..255 {
-            let target_node_id =
-                TrinNodeId::generate_random_node_id(bucket_index, self.local_enr().into());
-            self.init_find_nodes_query(&target_node_id.into(), None);
+            let target_node_id = generate_random_node_id(bucket_index, self.local_enr().into());
+            self.init_find_nodes_query(&target_node_id, None);
         }
     }
 
@@ -551,9 +549,7 @@ where
                 Some(bucket) => {
                     trace!(protocol = %self.protocol, bucket = %bucket.0, "Refreshing routing table bucket");
                     match u8::try_from(bucket.0) {
-                        Ok(idx) => {
-                            TrinNodeId::generate_random_node_id(idx, self.local_enr().into())
-                        }
+                        Ok(idx) => generate_random_node_id(idx, self.local_enr().into()),
                         Err(err) => {
                             error!(error = %err, "Error downcasting bucket index");
                             return;
@@ -567,7 +563,7 @@ where
             }
         };
 
-        self.init_find_nodes_query(&target_node_id.into(), None);
+        self.init_find_nodes_query(&target_node_id, None);
     }
 
     /// Returns the local ENR of the node.
@@ -2210,7 +2206,7 @@ where
 
         let trace: Option<QueryTrace> = {
             if is_trace {
-                let mut trace = QueryTrace::new(&self.local_enr(), target_node_id.into());
+                let mut trace = QueryTrace::new(&self.local_enr(), target_node_id);
                 let local_enr = self.local_enr();
                 trace.node_responded_with(&local_enr, closest_enrs.iter().collect());
                 Some(trace)

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -2206,7 +2206,7 @@ where
 
         let trace: Option<QueryTrace> = {
             if is_trace {
-                let mut trace = QueryTrace::new(&self.local_enr(), target_node_id);
+                let mut trace = QueryTrace::new(&self.local_enr(), target_node_id.into());
                 let local_enr = self.local_enr();
                 trace.node_responded_with(&local_enr, closest_enrs.iter().collect());
                 Some(trace)

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -12,6 +12,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
+discv5 = { version = "0.3.0", features = ["serde"] }
 ethportal-api = { path = "../ethportal-api"}
 portalnet = { path = "../portalnet"}
 tracing = "0.1.27"

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -1,5 +1,6 @@
 use crate::jsonrpsee::core::{async_trait, RpcResult};
 use anyhow::anyhow;
+use discv5::enr::NodeId;
 use ethportal_api::types::constants::CONTENT_ABSENT;
 use ethportal_api::types::content_value::PossibleBeaconContentValue;
 use ethportal_api::types::enr::Enr;
@@ -12,7 +13,7 @@ use ethportal_api::types::portal::{
 use ethportal_api::BeaconContentKey;
 use ethportal_api::BeaconContentValue;
 use ethportal_api::BeaconNetworkApiServer;
-use ethportal_api::{NodeId, RoutingTableInfo};
+use ethportal_api::RoutingTableInfo;
 use serde_json::{from_value, Value};
 use tokio::sync::mpsc;
 

--- a/rpc/src/discv5_rpc.rs
+++ b/rpc/src/discv5_rpc.rs
@@ -1,8 +1,9 @@
 use crate::jsonrpsee::core::{async_trait, RpcResult};
+use discv5::enr::NodeId;
 use ethportal_api::jsonrpsee::core::Error;
 use ethportal_api::types::enr::Enr;
 use ethportal_api::Discv5ApiServer;
-use ethportal_api::{NodeId, NodeInfo, RoutingTableInfo};
+use ethportal_api::{NodeInfo, RoutingTableInfo};
 use portalnet::discovery::Discovery;
 use std::sync::Arc;
 

--- a/rpc/src/history_rpc.rs
+++ b/rpc/src/history_rpc.rs
@@ -1,5 +1,6 @@
 use crate::jsonrpsee::core::{async_trait, RpcResult};
 use anyhow::anyhow;
+use discv5::enr::NodeId;
 use ethportal_api::types::constants::CONTENT_ABSENT;
 use ethportal_api::types::content_value::PossibleHistoryContentValue;
 use ethportal_api::types::enr::Enr;
@@ -12,7 +13,7 @@ use ethportal_api::types::portal::{
 use ethportal_api::HistoryContentKey;
 use ethportal_api::HistoryContentValue;
 use ethportal_api::HistoryNetworkApiServer;
-use ethportal_api::{NodeId, RoutingTableInfo};
+use ethportal_api::RoutingTableInfo;
 use serde_json::{from_value, Value};
 use tokio::sync::mpsc;
 

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -99,10 +99,8 @@ async fn recursive_find_content(
     let (possible_content_bytes, trace) = match local_content {
         Some(val) => {
             let local_enr = overlay.local_enr();
-            let mut trace = QueryTrace::new(
-                &overlay.local_enr(),
-                NodeId::new(&content_key.content_id()).into(),
-            );
+            let mut trace =
+                QueryTrace::new(&overlay.local_enr(), NodeId::new(&content_key.content_id()));
             trace.node_responded_with_content(&local_enr);
             (Some(val), if is_trace { Some(trace) } else { None })
         }
@@ -200,11 +198,7 @@ async fn add_enr(
 }
 
 /// Constructs a JSON call for the GetEnr method.
-async fn get_enr(
-    network: Arc<RwLock<BeaconNetwork>>,
-    node_id: ethportal_api::NodeId,
-) -> Result<Value, String> {
-    let node_id = discv5::enr::NodeId::from(node_id.0);
+async fn get_enr(network: Arc<RwLock<BeaconNetwork>>, node_id: NodeId) -> Result<Value, String> {
     let overlay = network.read().await.overlay.clone();
     match overlay.get_enr(node_id) {
         Ok(enr) => Ok(json!(enr)),
@@ -213,22 +207,14 @@ async fn get_enr(
 }
 
 /// Constructs a JSON call for the deleteEnr method.
-async fn delete_enr(
-    network: Arc<RwLock<BeaconNetwork>>,
-    node_id: ethportal_api::NodeId,
-) -> Result<Value, String> {
-    let node_id = discv5::enr::NodeId::from(node_id.0);
+async fn delete_enr(network: Arc<RwLock<BeaconNetwork>>, node_id: NodeId) -> Result<Value, String> {
     let overlay = network.read().await.overlay.clone();
     let is_deleted = overlay.delete_enr(node_id);
     Ok(json!(is_deleted))
 }
 
 /// Constructs a JSON call for the LookupEnr method.
-async fn lookup_enr(
-    network: Arc<RwLock<BeaconNetwork>>,
-    node_id: ethportal_api::NodeId,
-) -> Result<Value, String> {
-    let node_id = discv5::enr::NodeId::from(node_id.0);
+async fn lookup_enr(network: Arc<RwLock<BeaconNetwork>>, node_id: NodeId) -> Result<Value, String> {
     let overlay = network.read().await.overlay.clone();
     match overlay.lookup_enr(node_id).await {
         Ok(enr) => Ok(json!(enr)),
@@ -330,9 +316,8 @@ async fn ping(
 /// Constructs a JSON call for the RecursiveFindNodes method.
 async fn recursive_find_nodes(
     network: Arc<RwLock<BeaconNetwork>>,
-    node_id: ethportal_api::NodeId,
+    node_id: NodeId,
 ) -> Result<Value, String> {
-    let node_id = discv5::enr::NodeId::from(node_id.0);
     let overlay = network.read().await.overlay.clone();
     let nodes = overlay.lookup_node(node_id).await;
     Ok(json!(nodes))

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -99,8 +99,10 @@ async fn recursive_find_content(
     let (possible_content_bytes, trace) = match local_content {
         Some(val) => {
             let local_enr = overlay.local_enr();
-            let mut trace =
-                QueryTrace::new(&overlay.local_enr(), NodeId::new(&content_key.content_id()));
+            let mut trace = QueryTrace::new(
+                &overlay.local_enr(),
+                NodeId::new(&content_key.content_id()).into(),
+            );
             trace.node_responded_with_content(&local_enr);
             (Some(val), if is_trace { Some(trace) } else { None })
         }

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -104,10 +104,8 @@ async fn recursive_find_content(
     let (possible_content_bytes, trace) = match local_content {
         Some(val) => {
             let local_enr = overlay.local_enr();
-            let mut trace = QueryTrace::new(
-                &overlay.local_enr(),
-                NodeId::new(&content_key.content_id()).into(),
-            );
+            let mut trace =
+                QueryTrace::new(&overlay.local_enr(), NodeId::new(&content_key.content_id()));
             trace.node_responded_with_content(&local_enr);
             (Some(val), if is_trace { Some(trace) } else { None })
         }
@@ -205,11 +203,7 @@ async fn add_enr(
 }
 
 /// Constructs a JSON call for the GetEnr method.
-async fn get_enr(
-    network: Arc<RwLock<HistoryNetwork>>,
-    node_id: ethportal_api::NodeId,
-) -> Result<Value, String> {
-    let node_id = discv5::enr::NodeId::from(node_id.0);
+async fn get_enr(network: Arc<RwLock<HistoryNetwork>>, node_id: NodeId) -> Result<Value, String> {
     let overlay = network.read().await.overlay.clone();
     match overlay.get_enr(node_id) {
         Ok(enr) => Ok(json!(enr)),
@@ -220,9 +214,8 @@ async fn get_enr(
 /// Constructs a JSON call for the deleteEnr method.
 async fn delete_enr(
     network: Arc<RwLock<HistoryNetwork>>,
-    node_id: ethportal_api::NodeId,
+    node_id: NodeId,
 ) -> Result<Value, String> {
-    let node_id = discv5::enr::NodeId::from(node_id.0);
     let overlay = network.read().await.overlay.clone();
     let is_deleted = overlay.delete_enr(node_id);
     Ok(json!(is_deleted))
@@ -231,9 +224,8 @@ async fn delete_enr(
 /// Constructs a JSON call for the LookupEnr method.
 async fn lookup_enr(
     network: Arc<RwLock<HistoryNetwork>>,
-    node_id: ethportal_api::NodeId,
+    node_id: NodeId,
 ) -> Result<Value, String> {
-    let node_id = discv5::enr::NodeId::from(node_id.0);
     let overlay = network.read().await.overlay.clone();
     match overlay.lookup_enr(node_id).await {
         Ok(enr) => Ok(json!(enr)),
@@ -335,9 +327,8 @@ async fn ping(
 /// Constructs a JSON call for the RecursiveFindNodes method.
 async fn recursive_find_nodes(
     network: Arc<RwLock<HistoryNetwork>>,
-    node_id: ethportal_api::NodeId,
+    node_id: NodeId,
 ) -> Result<Value, String> {
-    let node_id = discv5::enr::NodeId::from(node_id.0);
     let overlay = network.read().await.overlay.clone();
     let nodes = overlay.lookup_node(node_id).await;
     Ok(json!(nodes))

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -104,8 +104,10 @@ async fn recursive_find_content(
     let (possible_content_bytes, trace) = match local_content {
         Some(val) => {
             let local_enr = overlay.local_enr();
-            let mut trace =
-                QueryTrace::new(&overlay.local_enr(), NodeId::new(&content_key.content_id()));
+            let mut trace = QueryTrace::new(
+                &overlay.local_enr(),
+                NodeId::new(&content_key.content_id()).into(),
+            );
             trace.node_responded_with_content(&local_enr);
             (Some(val), if is_trace { Some(trace) } else { None })
         }


### PR DESCRIPTION
### What was wrong?
Fix https://github.com/ethereum/trin/issues/539 

### How was it fixed?
Update discv5 to ``v0.3.0``

Use discv5 node_id type and remove our encapsulated one

#### Known issue
We can't fully remove it till we add ``#[serde(with = "SerHex::<StrictPfx>")]`` to ``sigp/enr`` it is used for recursive query tracing. It is a issue with serialization with hashmaps, if we don't have this flag checked.

https://github.com/sigp/enr/pull/34

^ here is a PR I made to resolve it.

I think we can still merge this even though we still have this 1 reliance, since our goal is to only have to use ``discv5::enr::NodeId`` and not maintain our own and this is one step closer. In the next version of discv5 we should be able to fully remove our wrapper.
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history
