### PR TITLE
change ``Into<Enr> for SszEnr`` into ``From<SsrEnr>``

### DIFF
--- a/trin-types/src/enr.rs
+++ b/trin-types/src/enr.rs
@@ -18,10 +18,9 @@ impl SszEnr {
     }
 }
 
-#[allow(clippy::from_over_into)] // todo: remove this
-impl Into<Enr> for SszEnr {
-    fn into(self) -> Enr {
-        self.0
+impl From<SszEnr> for Enr {
+    fn from(val: SszEnr) -> Self {
+        val.0
     }
 }
 


### PR DESCRIPTION
### What was wrong?
https://github.com/ethereum/trin/pull/588 added a todo to fix a clippy error caused by a refactor
### How was it fixed?
I changed
```
#[allow(clippy::from_over_into)] // todo: remove this
impl Into<Enr> for SszEnr {
    fn into(self) -> Enr {
        self.0
    }
}
```
to
```
impl From<SszEnr> for Enr {
    fn from(val: SszEnr) -> Self {
        val.0
    }
}
```
To my knowledge this could does the same thing, but clippy finds this a cleaner way to implement it