### PR TITLE
change web3_ipc_path from String to PathBuf

### DIFF
--- a/ethportal-peertest/src/lib.rs
+++ b/ethportal-peertest/src/lib.rs
@@ -2,6 +2,7 @@ pub mod constants;
 pub mod scenarios;
 
 use std::net::{IpAddr, Ipv4Addr};
+use std::path::PathBuf;
 use std::{thread, time};
 
 use ethportal_api::jsonrpsee::server::ServerHandle;
@@ -103,7 +104,7 @@ pub async fn launch_node(trin_config: TrinConfig) -> anyhow::Result<PeertestNode
 fn generate_trin_config(id: u16, bootnode_enr: Option<&Enr>) -> TrinConfig {
     let discovery_port: u16 = 9000 + id;
     let discovery_port: String = discovery_port.to_string();
-    let web3_ipc_path = format!("/tmp/ethportal-peertest-buddy-{id}.ipc");
+    let web3_ipc_path = PathBuf::from(format!("/tmp/ethportal-peertest-buddy-{id}.ipc"));
     // This specific private key scheme is chosen to enforce that the first peer node will be in
     // the 256 kbucket of the bootnode, to ensure consistent `FindNodes` tests.
     let mut private_key = vec![id as u8; 3];
@@ -117,6 +118,7 @@ fn generate_trin_config(id: u16, bootnode_enr: Option<&Enr>) -> TrinConfig {
                 discovery_port
             );
             let enr_base64 = enr.to_base64();
+            let web3_ipc_path_str = web3_ipc_path.as_path().display().to_string();
             let trin_config_args = vec![
                 "trin",
                 "--networks",
@@ -128,7 +130,7 @@ fn generate_trin_config(id: u16, bootnode_enr: Option<&Enr>) -> TrinConfig {
                 "--discovery-port",
                 discovery_port.as_str(),
                 "--web3-ipc-path",
-                web3_ipc_path.as_str(),
+                &web3_ipc_path_str[..],
                 "--unsafe-private-key",
                 private_key.as_str(),
                 "--ephemeral",
@@ -138,6 +140,7 @@ fn generate_trin_config(id: u16, bootnode_enr: Option<&Enr>) -> TrinConfig {
         None => {
             let ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
             let external_addr = format!("{ip_addr}:{discovery_port}");
+            let web3_ipc_path_str = web3_ipc_path.as_path().display().to_string();
             let trin_config_args = vec![
                 "trin",
                 "--networks",
@@ -149,7 +152,7 @@ fn generate_trin_config(id: u16, bootnode_enr: Option<&Enr>) -> TrinConfig {
                 "--discovery-port",
                 discovery_port.as_str(),
                 "--web3-ipc-path",
-                web3_ipc_path.as_str(),
+                &web3_ipc_path_str[..],
                 "--unsafe-private-key",
                 private_key.as_str(),
                 "--ephemeral",

--- a/newsfragments/671.fixed.md
+++ b/newsfragments/671.fixed.md
@@ -1,0 +1,1 @@
+Change web3_ipc_path from String to PathBuf

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -4,6 +4,7 @@ use ethportal_api::{Discv5ApiServer, HistoryNetworkApiServer, Web3ApiServer};
 use portalnet::discovery::Discovery;
 use reth_ipc::server::Builder as IpcServerBuilder;
 use std::net::SocketAddr;
+use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use trin_types::jsonrpc::request::HistoryJsonRpcRequest;
@@ -31,11 +32,12 @@ impl JsonRpcServer {
     }
 
     pub async fn run_ipc(
-        ipc_path: String,
+        ipc_path: Box<dyn AsRef<Path>>,
         discv5: Arc<Discovery>,
         history_handler: mpsc::UnboundedSender<HistoryJsonRpcRequest>,
     ) -> anyhow::Result<ServerHandle> {
-        let server = IpcServerBuilder::default().build(ipc_path)?;
+        let server =
+            IpcServerBuilder::default().build((*ipc_path).as_ref().display().to_string())?;
         let discv5_api = Discv5Api::new(discv5);
         let history_network_api = HistoryNetworkApi::new(history_handler);
         let mut api = discv5_api.into_rpc();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,10 +154,13 @@ async fn launch_jsonrpc_server(
     match trin_config.web3_transport {
         Web3TransportType::IPC => {
             // Launch jsonrpsee server with IPC transport
-            let rpc_handle =
-                JsonRpcServer::run_ipc(trin_config.web3_ipc_path, discv5, history_handler)
-                    .await
-                    .map_err(|e| format!("Launching IPC JSON-RPC server failed: {e:?}"))?;
+            let rpc_handle = JsonRpcServer::run_ipc(
+                Box::new(trin_config.web3_ipc_path),
+                discv5,
+                history_handler,
+            )
+            .await
+            .map_err(|e| format!("Launching IPC JSON-RPC server failed: {e:?}"))?;
             info!("IPC JSON-RPC server launched.");
             Ok(rpc_handle)
         }

--- a/trin-types/src/cli.rs
+++ b/trin-types/src/cli.rs
@@ -84,7 +84,7 @@ pub struct TrinConfig {
         long = "web3-ipc-path",
         help = "path to json-rpc endpoint over IPC"
     )]
-    pub web3_ipc_path: String, // TODO: Change to PathBuf
+    pub web3_ipc_path: PathBuf,
 
     #[structopt(
         default_value(DEFAULT_DISCOVERY_PORT),
@@ -180,7 +180,7 @@ impl Default for TrinConfig {
                 .expect("Parsing static DEFAULT_WEB3_TRANSPORT to work"),
             web3_http_address: Url::parse(DEFAULT_WEB3_HTTP_ADDRESS)
                 .expect("Parsing static DEFAULT_WEB3_HTTP_ADDRESS to work"),
-            web3_ipc_path: DEFAULT_WEB3_IPC_PATH.to_string(),
+            web3_ipc_path: PathBuf::from(DEFAULT_WEB3_IPC_PATH),
             discovery_port: DEFAULT_DISCOVERY_PORT
                 .parse()
                 .expect("Parsing static DEFAULT_DISCOVERY_PORT to work"),
@@ -216,7 +216,7 @@ impl TrinConfig {
         let config = Self::from_iter_safe(args)?;
 
         match config.web3_transport {
-            Web3TransportType::HTTP => match &config.web3_ipc_path[..] {
+            Web3TransportType::HTTP => match &config.web3_ipc_path.as_path().display().to_string()[..] {
                 DEFAULT_WEB3_IPC_PATH => {}
                 _ => panic!("Must not supply an ipc path when using http protocol for json-rpc"),
             },
@@ -278,9 +278,10 @@ fn check_private_key_length(private_key: String) -> Result<(), String> {
 
 impl fmt::Display for TrinConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let web3_ipc_path_str = self.web3_ipc_path.as_path().display().to_string();
         let json_rpc_url = match &self.web3_transport {
             Web3TransportType::HTTP => self.web3_http_address.as_str(),
-            Web3TransportType::IPC => &self.web3_ipc_path,
+            Web3TransportType::IPC => &web3_ipc_path_str[..],
         };
 
         write!(
@@ -380,7 +381,7 @@ mod test {
         assert!(env_is_set(&actual_config));
         let expected_config = TrinConfig {
             web3_http_address: Url::parse(DEFAULT_WEB3_HTTP_ADDRESS).unwrap(),
-            web3_ipc_path: "/path/test.ipc".to_string(),
+            web3_ipc_path: PathBuf::from("/path/test.ipc"),
             web3_transport: Web3TransportType::IPC,
             ..Default::default()
         };


### PR DESCRIPTION
### What was wrong?
Fixes todo added in this https://github.com/ethereum/trin/pull/44 PR
### How was it fixed?
Instead of using String/&str I converted the types of Path or PathBuf where it made sense. Basically just using PathBuf instead of using a String
