### PR TITLE
add ``--all-targets --all-features`` to clippy linting guidelines

### DIFF
--- a/book/src/developers/contributing/git/pull_requests.md
+++ b/book/src/developers/contributing/git/pull_requests.md
@@ -9,7 +9,7 @@ through github via pull requests.
 * Mark unfinished pull requests with the "Work in Progress" label.
 * Before submitting a pr for review, you should run the following commands
   locally and make sure they are passing, otherwise CI will raise an error.
-  * `cargo fmt --all -- --check` and `cargo clippy --all -- --deny warnings` for linting checks
+  * `cargo fmt --all -- --check` and `cargo clippy --all --all-targets --all-features -- --deny warnings` for linting checks
   * `RUSTFLAGS='-D warnings' cargo test --workspace` to run all tests
 * Pull requests **should** always be reviewed by another member of the team
   prior to being merged.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -32,7 +32,7 @@ through github via pull requests.
 * Mark unfinished pull requests with the "Work in Progress" label.
 * Before submitting a pr for review, you should run the following commands
   locally and make sure they are passing, otherwise CI will raise an error.
-  * `cargo fmt --all -- --check` and `cargo clippy --all -- --deny warnings` for linting checks
+  * `cargo fmt --all -- --check` and `cargo clippy --all --all-targets --all-features -- --deny warnings` for linting checks
   * `RUSTFLAGS='-D warnings' cargo test --workspace` to run all tests
 * Pull requests **should** always be reviewed by another member of the team
   prior to being merged.


### PR DESCRIPTION
### What was wrong?
When I made my PR https://github.com/ethereum/trin/pull/670 clippy failed on CI even though I ran the commands developers are told to use in the guidelines. I am on "Ubuntu 20.04.6 LTS". The clippy in CI tests features additional commands ``--all-targets --all-features --no-deps`` When I ran the command gotten from the CI I got the same output as it and was able to fix the issue.
### How was it fixed?
From testing what made the clippy error happen was adding ``--all-targets`` so I added that. I decided to add ``all-features`` too since I seen in tokio they use "features" a lot so if we ever start using them, it would be good to have this. Since if someone is working on a feature in the future and don't have this flag it won't error on their machine but will in CI.

I decided to not add ``--no-deps`` like CI has since it seems like a good idea to check if other depends are following clippy since it only takes additional time on the first gone so it seemed more beneficial to keep it. Also because it seems like a time saving measure in CI.