### PR TITLE
Switch from StructOpt to Clap in trin-bridge

### DIFF
--- a/newsfragments/674.changed.md
+++ b/newsfragments/674.changed.md
@@ -1,0 +1,1 @@
+Switch from StructOpt to Clap in trin-bridge.

--- a/trin-bridge/Cargo.toml
+++ b/trin-bridge/Cargo.toml
@@ -13,6 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
+clap = { version = "4.2.1", features = ["derive"] }
 discv5 = { version = "0.2.1", features = ["serde"]}
 ethportal-api = { path = "../ethportal-api" }
 ethereum-types = "0.12.1"
@@ -21,7 +22,6 @@ eth2_ssz_derive = "0.3.0"
 eth2_ssz_types = "0.2.1"
 jsonrpsee = {version="0.16.2", features = ["async-client", "client", "macros", "server"]}
 serde_json = "1.0.89"
-structopt = "0.3.26"
 surf = "2.3.2"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"

--- a/trin-bridge/src/cli.rs
+++ b/trin-bridge/src/cli.rs
@@ -1,6 +1,6 @@
+use clap::Parser;
 use std::path::PathBuf;
 use std::str::FromStr;
-use structopt::StructOpt;
 
 // max value of 16 b/c...
 // - reliably calculate spaced private keys in a reasonable time
@@ -9,38 +9,37 @@ use structopt::StructOpt;
 // - running more than 16 trin nodes simultaneously is not thoroughly tested
 pub const MAX_NODE_COUNT: u8 = 16;
 
-#[derive(StructOpt, Debug, PartialEq)]
-#[structopt(name = "Trin Bridge", about = "Feed the network")]
+#[derive(Parser, Debug, PartialEq)]
+#[command(name = "Trin Bridge", about = "Feed the network")]
 pub struct BridgeConfig {
-    #[structopt(
+    #[arg(
         long,
         help = "number of trin nodes to launch - must be between 1 and 16",
-        validator(check_node_count)
+        value_parser = check_node_count
     )]
     pub node_count: u8,
 
-    #[structopt(long, help = "path to portalnet client executable")]
+    #[arg(long, help = "path to portalnet client executable")]
     pub executable_path: PathBuf,
 
-    #[structopt(
+    #[arg(
         long,
         default_value = "latest",
         help = "['latest', 'backfill', <u64> to provide the starting epoch]"
     )]
     pub mode: BridgeMode,
 
-    #[structopt(
+    #[arg(
         long = "epoch-accumulator-path",
-        help = "Path to epoch accumulator repo for bridge mode",
-        parse(from_os_str)
+        help = "Path to epoch accumulator repo for bridge mode"
     )]
     pub epoch_acc_path: PathBuf,
 }
 
-fn check_node_count(val: String) -> Result<(), String> {
+fn check_node_count(val: &str) -> Result<u8, String> {
     let node_count: u8 = val.parse().map_err(|_| "Invalid node count".to_string())?;
     if node_count > 0 && node_count <= MAX_NODE_COUNT {
-        Ok(())
+        Ok(node_count)
     } else {
         Err(format!("Node count must be between 1 and {MAX_NODE_COUNT}"))
     }
@@ -70,5 +69,83 @@ impl FromStr for BridgeMode {
                 .map(BridgeMode::StartFromEpoch)
                 .map_err(|_| "Invalid bridge mode arg"),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_default_bridge_config() {
+        const NODE_COUNT: &str = "1";
+        const EXECUTABLE_PATH: &str = "path/to/executable";
+        const EPOCH_ACC_PATH: &str = "path/to/epoch/accumulator";
+        let bridge_config = BridgeConfig::parse_from([
+            "test",
+            "--node-count",
+            NODE_COUNT,
+            "--executable-path",
+            EXECUTABLE_PATH,
+            "--epoch-accumulator-path",
+            EPOCH_ACC_PATH,
+        ]);
+        assert_eq!(bridge_config.node_count, 1);
+        assert_eq!(
+            bridge_config.executable_path,
+            PathBuf::from(EXECUTABLE_PATH)
+        );
+        assert_eq!(bridge_config.mode, BridgeMode::Latest);
+        assert_eq!(bridge_config.epoch_acc_path, PathBuf::from(EPOCH_ACC_PATH));
+    }
+
+    #[test]
+    fn test_bridge_config_with_epoch() {
+        const NODE_COUNT: &str = "1";
+        const EXECUTABLE_PATH: &str = "path/to/executable";
+        const EPOCH_ACC_PATH: &str = "path/to/epoch/accumulator";
+        const EPOCH: &str = "100";
+        let bridge_config = BridgeConfig::parse_from([
+            "test",
+            "--node-count",
+            NODE_COUNT,
+            "--executable-path",
+            EXECUTABLE_PATH,
+            "--epoch-accumulator-path",
+            EPOCH_ACC_PATH,
+            "--mode",
+            EPOCH,
+        ]);
+        assert_eq!(bridge_config.node_count, 1);
+        assert_eq!(
+            bridge_config.executable_path,
+            PathBuf::from(EXECUTABLE_PATH)
+        );
+        assert_eq!(bridge_config.mode, BridgeMode::StartFromEpoch(100));
+        assert_eq!(bridge_config.epoch_acc_path, PathBuf::from(EPOCH_ACC_PATH));
+    }
+
+    #[test]
+    fn test_bridge_config_with_max_node_count() {
+        let node_count_string = MAX_NODE_COUNT.to_string();
+        let node_count: &str = node_count_string.as_str();
+        const EXECUTABLE_PATH: &str = "path/to/executable";
+        const EPOCH_ACC_PATH: &str = "path/to/epoch/accumulator";
+        let bridge_config = BridgeConfig::parse_from([
+            "test",
+            "--node-count",
+            node_count,
+            "--executable-path",
+            EXECUTABLE_PATH,
+            "--epoch-accumulator-path",
+            EPOCH_ACC_PATH,
+        ]);
+        assert_eq!(bridge_config.node_count, 16);
+        assert_eq!(
+            bridge_config.executable_path,
+            PathBuf::from(EXECUTABLE_PATH)
+        );
+        assert_eq!(bridge_config.mode, BridgeMode::Latest);
+        assert_eq!(bridge_config.epoch_acc_path, PathBuf::from(EPOCH_ACC_PATH));
     }
 }

--- a/trin-bridge/src/main.rs
+++ b/trin-bridge/src/main.rs
@@ -1,5 +1,5 @@
+use clap::Parser;
 use ethportal_api::jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
-use structopt::StructOpt;
 use tokio::process::Command;
 use tokio::time::{sleep, Duration};
 use tracing::info;
@@ -16,7 +16,7 @@ use trin_validation::oracle::HeaderOracle;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_tracing_logger();
 
-    let bridge_config = BridgeConfig::from_args();
+    let bridge_config = BridgeConfig::parse();
     let private_keys = generate_spaced_private_keys(bridge_config.node_count);
     let mut handles = vec![];
     let mut http_addresses = vec![];


### PR DESCRIPTION
### What was wrong?

Related to #627. A tiny PR of #651.

### How was it fixed?

Switched from StructOpt to Clap in trin-bridge.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
