### PR TITLE
Clap:Error instead of panicking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,6 +3823,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "clap 2.34.0",
  "ethers",
  "eyre",
  "figment",
@@ -4638,6 +4639,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.1",
  "bytes 1.4.0",
+ "clap 2.34.0",
  "delay_map 0.1.2",
  "directories",
  "discv5",
@@ -7000,6 +7002,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "clap 2.34.0",
  "eth2_hashing",
  "eth2_ssz",
  "eth2_ssz_derive",

--- a/ethportal-api/src/types/bootnodes.rs
+++ b/ethportal-api/src/types/bootnodes.rs
@@ -106,7 +106,11 @@ mod test {
             Bootnodes::Custom(bootnodes) => {
                 assert_eq!(bootnodes.len(), expected_length);
             }
-            _ => panic!("Bootnodes should be custom"),
+            _ => clap::Error::with_description(
+                "Bootnodes should be custom",
+                clap::ErrorKind::InvalidValue,
+            )
+            .exit(),
         };
         let bootnodes: Vec<Enr> = config.bootnodes.into();
         assert_eq!(bootnodes.len(), expected_length);

--- a/ethportal-api/src/types/content_key.rs
+++ b/ethportal-api/src/types/content_key.rs
@@ -480,7 +480,11 @@ impl OverlayContentKey for StateContentKey {
     }
 
     fn to_bytes(&self) -> Vec<u8> {
-        panic!("Not implemented: Implement in pr along w/ new state content key spec update.")
+        clap::Error::with_description(
+            "Not implemented: Implement in pr along w/ new state content key spec update.",
+            clap::ErrorKind::UnknownArgument,
+        )
+        .exit();
     }
 }
 

--- a/ethportal-api/src/types/execution/receipts.rs
+++ b/ethportal-api/src/types/execution/receipts.rs
@@ -710,7 +710,8 @@ mod tests {
         let receipt: Receipt = serde_json::from_value(response).unwrap();
         let receipt = match receipt {
             Receipt::Legacy(val) => val,
-            _ => panic!("invalid test"),
+            _ => clap::Error::with_description("invalid test", clap::ErrorKind::UnknownArgument)
+                .exit(),
         };
         assert_eq!(
             receipt.cumulative_gas_used,

--- a/ethportal-api/src/types/provider.rs
+++ b/ethportal-api/src/types/provider.rs
@@ -45,7 +45,11 @@ impl FromStr for TrustedProviderType {
             "pandaops" => Ok(TrustedProviderType::Pandaops),
             "infura" => Ok(TrustedProviderType::Infura),
             "custom" => Ok(TrustedProviderType::Custom),
-            _ => panic!("Invalid trusted provider arg: {s} is not an option."),
+            _ => clap::Error::with_description(
+                format!("Invalid trusted provider arg: {:?} is not an option.", s).as_str(),
+                clap::ErrorKind::InvalidValue,
+            )
+            .exit(),
         }
     }
 }
@@ -65,7 +69,10 @@ impl TrustedProvider {
             TrustedProviderType::Pandaops => match &trin_config.trusted_provider_url {
                 Some(val) => build_pandaops_http_client_from_env(val.to_string()),
                 None => {
-                    panic!("Must supply --trusted-provider-url cli flag to use pandaops as a trusted provider.")
+                    clap::Error::with_description(
+                        "Must supply --trusted-provider-url cli flag to use pandaops as a trusted provider.",
+                        clap::ErrorKind::MissingRequiredArgument,
+                    ).exit();
                 }
             },
             TrustedProviderType::Custom => match trin_config.trusted_provider_url.clone() {
@@ -139,10 +146,12 @@ fn proxy_to_url(request: &Value, trusted_http_client: Request) -> io::Result<Vec
 fn get_infura_project_id_from_env() -> String {
     match env::var("TRIN_INFURA_PROJECT_ID") {
         Ok(val) => val,
-        Err(_) => panic!(
+        Err(_) => clap::Error::with_description(
             "Must supply Infura key as environment variable, like:\n\
-            TRIN_INFURA_PROJECT_ID=\"your-key-here\" trin"
-        ),
+            TRIN_INFURA_PROJECT_ID=\"your-key-here\" trin",
+            clap::ErrorKind::MissingRequiredArgument,
+        )
+        .exit(),
     }
 }
 
@@ -155,20 +164,24 @@ fn build_infura_http_client_from_env() -> ureq::Request {
 fn get_pandaops_client_id_from_env() -> String {
     match env::var("PANDAOPS_CLIENT_ID") {
         Ok(val) => val,
-        Err(_) => panic!(
+        Err(_) => clap::Error::with_description(
             "Must supply pandaops client id as environment variable, like:\n\
-            PANDAOPS_CLIENT_ID=\"your-key-here\" trin"
-        ),
+            PANDAOPS_CLIENT_ID=\"your-key-here\" trin",
+            clap::ErrorKind::MissingRequiredArgument,
+        )
+        .exit(),
     }
 }
 
 fn get_pandaops_client_secret_from_env() -> String {
     match env::var("PANDAOPS_CLIENT_SECRET") {
         Ok(val) => val,
-        Err(_) => panic!(
+        Err(_) => clap::Error::with_description(
             "Must supply pandaops client secret as environment variable, like:\n\
-            PANDAOPS_CLIENT_SECRET=\"your-key-here\" trin"
-        ),
+            PANDAOPS_CLIENT_SECRET=\"your-key-here\" trin",
+            clap::ErrorKind::MissingRequiredArgument,
+        )
+        .exit(),
     }
 }
 

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -139,6 +139,7 @@ pub async fn test_history_local_content_absent(target: &Client) {
     let result = target.local_content(content_key).await.unwrap();
 
     if let PossibleHistoryContentValue::ContentPresent(_) = result {
-        panic!("Expected absent content");
+        clap::Error::with_description("Expected absent content", clap::ErrorKind::TooFewValues)
+            .exit();
     };
 }

--- a/ethportal-peertest/src/scenarios/offer_accept.rs
+++ b/ethportal-peertest/src/scenarios/offer_accept.rs
@@ -48,7 +48,11 @@ pub async fn test_unpopulated_offer(peertest: &Peertest, target: &Client) {
     let response = wait_for_content(target, content_key).await;
     let received_content_value = match response {
         PossibleHistoryContentValue::ContentPresent(c) => c,
-        PossibleHistoryContentValue::ContentAbsent => panic!("Expected content to be found"),
+        PossibleHistoryContentValue::ContentAbsent => clap::Error::with_description(
+            "Expected content to be found",
+            clap::ErrorKind::TooFewValues,
+        )
+        .exit(),
     };
     assert_eq!(
         content_value, received_content_value,
@@ -83,7 +87,11 @@ pub async fn test_populated_offer(peertest: &Peertest, target: &Client) {
     let response = wait_for_content(&peertest.bootnode.ipc_client, content_key).await;
     let received_content_value = match response {
         PossibleHistoryContentValue::ContentPresent(c) => c,
-        PossibleHistoryContentValue::ContentAbsent => panic!("Expected content to be found"),
+        PossibleHistoryContentValue::ContentAbsent => clap::Error::with_description(
+            "Expected content to be found",
+            clap::ErrorKind::TooFewValues,
+        )
+        .exit(),
     };
     assert_eq!(
         content_value, received_content_value,

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -12,6 +12,7 @@ description = "Beacon chain light client implementation"
 [dependencies]
 async-trait = "0.1.57"
 chrono = "0.4.22"
+clap = "2.33.3"
 eyre = "0.6.8"
 figment = { version = "0.10.7", features = ["toml", "env"] }
 jsonrpsee = { version = "0.15.1", features = ["full"] }

--- a/light-client/src/consensus/types.rs
+++ b/light-client/src/consensus/types.rs
@@ -84,7 +84,7 @@ impl ssz_rs::Deserialize for BeaconBlockBody {
     where
         Self: Sized,
     {
-        panic!("not implemented");
+        clap::Error::with_description("not implemented", clap::ErrorKind::UnknownArgument).exit();
     }
 }
 
@@ -198,7 +198,7 @@ impl ssz_rs::Deserialize for ExecutionPayload {
     where
         Self: Sized,
     {
-        panic!("not implemented");
+        clap::Error::with_description("not implemented", clap::ErrorKind::UnknownArgument).exit();
     }
 }
 

--- a/newsfragments/675.fixed.md
+++ b/newsfragments/675.fixed.md
@@ -1,0 +1,1 @@
+Clap:Error instead of panicking

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1.0.68"
 async-trait = "0.1.64"
 base64 = "0.13.0"
 bytes = "1.3.0"
+clap = "2.33.3"
 delay_map = "0.1.1"
 directories = "3.0"
 discv5 = { version = "0.2.1", features = ["serde"]}

--- a/portalnet/src/find/query_info.rs
+++ b/portalnet/src/find/query_info.rs
@@ -91,7 +91,11 @@ impl<TContentKey: OverlayContentKey> TargetKey<NodeId> for QueryInfo<TContentKey
 fn findnode_log2distance(target: NodeId, peer: NodeId, size: usize) -> Option<Vec<u16>> {
     if size > 127 {
         // invoke and endless loop - coding error
-        panic!("Iterations cannot be greater than 127");
+        clap::Error::with_description(
+            "Iterations cannot be greater than 127",
+            clap::ErrorKind::TooManyValues,
+        )
+        .exit();
     }
 
     let dst_key: Key<NodeId> = peer.into();

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -762,7 +762,11 @@ mod test {
     fn test_nodes_validator_rejects_invalid_input(#[case] input: Vec<u16>, #[case] msg: String) {
         let result = validate_find_nodes_distances(&input);
         match result {
-            Ok(_) => panic!("Invalid test case passed"),
+            Ok(_) => clap::Error::with_description(
+                "Invalid test case passed",
+                clap::ErrorKind::InvalidValue,
+            )
+            .exit(),
             Err(err) => assert!(err.to_string().contains(&msg)),
         }
     }

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -2552,7 +2552,11 @@ mod tests {
         let request = if let OverlayCommand::Request(request) = command {
             request
         } else {
-            panic!("Unexpected overlay command variant");
+            clap::Error::with_description(
+                "Unexpected overlay command variant",
+                clap::ErrorKind::UnknownArgument,
+            )
+            .exit();
         };
 
         assert!(request.responder.is_none());
@@ -2570,7 +2574,7 @@ mod tests {
             Request::FindNodes(find_nodes) => {
                 assert_eq!(vec![0], find_nodes.distances)
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         };
     }
 
@@ -2631,7 +2635,7 @@ mod tests {
             kbucket::Entry::Present(_entry, status) => {
                 assert_eq!(ConnectionState::Disconnected, status.state)
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         };
     }
 
@@ -2670,7 +2674,11 @@ mod tests {
         let request = if let OverlayCommand::Request(request) = command {
             request
         } else {
-            panic!("Unexpected overlay command variant");
+            clap::Error::with_description(
+                "Unexpected overlay command variant",
+                clap::ErrorKind::UnknownArgument,
+            )
+            .exit();
         };
 
         assert!(request.responder.is_none());
@@ -2688,7 +2696,7 @@ mod tests {
             Request::FindNodes(find_nodes) => {
                 assert_eq!(vec![0], find_nodes.distances)
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         };
     }
 
@@ -2752,7 +2760,7 @@ mod tests {
                 assert_eq!(ConnectionState::Disconnected, status.state);
                 assert_eq!(ConnectionDirection::Outgoing, status.direction);
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         };
 
         // Check routing table for second ENR.
@@ -2762,7 +2770,7 @@ mod tests {
                 assert_eq!(ConnectionState::Disconnected, status.state);
                 assert_eq!(ConnectionDirection::Outgoing, status.direction);
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         };
 
         // Check ping queue for first ENR.
@@ -2827,7 +2835,7 @@ mod tests {
             kbucket::Entry::Present(entry, _status) => {
                 assert_eq!(2, entry.value().enr.seq());
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         };
 
         // Check routing table for second ENR.
@@ -2836,7 +2844,7 @@ mod tests {
             kbucket::Entry::Present(entry, _status) => {
                 assert_eq!(1, entry.value().enr.seq());
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         };
     }
 
@@ -2879,7 +2887,11 @@ mod tests {
                 req.direction
             );
         } else {
-            panic!("Unexpected overlay command variant");
+            clap::Error::with_description(
+                "Unexpected overlay command variant",
+                clap::ErrorKind::UnknownArgument,
+            )
+            .exit();
         }
         assert_pending!(poll_command_rx!(service));
     }
@@ -2955,7 +2967,11 @@ mod tests {
                 req.direction
             );
         } else {
-            panic!("Unexpected overlay command variant");
+            clap::Error::with_description(
+                "Unexpected overlay command variant",
+                clap::ErrorKind::UnknownArgument,
+            )
+            .exit();
         }
         assert_pending!(poll_command_rx!(service));
     }
@@ -2975,7 +2991,11 @@ mod tests {
         let request = if let OverlayCommand::Request(request) = command {
             request
         } else {
-            panic!("Unexpected overlay command variant");
+            clap::Error::with_description(
+                "Unexpected overlay command variant",
+                clap::ErrorKind::UnknownArgument,
+            )
+            .exit();
         };
 
         assert!(request.responder.is_none());
@@ -2991,7 +3011,7 @@ mod tests {
             Request::FindNodes(find_nodes) => {
                 assert_eq!(vec![0], find_nodes.distances)
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         };
     }
 
@@ -3010,7 +3030,11 @@ mod tests {
         let request = if let OverlayCommand::Request(request) = command {
             request
         } else {
-            panic!("Unexpected overlay command variant");
+            clap::Error::with_description(
+                "Unexpected overlay command variant",
+                clap::ErrorKind::UnknownArgument,
+            )
+            .exit();
         };
 
         assert!(request.responder.is_none());
@@ -3051,7 +3075,7 @@ mod tests {
                 assert_eq!(ConnectionState::Connected, status.state);
                 assert_eq!(connection_direction, status.direction);
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         };
     }
 
@@ -3083,7 +3107,7 @@ mod tests {
                 assert_eq!(ConnectionState::Disconnected, status.state);
                 assert_eq!(connection_direction, status.direction);
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         };
 
         let _ = service.update_node_connection_state(node_id, ConnectionState::Connected);
@@ -3093,7 +3117,7 @@ mod tests {
                 assert_eq!(ConnectionState::Connected, status.state);
                 assert_eq!(connection_direction, status.direction);
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         };
     }
 
@@ -3125,7 +3149,7 @@ mod tests {
                 assert_eq!(ConnectionState::Connected, status.state);
                 assert_eq!(connection_direction, status.direction);
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         };
 
         let _ = service.update_node_connection_state(node_id, ConnectionState::Disconnected);
@@ -3135,7 +3159,7 @@ mod tests {
                 assert_eq!(ConnectionState::Disconnected, status.state);
                 assert_eq!(connection_direction, status.direction);
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         };
     }
 
@@ -3196,7 +3220,11 @@ mod tests {
                     service.findnodes_query_distances_per_peer
                 );
             }
-            _ => panic!("Unexpected query type"),
+            _ => clap::Error::with_description(
+                "Unexpected query type",
+                clap::ErrorKind::UnknownArgument,
+            )
+            .exit(),
         }
 
         assert!(query.started().is_some());
@@ -3234,12 +3262,14 @@ mod tests {
                             service.findnodes_query_distances_per_peer
                         );
                     }
-                    _ => panic!(),
+                    _ => {
+                        clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit()
+                    }
                 }
                 assert_eq!(query_id, QueryId(0));
                 assert_eq!(node_id, bootnode_node_id);
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         }
 
         // Create two ENRs to use as dummy responses to the query from the bootnode.
@@ -3268,7 +3298,7 @@ mod tests {
                 assert!((node_id == node_id_1) || (node_id == node_id_2));
                 Some(node_id)
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         };
 
         let event = OverlayService::<
@@ -3289,7 +3319,7 @@ mod tests {
             QueryEvent::Waiting(_, node_id, _) => {
                 assert_eq!(node_id, second_node_id);
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         };
 
         service.advance_find_node_query(enr1.clone(), vec![enr2.clone()], QueryId(0));
@@ -3319,7 +3349,7 @@ mod tests {
                 assert!(untrusted_enrs.contains(&enr2));
                 assert!(untrusted_enrs.contains(&bootnode));
             }
-            _ => panic!(),
+            _ => clap::Error::with_description("", clap::ErrorKind::ArgumentConflict).exit(),
         }
     }
 
@@ -3482,7 +3512,11 @@ mod tests {
             FindContentQueryResult::ClosestNodes(closest_nodes) => {
                 assert!(closest_nodes.contains(&bootnode_enr.node_id()));
             }
-            _ => panic!("Unexpected find content query result"),
+            _ => clap::Error::with_description(
+                "Unexpected find content query result",
+                clap::ErrorKind::InvalidValue,
+            )
+            .exit(),
         }
     }
 
@@ -3543,7 +3577,11 @@ mod tests {
             } => {
                 assert_eq!(result_content, content);
             }
-            _ => panic!("Unexpected find content query result"),
+            _ => clap::Error::with_description(
+                "Unexpected find content query result",
+                clap::ErrorKind::InvalidValue,
+            )
+            .exit(),
         }
     }
 
@@ -3600,7 +3638,11 @@ mod tests {
         let request = if let OverlayCommand::Request(request) = command {
             request
         } else {
-            panic!("Unexpected overlay command variant");
+            clap::Error::with_description(
+                "Unexpected overlay command variant",
+                clap::ErrorKind::UnknownArgument,
+            )
+            .exit();
         };
 
         assert_eq!(
@@ -3637,7 +3679,11 @@ mod tests {
             (Some(result_content), _) => {
                 assert_eq!(result_content, content);
             }
-            _ => panic!("Unexpected find content query result type"),
+            _ => clap::Error::with_description(
+                "Unexpected find content query result type",
+                clap::ErrorKind::UnknownArgument,
+            )
+            .exit(),
         }
     }
 

--- a/trin-bridge/src/bridge.rs
+++ b/trin-bridge/src/bridge.rs
@@ -26,6 +26,7 @@ use std::fs;
 use std::ops::Range;
 use std::path::PathBuf;
 use std::time;
+use structopt::clap;
 use tokio::task::JoinHandle;
 use tokio::time::{sleep, Duration};
 use tracing::{debug, info, warn};
@@ -105,10 +106,11 @@ impl Bridge {
         let mut epoch_index = match starting_epoch {
             Some(val) => {
                 if val * EPOCH_SIZE > latest_block {
-                    panic!(
-                        "Starting epoch is greater than current epoch. 
-                        Please specify a starting epoch that begins before the current block."
-                    );
+                    clap::Error::with_description(
+                        "Starting epoch is greater than current epoch. Please specify a starting epoch that begins before the current block.",
+                        clap::ErrorKind::InvalidValue,
+                    )
+                    .exit();
                 }
                 val
             }

--- a/trin-validation/Cargo.toml
+++ b/trin-validation/Cargo.toml
@@ -13,6 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 async-trait = "0.1.53"
+clap = "2.33.3"
 eth2_hashing = "0.2.0"
 eth2_ssz = "0.4.0"
 eth2_ssz_derive = "0.3.0"

--- a/trin-validation/src/accumulator.rs
+++ b/trin-validation/src/accumulator.rs
@@ -275,7 +275,11 @@ mod test {
         let ck = HistoryContentKey::from_ssz_bytes(&raw_ck).unwrap();
         match ck {
             HistoryContentKey::BlockHeaderWithProof(_) => (),
-            _ => panic!("Invalid test, content key decoded improperly"),
+            _ => clap::Error::with_description(
+                "Invalid test, content key decoded improperly",
+                clap::ErrorKind::InvalidValue,
+            )
+            .exit(),
         }
         let raw_fluffy_hwp = obj.get("value").unwrap().as_str().unwrap();
         let fluffy_hwp =
@@ -284,7 +288,11 @@ mod test {
         let trin_proof = trin_macc.generate_proof(&header, tx).await.unwrap();
         let fluffy_proof = match fluffy_hwp.proof {
             BlockHeaderProof::AccumulatorProof(val) => val,
-            _ => panic!("test reached invalid state"),
+            _ => clap::Error::with_description(
+                "test reached invalid state",
+                clap::ErrorKind::InvalidValue,
+            )
+            .exit(),
         };
         assert_eq!(trin_proof, fluffy_proof.proof);
         let hwp = HeaderWithProof {
@@ -411,10 +419,18 @@ mod test {
                     let content: Value = json!(epoch_acc);
                     let _ = request.resp.send(Ok(content));
                 }
-                _ => panic!("Unexpected request endpoint"),
+                _ => clap::Error::with_description(
+                    "Unexpected request endpoint",
+                    clap::ErrorKind::UnknownArgument,
+                )
+                .exit(),
             },
             None => {
-                panic!("Test run failed: Unable to get response from master_acc validation.")
+                clap::Error::with_description(
+                    "Test run failed: Unable to get response from master_acc validation.",
+                    clap::ErrorKind::ValueValidation,
+                )
+                .exit();
             }
         }
     }


### PR DESCRIPTION
### What was wrong?
Fixs https://github.com/ethereum/trin/issues/618
### How was it fixed?
I changed all the panic! to use Clap::Error instead. I also added .exit() to the end of it because that is what panic does but this want displayed in the issue, probably because it was assumed it exits by default.

for ErrorKind I matched it to what I thought best suited the error 
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
