### PR TITLE
readded mistakenly removed dependency trin-bridge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ sha3 = "0.9.1"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
+trin-bridge = { path = "trin-bridge" }
 trin-history = { path = "trin-history" }
 trin-state = { path = "trin-state" }
 trin-types = { path = "trin-types" }


### PR DESCRIPTION
### What was wrong?
Fixes https://github.com/ethereum/trin/issues/676
### How was it fixed?
by readding removed ``trin-bridge = { path = "trin-bridge" }``
