### PR TITLE
Return early if there's an error while reading utp stream to eof

### DIFF
--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -1105,7 +1105,6 @@ where
         let enr = crate::discovery::UtpEnr(node_addr.enr);
         let cid = self.utp_socket.cid(enr, false);
         let cid_send = cid.send;
-
         let validator = Arc::clone(&self.validator);
         let store = Arc::clone(&self.store);
         let kbuckets = Arc::clone(&self.kbuckets);
@@ -1125,7 +1124,8 @@ where
 
             let mut data = vec![];
             if let Err(err) = stream.read_to_eof(&mut data).await {
-                warn!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), "error reading data from uTP stream");
+                error!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), "error reading data from uTP stream");
+                return;
             }
 
             if let Err(err) = Self::process_accept_utp_payload(


### PR DESCRIPTION
### What was wrong?
During some debugging with @mrferris we discovered what appears to be a bit of a bug in how we handle utp streams. 

If there is an error while reading to eof - we should return early - in the same way as if there is an error for `accept_with_cid`. Currently, we do not return early upon an error. This means that we go ahead and try to `process_accept_utp_payload` with an invalid payload - which is usually just an empty vector.

### How was it fixed?
Return early

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
