### PR TITLE
depreciate find_assigned_ip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,8 +8,8 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 dependencies = [
- "lazy_static 1.4.0",
- "regex 1.7.3",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -128,15 +128,6 @@ dependencies = [
  "getrandom 0.2.9",
  "once_cell",
  "version_check",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -317,12 +308,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "concurrent-queue",
  "futures-lite",
- "log 0.4.17",
+ "log",
  "parking",
  "polling",
  "rustix",
  "slab",
- "socket2 0.4.9",
+ "socket2",
  "waker-fn",
 ]
 
@@ -380,7 +371,7 @@ dependencies = [
  "futures-lite",
  "gloo-timers",
  "kv-log-macro",
- "log 0.4.17",
+ "log",
  "memchr",
  "once_cell",
  "pin-project-lite",
@@ -573,7 +564,7 @@ checksum = "cb53b6b315f924c7f113b162e53b3901c05fc9966baf84d201dfcc7432a4bb38"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
- "regex 1.7.3",
+ "regex",
 ]
 
 [[package]]
@@ -609,12 +600,12 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "lazy_static 1.4.0",
+ "lazy_static",
  "lazycell",
  "peeking_take_while",
  "proc-macro2",
  "quote",
- "regex 1.7.3",
+ "regex",
  "rustc-hash",
  "shlex",
 ]
@@ -741,7 +732,7 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-lite",
- "log 0.4.17",
+ "log",
 ]
 
 [[package]]
@@ -1053,7 +1044,7 @@ dependencies = [
  "getrandom 0.2.9",
  "hmac 0.12.1",
  "k256",
- "lazy_static 1.4.0",
+ "lazy_static",
  "serde",
  "sha2 0.10.6",
  "thiserror",
@@ -1216,7 +1207,7 @@ checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg 1.1.0",
  "cfg-if 0.1.10",
- "lazy_static 1.4.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -1320,7 +1311,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2 0.4.9",
+ "socket2",
  "winapi 0.3.9",
 ]
 
@@ -1571,14 +1562,14 @@ dependencies = [
  "hashlink",
  "hex",
  "hkdf 0.12.3",
- "lazy_static 1.4.0",
+ "lazy_static",
  "lru",
  "more-asserts",
  "parking_lot 0.11.2",
  "rand 0.8.5",
  "rlp 0.5.2",
  "smallvec 1.10.0",
- "socket2 0.4.9",
+ "socket2",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",
@@ -1661,7 +1652,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
 dependencies = [
- "log 0.4.17",
+ "log",
 ]
 
 [[package]]
@@ -1685,7 +1676,7 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "k256",
- "log 0.4.17",
+ "log",
  "rand 0.8.5",
  "rlp 0.5.2",
  "serde",
@@ -1699,8 +1690,8 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
- "log 0.4.17",
- "regex 1.7.3",
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -1711,8 +1702,8 @@ checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.17",
- "regex 1.7.3",
+ "log",
+ "regex",
  "termcolor",
 ]
 
@@ -1766,7 +1757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b67737df7e3769e823d9d583eb5d60bcc4b2ef97ca674d1964ef287a02f8517"
 dependencies = [
  "cpufeatures 0.1.5",
- "lazy_static 1.4.0",
+ "lazy_static",
  "ring",
  "sha2 0.9.9",
 ]
@@ -1826,7 +1817,7 @@ checksum = "219675dc3593f2b99d5cc22d8bbaf956059a66b7eb69444d8502e2b9f5199814"
 dependencies = [
  "hashbrown 0.3.1",
  "keccak-hash",
- "log 0.4.17",
+ "log",
  "parking_lot 0.8.0",
  "rlp 0.3.0",
 ]
@@ -1840,7 +1831,7 @@ dependencies = [
  "ethereum-types 0.14.1",
  "hex",
  "once_cell",
- "regex 1.7.3",
+ "regex",
  "serde",
  "serde_json",
  "sha3 0.10.7",
@@ -2003,7 +1994,7 @@ dependencies = [
  "hex",
  "proc-macro2",
  "quote",
- "regex 1.7.3",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -2617,11 +2608,11 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
- "aho-corasick 0.7.20",
+ "aho-corasick",
  "bstr",
  "fnv",
- "log 0.4.17",
- "regex 1.7.3",
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -2697,21 +2688,6 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.7",
  "tracing",
-]
-
-[[package]]
-name = "handlebars"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb04af2006ea09d985fef82b81e0eb25337e51b691c76403332378a53d521edc"
-dependencies = [
- "lazy_static 0.2.11",
- "log 0.3.9",
- "pest",
- "quick-error",
- "regex 0.2.11",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2890,7 +2866,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "http-types",
  "isahc 0.9.14",
- "log 0.4.17",
+ "log",
 ]
 
 [[package]]
@@ -2943,10 +2919,10 @@ dependencies = [
  "futures-util",
  "hyper",
  "isahc 1.7.2",
- "lazy_static 1.4.0",
+ "lazy_static",
  "levenshtein",
- "log 0.4.17",
- "regex 1.7.3",
+ "log",
+ "regex",
  "serde",
  "serde_json",
  "serde_regex",
@@ -2978,7 +2954,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2993,7 +2969,7 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "log 0.4.17",
+ "log",
  "rustls",
  "rustls-native-certs",
  "tokio",
@@ -3177,22 +3153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interfaces"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82971b4f9e8bd1c3132e8d480e5b4c49431ade79e0339aad1abb917affe1e877"
-dependencies = [
- "bitflags",
- "cc",
- "handlebars",
- "lazy_static 1.4.0",
- "libc",
- "nix",
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3210,18 +3170,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "ipconfig"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
-dependencies = [
- "socket2 0.3.19",
- "widestring",
- "winapi 0.3.9",
- "winreg 0.6.2",
 ]
 
 [[package]]
@@ -3255,7 +3203,7 @@ dependencies = [
  "flume",
  "futures-lite",
  "http",
- "log 0.4.17",
+ "log",
  "once_cell",
  "slab",
  "sluice",
@@ -3280,7 +3228,7 @@ dependencies = [
  "event-listener",
  "futures-lite",
  "http",
- "log 0.4.17",
+ "log",
  "mime",
  "once_cell",
  "polling",
@@ -3440,7 +3388,7 @@ dependencies = [
  "http",
  "hyper",
  "jsonrpsee-types 0.15.1",
- "lazy_static 1.4.0",
+ "lazy_static",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rustc-hash",
@@ -3730,7 +3678,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
- "log 0.4.17",
+ "log",
 ]
 
 [[package]]
@@ -3748,8 +3696,8 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "pico-args",
- "regex 1.7.3",
- "regex-syntax 0.6.29",
+ "regex",
+ "regex-syntax",
  "string_cache",
  "term",
  "tiny-keccak 2.0.2",
@@ -3762,14 +3710,8 @@ version = "0.19.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5c1f7869c94d214466c5fd432dfed12c379fd87786768d36455892d46b18edd"
 dependencies = [
- "regex 1.7.3",
+ "regex",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 
 [[package]]
 name = "lazy_static"
@@ -3871,7 +3813,7 @@ dependencies = [
  "futures 0.3.28",
  "hex",
  "jsonrpsee 0.15.1",
- "log 0.4.17",
+ "log",
  "milagro_bls",
  "reqwest",
  "serde",
@@ -3927,15 +3869,6 @@ checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg 1.1.0",
  "scopeguard",
-]
-
-[[package]]
-name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.17",
 ]
 
 [[package]]
@@ -3997,7 +3930,7 @@ source = "git+https://github.com/Snowfork/milagro_bls#bc2b5b5e8d48b7e2e1bfaa56dc
 dependencies = [
  "amcl",
  "hex",
- "lazy_static 1.4.0",
+ "lazy_static",
  "rand 0.8.5",
  "zeroize",
 ]
@@ -4045,7 +3978,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.17",
+ "log",
  "miow",
  "net2",
  "slab",
@@ -4059,7 +3992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
- "log 0.4.17",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
 ]
@@ -4094,9 +4027,9 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
- "log 0.4.17",
+ "log",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -4122,18 +4055,6 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
-
-[[package]]
-name = "nix"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
-]
 
 [[package]]
 name = "nodrop"
@@ -4400,7 +4321,7 @@ checksum = "9981e32fb75e004cc148f5fb70342f393830e0a4aa62e3cc93b50976218d42b6"
 dependencies = [
  "futures 0.3.28",
  "libc",
- "log 0.4.17",
+ "log",
  "rand 0.7.3",
  "tokio",
  "winapi 0.3.9",
@@ -4572,12 +4493,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
-name = "pest"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6dda33d67c26f0aac90d324ab2eb7239c819fc7b2552fe9faa4fe88441edc8"
-
-[[package]]
 name = "petgraph"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4671,7 +4586,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "concurrent-queue",
  "libc",
- "log 0.4.17",
+ "log",
  "pin-project-lite",
  "windows-sys 0.48.0",
 ]
@@ -4718,8 +4633,6 @@ dependencies = [
  "ethportal-api",
  "fnv",
  "futures 0.3.28",
- "interfaces",
- "ipconfig",
  "leb128",
  "lru",
  "parking_lot 0.11.2",
@@ -4862,7 +4775,7 @@ checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
 dependencies = [
  "cfg-if 1.0.0",
  "fnv",
- "lazy_static 1.4.0",
+ "lazy_static",
  "memchr",
  "parking_lot 0.12.1",
  "thiserror",
@@ -4875,18 +4788,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf17cbebe0bfdf4f279ef84eeefe0d50468b0b7116f078acf41d456e48fe81a"
 dependencies = [
  "ascii",
- "lazy_static 1.4.0",
- "log 0.4.17",
+ "lazy_static",
+ "log",
  "prometheus",
  "thiserror",
  "tiny_http",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quickcheck"
@@ -4895,7 +4802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger 0.8.4",
- "log 0.4.17",
+ "log",
  "rand 0.8.5",
 ]
 
@@ -4925,7 +4832,7 @@ version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
- "log 0.4.17",
+ "log",
  "parking_lot 0.12.1",
  "scheduled-thread-pool",
 ]
@@ -5194,26 +5101,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-dependencies = [
- "aho-corasick 0.6.10",
- "memchr",
- "regex-syntax 0.5.6",
- "thread_local 0.3.6",
- "utf8-ranges",
-]
-
-[[package]]
-name = "regex"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
- "aho-corasick 0.7.20",
+ "aho-corasick",
  "memchr",
- "regex-syntax 0.6.29",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5222,16 +5116,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
-dependencies = [
- "ucd-util",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5259,7 +5144,7 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "log 0.4.17",
+ "log",
  "mime",
  "native-tls",
  "once_cell",
@@ -5279,7 +5164,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg 0.10.1",
+ "winreg",
 ]
 
 [[package]]
@@ -5497,7 +5382,7 @@ version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
- "log 0.4.17",
+ "log",
  "ring",
  "sct",
  "webpki",
@@ -5773,7 +5658,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
 dependencies = [
- "regex 1.7.3",
+ "regex",
  "serde",
 ]
 
@@ -5808,7 +5693,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "parking_lot 0.11.2",
  "serial_test_derive",
 ]
@@ -5922,7 +5807,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -6015,17 +5900,6 @@ checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "socket2"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
@@ -6045,7 +5919,7 @@ dependencies = [
  "futures 0.3.28",
  "http",
  "httparse",
- "log 0.4.17",
+ "log",
  "rand 0.8.5",
  "sha-1",
 ]
@@ -6082,7 +5956,7 @@ source = "git+https://github.com/ralexstokes/ssz-rs?rev=d09f55b4f8554491e3431e01
 dependencies = [
  "bitvec 1.0.1",
  "hex",
- "lazy_static 1.4.0",
+ "lazy_static",
  "num-bigint",
  "serde",
  "sha2 0.9.9",
@@ -6207,7 +6081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap 2.34.0",
- "lazy_static 1.4.0",
+ "lazy_static",
  "structopt-derive",
 ]
 
@@ -6308,7 +6182,7 @@ dependencies = [
  "getrandom 0.2.9",
  "http-client",
  "http-types",
- "log 0.4.17",
+ "log",
  "mime_guess",
  "once_cell",
  "pin-project-lite",
@@ -6416,15 +6290,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
-]
-
-[[package]]
-name = "thread_local"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-dependencies = [
- "lazy_static 1.4.0",
 ]
 
 [[package]]
@@ -6539,7 +6404,7 @@ checksum = "c5f8734c6d6943ad6df6b588d228a87b4af184998bcffa268ceddf05c2055a8c"
 dependencies = [
  "ascii",
  "chunked_transfer",
- "log 0.4.17",
+ "log",
  "time 0.3.20",
  "url",
 ]
@@ -6573,7 +6438,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.45.0",
 ]
@@ -6607,7 +6472,7 @@ checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
- "log 0.4.17",
+ "log",
 ]
 
 [[package]]
@@ -6639,8 +6504,8 @@ checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.31",
- "lazy_static 1.4.0",
- "log 0.4.17",
+ "lazy_static",
+ "log",
  "mio 0.6.23",
  "num_cpus",
  "parking_lot 0.9.0",
@@ -6715,7 +6580,7 @@ checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
- "log 0.4.17",
+ "log",
  "mio 0.6.23",
  "tokio-codec",
  "tokio-io",
@@ -6731,7 +6596,7 @@ dependencies = [
  "bytes 1.4.0",
  "futures-core",
  "futures-sink",
- "log 0.4.17",
+ "log",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -6809,7 +6674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
- "log 0.4.17",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -6852,8 +6717,8 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
- "lazy_static 1.4.0",
- "log 0.4.17",
+ "lazy_static",
+ "log",
  "tracing-core",
 ]
 
@@ -6866,10 +6731,10 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex 1.7.3",
+ "regex",
  "sharded-slab",
  "smallvec 1.10.0",
- "thread_local 1.1.7",
+ "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -7074,7 +6939,7 @@ dependencies = [
  "ethereum-types 0.12.1",
  "ethnum",
  "keccak-hash",
- "lazy_static 1.4.0",
+ "lazy_static",
  "quickcheck",
  "rand 0.8.5",
  "rlp 0.5.2",
@@ -7126,7 +6991,7 @@ dependencies = [
  "eth2_ssz_derive",
  "eth2_ssz_types",
  "ethereum-types 0.12.1",
- "lazy_static 1.4.0",
+ "lazy_static",
  "quickcheck",
  "quickcheck_macros",
  "rlp 0.5.2",
@@ -7151,12 +7016,6 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "ucd-util"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd2fc5d32b590614af8b0a20d837f32eca055edd0bbead59a9cfe80858be003"
 
 [[package]]
 name = "uds_windows"
@@ -7279,7 +7138,7 @@ checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
 dependencies = [
  "base64 0.13.1",
  "flate2",
- "log 0.4.17",
+ "log",
  "once_cell",
  "rustls",
  "serde",
@@ -7300,12 +7159,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf8-ranges"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utf8parse"
@@ -7362,8 +7215,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be110dc66fa015b8b1d2c4eae40c495a27fae55f82b9cae3efb8178241ed20eb"
 dependencies = [
  "idna 0.2.3",
- "lazy_static 1.4.0",
- "regex 1.7.3",
+ "lazy_static",
+ "regex",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7379,11 +7232,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f14fe757e2894ce4271991901567be07fbc3eac6b24246122214e1d5a16554"
 dependencies = [
  "if_chain",
- "lazy_static 1.4.0",
+ "lazy_static",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "regex 1.7.3",
+ "regex",
  "syn 1.0.109",
  "validator_types",
 ]
@@ -7450,7 +7303,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.17",
+ "log",
  "try-lock",
 ]
 
@@ -7489,7 +7342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
- "log 0.4.17",
+ "log",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -7581,12 +7434,6 @@ checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
-
-[[package]]
-name = "widestring"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"
@@ -7798,15 +7645,6 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
@@ -7833,7 +7671,7 @@ dependencies = [
  "async_io_stream",
  "futures 0.3.28",
  "js-sys",
- "log 0.4.17",
+ "log",
  "pharos",
  "rustc_version 0.4.0",
  "send_wrapper 0.6.0",

--- a/newsfragments/680.fixed.md
+++ b/newsfragments/680.fixed.md
@@ -1,0 +1,1 @@
+Depreciate ``find_assigned_ip()``

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -51,11 +51,7 @@ url = "2.3.1"
 utp-rs = "0.1.0-alpha.4"
 
 [target.'cfg(windows)'.dependencies]
-ipconfig = "0.2.2"
 uds_windows = "1.0.1"
-
-[target.'cfg(unix)'.dependencies]
-interfaces = "0.0.7"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -1,9 +1,9 @@
+use std::net::{IpAddr, Ipv4Addr};
 use std::{net::SocketAddr, str::FromStr, sync::Arc};
 
 use portalnet::{
     discovery::{Discovery, Discv5UdpSocket},
     overlay::{OverlayConfig, OverlayProtocol},
-    socket,
     storage::{ContentStore, DistanceFunction, MemoryContentStore},
     types::messages::{Content, Message, PortalnetConfig, ProtocolId},
 };
@@ -94,7 +94,7 @@ async fn spawn_overlay(
 async fn overlay() {
     let protocol = ProtocolId::History;
     let sleep_duration = Duration::from_millis(5);
-    let ip_addr = socket::find_assigned_ip().expect("Could not find an IP for local connections");
+    let ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 
     // Node one.
     let portal_config_one = PortalnetConfig {


### PR DESCRIPTION
### What was wrong?
fixes https://github.com/ethereum/trin/issues/358
### How was it fixed?
By depreciating ``find_assigned_ip()``. ``find_assigned_ip()`` was only still used for this one test case and is no longer part of anything else so if using 127.0.0.1 is a solution to the problem it doesn't make much sense keeping the function around. This also lowers the dependency count which is nice.
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
