### PR TITLE
Implement non-implemented discv5 api endpoints for jsonrpsee

### DIFF
--- a/ethportal-api/src/discv5.rs
+++ b/ethportal-api/src/discv5.rs
@@ -1,7 +1,9 @@
 use crate::types::discv5::{NodeInfo, RoutingTableInfo};
 use crate::types::enr::Enr;
 use discv5::enr::NodeId;
+use discv5::service::Pong;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use crate::types::portal::FindNodesInfo;
 
 /// Discv5 JSON-RPC endpoints
 #[rpc(client, server, namespace = "discv5")]
@@ -12,11 +14,7 @@ pub trait Discv5Api {
 
     /// Update the socket address of the local node record.
     #[method(name = "updateNodeInfo")]
-    async fn update_node_info(
-        &self,
-        socket_addr: String,
-        is_tcp: Option<bool>,
-    ) -> RpcResult<NodeInfo>;
+    async fn update_node_info(&self, socket_addr: String, is_tcp: bool) -> RpcResult<NodeInfo>;
 
     /// Returns meta information about discv5 routing table.
     #[method(name = "routingTableInfo")]
@@ -37,4 +35,21 @@ pub trait Discv5Api {
     /// Fetch the ENR representation associated with the given Node ID.
     #[method(name = "lookupEnr")]
     async fn lookup_enr(&self, node_id: NodeId) -> RpcResult<Enr>;
+
+
+    /// Send a PING message to the designated node and wait for a PONG response
+    #[method(name = "ping")]
+    async fn send_ping(&self, _enr: Enr) -> RpcResult<Pong>;
+
+    /// Send a FINDNODES request for nodes that fall within the given set of distances, to the designated peer and wait for a response.
+    #[method(name = "findNodes")]
+    async fn find_node(&self, _enr: Enr, _distances: Vec<u16>) -> RpcResult<FindNodesInfo>;
+
+    /// Send a TALKREQ request with a payload to a given peer and wait for response.
+    #[method(name = "talkReq")]
+    async fn talk_req(&self, enr: Enr, protocol: String, request: Vec<u8>) -> RpcResult<Vec<u8>>;
+
+    /// Look up ENRs closest to the given target
+    #[method(name = "recursiveFindNodes")]
+    async fn recursive_find_nodes(&self, _node_id: NodeId) -> RpcResult<Vec<Enr>>;
 }

--- a/newsfragments/683.fixed.md
+++ b/newsfragments/683.fixed.md
@@ -1,0 +1,1 @@
+Implement non-implemented discv5 api endpoints for jsonrpsee

--- a/rpc/src/discv5_rpc.rs
+++ b/rpc/src/discv5_rpc.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+use std::str::FromStr;
 use crate::jsonrpsee::core::{async_trait, RpcResult};
 use discv5::enr::NodeId;
 use ethportal_api::jsonrpsee::core::Error;
@@ -6,6 +8,10 @@ use ethportal_api::Discv5ApiServer;
 use ethportal_api::{NodeInfo, RoutingTableInfo};
 use portalnet::discovery::Discovery;
 use std::sync::Arc;
+use discv5::RequestError;
+use discv5::service::Pong;
+use ethportal_api::types::portal::FindNodesInfo;
+use portalnet::types::messages::ProtocolId;
 
 pub struct Discv5Api {
     discv5: Arc<Discovery>,
@@ -25,12 +31,10 @@ impl Discv5ApiServer for Discv5Api {
     }
 
     /// Update the socket address of the local node record.
-    async fn update_node_info(
-        &self,
-        _socket_addr: String,
-        _is_tcp: Option<bool>,
-    ) -> RpcResult<NodeInfo> {
-        Err(Error::MethodNotFound("update_node_info".to_owned()))
+    async fn update_node_info(&self, socket_addr: String, is_tcp: bool) -> RpcResult<bool> {
+        let socket_addr = std::net::SocketAddr::from_str(&socket_addr[..])
+            .map_err(|err| Error::Custom(format!("Unable to decode SocketAddr: {}", err)))?;
+        Ok(self.discv5.update_node_info(socket_addr, is_tcp))
     }
 
     /// Returns meta information about discv5 routing table.
@@ -40,22 +44,71 @@ impl Discv5ApiServer for Discv5Api {
 
     /// Write an Ethereum Node Record to the routing table.
     async fn add_enr(&self, _enr: Enr) -> RpcResult<bool> {
-        Err(Error::MethodNotFound("add_enr".to_owned()))
+        match self.discv5.add_enr(enr) {
+            Ok(_) => Ok(true),
+            Err(_) => Ok(false),
+        }
     }
 
     /// Fetch the latest ENR associated with the given node ID.
     async fn get_enr(&self, _node_id: NodeId) -> RpcResult<Enr> {
-        Err(Error::MethodNotFound("get_enr".to_owned()))
+        match self.discv5.find_enr(&node_id.into()) {
+            None => Err(Error::Custom("ENR not found for get_enr".into())),
+            Some(enr) => Ok(enr),
+        }
     }
 
     /// Delete Node ID from the routing table.
     async fn delete_enr(&self, _node_id: NodeId) -> RpcResult<bool> {
-        Err(Error::MethodNotFound("delete_enr".to_owned()))
+        match self.discv5.remove_node(&node_id.into()) {
+            true => Ok(true),
+            false => Ok(false),
+        }
     }
 
     /// Fetch the ENR representation associated with the given Node ID.
     async fn lookup_enr(&self, _node_id: NodeId) -> RpcResult<Enr> {
         Err(Error::MethodNotFound("lookup_enr".to_owned()))
+    }
+
+    /// Send a PING message to the designated node and wait for a PONG response
+    async fn send_ping(&self, enr: Enr) -> RpcResult<Pong> {
+        match self.discv5.send_ping(enr) {
+            Ok(talk_resp) => Ok(talk_resp),
+            Err(err) => Err(Error::Custom(format!(
+                "Unable to send talk request: {}",
+                err
+            ))),
+        }
+    }
+
+    /// Send a FINDNODE request for nodes that fall within the given set of distances, to the designated peer and wait for a response.
+    async fn find_node(&self, _enr: Enr, _distances: Vec<u16>) -> RpcResult<FindNodesInfo> {
+        Err(Error::MethodNotFound("find_nodes".to_owned()))
+    }
+
+    /// Send a TALKREQ request with a payload to a given peer and wait for response.
+    async fn talk_req(&self, enr: Enr, protocol: String, request: Vec<u8>) -> RpcResult<Vec<u8>> {
+        let protocol_id = ProtocolId::from_str(&protocol[..])
+            .map_err(|err| Error::Custom(format!("Unable to decode Protocol ID: {}", err)))?;
+        match self.discv5.send_talk_req(enr, protocol_id, request).await {
+            Ok(talk_resp) => Ok(talk_resp),
+            Err(err) => Err(Error::Custom(format!(
+                "Unable to send talk request: {}",
+                err
+            ))),
+        }
+    }
+
+    /// Look up ENRs closest to the given target
+    async fn recursive_find_nodes(&self, node_id: NodeId) -> RpcResult<Vec<Enr>> {
+        match self.discv5.recursive_find_nodes(node_id.into()).await {
+            Ok(enrs) => Ok(enrs),
+            Err(err) => Err(Error::Custom(format!(
+                "Unable to send recursive_find_nodes request: {}",
+                err
+            ))),
+        }
     }
 }
 

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -55,6 +55,10 @@ mod test {
         peertest::scenarios::basic::test_web3_client_version(&target).await;
         peertest::scenarios::basic::test_discv5_node_info(&peertest).await;
         peertest::scenarios::basic::test_discv5_routing_table_info(&target).await;
+        peertest::scenarios::basic::test_discv5_add_enr(&target, &peertest).await;
+        peertest::scenarios::basic::test_discv5_get_enr(&target, &peertest).await;
+        peertest::scenarios::basic::test_discv5_delete_enr(&target, &peertest).await;
+        peertest::scenarios::basic::test_discv5_update_node_info(&target, &peertest).await;
         peertest::scenarios::basic::test_history_radius(&target).await;
         peertest::scenarios::basic::test_history_add_enr(&target, &peertest).await;
         peertest::scenarios::basic::test_history_get_enr(&target, &peertest).await;


### PR DESCRIPTION
### What was wrong?
quite a few api endpoints aren't implemented yet, this was discussed in the meeting on 4/20/2023, so I decided to do it for discv5, hopefully history when I get time
### How was it fixed?
By calling the discv5 functions (the wrapper in trin I did have to add a quick one that wasn't added yet) for the endpoints

I removed enr_seq from the api endpoints because after what I said and deme said it was removed from the spec.

I implemented ``addEnr``, ``getEnr``, ``deleteEnr``, ``talkReq``, ``updateNodeInfo``, ``recursiveFindNodes``

### edit
I am going to wait till sigp/discv5 makes there new release it should be done after Emilia's Nat PR goes through it is pretty big so I am not sure how long that will take, but it shouldn't be forever.

Here is a issue outlining my PR https://github.com/ethereum/trin/issues/689 and the 3 requests I have left to add
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
