### PR TITLE
Switch from StructOpt to Clap in trin-cli

### DIFF
--- a/newsfragments/688.changed.md
+++ b/newsfragments/688.changed.md
@@ -1,0 +1,1 @@
+Switch from StructOpt to Clap in trin-cli.

--- a/trin-cli/Cargo.toml
+++ b/trin-cli/Cargo.toml
@@ -13,13 +13,14 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 base64 = "0.13.0"
+clap = { version = "4.2.1", features = ["derive"] }
 ethereum-types = "0.12.1"
 ethportal-api = { path = "../ethportal-api" }
 jsonrpc = "0.12.0"
 nanotemplate = "0.3.0"
 serde = "1.0.150"
 serde_json = { version = "1.0.89", features = ["raw_value"] }
-structopt="0.3.26"
+
 thiserror = "1.0.29"
 trin-types = { path = "../trin-types" }
 trin-utils = { path = "../trin-utils" }


### PR DESCRIPTION
### What was wrong?
Related to #627. A tiny PR of #651.

### How was it fixed?
Switched from StructOpt to Clap in trin-cli.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
