### PR TITLE
Add purge db executable to bridge docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,9 +36,6 @@ RUN cargo build -p trin -p trin-cli --release
 # final base
 FROM ubuntu:22.04
 
-# copy default merge master acc to expected location
-RUN mkdir -p /trin/trin-validation/src/assets
-COPY --from=builder /trin/trin-validation/src/assets/merge_macc.bin ./trin/trin-validation/src/assets/merge_macc.bin
 # copy build artifacts from build stage
 COPY --from=builder /trin/target/release/trin /usr/bin/
 COPY --from=builder /trin/target/release/trin-cli /usr/bin/

--- a/docker/Dockerfile.bridge
+++ b/docker/Dockerfile.bridge
@@ -37,12 +37,10 @@ RUN cargo build -p trin -p trin-bridge --release
 # final base
 FROM ubuntu:22.04
 
-# copy default merge master acc to expected location
-RUN mkdir -p /trin/trin-validation/src/assets
-COPY --from=builder /trin/trin-validation/src/assets/merge_macc.bin ./trin/trin-validation/src/assets/merge_macc.bin
 # copy build artifacts from build stage
 COPY --from=builder /trin/target/release/trin /usr/bin/
 COPY --from=builder /trin/target/release/trin-bridge /usr/bin/
+COPY --from=builder /trin/target/release/purge_db /usr/bin/
 # These steps copy over the epoch accumulators repo for the bridge to use
 # This data is too large to be kept inside trin-source code
 # It must be downloaded separately and moved to the correct location


### PR DESCRIPTION
### What was wrong?
We never added the `purge_db` script to the docker bridge image.
Also removed some unnecessary lines post #681 

### How was it fixed?


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
