### PR TITLE
Remove cli args from bridge dockerfile entrypoint

### DIFF
--- a/docker/Dockerfile.bridge
+++ b/docker/Dockerfile.bridge
@@ -52,4 +52,4 @@ RUN apt-get update && apt-get install libcurl4 -y
 
 ENV RUST_LOG=debug
 
-ENTRYPOINT ["/usr/bin/trin-bridge", "--node-count=1", "--executable-path=/usr/bin/trin", "--epoch-accumulator-path=./portal-accumulators"]
+ENTRYPOINT ["/usr/bin/trin-bridge"]


### PR DESCRIPTION
### What was wrong?

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
