### PR TITLE
Bump trin-types and trin-utils dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,8 +2164,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
- "trin-types",
- "trin-utils 0.1.1-alpha.1",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2195,8 +2195,8 @@ dependencies = [
  "trin",
  "trin-history",
  "trin-state",
- "trin-types",
- "trin-utils 0.1.1-alpha.1",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uds_windows",
  "ureq",
 ]
@@ -4657,8 +4657,8 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-subscriber",
- "trin-types",
- "trin-utils 0.1.1-alpha.1",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "trin-validation",
  "uds_windows",
  "url",
@@ -5273,8 +5273,8 @@ dependencies = [
  "reth-ipc",
  "serde_json",
  "tokio",
- "trin-types",
- "trin-utils 0.1.1-alpha.1",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url",
 ]
 
@@ -6853,8 +6853,8 @@ dependencies = [
  "trin-bridge",
  "trin-history",
  "trin-state",
- "trin-types",
- "trin-utils 0.1.1-alpha.1",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "trin-validation",
  "ureq",
  "utp-rs",
@@ -6879,8 +6879,8 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "trin-types",
- "trin-utils 0.1.1-alpha.1",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "trin-validation",
 ]
 
@@ -6898,8 +6898,8 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "trin-types",
- "trin-utils 0.1.1-alpha.1",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ureq",
 ]
 
@@ -6925,8 +6925,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tree_hash",
- "trin-types",
- "trin-utils 0.1.1-alpha.1",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "trin-validation",
  "ureq",
  "utp-rs",
@@ -6951,7 +6951,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "trin-types",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "trin-validation",
  "utp-rs",
 ]
@@ -6993,6 +6993,48 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tree_hash",
+ "tree_hash_derive",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ureq",
+ "url",
+ "validator",
+]
+
+[[package]]
+name = "trin-types"
+version = "0.1.1-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a926388451bb3243f8d76f4fbf358c664b587007b1a5585b465d13b0633abe20"
+dependencies = [
+ "anyhow",
+ "base64 0.13.1",
+ "bytes 1.4.0",
+ "clap 2.34.0",
+ "discv5",
+ "eth2_ssz",
+ "eth2_ssz_derive",
+ "eth2_ssz_types",
+ "eth_trie",
+ "ethereum-types 0.12.1",
+ "ethnum",
+ "keccak-hash",
+ "lazy_static",
+ "quickcheck",
+ "rand 0.8.5",
+ "rlp 0.5.2",
+ "rlp-derive",
+ "serde",
+ "serde-hex",
+ "serde_json",
+ "serde_yaml",
+ "sha2 0.10.6",
+ "sha3 0.9.1",
+ "snap",
+ "stremio-serde-hex",
+ "structopt",
+ "thiserror",
+ "tokio",
  "tree_hash",
  "tree_hash_derive",
  "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7051,8 +7093,8 @@ dependencies = [
  "tokio",
  "tree_hash",
  "tree_hash_derive",
- "trin-types",
- "trin-utils 0.1.1-alpha.1",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7243,7 +7285,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "trin-types",
+ "trin-types 0.1.1-alpha.1",
  "trin-utils 0.1.1-alpha.1",
  "utp-rs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ tracing-subscriber = "0.3.15"
 trin-bridge = { path = "trin-bridge" }
 trin-history = { path = "trin-history" }
 trin-state = { path = "trin-state" }
-trin-types = { path = "trin-types" }
-trin-utils = { path = "trin-utils" }
+trin-types = "0.1.1-alpha.1"
+trin-utils = "0.1.1-alpha.1"
 trin-validation = { path = "trin-validation" }
 utp-rs = "0.1.0-alpha.4"
 

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -17,8 +17,8 @@ eth2_ssz_types = "0.2.1"
 jsonrpsee = {version="0.16.2", features = ["async-client", "client", "macros", "server"]}
 serde = { version = "1.0.150", features = ["derive"] }
 serde_json = "1.0.89"
-trin-types = { path = "../trin-types" }
-trin-utils = { path = "../trin-utils" }
+trin-types = "0.1.1-alpha.1"
+trin-utils = "0.1.1-alpha.1"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -34,8 +34,8 @@ tree_hash = "0.4.0"
 trin = { path = ".." }
 trin-history = { path = "../trin-history" }
 trin-state = { path = "../trin-state" }
-trin-types = { path = "../trin-types" }
-trin-utils = { path = "../trin-utils" }
+trin-types = "0.1.1-alpha.1"
+trin-utils = "0.1.1-alpha.1"
 ureq = { version = "2.5.0", features = ["json"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -43,8 +43,8 @@ tempfile = "3.3.0"
 thiserror = "1.0.29"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
-trin-types = { path="../trin-types" }
-trin-utils = { path="../trin-utils" }
+trin-types = "0.1.1-alpha.1"
+trin-utils = "0.1.1-alpha.1"
 trin-validation = { path="../trin-validation" }
 validator = { version = "0.13.0", features = ["derive"] }
 url = "2.3.1"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -14,8 +14,8 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 anyhow = "1.0.68"
 ethportal-api = { path = "../ethportal-api"}
 portalnet = { path = "../portalnet"}
-trin-types = { path = "../trin-types"}
-trin-utils = { path = "../trin-utils"}
+trin-types = "0.1.1-alpha.1"
+trin-utils = "0.1.1-alpha.1"
 tokio = { version = "1.14.0", features = ["full"] }
 reth-ipc = { version = "0.1.0", git = "https://github.com/paradigmxyz/reth.git"}
 url = "2.3.1"

--- a/trin-bridge/Cargo.toml
+++ b/trin-bridge/Cargo.toml
@@ -26,8 +26,8 @@ surf = "2.3.2"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
-trin-types = { path = "../trin-types" }
-trin-utils = { path = "../trin-utils" }
+trin-types = "0.1.1-alpha.1"
+trin-utils = "0.1.1-alpha.1"
 trin-validation = { path = "../trin-validation" }
 
 [dev-dependencies]

--- a/trin-cli/Cargo.toml
+++ b/trin-cli/Cargo.toml
@@ -20,10 +20,9 @@ jsonrpc = "0.12.0"
 nanotemplate = "0.3.0"
 serde = "1.0.150"
 serde_json = { version = "1.0.89", features = ["raw_value"] }
-
 thiserror = "1.0.29"
-trin-types = { path = "../trin-types" }
-trin-utils = { path = "../trin-utils" }
+trin-types = "0.1.1-alpha.1"
+trin-utils = "0.1.1-alpha.1"
 ureq = { version = "2.5.0", features = ["json"] }
 
 [[bin]]

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -23,8 +23,8 @@ serde_json = "1.0.89"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
 tree_hash = "0.4.0"
-trin-types = { path = "../trin-types" }
-trin-utils = { path = "../trin-utils" }
+trin-types = "0.1.1-alpha.1"
+trin-utils = "0.1.1-alpha.1"
 trin-validation = { path = "../trin-validation" }
 utp-rs = "0.1.0-alpha.4"
 

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -23,7 +23,7 @@ portalnet = { path = "../portalnet" }
 rocksdb = "0.18.0"
 tracing = "0.1.36"
 tokio = {version = "1.14.0", features = ["full"]}
-trin-types = { path = "../trin-types" }
+trin-types = "0.1.1-alpha.1"
 trin-validation = { path = "../trin-validation" }
 utp-rs = "0.1.0-alpha.4"
 

--- a/trin-validation/Cargo.toml
+++ b/trin-validation/Cargo.toml
@@ -25,8 +25,8 @@ serde_json = "1.0.89"
 tokio = { version = "1.14.0", features = ["full"] }
 tree_hash = "0.4.0"
 tree_hash_derive = "0.4.0"
-trin-types = { path = "../trin-types" }
-trin-utils = { path = "../trin-utils" }
+trin-types = "0.1.1-alpha.1"
+trin-utils = "0.1.1-alpha.1"
 
 [dev-dependencies]
 quickcheck = "1.0.3"


### PR DESCRIPTION
### What was wrong?
Update `trin-types` and `trin-utils` dependencies to use the published versions of the crate rather than directly linking to the project directories.

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
