### PR TITLE
Remove data radius from json-rpc ping

### DIFF
--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -37,7 +37,7 @@ pub trait HistoryNetworkApi {
 
     /// Send a PING message to the designated node and wait for a PONG response
     #[method(name = "historyPing")]
-    async fn ping(&self, enr: Enr, data_radius: Option<DataRadius>) -> RpcResult<PongInfo>;
+    async fn ping(&self, enr: Enr) -> RpcResult<PongInfo>;
 
     /// Send a FINDNODES request for nodes that fall within the given set of distances, to the designated
     /// peer and wait for a response

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -44,13 +44,7 @@ pub async fn test_history_radius(target: &Client) {
 
 pub async fn test_history_ping(target: &Client, peertest: &Peertest) {
     info!("Testing portal_historyPing");
-    let result = target
-        .ping(
-            peertest.bootnode.enr.clone(),
-            Some(U256::from_dec_str("256").unwrap()),
-        )
-        .await
-        .unwrap();
+    let result = target.ping(peertest.bootnode.enr.clone()).await.unwrap();
     assert_eq!(
         result.data_radius,
         U256::from_big_endian(Distance::MAX.as_ssz_bytes().as_slice())

--- a/rpc/src/history_rpc.rs
+++ b/rpc/src/history_rpc.rs
@@ -79,8 +79,8 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
     }
 
     /// Send a PING message to the designated node and wait for a PONG response
-    async fn ping(&self, enr: Enr, data_radius: Option<DataRadius>) -> RpcResult<PongInfo> {
-        let endpoint = HistoryEndpoint::Ping(enr, data_radius);
+    async fn ping(&self, enr: Enr) -> RpcResult<PongInfo> {
+        let endpoint = HistoryEndpoint::Ping(enr);
         let result = self.proxy_query_to_history_subnet(endpoint).await?;
         let result: PongInfo = from_value(result)?;
         Ok(result)

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -152,7 +152,7 @@ impl HistoryRequestHandler {
 
                     let _ = request.resp.send(response);
                 }
-                HistoryEndpoint::Ping(enr, _) => {
+                HistoryEndpoint::Ping(enr) => {
                     let response = match self.network.overlay.send_ping(enr).await {
                         Ok(pong) => Ok(json!(PongInfo {
                             enr_seq: pong.enr_seq as u32,

--- a/trin-types/src/jsonrpc/endpoints.rs
+++ b/trin-types/src/jsonrpc/endpoints.rs
@@ -1,6 +1,5 @@
 use crate::content_key::HistoryContentKey;
 use crate::content_value::HistoryContentValue;
-use crate::distance::DataRadius;
 use crate::enr::Enr;
 use crate::node_id::NodeId;
 
@@ -40,8 +39,8 @@ pub enum HistoryEndpoint {
     Gossip(HistoryContentKey, HistoryContentValue),
     /// params: [enr, content_key]
     Offer(Enr, HistoryContentKey, Option<HistoryContentValue>),
-    /// params: [enr, data_radius]
-    Ping(Enr, Option<DataRadius>),
+    /// params: [enr]
+    Ping(Enr),
     /// params: content_key
     RecursiveFindContent(HistoryContentKey),
     /// params: content_key


### PR DESCRIPTION
Spec changed here:
https://github.com/ethereum/portal-network-specs/pull/202

### What was wrong?

Fix #696 

### How was it fixed?

Remove the paramater. We just ignored it anyway, so it's pretty straightforward.

### To-Do

- [x] Clean up commit history
