### PR TITLE
Depend on released trin-types and trin-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,8 +2175,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
- "trin-types",
- "trin-utils 0.1.1-alpha.1",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2207,7 +2207,7 @@ dependencies = [
  "trin",
  "trin-history",
  "trin-state",
- "trin-types",
+ "trin-types 0.1.1-alpha.1",
  "trin-utils 0.1.1-alpha.1",
  "uds_windows",
  "ureq",
@@ -4669,8 +4669,8 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-subscriber",
- "trin-types",
- "trin-utils 0.1.1-alpha.1",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "trin-validation",
  "uds_windows",
  "url",
@@ -5301,8 +5301,8 @@ dependencies = [
  "reth-ipc",
  "serde_json",
  "tokio",
- "trin-types",
- "trin-utils 0.1.1-alpha.1",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url",
 ]
 
@@ -6882,7 +6882,7 @@ dependencies = [
  "trin-bridge",
  "trin-history",
  "trin-state",
- "trin-types",
+ "trin-types 0.1.1-alpha.1",
  "trin-utils 0.1.1-alpha.1",
  "trin-validation",
  "ureq",
@@ -6908,8 +6908,8 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "trin-types",
- "trin-utils 0.1.1-alpha.1",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "trin-validation",
 ]
 
@@ -6927,7 +6927,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "trin-types",
+ "trin-types 0.1.1-alpha.1",
  "trin-utils 0.1.1-alpha.1",
  "ureq",
 ]
@@ -6954,8 +6954,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tree_hash",
- "trin-types",
- "trin-utils 0.1.1-alpha.1",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "trin-validation",
  "ureq",
  "utp-rs",
@@ -6980,7 +6980,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "trin-types",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "trin-validation",
  "utp-rs",
 ]
@@ -7022,6 +7022,48 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tree_hash",
+ "tree_hash_derive",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ureq",
+ "url",
+ "validator",
+]
+
+[[package]]
+name = "trin-types"
+version = "0.1.1-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a926388451bb3243f8d76f4fbf358c664b587007b1a5585b465d13b0633abe20"
+dependencies = [
+ "anyhow",
+ "base64 0.13.1",
+ "bytes 1.4.0",
+ "clap 2.34.0",
+ "discv5",
+ "eth2_ssz",
+ "eth2_ssz_derive",
+ "eth2_ssz_types",
+ "eth_trie",
+ "ethereum-types 0.12.1",
+ "ethnum",
+ "keccak-hash",
+ "lazy_static",
+ "quickcheck",
+ "rand 0.8.5",
+ "rlp 0.5.2",
+ "rlp-derive",
+ "serde",
+ "serde-hex",
+ "serde_json",
+ "serde_yaml",
+ "sha2 0.10.6",
+ "sha3 0.9.1",
+ "snap",
+ "stremio-serde-hex",
+ "structopt",
+ "thiserror",
+ "tokio",
  "tree_hash",
  "tree_hash_derive",
  "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7080,8 +7122,8 @@ dependencies = [
  "tokio",
  "tree_hash",
  "tree_hash_derive",
- "trin-types",
- "trin-utils 0.1.1-alpha.1",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7272,7 +7314,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "trin-types",
+ "trin-types 0.1.1-alpha.1",
  "trin-utils 0.1.1-alpha.1",
  "utp-rs",
 ]

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -17,8 +17,8 @@ eth2_ssz_types = "0.2.1"
 jsonrpsee = {version="0.16.2", features = ["async-client", "client", "macros", "server"]}
 serde = { version = "1.0.150", features = ["derive"] }
 serde_json = "1.0.89"
-trin-types = { path = "../trin-types" }
-trin-utils = { path = "../trin-utils" }
+trin-types = "0.1.1-alpha.1"
+trin-utils = "0.1.1-alpha.1"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -43,8 +43,8 @@ tempfile = "3.3.0"
 thiserror = "1.0.29"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
-trin-types = { path="../trin-types" }
-trin-utils = { path="../trin-utils" }
+trin-types = "0.1.1-alpha.1"
+trin-utils = "0.1.1-alpha.1"
 trin-validation = { path="../trin-validation" }
 validator = { version = "0.13.0", features = ["derive"] }
 url = "2.3.1"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -14,8 +14,8 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 anyhow = "1.0.68"
 ethportal-api = { path = "../ethportal-api"}
 portalnet = { path = "../portalnet"}
-trin-types = { path = "../trin-types"}
-trin-utils = { path = "../trin-utils"}
+trin-types = "0.1.1-alpha.1"
+trin-utils = "0.1.1-alpha.1"
 tokio = { version = "1.14.0", features = ["full"] }
 reth-ipc = { version = "0.1.0", git = "https://github.com/paradigmxyz/reth.git"}
 url = "2.3.1"

--- a/trin-bridge/Cargo.toml
+++ b/trin-bridge/Cargo.toml
@@ -26,8 +26,8 @@ surf = "2.3.2"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
-trin-types = { path = "../trin-types" }
-trin-utils = { path = "../trin-utils" }
+trin-types = "0.1.1-alpha.1"
+trin-utils = "0.1.1-alpha.1"
 trin-validation = { path = "../trin-validation" }
 
 [dev-dependencies]

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -23,8 +23,8 @@ serde_json = "1.0.89"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
 tree_hash = "0.4.0"
-trin-types = { path = "../trin-types" }
-trin-utils = { path = "../trin-utils" }
+trin-types = "0.1.1-alpha.1"
+trin-utils = "0.1.1-alpha.1"
 trin-validation = { path = "../trin-validation" }
 utp-rs = "0.1.0-alpha.4"
 

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -23,7 +23,7 @@ portalnet = { path = "../portalnet" }
 rocksdb = "0.18.0"
 tracing = "0.1.36"
 tokio = {version = "1.14.0", features = ["full"]}
-trin-types = { path = "../trin-types" }
+trin-types = "0.1.1-alpha.1"
 trin-validation = { path = "../trin-validation" }
 utp-rs = "0.1.0-alpha.4"
 

--- a/trin-validation/Cargo.toml
+++ b/trin-validation/Cargo.toml
@@ -25,8 +25,8 @@ serde_json = "1.0.89"
 tokio = { version = "1.14.0", features = ["full"] }
 tree_hash = "0.4.0"
 tree_hash_derive = "0.4.0"
-trin-types = { path = "../trin-types" }
-trin-utils = { path = "../trin-utils" }
+trin-types = "0.1.1-alpha.1"
+trin-utils = "0.1.1-alpha.1"
 
 [dev-dependencies]
 quickcheck = "1.0.3"


### PR DESCRIPTION
### What was wrong?

We can't release ethportal-api with a relative dependency.

### How was it fixed?

Switch to depending on the released versions.

### To-Do

- [ ] Clean up commit history
