### PR TITLE
Remove total from result for portal_historyFindNodes

### DIFF
--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -25,13 +25,7 @@ pub struct PongInfo {
     pub data_radius: DataRadius,
 }
 
-/// Response for FindNodes endpoint
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FindNodesInfo {
-    pub total: u8,
-    pub enrs: Vec<Enr>,
-}
+pub type FindNodesInfo = Vec<Enr>;
 
 /// Response for FindContent endpoint
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -58,8 +58,7 @@ pub async fn test_history_find_nodes(target: &Client, peertest: &Peertest) {
         .find_nodes(peertest.bootnode.enr.clone(), vec![256])
         .await
         .unwrap();
-    assert_eq!(result.total, 1);
-    assert!(result.enrs.contains(&peertest.nodes[0].enr));
+    assert!(result.contains(&peertest.nodes[0].enr));
 }
 
 pub async fn test_history_find_nodes_zero_distance(target: &Client, peertest: &Peertest) {
@@ -68,8 +67,7 @@ pub async fn test_history_find_nodes_zero_distance(target: &Client, peertest: &P
         .find_nodes(peertest.bootnode.enr.clone(), vec![0])
         .await
         .unwrap();
-    assert_eq!(result.total, 1);
-    assert!(result.enrs.contains(&peertest.bootnode.enr));
+    assert!(result.contains(&peertest.bootnode.enr));
 }
 
 pub async fn test_history_store(target: &Client) {

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -217,14 +217,11 @@ async fn find_nodes(
 ) -> Result<Value, String> {
     let overlay = network.read().await.overlay.clone();
     match overlay.send_find_nodes(enr, distances).await {
-        Ok(nodes) => Ok(json!(FindNodesInfo {
-            total: nodes.total,
-            enrs: nodes
-                .enrs
-                .into_iter()
-                .map(|enr| enr.into())
-                .collect::<Vec<Enr>>(),
-        })),
+        Ok(nodes) => Ok(json!(nodes
+            .enrs
+            .into_iter()
+            .map(|enr| enr.into())
+            .collect::<FindNodesInfo>())),
         Err(msg) => Err(format!("FindNodes request timeout: {msg:?}")),
     }
 }


### PR DESCRIPTION
The `total` field doesn't match the spec, it is just supposed to return a top-level list of ENRs.

### What was wrong?

Fix #702 

### How was it fixed?

Redefine the `FindNodesInfo` type to a vector of ENRs.
### To-Do

- [x] Clean up commit history
