### PR TITLE
Update protocol identifiers

### DIFF
--- a/portalnet/src/metrics.rs
+++ b/portalnet/src/metrics.rs
@@ -21,8 +21,8 @@ pub enum ProtocolLabel {
     State,
     History,
     TransactionGossip,
-    HeaderGossip,
     CanonicalIndices,
+    Beacon,
     Utp,
 }
 
@@ -135,8 +135,8 @@ impl From<ProtocolLabel> for MetricLabel {
             ProtocolLabel::State => "state",
             ProtocolLabel::History => "history",
             ProtocolLabel::TransactionGossip => "transaction_gossip",
-            ProtocolLabel::HeaderGossip => "header_gossip",
             ProtocolLabel::CanonicalIndices => "canonical_indices",
+            ProtocolLabel::Beacon => "beacon",
             ProtocolLabel::Utp => "utp",
         }
     }
@@ -172,8 +172,8 @@ impl From<&ProtocolId> for ProtocolLabel {
             ProtocolId::State => Self::State,
             ProtocolId::History => Self::History,
             ProtocolId::TransactionGossip => Self::TransactionGossip,
-            ProtocolId::HeaderGossip => Self::HeaderGossip,
             ProtocolId::CanonicalIndices => Self::CanonicalIndices,
+            ProtocolId::Beacon => Self::Beacon,
             ProtocolId::Utp => Self::Utp,
         }
     }

--- a/portalnet/src/types/messages.rs
+++ b/portalnet/src/types/messages.rs
@@ -199,8 +199,8 @@ pub enum ProtocolId {
     State,
     History,
     TransactionGossip,
-    HeaderGossip,
     CanonicalIndices,
+    Beacon,
     Utp,
 }
 
@@ -213,8 +213,8 @@ impl FromStr for ProtocolId {
             "0x500A" => Ok(ProtocolId::State),
             "0x500B" => Ok(ProtocolId::History),
             "0x500C" => Ok(ProtocolId::TransactionGossip),
-            "0x500D" => Ok(ProtocolId::HeaderGossip),
-            "0x500E" => Ok(ProtocolId::CanonicalIndices),
+            "0x500D" => Ok(ProtocolId::CanonicalIndices),
+            "0x501A" => Ok(ProtocolId::Beacon),
             "0x757470" => Ok(ProtocolId::Utp),
             _ => Err(ProtocolIdError::Invalid),
         }
@@ -227,8 +227,8 @@ impl fmt::Display for ProtocolId {
             ProtocolId::State => "State",
             ProtocolId::History => "History",
             ProtocolId::TransactionGossip => "Transaction Gossip",
-            ProtocolId::HeaderGossip => "Header Gossip",
             ProtocolId::CanonicalIndices => "Canonical Indices",
+            ProtocolId::Beacon => "Beacon",
             ProtocolId::Utp => "uTP",
         };
         write!(f, "{}", protocol)
@@ -244,8 +244,8 @@ impl TryFrom<ProtocolId> for Vec<u8> {
             ProtocolId::State => hex_decode("0x500A"),
             ProtocolId::History => hex_decode("0x500B"),
             ProtocolId::TransactionGossip => hex_decode("0x500C"),
-            ProtocolId::HeaderGossip => hex_decode("0x500D"),
-            ProtocolId::CanonicalIndices => hex_decode("0x500E"),
+            ProtocolId::CanonicalIndices => hex_decode("0x500D"),
+            ProtocolId::Beacon => hex_decode("0x501A"),
             ProtocolId::Utp => hex_decode("0x757470"),
         };
         bytes.map_err(ProtocolIdError::Decode)


### PR DESCRIPTION
### What was wrong?
Outdated protocol identifiers

### How was it fixed?

Update protocol identifiers according to [portal wire specs](https://github.com/ethereum/portal-network-specs/blob/master/portal-wire-protocol.md#protocol-identifiers).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
