### PR TITLE
Re-exports trin-types's Enr type from `ethportal_api`

### DIFF
--- a/ethportal-api/src/lib.rs
+++ b/ethportal-api/src/lib.rs
@@ -28,4 +28,5 @@ pub use trin_types::execution::receipts::*;
 pub use jsonrpsee;
 
 pub use trin_types::discv5::*;
+pub use trin_types::enr::*;
 pub use trin_types::node_id::*;


### PR DESCRIPTION
### What was wrong?

`trin-types`'s `Enr` type was not re-exported from `ethportal_api`, like `NodeId` was

### How was it fixed?

re-exported it

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
