### PR TITLE
Remove not used import and fix a windows clippy issue

### DIFF
--- a/newsfragments/719.fixed.md
+++ b/newsfragments/719.fixed.md
@@ -1,0 +1,1 @@
+Remove not used import and fix a windows clippy issue

--- a/trin-utils/src/log.rs
+++ b/trin-utils/src/log.rs
@@ -1,10 +1,3 @@
-use std::env;
-
-#[cfg(windows)]
-use ansi_term;
-#[cfg(not(windows))]
-use atty;
-
 pub fn init_tracing_logger() {
     tracing_subscriber::fmt()
         .with_ansi(detect_ansi_support())
@@ -28,6 +21,8 @@ fn detect_ansi_support() -> bool {
         }
 
         // Return whether terminal defined in TERM supports ANSI
-        env::var("TERM").map(|term| term != "dumb").unwrap_or(false)
+        std::env::var("TERM")
+            .map(|term| term != "dumb")
+            .unwrap_or(false)
     }
 }


### PR DESCRIPTION
### What was wrong?
``use std::env`` is only used on none windows so it breaks clippy since it doesn't have a cfg.

Also we have 2 not needed use's which don't do anything
### How was it fixed?

I changed ``env::var(`` to ``std::env::var(`` then I removed not 2 not used uses
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
