### PR TITLE
Add optimizations for CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,17 @@ commands:
           key: sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
             - "~/.cache/sccache"
-
+  install-depends:
+    steps:
+      - run:
+          name: Prepare for apt upgrades
+          command: sudo apt update
+      - run:
+          name: Install libssl-dev for openssl-sys
+          command: sudo apt install -y libssl-dev
+      - run:
+          name: Install libclang for rocksdb
+          command: sudo apt install clang
 orbs:
   rust: circleci/rust@1.6.0
 executors:
@@ -104,9 +114,9 @@ jobs:
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             docker push $IMAGE_NAME:latest-bridge
-  lint-build-test:
+  lint:
         description: |
-            Check linting with Clippy and rustfmt, build the crate, and run tests.
+            Check linting with Clippy and rustfmt.
         resource_class: xlarge
         executor:
             name: rust/default
@@ -116,18 +126,7 @@ jobs:
             RUST_LOG: 'debug'
         steps:
             - checkout
-            - run:
-                name: Prepare for apt upgrades
-                command: sudo apt update
-            - run:
-                name: Install libssl-dev for openssl-sys
-                command: sudo apt install -y libssl-dev
-            - run:
-                name: Install libclang for rocksdb
-                command: sudo apt install clang
-            - run:
-                name: Install rustfmt
-                command: rustup component add rustfmt
+            - install-depends
             - run:
                 name: Validate release notes entry
                 command: ./newsfragments/validate_files.py
@@ -141,13 +140,43 @@ jobs:
             - run:
                 name: Run Clippy
                 command: cargo clippy --all --all-targets --all-features --no-deps -- --deny warnings
-            - run:
-                name: Build Trin workspace
-                command: cargo build --workspace
-            - run:
-                name: Test Trin workspace
-                command: cargo test --workspace -- --nocapture
             - save-sccache-cache
+  build:
+    description: |
+      Build the crate.
+    resource_class: xlarge
+    executor:
+      name: rust/default
+      tag: 1.66.1
+    environment:
+      RUSTFLAGS: '-D warnings'
+      RUST_LOG: 'debug'
+    steps:
+      - checkout
+      - install-depends
+      - setup-and-restore-sccache-cache
+      - run:
+          name: Build Trin workspace
+          command: cargo build --workspace
+      - save-sccache-cache
+  test:
+    description: |
+      Run tests.
+    resource_class: xlarge
+    executor:
+      name: rust/default
+      tag: 1.66.1
+    environment:
+      RUSTFLAGS: '-D warnings'
+      RUST_LOG: 'debug'
+    steps:
+      - checkout
+      - install-depends
+      - setup-and-restore-sccache-cache
+      - run:
+          name: Test Trin workspace
+          command: cargo test --workspace -- --nocapture
+      - save-sccache-cache
   utp-test:
     description: |
       Run uTP network simulator
@@ -227,5 +256,7 @@ workflows:
           filters:
             branches:
               only: master
-      - lint-build-test
+      - lint
+      - build
+      - test
       - utp-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,35 @@
 version: 2.1
+commands:
+  setup-and-restore-sccache-cache:
+    steps:
+      - run:
+          name: Install sccache
+          command: |
+            wget https://github.com/mozilla/sccache/releases/download/v0.4.2/sccache-v0.4.2-x86_64-unknown-linux-musl.tar.gz \
+            && tar xzf sccache-v0.4.2-x86_64-unknown-linux-musl.tar.gz \
+            && mkdir -p $HOME/.local/bin\
+            && mv sccache-v0.4.2-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache \
+            && chmod +x $HOME/.local/bin/sccache
+            # This configures Rust to use sccache.
+            echo 'export "RUSTC_WRAPPER"="$HOME/.local/bin/sccache"' >> $BASH_ENV
+            # This is the maximum space sccache cache will use on disk.
+            echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
+            $HOME/.local/bin/sccache --version
+      - restore_cache:
+          name: Restore sccache cache
+          key: sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+  save-sccache-cache:
+    steps:
+      - save_cache:
+          name: Save sccache cache
+          # We use {{ epoch }} to always upload a fresh cache:
+          # Of course, restore_cache will not find this exact key,
+          # but it will fall back to the closest key (aka the most recent).
+          # See https://discuss.circleci.com/t/add-mechanism-to-update-existing-cache-key/9014/13
+          key: sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
+          paths:
+            - "~/.cache/sccache"
+
 orbs:
   rust: circleci/rust@1.6.0
 executors:
@@ -106,6 +137,7 @@ jobs:
             - run:
                 name: Install Clippy
                 command: rustup component add clippy
+            - setup-and-restore-sccache-cache
             - run:
                 name: Run Clippy
                 command: cargo clippy --all --all-targets --all-features --no-deps -- --deny warnings
@@ -115,6 +147,7 @@ jobs:
             - run:
                 name: Test Trin workspace
                 command: cargo test --workspace -- --nocapture
+            - save-sccache-cache
   utp-test:
     description: |
       Run uTP network simulator
@@ -144,9 +177,11 @@ jobs:
       - run:
           name: Install Rust
           command: curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - setup-and-restore-sccache-cache
       - run:
           name: Build utp-testing package
           command: cargo build --workspace --release
+      - save-sccache-cache
       - run:
           name: Move docker artifacts
           command: mv -t utp-testing/docker/circleci/ target/release/utp-test-app utp-testing/docker/run_endpoint.sh utp-testing/docker/setup.sh


### PR DESCRIPTION
### What was wrong?
The CI takes so long most of this is just building libraries!

The cause? The mass amount of libraries Rust projects use as a side affect of an easy to use package manager!!!
### How was it fixed?

1. By adding [Mozilla'a sccache](https://github.com/mozilla/sccache) library.
2. Splitting lint-build-test CI into lint, build, and test

### Before
![image](https://user-images.githubusercontent.com/31669092/236640541-1ac6f80d-91a4-4b82-aee6-2ff1dabf0041.png)
### After
![image](https://user-images.githubusercontent.com/31669092/236640583-15252d0a-2f99-4134-b93c-18325cbbe106.png)



### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
