### PR TITLE
Launch beacon portal network

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tempfile = "3.3.0"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
+trin-beacon = { path = "trin-beacon" }
 trin-bridge = { path = "trin-bridge" }
 trin-history = { path = "trin-history" }
 trin-state = { path = "trin-state" }

--- a/newsfragments/725.added.md
+++ b/newsfragments/725.added.md
@@ -1,0 +1,1 @@
+Launch beacon portal network without RPC support

--- a/trin-types/src/cli.rs
+++ b/trin-types/src/cli.rs
@@ -11,6 +11,7 @@ pub const DEFAULT_MASTER_ACC_PATH: &str = "validation_assets/merge_macc.bin";
 pub const DEFAULT_WEB3_IPC_PATH: &str = "/tmp/trin-jsonrpc.ipc";
 pub const DEFAULT_WEB3_HTTP_ADDRESS: &str = "http://127.0.0.1:8545/";
 const DEFAULT_DISCOVERY_PORT: &str = "9000";
+pub const BEACON_NETWORK: &str = "beacon";
 pub const HISTORY_NETWORK: &str = "history";
 pub const STATE_NETWORK: &str = "state";
 const DEFAULT_SUBNETWORKS: &str = "history";


### PR DESCRIPTION
### What was wrong?
We want to launch the beacon chain network

### How was it fixed?
This PR launches the beacon portal network **without** RPC support when "beacon" is included in the `networks` cli flag.

To enable RPC for the beacon network, we need first to refactor how JSON-RPC server endpoints are initialized based on the networks launched, which will follow in a separate PR.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
