### PR TITLE
fix ``historyRecursiveFindNodes`` endpoint taking too long to return

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6879,7 +6879,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "trin-beacon",
  "trin-bridge",
  "trin-history",
  "trin-state",

--- a/newsfragments/726.fixed.md
+++ b/newsfragments/726.fixed.md
@@ -1,0 +1,1 @@
+fix ``historyRecursiveFindNodes`` endpoint taking too long to return

--- a/portalnet/src/find/iterators/query.rs
+++ b/portalnet/src/find/iterators/query.rs
@@ -58,7 +58,7 @@ impl Default for QueryConfig {
         Self {
             parallelism: 3,
             num_results: 20,
-            peer_timeout: Duration::from_secs(10),
+            peer_timeout: Duration::from_secs(2),
         }
     }
 }

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -69,7 +69,7 @@ impl Default for OverlayConfig {
             bucket_filter: None,
             ping_queue_interval: None,
             query_parallelism: 3, // (recommended α from kademlia paper)
-            query_peer_timeout: Duration::from_secs(10),
+            query_peer_timeout: Duration::from_secs(2),
             query_timeout: Duration::from_secs(60),
             query_num_results: MAX_NODES_PER_BUCKET,
             findnodes_query_distances_per_peer: 3,


### PR DESCRIPTION
### What was wrong?
fix https://github.com/ethereum/trin/issues/708 supersedes https://github.com/ethereum/trin/pull/698 since this resolves the root of the problem
### How was it fixed?
By changing our ``query_peer_timeout`` from 10s to 2s.

Our recursiveFindNode code is heavily based off sigp/discv5 implementation. The biggest difference? Our ``query_peer_timeout`` is set 5 times higher. 

Our ``query_timeout`` is 60 seconds with 3 allowed async queries. The issue is if we ping 3 bad nodes that means 1/6th of our query time is gone. So worst case we can only make 18 queries. Where as if we match the timeout our implementation is based off of, of 2s our worst case is 90.

    /// The timeout after which a `QueryPeer` in an ongoing query is marked unresponsive.
    /// Unresponsive peers don't count towards the parallelism limits for a query.
    /// Hence, we may potentially end up making more requests to good peers. Default: 2 seconds.
    ^ Taken from the doc in sigp/dicv5 our base implementation for ours
   Having a lower timeout means we will accept there response if they do respond, we just get to make more calls to responsive nodes since they will no longer count towards are parallelism limit
   
   
Also having a high peer_timeout will prevent the call from returning since we wait have longstanding waiting requests 
```
                        // The query is still waiting for a result from a peer and the
                        // `result_counter` did not yet reach `num_results`. Therefore
                        // the query is not yet done, regardless of already successful
                        // queries to peers farther from the target.
                        result_counter = None;
```
                       
So this resolves that
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
