### PR TITLE
Fix 2 issues with Monitoring docs

### DIFF
--- a/book/src/users/monitoring.md
+++ b/book/src/users/monitoring.md
@@ -207,6 +207,9 @@ Node explorer uses port 9100 by default.
 
 Install
 ```sh
+sudo apt-get install -y apt-transport-https software-properties-common wget
+sudo wget -q -O /usr/share/keyrings/grafana.key https://apt.grafana.com/gpg.key
+echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
 sudo apt install grafana
 ```
 Open config

--- a/book/src/users/monitoring.md
+++ b/book/src/users/monitoring.md
@@ -210,6 +210,7 @@ Install
 sudo apt-get install -y apt-transport-https software-properties-common wget
 sudo wget -q -O /usr/share/keyrings/grafana.key https://apt.grafana.com/gpg.key
 echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+sudo apt update
 sudo apt install grafana
 ```
 Open config

--- a/book/src/users/monitoring.md
+++ b/book/src/users/monitoring.md
@@ -107,7 +107,7 @@ scrape_configs:
   - job_name: 'node_exporter'
     static_configs:
       - targets: ['localhost:9100']
-- job_name: 'trin'
+  - job_name: 'trin'
     static_configs:
       - targets: ['localhost:9101']
 ```


### PR DESCRIPTION
### What was wrong?
The template prometheus config is missing 2 spaces so if a user follows the instructions Prometheus won't launch

Grafana isn't in the default package repos on Ubuntu 22.04
### How was it fixed?
I added 2 spaces so the config is valid yml and add 3 commands from https://grafana.com/docs/grafana/latest/setup-grafana/installation/debian/
