### PR TITLE
Implement Beacon network RPC endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6879,6 +6879,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "trin-beacon",
  "trin-bridge",
  "trin-history",
  "trin-state",

--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -4,74 +4,71 @@ use crate::types::portal::{
 };
 use crate::{NodeId, RoutingTableInfo};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use trin_types::content_key::HistoryContentKey;
-use trin_types::content_value::{HistoryContentValue, PossibleHistoryContentValue};
+use trin_types::content_key::BeaconContentKey;
+use trin_types::content_value::{BeaconContentValue, PossibleBeaconContentValue};
 use trin_types::enr::Enr;
 
-/// Portal History JSON-RPC endpoints
+/// Portal Beacon JSON-RPC endpoints
 #[rpc(client, server, namespace = "portal")]
-pub trait HistoryNetworkApi {
+pub trait BeaconNetworkApi {
     /// Returns meta information about overlay routing table.
-    #[method(name = "historyRoutingTableInfo")]
+    #[method(name = "beaconRoutingTableInfo")]
     async fn routing_table_info(&self) -> RpcResult<RoutingTableInfo>;
 
     /// Returns the node data radios
-    #[method(name = "historyRadius")]
+    #[method(name = "beaconRadius")]
     async fn radius(&self) -> RpcResult<DataRadius>;
 
     /// Write an Ethereum Node Record to the overlay routing table.
-    #[method(name = "historyAddEnr")]
+    #[method(name = "beaconAddEnr")]
     async fn add_enr(&self, enr: Enr) -> RpcResult<bool>;
 
     /// Fetch the latest ENR associated with the given node ID.
-    #[method(name = "historyGetEnr")]
+    #[method(name = "beaconGetEnr")]
     async fn get_enr(&self, node_id: NodeId) -> RpcResult<Enr>;
 
     /// Delete Node ID from the overlay routing table.
-    #[method(name = "historyDeleteEnr")]
+    #[method(name = "beaconDeleteEnr")]
     async fn delete_enr(&self, node_id: NodeId) -> RpcResult<bool>;
 
     /// Fetch the ENR representation associated with the given Node ID.
-    #[method(name = "historyLookupEnr")]
+    #[method(name = "beaconLookupEnr")]
     async fn lookup_enr(&self, node_id: NodeId) -> RpcResult<Enr>;
 
     /// Send a PING message to the designated node and wait for a PONG response
-    #[method(name = "historyPing")]
+    #[method(name = "beaconPing")]
     async fn ping(&self, enr: Enr) -> RpcResult<PongInfo>;
 
     /// Send a FINDNODES request for nodes that fall within the given set of distances, to the designated
     /// peer and wait for a response
-    #[method(name = "historyFindNodes")]
+    #[method(name = "beaconFindNodes")]
     async fn find_nodes(&self, enr: Enr, distances: Vec<u16>) -> RpcResult<FindNodesInfo>;
 
     /// Lookup a target node within in the network
-    #[method(name = "historyRecursiveFindNodes")]
+    #[method(name = "beaconRecursiveFindNodes")]
     async fn recursive_find_nodes(&self, node_id: NodeId) -> RpcResult<Vec<Enr>>;
 
     /// Send FINDCONTENT message to get the content with a content key.
-    #[method(name = "historyFindContent")]
-    async fn find_content(
-        &self,
-        enr: Enr,
-        content_key: HistoryContentKey,
-    ) -> RpcResult<ContentInfo>;
+    #[method(name = "beaconFindContent")]
+    async fn find_content(&self, enr: Enr, content_key: BeaconContentKey)
+        -> RpcResult<ContentInfo>;
 
     /// Lookup a target content key in the network
-    #[method(name = "historyRecursiveFindContent")]
+    #[method(name = "beaconRecursiveFindContent")]
     async fn recursive_find_content(
         &self,
-        content_key: HistoryContentKey,
-    ) -> RpcResult<PossibleHistoryContentValue>;
+        content_key: BeaconContentKey,
+    ) -> RpcResult<PossibleBeaconContentValue>;
 
     /// Lookup a target content key in the network. Return tracing info.
-    #[method(name = "historyTraceRecursiveFindContent")]
+    #[method(name = "beaconTraceRecursiveFindContent")]
     async fn trace_recursive_find_content(
         &self,
-        content_key: HistoryContentKey,
+        content_key: BeaconContentKey,
     ) -> RpcResult<TraceContentInfo>;
 
     /// Pagination of local content keys
-    #[method(name = "historyPaginateLocalContentKeys")]
+    #[method(name = "beaconPaginateLocalContentKeys")]
     async fn paginate_local_content_keys(
         &self,
         offset: u64,
@@ -80,35 +77,35 @@ pub trait HistoryNetworkApi {
 
     /// Send the provided content value to interested peers. Clients may choose to send to some or all peers.
     /// Return the number of peers that the content was gossiped to.
-    #[method(name = "historyGossip")]
+    #[method(name = "beaconGossip")]
     async fn gossip(
         &self,
-        content_key: HistoryContentKey,
-        content_value: HistoryContentValue,
+        content_key: BeaconContentKey,
+        content_value: BeaconContentValue,
     ) -> RpcResult<u32>;
 
     /// Send an OFFER request with given ContentKey, to the designated peer and wait for a response.
     /// Returns the content keys bitlist upon successful content transmission or empty bitlist receive.
-    #[method(name = "historyOffer")]
+    #[method(name = "beaconOffer")]
     async fn offer(
         &self,
         enr: Enr,
-        content_key: HistoryContentKey,
-        content_value: Option<HistoryContentValue>,
+        content_key: BeaconContentKey,
+        content_value: Option<BeaconContentValue>,
     ) -> RpcResult<AcceptInfo>;
 
     /// Store content key with a content data to the local database.
-    #[method(name = "historyStore")]
+    #[method(name = "beaconStore")]
     async fn store(
         &self,
-        content_key: HistoryContentKey,
-        content_value: HistoryContentValue,
+        content_key: BeaconContentKey,
+        content_value: BeaconContentValue,
     ) -> RpcResult<bool>;
 
     /// Get a content from the local database
-    #[method(name = "historyLocalContent")]
+    #[method(name = "beaconLocalContent")]
     async fn local_content(
         &self,
-        content_key: HistoryContentKey,
-    ) -> RpcResult<PossibleHistoryContentValue>;
+        content_key: BeaconContentKey,
+    ) -> RpcResult<PossibleBeaconContentValue>;
 }

--- a/ethportal-api/src/lib.rs
+++ b/ethportal-api/src/lib.rs
@@ -3,22 +3,26 @@
 //! `ethportal_api` is a collection of Portal Network APIs and types.
 #![warn(clippy::unwrap_used)]
 
+mod beacon;
 pub mod discv5;
 mod history;
 pub mod types;
 mod web3;
 
 pub use crate::discv5::{Discv5ApiClient, Discv5ApiServer};
+pub use beacon::{BeaconNetworkApiClient, BeaconNetworkApiServer};
 pub use history::{HistoryNetworkApiClient, HistoryNetworkApiServer};
 pub use web3::{Web3ApiClient, Web3ApiServer};
 
 // Re-exports trin-types
 pub use trin_types::content_key::{
-    BlockBodyKey, BlockHeaderKey, BlockReceiptsKey, EpochAccumulatorKey, HistoryContentKey,
-    OverlayContentKey, StateContentKey,
+    BeaconContentKey, BlockBodyKey, BlockHeaderKey, BlockReceiptsKey, EpochAccumulatorKey,
+    HistoryContentKey, LightClientBootstrapKey, LightClientUpdatesKey, OverlayContentKey,
+    StateContentKey,
 };
 pub use trin_types::content_value::{
-    ContentValue, ContentValueError, HistoryContentValue, PossibleHistoryContentValue,
+    BeaconContentValue, ContentValue, ContentValueError, HistoryContentValue,
+    PossibleBeaconContentValue, PossibleHistoryContentValue,
 };
 pub use trin_types::execution::block_body::*;
 pub use trin_types::execution::header::*;

--- a/newsfragments/732.added.md
+++ b/newsfragments/732.added.md
@@ -1,0 +1,1 @@
+Implement Beacon portal network json-rpc API

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -1,0 +1,234 @@
+use crate::jsonrpsee::core::{async_trait, RpcResult};
+use anyhow::anyhow;
+use ethportal_api::types::portal::{
+    AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
+    TraceContentInfo,
+};
+use ethportal_api::BeaconContentKey;
+use ethportal_api::BeaconContentValue;
+use ethportal_api::BeaconNetworkApiServer;
+use ethportal_api::{NodeId, RoutingTableInfo};
+use serde_json::{from_value, Value};
+use tokio::sync::mpsc;
+use trin_types::constants::CONTENT_ABSENT;
+use trin_types::content_value::PossibleBeaconContentValue;
+use trin_types::enr::Enr;
+use trin_types::jsonrpc::endpoints::BeaconEndpoint;
+use trin_types::jsonrpc::request::BeaconJsonRpcRequest;
+
+pub struct BeaconNetworkApi {
+    network: mpsc::UnboundedSender<BeaconJsonRpcRequest>,
+}
+
+impl BeaconNetworkApi {
+    #[allow(dead_code)]
+    pub fn new(network: mpsc::UnboundedSender<BeaconJsonRpcRequest>) -> Self {
+        Self { network }
+    }
+
+    pub async fn proxy_query_to_beacon_subnet(
+        &self,
+        endpoint: BeaconEndpoint,
+    ) -> anyhow::Result<Value> {
+        let (resp_tx, mut resp_rx) = mpsc::unbounded_channel::<Result<Value, String>>();
+        let message = BeaconJsonRpcRequest {
+            endpoint,
+            resp: resp_tx,
+        };
+        let _ = self.network.send(message);
+
+        match resp_rx.recv().await {
+            Some(val) => match val {
+                Ok(result) => Ok(result),
+                Err(msg) => Err(anyhow!(msg)),
+            },
+            None => Err(anyhow!(
+                "Internal error: No response from chain beacon subnetwork"
+            )),
+        }
+    }
+}
+
+#[async_trait]
+impl BeaconNetworkApiServer for BeaconNetworkApi {
+    /// Returns meta information about overlay routing table.
+    async fn routing_table_info(&self) -> RpcResult<RoutingTableInfo> {
+        let endpoint = BeaconEndpoint::RoutingTableInfo;
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: RoutingTableInfo = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Write an Ethereum Node Record to the overlay routing table.
+    async fn add_enr(&self, enr: Enr) -> RpcResult<bool> {
+        let endpoint = BeaconEndpoint::AddEnr(enr);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: bool = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Fetch the latest ENR associated with the given node ID.
+    async fn get_enr(&self, node_id: NodeId) -> RpcResult<Enr> {
+        let endpoint = BeaconEndpoint::GetEnr(node_id);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: Enr = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Delete Node ID from the overlay routing table.
+    async fn delete_enr(&self, node_id: NodeId) -> RpcResult<bool> {
+        let endpoint = BeaconEndpoint::DeleteEnr(node_id);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: bool = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Fetch the ENR representation associated with the given Node ID.
+    async fn lookup_enr(&self, node_id: NodeId) -> RpcResult<Enr> {
+        let endpoint = BeaconEndpoint::LookupEnr(node_id);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: Enr = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Send a PING message to the designated node and wait for a PONG response
+    async fn ping(&self, enr: Enr) -> RpcResult<PongInfo> {
+        let endpoint = BeaconEndpoint::Ping(enr);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: PongInfo = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Send a FINDNODES request for nodes that fall within the given set of distances, to the designated
+    /// peer and wait for a response
+    async fn find_nodes(&self, enr: Enr, distances: Vec<u16>) -> RpcResult<FindNodesInfo> {
+        let endpoint = BeaconEndpoint::FindNodes(enr, distances);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: FindNodesInfo = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Lookup a target node within in the network
+    async fn recursive_find_nodes(&self, node_id: NodeId) -> RpcResult<Vec<Enr>> {
+        let endpoint = BeaconEndpoint::RecursiveFindNodes(node_id);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: Vec<Enr> = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Lookup a target node within in the network
+    async fn radius(&self) -> RpcResult<DataRadius> {
+        let endpoint = BeaconEndpoint::DataRadius;
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: DataRadius = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Send FINDCONTENT message to get the content with a content key.
+    async fn find_content(
+        &self,
+        enr: Enr,
+        content_key: BeaconContentKey,
+    ) -> RpcResult<ContentInfo> {
+        let endpoint = BeaconEndpoint::FindContent(enr, content_key);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: ContentInfo = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Lookup a target content key in the network
+    async fn recursive_find_content(
+        &self,
+        content_key: BeaconContentKey,
+    ) -> RpcResult<PossibleBeaconContentValue> {
+        let endpoint = BeaconEndpoint::RecursiveFindContent(content_key);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        if result == serde_json::Value::String(CONTENT_ABSENT.to_string()) {
+            return Ok(PossibleBeaconContentValue::ContentAbsent);
+        };
+        let result: BeaconContentValue = from_value(result)?;
+        Ok(PossibleBeaconContentValue::ContentPresent(result))
+    }
+
+    /// Lookup a target content key in the network. Return tracing info.
+    async fn trace_recursive_find_content(
+        &self,
+        content_key: BeaconContentKey,
+    ) -> RpcResult<TraceContentInfo> {
+        let endpoint = BeaconEndpoint::TraceRecursiveFindContent(content_key);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let info: TraceContentInfo = from_value(result)?;
+        Ok(info)
+    }
+
+    /// Pagination of local content keys
+    async fn paginate_local_content_keys(
+        &self,
+        offset: u64,
+        limit: u64,
+    ) -> RpcResult<PaginateLocalContentInfo> {
+        let endpoint = BeaconEndpoint::PaginateLocalContentKeys(offset, limit);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: PaginateLocalContentInfo = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Send the provided content to interested peers. Clients may choose to send to some or all peers.
+    /// Return the number of peers that the content was gossiped to.
+    async fn gossip(
+        &self,
+        content_key: BeaconContentKey,
+        content_value: BeaconContentValue,
+    ) -> RpcResult<u32> {
+        let endpoint = BeaconEndpoint::Gossip(content_key, content_value);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: u32 = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Send an OFFER request with given ContentKey, to the designated peer and wait for a response.
+    /// Returns the content keys bitlist upon successful content transmission or empty bitlist receive.
+    async fn offer(
+        &self,
+        enr: Enr,
+        content_key: BeaconContentKey,
+        content_value: Option<BeaconContentValue>,
+    ) -> RpcResult<AcceptInfo> {
+        let endpoint = BeaconEndpoint::Offer(enr, content_key, content_value);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: AcceptInfo = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Store content key with a content data to the local database.
+    async fn store(
+        &self,
+        content_key: BeaconContentKey,
+        content_value: BeaconContentValue,
+    ) -> RpcResult<bool> {
+        let endpoint = BeaconEndpoint::Store(content_key, content_value);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: bool = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Get a content from the local database.
+    async fn local_content(
+        &self,
+        content_key: BeaconContentKey,
+    ) -> RpcResult<PossibleBeaconContentValue> {
+        let endpoint = BeaconEndpoint::LocalContent(content_key);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        if result == serde_json::Value::String(CONTENT_ABSENT.to_string()) {
+            return Ok(PossibleBeaconContentValue::ContentAbsent);
+        };
+        let content: BeaconContentValue = from_value(result)?;
+        Ok(PossibleBeaconContentValue::ContentPresent(content))
+    }
+}
+
+impl std::fmt::Debug for BeaconNetworkApi {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BeaconNetworkApi").finish_non_exhaustive()
+    }
+}

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::unwrap_used)]
 
+mod beacon_rpc;
 mod discv5_rpc;
 mod history_rpc;
 mod server_rpc;

--- a/trin-types/src/jsonrpc/endpoints.rs
+++ b/trin-types/src/jsonrpc/endpoints.rs
@@ -67,14 +67,22 @@ pub enum HistoryEndpoint {
 /// Beacon network JSON-RPC endpoints. Start with "portal_beacon" prefix
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum BeaconEndpoint {
+    /// params: enr
+    AddEnr(Enr),
     /// params: None
     DataRadius,
+    /// params: node_id
+    DeleteEnr(NodeId),
     /// params: [enr, content_key]
     FindContent(Enr, BeaconContentKey),
     /// params: [enr, distances]
     FindNodes(Enr, Vec<u16>),
+    /// params: node_id
+    GetEnr(NodeId),
     /// params: content_key
     LocalContent(BeaconContentKey),
+    /// params: node_id
+    LookupEnr(NodeId),
     /// params: [content_key, content_value]
     Gossip(BeaconContentKey, BeaconContentValue),
     /// params: [enr, content_key]


### PR DESCRIPTION
### What was wrong?
No Beacon network json-rpc endpoints were implemented.

### How was it fixed?
Implement Beacon network RPC endpoints.

**Note**: The RPC server is still not running those endpoints, because some additional refactoring is needed on the server side which will follow in a separate PR. Then we can also add tests for those endpoints and refactor the duplication in the history and beacon crates.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
