### PR TITLE
remove json-rpc from ``trin-cli``

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6879,6 +6879,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "trin-beacon",
  "trin-bridge",
  "trin-history",
  "trin-state",

--- a/newsfragments/737.fixed.md
+++ b/newsfragments/737.fixed.md
@@ -1,0 +1,1 @@
+### Remove json-rpc from ``trin-cli``

--- a/trin-cli/src/main.rs
+++ b/trin-cli/src/main.rs
@@ -1,20 +1,10 @@
 pub mod dashboard;
 use clap::{Args, Parser, Subcommand};
 
-#[cfg(unix)]
-use std::os::unix::net::UnixStream;
-#[cfg(windows)]
-use uds_windows::UnixStream;
-
-use std::path::{Path, PathBuf};
-
 use ethereum_types::H256;
-use serde_json::value::RawValue;
-use thiserror::Error;
 
 use dashboard::grafana::{GrafanaAPI, DASHBOARD_TEMPLATES};
 use ethportal_api::{BlockBodyKey, BlockHeaderKey, BlockReceiptsKey, HistoryContentKey};
-use trin_types::cli::DEFAULT_WEB3_IPC_PATH;
 use trin_utils::bytes::hex_encode;
 
 #[derive(Parser, Debug, PartialEq)]
@@ -25,26 +15,9 @@ use trin_utils::bytes::hex_encode;
     about = "Portal Network command line utilities"
 )]
 enum Trin {
-    JsonRpc(JsonRpc),
     #[command(subcommand)]
     EncodeKey(EncodeKey),
     CreateDashboard(DashboardConfig),
-}
-
-#[derive(Args, Debug, PartialEq)]
-#[command(name = "json-rpc", about = "Run JSON-RPC commands against a trin node")]
-struct JsonRpc {
-    /// IPC path of target JSON-RPC endpoint.
-    #[arg(default_value = DEFAULT_WEB3_IPC_PATH, long)]
-    ipc: PathBuf,
-
-    /// JSON-RPC method (e.g. discv5_routingTableInfo).
-    #[arg(required = true)]
-    endpoint: String,
-
-    /// Comma-separated list of JSON-RPC parameters.
-    #[arg(long, value_delimiter = ',')]
-    params: Option<Vec<String>>,
 }
 
 // TODO: Remove clippy allow once a variant with non-"Block" prefix is added.
@@ -91,30 +64,9 @@ struct DashboardConfig {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     match Trin::parse() {
-        Trin::JsonRpc(rpc) => json_rpc(rpc),
         Trin::EncodeKey(content_key) => encode_content_key(content_key),
         Trin::CreateDashboard(dashboard_config) => create_dashboard(dashboard_config),
     }
-}
-
-fn json_rpc(rpc: JsonRpc) -> Result<(), Box<dyn std::error::Error>> {
-    let params: Option<Vec<Box<RawValue>>> = rpc
-        .params
-        .map(|param| param.into_iter().map(jsonrpc::arg).collect());
-    eprintln!(
-        "Attempting RPC. endpoint={} params={:?} file={}",
-        rpc.endpoint,
-        params,
-        rpc.ipc.to_string_lossy()
-    );
-    let mut client = TrinClient::from_ipc(&rpc.ipc)?;
-
-    let req = client.build_request(rpc.endpoint.as_str(), &params);
-    let resp = client.make_request(req)?;
-
-    println!("{}", serde_json::to_string_pretty(&resp).unwrap());
-
-    Ok(())
 }
 
 fn encode_content_key(content_key: EncodeKey) -> Result<(), Box<dyn std::error::Error>> {
@@ -161,136 +113,10 @@ fn create_dashboard(dashboard_config: DashboardConfig) -> Result<(), Box<dyn std
     Ok(())
 }
 
-fn build_request<'a>(
-    method: &'a str,
-    raw_params: &'a Option<Vec<Box<RawValue>>>,
-    request_id: u64,
-) -> jsonrpc::Request<'a> {
-    match raw_params {
-        Some(val) => jsonrpc::Request {
-            method,
-            params: val,
-            id: serde_json::json!(request_id),
-            jsonrpc: Some("2.0"),
-        },
-        None => jsonrpc::Request {
-            method,
-            params: &[],
-            id: serde_json::json!(request_id),
-            jsonrpc: Some("2.0"),
-        },
-    }
-}
-
-pub trait TryClone {
-    fn try_clone(&self) -> std::io::Result<Self>
-    where
-        Self: Sized;
-}
-
-impl TryClone for UnixStream {
-    fn try_clone(&self) -> std::io::Result<Self> {
-        UnixStream::try_clone(self)
-    }
-}
-
-pub struct TrinClient<S>
-where
-    S: std::io::Read + std::io::Write + TryClone,
-{
-    stream: S,
-    request_id: u64,
-}
-
-impl TrinClient<UnixStream> {
-    fn from_ipc(path: &Path) -> std::io::Result<Self> {
-        // TODO: a nice error if this file does not exist
-        Ok(Self {
-            stream: UnixStream::connect(path)?,
-            request_id: 0,
-        })
-    }
-}
-
-#[derive(Error, Debug)]
-pub enum JsonRpcError {
-    #[error("Received malformed response: {0}")]
-    Malformed(serde_json::Error),
-
-    #[error("Received empty response")]
-    Empty,
-}
-
-// TryClone is used because JSON-RPC responses are not followed by EOF. We must read bytes
-// from the stream until a complete object is detected, and the simplest way of doing that
-// with available APIs is to give ownership of a Read to a serde_json::Deserializer. If we
-// gave it exclusive ownership that would require us to open a new connection for every
-// command we wanted to send! By making a clone (or, by trying to) we can have our cake
-// and eat it too.
-//
-// TryClone is not necessary if TrinClient stays in this file forever; this script only
-// needs to make a single request before it exits. However, in a future where TrinClient
-// becomes the mechanism other parts of the codebase (such as peertester) use to act as
-// JSON-RPC clients then this becomes necessary. So, this is slightly over-engineered but
-// with an eye to future growth.
-impl<'a, S> TrinClient<S>
-where
-    S: std::io::Read + std::io::Write + TryClone,
-{
-    fn build_request(
-        &mut self,
-        method: &'a str,
-        params: &'a Option<Vec<Box<RawValue>>>,
-    ) -> jsonrpc::Request<'a> {
-        let result = build_request(method, params, self.request_id);
-        self.request_id += 1;
-
-        result
-    }
-
-    fn make_request(&mut self, req: jsonrpc::Request) -> Result<serde_json::Value, JsonRpcError> {
-        let data = serde_json::to_vec(&req).unwrap();
-
-        self.stream.write_all(&data).unwrap();
-        self.stream.flush().unwrap();
-
-        let clone = self.stream.try_clone().unwrap();
-        let deser = serde_json::Deserializer::from_reader(clone);
-
-        if let Some(obj) = deser.into_iter::<serde_json::Value>().next() {
-            return obj.map_err(JsonRpcError::Malformed);
-        }
-
-        // this should only happen when they immediately send EOF
-        Err(JsonRpcError::Empty)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::str::FromStr;
-
-    #[test]
-    fn test_trin_with_json_rpc() {
-        let trin = Trin::parse_from([
-            "test",
-            "json-rpc",
-            "--ipc",
-            "/tmp/trin.ipc",
-            "--params",
-            "p1,p2",
-            "discv5_routingTableInfo",
-        ]);
-        assert_eq!(
-            trin,
-            Trin::JsonRpc(JsonRpc {
-                ipc: PathBuf::from("/tmp/trin.ipc"),
-                endpoint: "discv5_routingTableInfo".to_string(),
-                params: Some(vec!["p1".to_string(), "p2".to_string()]),
-            })
-        );
-    }
 
     #[test]
     fn test_trin_with_encode_key() {


### PR DESCRIPTION
### What was wrong?
https://github.com/ethereum/trin/issues/573 (``trin-cli`` removal as talked about in the meeting 5/11/2023)
### How was it fixed?
removed json-rpc from ``trin-cli``