### PR TITLE
remove EncodeKey from ``trin-cli``

### DIFF
--- a/newsfragments/738.fixed.md
+++ b/newsfragments/738.fixed.md
@@ -1,0 +1,1 @@
+### Remove enocdekey from ``trin-cli``

--- a/trin-cli/src/main.rs
+++ b/trin-cli/src/main.rs
@@ -1,11 +1,7 @@
 pub mod dashboard;
-use clap::{Args, Parser, Subcommand};
-
-use ethereum_types::H256;
+use clap::{Args, Parser};
 
 use dashboard::grafana::{GrafanaAPI, DASHBOARD_TEMPLATES};
-use ethportal_api::{BlockBodyKey, BlockHeaderKey, BlockReceiptsKey, HistoryContentKey};
-use trin_utils::bytes::hex_encode;
 
 #[derive(Parser, Debug, PartialEq)]
 #[command(
@@ -15,34 +11,7 @@ use trin_utils::bytes::hex_encode;
     about = "Portal Network command line utilities"
 )]
 enum Trin {
-    #[command(subcommand)]
-    EncodeKey(EncodeKey),
     CreateDashboard(DashboardConfig),
-}
-
-// TODO: Remove clippy allow once a variant with non-"Block" prefix is added.
-/// Encode a content key.
-#[derive(Subcommand, Debug, PartialEq)]
-#[allow(clippy::enum_variant_names)]
-enum EncodeKey {
-    /// Encode the content key for a block header.
-    BlockHeader {
-        /// Hex-encoded block hash (omit '0x' prefix).
-        #[arg(long)]
-        block_hash: H256,
-    },
-    /// Encode the content key for a block body.
-    BlockBody {
-        /// Hex-encoded block hash (omit '0x' prefix).
-        #[arg(long)]
-        block_hash: H256,
-    },
-    /// Encode the content key for a block's transaction receipts.
-    BlockReceipts {
-        /// Hex-encoded block hash (omit '0x' prefix).
-        #[arg(long)]
-        block_hash: H256,
-    },
 }
 
 #[derive(Args, Debug, PartialEq)]
@@ -64,31 +33,8 @@ struct DashboardConfig {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     match Trin::parse() {
-        Trin::EncodeKey(content_key) => encode_content_key(content_key),
         Trin::CreateDashboard(dashboard_config) => create_dashboard(dashboard_config),
     }
-}
-
-fn encode_content_key(content_key: EncodeKey) -> Result<(), Box<dyn std::error::Error>> {
-    let key = match content_key {
-        EncodeKey::BlockHeader { block_hash } => {
-            HistoryContentKey::BlockHeaderWithProof(BlockHeaderKey {
-                block_hash: block_hash.into(),
-            })
-        }
-        EncodeKey::BlockBody { block_hash } => HistoryContentKey::BlockBody(BlockBodyKey {
-            block_hash: block_hash.into(),
-        }),
-        EncodeKey::BlockReceipts { block_hash } => {
-            HistoryContentKey::BlockReceipts(BlockReceiptsKey {
-                block_hash: block_hash.into(),
-            })
-        }
-    };
-
-    println!("{}", hex_encode(Into::<Vec<u8>>::into(key)));
-
-    Ok(())
 }
 
 fn create_dashboard(dashboard_config: DashboardConfig) -> Result<(), Box<dyn std::error::Error>> {
@@ -116,54 +62,6 @@ fn create_dashboard(dashboard_config: DashboardConfig) -> Result<(), Box<dyn std
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::FromStr;
-
-    #[test]
-    fn test_trin_with_encode_key() {
-        const BLOCK_HASH: &str =
-            "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
-        let trin = Trin::parse_from([
-            "test",
-            "encode-key",
-            "block-header",
-            "--block-hash",
-            BLOCK_HASH,
-        ]);
-        assert_eq!(
-            trin,
-            Trin::EncodeKey(EncodeKey::BlockHeader {
-                block_hash: H256::from_str(BLOCK_HASH).unwrap()
-            })
-        );
-
-        let trin = Trin::parse_from([
-            "test",
-            "encode-key",
-            "block-body",
-            "--block-hash",
-            BLOCK_HASH,
-        ]);
-        assert_eq!(
-            trin,
-            Trin::EncodeKey(EncodeKey::BlockBody {
-                block_hash: H256::from_str(BLOCK_HASH).unwrap()
-            })
-        );
-
-        let trin = Trin::parse_from([
-            "test",
-            "encode-key",
-            "block-receipts",
-            "--block-hash",
-            BLOCK_HASH,
-        ]);
-        assert_eq!(
-            trin,
-            Trin::EncodeKey(EncodeKey::BlockReceipts {
-                block_hash: H256::from_str(BLOCK_HASH).unwrap()
-            })
-        );
-    }
 
     #[test]
     fn test_trin_with_create_dashboard() {


### PR DESCRIPTION
### What was wrong?
in call on 5/11/2023 we talked about removing this with the cli
### How was it fixed?
by removing it
