### PR TITLE
Remove unused sort and take 16 from recursive_find_nodes

### DIFF
--- a/newsfragments/743.fixed.md
+++ b/newsfragments/743.fixed.md
@@ -1,0 +1,1 @@
+Remove redundant code from the `recursive_find_nodes` API

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -7,10 +7,7 @@ use ethportal_api::types::jsonrpc::endpoints::BeaconEndpoint;
 use ethportal_api::types::jsonrpc::request::BeaconJsonRpcRequest;
 use ethportal_api::types::portal::{AcceptInfo, FindNodesInfo, PongInfo, TraceContentInfo};
 use ethportal_api::types::{
-    constants::CONTENT_ABSENT,
-    content_key::RawContentKey,
-    enr::Enr,
-    query_trace::QueryTrace,
+    constants::CONTENT_ABSENT, content_key::RawContentKey, query_trace::QueryTrace,
 };
 use ethportal_api::utils::bytes::hex_encode;
 use portalnet::storage::ContentStore;
@@ -338,6 +335,5 @@ async fn recursive_find_nodes(
     let node_id = discv5::enr::NodeId::from(node_id.0);
     let overlay = network.read().await.overlay.clone();
     let nodes = overlay.lookup_node(node_id).await;
-    let nodes: Vec<Enr> = nodes.into_iter().take(16).collect();
     Ok(json!(nodes))
 }

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -9,7 +9,6 @@ use ethportal_api::types::portal::{AcceptInfo, FindNodesInfo, PongInfo, TraceCon
 use ethportal_api::types::{
     constants::CONTENT_ABSENT,
     content_key::RawContentKey,
-    distance::{Metric, XorMetric},
     enr::Enr,
     query_trace::QueryTrace,
 };
@@ -338,11 +337,7 @@ async fn recursive_find_nodes(
 ) -> Result<Value, String> {
     let node_id = discv5::enr::NodeId::from(node_id.0);
     let overlay = network.read().await.overlay.clone();
-    let mut nodes = overlay.lookup_node(node_id).await;
-    nodes.sort_by(|a, b| {
-        XorMetric::distance(&node_id.raw(), &a.node_id().raw())
-            .cmp(&XorMetric::distance(&node_id.raw(), &b.node_id().raw()))
-    });
+    let nodes = overlay.lookup_node(node_id).await;
     let nodes: Vec<Enr> = nodes.into_iter().take(16).collect();
     Ok(json!(nodes))
 }

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -4,7 +4,6 @@ use discv5::enr::NodeId;
 use ethportal_api::types::{
     constants::CONTENT_ABSENT,
     content_key::RawContentKey,
-    distance::{Metric, XorMetric},
     enr::Enr,
     jsonrpc::endpoints::HistoryEndpoint,
     jsonrpc::request::HistoryJsonRpcRequest,
@@ -344,11 +343,7 @@ async fn recursive_find_nodes(
 ) -> Result<Value, String> {
     let node_id = discv5::enr::NodeId::from(node_id.0);
     let overlay = network.read().await.overlay.clone();
-    let mut nodes = overlay.lookup_node(node_id).await;
-    nodes.sort_by(|a, b| {
-        XorMetric::distance(&node_id.raw(), &a.node_id().raw())
-            .cmp(&XorMetric::distance(&node_id.raw(), &b.node_id().raw()))
-    });
+    let nodes = overlay.lookup_node(node_id).await;
     let nodes: Vec<Enr> = nodes.into_iter().take(16).collect();
     Ok(json!(nodes))
 }

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -2,12 +2,8 @@ use std::sync::Arc;
 
 use discv5::enr::NodeId;
 use ethportal_api::types::{
-    constants::CONTENT_ABSENT,
-    content_key::RawContentKey,
-    enr::Enr,
-    jsonrpc::endpoints::HistoryEndpoint,
-    jsonrpc::request::HistoryJsonRpcRequest,
-    query_trace::QueryTrace,
+    constants::CONTENT_ABSENT, content_key::RawContentKey, jsonrpc::endpoints::HistoryEndpoint,
+    jsonrpc::request::HistoryJsonRpcRequest, query_trace::QueryTrace,
 };
 use ethportal_api::utils::bytes::hex_encode;
 use ethportal_api::{
@@ -344,6 +340,5 @@ async fn recursive_find_nodes(
     let node_id = discv5::enr::NodeId::from(node_id.0);
     let overlay = network.read().await.overlay.clone();
     let nodes = overlay.lookup_node(node_id).await;
-    let nodes: Vec<Enr> = nodes.into_iter().take(16).collect();
     Ok(json!(nodes))
 }


### PR DESCRIPTION
### What was wrong?
```
/// Constructs a JSON call for the RecursiveFindNodes method.
async fn recursive_find_nodes(
    network: Arc<RwLock<HistoryNetwork>>,
    node_id: ethportal_api::NodeId,
) -> Result<Value, String> {
    let node_id = discv5::enr::NodeId::from(node_id.0);
    let overlay = network.read().await.overlay.clone();
    let mut nodes = overlay.lookup_node(node_id).await;
    nodes.sort_by(|a, b| {
        XorMetric::distance(&node_id.raw(), &a.node_id().raw())
            .cmp(&XorMetric::distance(&node_id.raw(), &b.node_id().raw()))
    });
    let nodes: Vec<Enr> = nodes.into_iter().take(16).collect();
    Ok(json!(nodes))
}
```


```
    nodes.sort_by(|a, b| {
        XorMetric::distance(&node_id.raw(), &a.node_id().raw())
            .cmp(&XorMetric::distance(&node_id.raw(), &b.node_id().raw()))
    });
    let nodes: Vec<Enr> = nodes.into_iter().take(16).collect();
```


^ this part of the code does nothing because this work is already done lower in the chain.
https://hackmd.io/@ZaEk4HVeTgieC1VFF87xDA/Hy-KPQgB3 here is me running the command over 20 times (I got the result before this sort happened). This is just me testing proof.

I will now show code proof
https://github.com/ethereum/trin/blob/c20ee54897094293adf9297e031ab9b41985f22f/portalnet/src/find/iterators/findnodes.rs#L46
The data structure we get the list from is a BTreeMap ordered by increasing distance

For take 16 we do that in this function
https://github.com/ethereum/trin/blob/c20ee54897094293adf9297e031ab9b41985f22f/portalnet/src/find/iterators/findnodes.rs#L252
### How was it fixed?
removed the 2 redundant lines of code
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
