### PR TITLE
Remove trin-types from dockerfiles

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,6 @@ COPY ./trin-bridge ./trin-bridge
 COPY ./trin-cli ./trin-cli
 COPY ./trin-history ./trin-history 
 COPY ./trin-state ./trin-state 
-COPY ./trin-types ./trin-types
 COPY ./trin-utils ./trin-utils 
 COPY ./trin-validation ./trin-validation 
 COPY ./utp-testing ./utp-testing

--- a/docker/Dockerfile.bridge
+++ b/docker/Dockerfile.bridge
@@ -23,7 +23,6 @@ COPY ./trin-bridge ./trin-bridge
 COPY ./trin-cli ./trin-cli
 COPY ./trin-history ./trin-history 
 COPY ./trin-state ./trin-state 
-COPY ./trin-types ./trin-types
 COPY ./trin-utils ./trin-utils
 COPY ./trin-validation ./trin-validation
 COPY ./ethportal-peertest ./ethportal-peertest 


### PR DESCRIPTION
### What was wrong?
Dockerfile builds on master are broken post #723 

### How was it fixed?
Remove `trin-types` references from dockerfiles

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
