### PR TITLE
Fix tracing subscriber init to support env log levels

### DIFF
--- a/trin-utils/Cargo.toml
+++ b/trin-utils/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 build = "build.rs"
 
 [dependencies]
-tracing-subscriber = "0.3.15"
+tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 
 [target.'cfg(windows)'.dependencies]
 # The crates for detecting whether the terminal supports colors are OS-specific.

--- a/trin-utils/src/log.rs
+++ b/trin-utils/src/log.rs
@@ -1,5 +1,8 @@
+use tracing_subscriber::EnvFilter;
+
 pub fn init_tracing_logger() {
     tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
         .with_ansi(detect_ansi_support())
         .init();
 }


### PR DESCRIPTION
### What was wrong?
Fixes #734 

### How was it fixed?
Added explicit support for env-set log levels, which isn't supported when calling `.init()` as opposed to `::init()`.
https://github.com/tokio-rs/tracing/issues/1697#issuecomment-1003513224

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
