### PR TITLE
CLI parsing return clap:Error instead of panicking

### DIFF
--- a/newsfragments/748.fixed.md
+++ b/newsfragments/748.fixed.md
@@ -1,0 +1,1 @@
+CLI parsing return clap:Error instead of panicking


### PR DESCRIPTION
### What was wrong?
fix's https://github.com/ethereum/trin/issues/618
### How was it fixed?
i replaced the panics in CLI with clap::Error
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
