### PR TITLE
Simplify state network distance code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4099,20 +4099,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4124,44 +4110,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg 1.1.0",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg 1.1.0",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-dependencies = [
- "autocfg 1.1.0",
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
@@ -6973,7 +6927,6 @@ dependencies = [
  "eth_trie",
  "ethereum-types 0.12.1",
  "ethportal-api",
- "num",
  "parking_lot 0.11.2",
  "portalnet",
  "rocksdb",

--- a/newsfragments/749.fixed.md
+++ b/newsfragments/749.fixed.md
@@ -1,0 +1,1 @@
+Simplify state network distance code

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -17,7 +17,6 @@ discv5 = { version = "0.2.1", features = ["serde"]}
 ethereum-types = "0.12.1"
 ethportal-api = { path = "../ethportal-api" }
 eth_trie = "0.1.0"
-num = "0.4.0"
 parking_lot = "0.11.2"
 portalnet = { path = "../portalnet" }
 rocksdb = "0.18.0"

--- a/trin-state/src/utils.rs
+++ b/trin-state/src/utils.rs
@@ -1,72 +1,22 @@
 use ethereum_types::U256;
-use num::{
-    bigint::{BigInt, Sign},
-    Signed,
-};
-
-// 2 ** 256
-const MODULO: [u8; 78] = [
-    49, 49, 53, 55, 57, 50, 48, 56, 57, 50, 51, 55, 51, 49, 54, 49, 57, 53, 52, 50, 51, 53, 55, 48,
-    57, 56, 53, 48, 48, 56, 54, 56, 55, 57, 48, 55, 56, 53, 51, 50, 54, 57, 57, 56, 52, 54, 54, 53,
-    54, 52, 48, 53, 54, 52, 48, 51, 57, 52, 53, 55, 53, 56, 52, 48, 48, 55, 57, 49, 51, 49, 50, 57,
-    54, 51, 57, 57, 51, 54,
-];
-
-// 2 ** 255
-const MID: [u8; 77] = [
-    53, 55, 56, 57, 54, 48, 52, 52, 54, 49, 56, 54, 53, 56, 48, 57, 55, 55, 49, 49, 55, 56, 53, 52,
-    57, 50, 53, 48, 52, 51, 52, 51, 57, 53, 51, 57, 50, 54, 54, 51, 52, 57, 57, 50, 51, 51, 50, 56,
-    50, 48, 50, 56, 50, 48, 49, 57, 55, 50, 56, 55, 57, 50, 48, 48, 51, 57, 53, 54, 53, 54, 52, 56,
-    49, 57, 57, 54, 56,
-];
-
-trait FromU256 {
-    fn from_u256(n: U256) -> Self;
-}
-
-impl FromU256 for BigInt {
-    fn from_u256(n: U256) -> Self {
-        let mut bytes: [u8; 32] = [0u8; 32];
-        n.to_little_endian(&mut bytes);
-        BigInt::from_bytes_le(Sign::Plus, &bytes)
-    }
-}
-
-trait ToU256 {
-    fn to_u256(&self) -> Result<U256, String>;
-}
-
-impl ToU256 for BigInt {
-    fn to_u256(&self) -> Result<U256, String> {
-        let (sign, bytes) = self.to_bytes_be();
-        match sign {
-            Sign::Plus => Ok(U256::from_big_endian(&bytes)),
-            Sign::Minus => Err("Cannot convert negative BigInt to unsigned int".to_string()),
-            Sign::NoSign => Ok(U256::from_big_endian(&bytes)),
-        }
-    }
-}
 
 // distance function as defined at...
-// https://notes.ethereum.org/h58LZcqqRRuarxx4etOnGQ#Storage-Layout
-// todo: measure performance & optimize if necessary
-pub fn distance(node_id: U256, content_id: U256) -> Result<U256, String> {
-    let node_id_int = BigInt::from_u256(node_id);
-    let content_id_int = BigInt::from_u256(content_id);
-    let modulo = BigInt::parse_bytes(&MODULO, 10).expect("Parse static MODULO always works");
-    let mid = BigInt::parse_bytes(&MID, 10).expect("Parse static MID always works");
-    let negative_mid = mid
-        .checked_mul(&BigInt::from_bytes_le(Sign::Minus, &[1u8]))
-        .expect("Static multiplication always works");
+// https://github.com/ethereum/portal-network-specs/blob/master/state-network.md
+pub fn distance(node_id: U256, content_id: U256) -> U256 {
+    let diff: U256 = if node_id > content_id {
+        node_id.saturating_sub(content_id)
+    } else {
+        content_id.saturating_sub(node_id)
+    };
 
-    let first_phrase = node_id_int - content_id_int + &mid;
-    // % returns the remainder, we want to return the modulus
-    let modulus_result = ((first_phrase % &modulo) + &modulo) % &modulo;
-    let delta = modulus_result - &mid;
-    match delta < negative_mid {
-        true => (delta + mid).abs().to_u256(),
-        _ => delta.abs().to_u256(),
+    let mid = U256::from(2).pow(U256::from(255));
+    if diff > mid {
+        return U256::max_value()
+            .saturating_sub(diff)
+            .saturating_add(U256::from(1));
     }
+
+    diff
 }
 
 #[cfg(test)]
@@ -75,84 +25,62 @@ mod test {
     use super::*;
     use test_log::test;
 
-    // 2 ** 256 - 1
-    const MOD_SUB_ONE: &str =
-        "115792089237316195423570985008687907853269984665640564039457584007913129639935";
-    // 2 ** 255
-    const MID_DEC_STR: &str =
-        "57896044618658097711785492504343953926634992332820282019728792003956564819968";
-
-    #[test]
-    fn test_number_conversion() {
-        let number = "10";
-        let u_256 = U256::from_dec_str(number).unwrap();
-        let big_int = BigInt::from_u256(u_256);
-        let next = big_int.to_u256().unwrap();
-        assert_eq!(next, u_256)
-    }
-
-    //test cases yanked from: https://notes.ethereum.org/h58LZcqqRRuarxx4etOnGQ
-    #[test]
-    fn test_distance_with_zeros() {
-        let content_id = U256::from_dec_str("10").unwrap();
-        let node_id = U256::from_dec_str("10").unwrap();
-        let expected = U256::from_dec_str("0").unwrap();
-        let calculated_distance = distance(content_id, node_id).unwrap();
-        assert_eq!(calculated_distance, expected);
-    }
-
+    // all 7 of these test cases are from
+    // https://github.com/ethereum/portal-network-specs/blob/master/state-network.md
+    // assert distance(10, 10) == 0
     #[test]
     fn test_distance_one() {
-        let content_id = U256::from_dec_str("5").unwrap();
-        let node_id = U256::from_dec_str("1").unwrap();
-        let expected = U256::from_dec_str("4").unwrap();
-        let calculated_distance = distance(content_id, node_id).unwrap();
-        assert_eq!(calculated_distance, expected);
-        let reversed = distance(node_id, content_id).unwrap();
-        assert_eq!(reversed, expected);
+        let calculated_distance = distance(U256::from(10), U256::from(10));
+        assert_eq!(calculated_distance, U256::from(0))
     }
 
+    // assert distance(5, 2**256 - 1) == 6
     #[test]
     fn test_distance_two() {
-        let content_id = U256::from_dec_str("5").unwrap();
-        let node_id = U256::from_dec_str(MOD_SUB_ONE).unwrap();
-        let expected = U256::from_dec_str("6").unwrap();
-        let calculated_distance = distance(content_id, node_id).unwrap();
-        assert_eq!(calculated_distance, expected);
+        let calculated_distance = distance(U256::from(5), U256::max_value());
+        assert_eq!(calculated_distance, U256::from(6))
     }
 
+    // assert distance(2**256 - 1, 6) == 7
     #[test]
     fn test_distance_three() {
-        let content_id = U256::from_dec_str(MOD_SUB_ONE).unwrap();
-        let node_id = U256::from_dec_str("6").unwrap();
-        let expected = U256::from_dec_str("7").unwrap();
-        let calculated_distance = distance(content_id, node_id).unwrap();
-        assert_eq!(calculated_distance, expected);
+        let calculated_distance = distance(U256::max_value(), U256::from(6));
+        assert_eq!(calculated_distance, U256::from(7))
     }
 
+    // assert distance(5, 1) == 4
     #[test]
     fn test_distance_four() {
-        let content_id = U256::from_dec_str("0").unwrap();
-        let node_id = U256::from_dec_str(MID_DEC_STR).unwrap();
-        let expected = U256::from_dec_str(MID_DEC_STR).unwrap();
-        let calculated_distance = distance(content_id, node_id).unwrap();
-        assert_eq!(calculated_distance, expected);
+        let calculated_distance = distance(U256::from(5), U256::from(1));
+        assert_eq!(calculated_distance, U256::from(4))
     }
 
+    // assert distance(1, 5) == 4
     #[test]
     fn test_distance_five() {
-        let content_id = U256::from_dec_str("0").unwrap();
-        // 2 ** 255 + 1
-        let node_id = U256::from_dec_str(
-            "57896044618658097711785492504343953926634992332820282019728792003956564819969",
+        let calculated_distance = distance(U256::from(1), U256::from(5));
+        assert_eq!(calculated_distance, U256::from(4))
+    }
+
+    // assert distance(0, 2**255) == 2**255
+    #[test]
+    fn test_distance_six() {
+        let calculated_2_power_255 = U256::from(2).pow(U256::from(255));
+        let calculated_distance = distance(U256::from(0), calculated_2_power_255);
+        assert_eq!(calculated_distance, calculated_2_power_255)
+    }
+
+    // assert distance(0, 2**255 + 1) == 2**255 - 1
+    #[test]
+    fn test_distance_seven() {
+        let calculated_2_power_255 = U256::from(2).pow(U256::from(255));
+        let calculated_distance = distance(
+            U256::from(0),
+            calculated_2_power_255.saturating_add(U256::from(1)),
+        );
+        assert_eq!(
+            calculated_distance,
+            calculated_2_power_255.saturating_sub(U256::from(1))
         )
-        .unwrap();
-        // 2 ** 255 - 1
-        let expected = U256::from_dec_str(
-            "57896044618658097711785492504343953926634992332820282019728792003956564819967",
-        )
-        .unwrap();
-        let calculated_distance = distance(content_id, node_id).unwrap();
-        assert_eq!(calculated_distance, expected);
     }
 }


### PR DESCRIPTION
### What was wrong?
The distance function code for the state network was undated and hard to read.
### How was it fixed?
It was fixed by simplifying the way we do the calculation instead of using the nums library we natively use U256 to do the calcluation.

The result of this in much more readable code, as well as the code resembling the spec's implementation which increases readability

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
