### PR TITLE
Update default ws port to avoid collisions when running multiple nodes

### DIFF
--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -11,7 +11,6 @@ pub const DEFAULT_MASTER_ACC_PATH: &str = "validation_assets/merge_macc.bin";
 pub const DEFAULT_WEB3_IPC_PATH: &str = "/tmp/trin-jsonrpc.ipc";
 pub const DEFAULT_WEB3_HTTP_ADDRESS: &str = "http://127.0.0.1:8545/";
 pub const DEFAULT_WEB3_HTTP_PORT: u16 = 8545;
-pub const DEFAULT_WEB3_WS_PORT: u16 = 8546;
 const DEFAULT_DISCOVERY_PORT: &str = "9000";
 pub const BEACON_NETWORK: &str = "beacon";
 pub const HISTORY_NETWORK: &str = "history";

--- a/newsfragments/757.fixed.md
+++ b/newsfragments/757.fixed.md
@@ -1,0 +1,1 @@
+Updated ws config to avoid port collision when using multiple nodes.

--- a/rpc/src/rpc_server.rs
+++ b/rpc/src/rpc_server.rs
@@ -6,9 +6,7 @@ use crate::jsonrpsee::server::{IdProvider, Server, ServerBuilder, ServerHandle};
 use crate::jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 use crate::jsonrpsee::RpcModule;
 use crate::{RpcError, TransportRpcModuleConfig};
-use ethportal_api::types::cli::{
-    DEFAULT_WEB3_HTTP_PORT, DEFAULT_WEB3_IPC_PATH, DEFAULT_WEB3_WS_PORT,
-};
+use ethportal_api::types::cli::{DEFAULT_WEB3_HTTP_PORT, DEFAULT_WEB3_IPC_PATH};
 use reth_ipc::server::Builder as IpcServerBuilder;
 use reth_ipc::server::{Endpoint, IpcServer};
 use std::fmt;
@@ -375,10 +373,13 @@ impl RpcServerConfig {
             ))
         });
 
-        let ws_socket_addr = self.ws_addr.unwrap_or(SocketAddr::V4(SocketAddrV4::new(
-            Ipv4Addr::UNSPECIFIED,
-            DEFAULT_WEB3_WS_PORT,
-        )));
+        // by default, we configure ws on the same port as http
+        let ws_socket_addr = self.ws_addr.unwrap_or_else(|| {
+            SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::UNSPECIFIED,
+                http_socket_addr.port(),
+            ))
+        });
 
         // If both are configured on the same port, we combine them into one server.
         if self.http_addr == self.ws_addr

--- a/trin-beacon/src/events.rs
+++ b/trin-beacon/src/events.rs
@@ -16,6 +16,9 @@ impl BeaconEvents {
             tokio::select! {
                 Some(talk_request) = self.event_rx.recv() => {
                     self.handle_beacon_talk_request(talk_request);
+                } else => {
+                    error!("Beacon event channel closed, shutting down");
+                    break;
                 }
             }
         }

--- a/trin-history/src/events.rs
+++ b/trin-history/src/events.rs
@@ -16,6 +16,9 @@ impl HistoryEvents {
             tokio::select! {
                 Some(talk_request) = self.event_rx.recv() => {
                     self.handle_history_talk_request(talk_request);
+                } else => {
+                    error!("History event channel closed, shutting down");
+                    break;
                 }
             }
         }

--- a/trin-state/src/events.rs
+++ b/trin-state/src/events.rs
@@ -16,6 +16,9 @@ impl StateEvents {
             tokio::select! {
                 Some(talk_request) = self.event_rx.recv() => {
                     self.handle_state_talk_request(talk_request);
+                } else => {
+                    error!("State event channel closed, shutting down");
+                    break;
                 }
             }
         }


### PR DESCRIPTION
### What was wrong?
#742 introduced support for websockets. When running trin-bridge with multiple nodes running at once, we end up with a panic resulting from a port collision. Since, the websocket port is set by default, spinning up multiple nodes at the same time results in multiple nodes trying to open a ws connection on the same port. This causes the events channel to close, and results in a panic.

A long-term solution would be to enable configuration for custom ws ports via a cli argument.

### How was it fixed?
- Update default ws to use the same port as http
- Handle panics inside a subnetwork events loop

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
