### PR TITLE
Add `network` cli flag to trin-bridge

### DIFF
--- a/newsfragments/763.added.md
+++ b/newsfragments/763.added.md
@@ -1,0 +1,1 @@
+Add `network` cli flag to trin-bridge.

--- a/trin-bridge/src/lib.rs
+++ b/trin-bridge/src/lib.rs
@@ -4,6 +4,7 @@ pub mod bridge;
 pub mod cli;
 pub mod constants;
 pub mod full_header;
+pub mod types;
 pub mod utils;
 
 use lazy_static::lazy_static;

--- a/trin-bridge/src/types.rs
+++ b/trin-bridge/src/types.rs
@@ -1,0 +1,33 @@
+use std::fmt;
+use std::str::FromStr;
+
+/// The different subnetworks that can be used to run the bridge
+#[derive(Debug, PartialEq, Clone)]
+pub enum NetworkKind {
+    Beacon,
+    History,
+    State,
+}
+
+impl fmt::Display for NetworkKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Beacon => write!(f, "beacon"),
+            Self::History => write!(f, "history"),
+            Self::State => write!(f, "state"),
+        }
+    }
+}
+
+impl FromStr for NetworkKind {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "beacon" => Ok(NetworkKind::Beacon),
+            "history" => Ok(NetworkKind::History),
+            "state" => Ok(NetworkKind::State),
+            _ => Err("Invalid network arg. Expected either 'beacon', 'history' or 'state'"),
+        }
+    }
+}


### PR DESCRIPTION
### What was wrong?
No support for running a bridge node with more than one overlay network.

### How was it fixed?
Add 'network' cli flag to trin-bridge

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
