### PR TITLE
Use default utp connection config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4689,6 +4689,7 @@ dependencies = [
  "ethportal-api",
  "fnv",
  "futures 0.3.28",
+ "lazy_static",
  "leb128",
  "lru",
  "parking_lot 0.11.2",

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -25,6 +25,7 @@ ethereum-types = "0.12.1"
 ethportal-api = { path="../ethportal-api" }
 fnv = "1.0.7"
 futures = "0.3.21"
+lazy_static = "1.4.0"
 leb128 = "0.2.1"
 lru = "0.7.8"
 parking_lot = "0.11.2"

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -18,7 +18,6 @@ use std::{
 };
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, error, info, warn};
-use utp_rs::conn::ConnectionConfig;
 use utp_rs::socket::UtpSocket;
 
 use crate::{
@@ -26,6 +25,7 @@ use crate::{
     metrics::{MessageDirectionLabel, MessageLabel, OverlayMetrics, ProtocolLabel},
     overlay_service::{
         OverlayCommand, OverlayRequest, OverlayRequestError, OverlayService, RequestDirection,
+        UTP_CONN_CFG,
     },
     storage::ContentStore,
     types::{
@@ -478,7 +478,7 @@ where
         };
         let mut stream = self
             .utp_socket
-            .connect_with_cid(cid, ConnectionConfig::default())
+            .connect_with_cid(cid, *UTP_CONN_CFG)
             .await
             .map_err(|err| OverlayRequestError::UtpError(format!("{err:?}")))?;
         let mut data = vec![];

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -18,6 +18,7 @@ use std::{
 };
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, error, info, warn};
+use utp_rs::conn::ConnectionConfig;
 use utp_rs::socket::UtpSocket;
 
 use crate::{
@@ -25,7 +26,6 @@ use crate::{
     metrics::{MessageDirectionLabel, MessageLabel, OverlayMetrics, ProtocolLabel},
     overlay_service::{
         OverlayCommand, OverlayRequest, OverlayRequestError, OverlayService, RequestDirection,
-        UTP_CONN_CFG,
     },
     storage::ContentStore,
     types::{
@@ -478,7 +478,7 @@ where
         };
         let mut stream = self
             .utp_socket
-            .connect_with_cid(cid, UTP_CONN_CFG)
+            .connect_with_cid(cid, ConnectionConfig::default())
             .await
             .map_err(|err| OverlayRequestError::UtpError(format!("{err:?}")))?;
         let mut data = vec![];

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -77,17 +77,6 @@ const EXPECTED_NON_EMPTY_BUCKETS: usize = 17;
 /// Bucket refresh lookup interval in seconds
 const BUCKET_REFRESH_INTERVAL_SECS: u64 = 60;
 
-/// The default configuration to use for uTP connections.
-pub const UTP_CONN_CFG: ConnectionConfig = ConnectionConfig {
-    max_packet_size: 1024,
-    max_conn_attempts: 3,
-    max_idle_timeout: Duration::from_secs(32),
-    max_timeout: Duration::from_secs(60),
-    initial_timeout: Duration::from_millis(1500),
-    min_timeout: Duration::from_millis(500),
-    target_delay: Duration::from_millis(250),
-};
-
 /// A network-based action that the overlay may perform.
 ///
 /// The overlay performs network-based actions on behalf of the command issuer. The issuer may be
@@ -978,7 +967,9 @@ where
                     // over the uTP stream.
                     let utp = Arc::clone(&self.utp_socket);
                     tokio::spawn(async move {
-                        let mut stream = match utp.accept_with_cid(cid.clone(), UTP_CONN_CFG).await
+                        let mut stream = match utp
+                            .accept_with_cid(cid.clone(), ConnectionConfig::default())
+                            .await
                         {
                             Ok(stream) => stream,
                             Err(err) => {
@@ -1111,7 +1102,10 @@ where
         tokio::spawn(async move {
             // Wait for an incoming connection with the given CID. Then, read the data from the uTP
             // stream.
-            let mut stream = match utp.accept_with_cid(cid.clone(), UTP_CONN_CFG).await {
+            let mut stream = match utp
+                .accept_with_cid(cid.clone(), ConnectionConfig::default())
+                .await
+            {
                 Ok(stream) => stream,
                 Err(err) => {
                     warn!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), "unable to accept uTP stream");
@@ -1375,7 +1369,10 @@ where
 
         let utp = Arc::clone(&self.utp_socket);
         tokio::spawn(async move {
-            let mut stream = match utp.connect_with_cid(cid.clone(), UTP_CONN_CFG).await {
+            let mut stream = match utp
+                .connect_with_cid(cid.clone(), ConnectionConfig::default())
+                .await
+            {
                 Ok(stream) => stream,
                 Err(err) => {
                     warn!(

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -13,16 +13,16 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 ethportal-api = { path = "../ethportal-api"}
-portalnet = { path = "../portalnet"}
-tracing = "0.1.27"
-trin-utils = { path = "../trin-utils"}
-tokio = { version = "1.14.0", features = ["full"] }
 hyper = "0.14"
+portalnet = { path = "../portalnet"}
 reth-ipc = { version = "0.1.0", git = "https://github.com/paradigmxyz/reth.git"}
-url = "2.3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.95"
 strum = { version = "0.24.1", features = ["derive"] }
-tower-http = { version = "0.4", features = ["full"] }
-tower = { version = "0.4", features = ["full"] }
 thiserror = "1.0"
+tracing = "0.1.27"
+trin-utils = { path = "../trin-utils"}
+tokio = { version = "1.14.0", features = ["full"] }
+tower = { version = "0.4", features = ["full"] }
+tower-http = { version = "0.4", features = ["full"] }
+url = "2.3.1"


### PR DESCRIPTION
### What was wrong?
Rather than maintaining our own set of config constants, we should defer to the utp crate's default value for `ConnectionConfig`

The initial set of constant values was created in https://github.com/ethereum/trin/pull/551/files#diff-354721dfd15f4b0d0f5df418d0ac4118592bf96bda720655548e380faf9f1b37R77 - without any comment explaining as to why those values were chosen.

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
