### PR TITLE
Do not run WebSocket RPC by default

### DIFF
--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -10,6 +10,7 @@ pub const DEFAULT_MASTER_ACC_PATH: &str = "validation_assets/merge_macc.bin";
 pub const DEFAULT_WEB3_IPC_PATH: &str = "/tmp/trin-jsonrpc.ipc";
 pub const DEFAULT_WEB3_HTTP_ADDRESS: &str = "http://127.0.0.1:8545/";
 pub const DEFAULT_WEB3_HTTP_PORT: u16 = 8545;
+pub const DEFAULT_WEB3_WS_PORT: u16 = 8546;
 const DEFAULT_DISCOVERY_PORT: &str = "9000";
 pub const BEACON_NETWORK: &str = "beacon";
 pub const HISTORY_NETWORK: &str = "history";

--- a/newsfragments/768.changed.md
+++ b/newsfragments/768.changed.md
@@ -1,0 +1,1 @@
+Do not run WebSocket RPC by default.

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -75,10 +75,7 @@ pub async fn launch_jsonrpc_server(
                 .await?
         }
         Web3TransportType::HTTP => {
-            // Run WebSockets support alongside HTTP
-            let transport = TransportRpcModuleConfig::default()
-                .with_http(modules.clone())
-                .with_ws(modules);
+            let transport = TransportRpcModuleConfig::default().with_http(modules);
             let transport_modules = RpcModuleBuilder::new(discv5)
                 .maybe_with_history(history_handler)
                 .maybe_with_beacon(beacon_handler)

--- a/rpc/src/rpc_server.rs
+++ b/rpc/src/rpc_server.rs
@@ -6,7 +6,9 @@ use crate::jsonrpsee::server::{IdProvider, Server, ServerBuilder, ServerHandle};
 use crate::jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 use crate::jsonrpsee::RpcModule;
 use crate::{RpcError, TransportRpcModuleConfig};
-use ethportal_api::types::cli::{DEFAULT_WEB3_HTTP_PORT, DEFAULT_WEB3_IPC_PATH};
+use ethportal_api::types::cli::{
+    DEFAULT_WEB3_HTTP_PORT, DEFAULT_WEB3_IPC_PATH, DEFAULT_WEB3_WS_PORT,
+};
 use reth_ipc::server::Builder as IpcServerBuilder;
 use reth_ipc::server::{Endpoint, IpcServer};
 use std::fmt;
@@ -373,11 +375,10 @@ impl RpcServerConfig {
             ))
         });
 
-        // by default, we configure ws on the same port as http
         let ws_socket_addr = self.ws_addr.unwrap_or_else(|| {
             SocketAddr::V4(SocketAddrV4::new(
                 Ipv4Addr::UNSPECIFIED,
-                http_socket_addr.port(),
+                DEFAULT_WEB3_WS_PORT,
             ))
         });
 


### PR DESCRIPTION
### What was wrong?
Running Http and Websocket on the same port cause Trin to crash

### How was it fixed?
Remove default support for WS.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
