### PR TITLE
Refactor `trin-bridge` with PandaOps middleware

### DIFF
--- a/ethportal-api/src/types/jsonrpc/request.rs
+++ b/ethportal-api/src/types/jsonrpc/request.rs
@@ -18,6 +18,17 @@ pub struct JsonRequest {
     pub id: u32,
 }
 
+impl JsonRequest {
+    pub fn new(method: String, params: Params, id: u32) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            params,
+            method,
+            id,
+        }
+    }
+}
+
 impl Default for JsonRequest {
     fn default() -> Self {
         Self {

--- a/newsfragments/772.changed.md
+++ b/newsfragments/772.changed.md
@@ -1,0 +1,1 @@
+Refactor `trin-bridge` with PandaOps middleware.

--- a/trin-bridge/src/constants.rs
+++ b/trin-bridge/src/constants.rs
@@ -7,4 +7,7 @@ pub const BATCH_SIZE: u64 = 128;
 // These are only intended to be used by core team members who have access to the nodes.
 // If you don't have access to the PANDAOPS nodes, but still want to use the bridge feature, let us
 // know on Discord or Github and we'll prioritize support for any provider.
-pub const PANDAOPS_URL: &str = "https://archive.mainnet.ethpandaops.io/";
+/// Execution layer PandaOps endpoint
+pub const BASE_EL_ENDPOINT: &str = "https://archive.mainnet.eu1.ethpandaops.io";
+/// Consensus layer PandaOps endpoint
+pub const BASE_CL_ENDPOINT: &str = "https://beacon.mainnet.ethpandaops.io";

--- a/trin-bridge/src/lib.rs
+++ b/trin-bridge/src/lib.rs
@@ -4,6 +4,7 @@ pub mod bridge;
 pub mod cli;
 pub mod constants;
 pub mod full_header;
+pub mod pandaops;
 pub mod types;
 pub mod utils;
 

--- a/trin-bridge/src/main.rs
+++ b/trin-bridge/src/main.rs
@@ -46,12 +46,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .map_err(|e| e.to_string())
         })
         .collect();
-    let bridge = Bridge {
-        mode: bridge_config.mode,
-        portal_clients: portal_clients?,
+    let bridge = Bridge::new(
+        bridge_config.mode,
+        portal_clients?,
         header_oracle,
-        epoch_acc_path: bridge_config.epoch_acc_path,
-    };
+        bridge_config.epoch_acc_path,
+    );
 
     info!("Launching bridge mode: {:?}", bridge.mode);
     match bridge.mode {

--- a/trin-bridge/src/pandaops.rs
+++ b/trin-bridge/src/pandaops.rs
@@ -1,0 +1,148 @@
+use crate::bridge::Retry;
+use crate::constants::{BASE_CL_ENDPOINT, BASE_EL_ENDPOINT};
+use crate::full_header::{FullHeader, FullHeaderBatch};
+use crate::{PANDAOPS_CLIENT_ID, PANDAOPS_CLIENT_SECRET};
+use anyhow::{anyhow, bail};
+use ethereum_types::H256;
+use ethportal_api::types::jsonrpc::params::Params;
+use ethportal_api::types::jsonrpc::request::JsonRequest;
+use ethportal_api::utils::bytes::hex_encode;
+use ethportal_api::{Header, Receipts};
+use serde_json::{json, Value};
+
+pub struct PandaOpsMiddleware {
+    pub base_el_endpoint: String,
+    pub base_cl_endpoint: String,
+    pub client_id: String,
+    pub client_secret: String,
+}
+
+impl PandaOpsMiddleware {
+    pub fn new(
+        base_el_endpoint: String,
+        base_cl_endpoint: String,
+        client_id: String,
+        client_secret: String,
+    ) -> Self {
+        Self {
+            base_el_endpoint,
+            base_cl_endpoint,
+            client_id,
+            client_secret,
+        }
+    }
+}
+
+impl Default for PandaOpsMiddleware {
+    fn default() -> Self {
+        Self {
+            base_el_endpoint: BASE_EL_ENDPOINT.to_string(),
+            base_cl_endpoint: BASE_CL_ENDPOINT.to_string(),
+            client_id: PANDAOPS_CLIENT_ID.clone(),
+            client_secret: PANDAOPS_CLIENT_SECRET.clone(),
+        }
+    }
+}
+
+impl PandaOpsMiddleware {
+    /// Used the "surf" library here instead of "ureq" since "surf" is much more capable of handling
+    /// multiple async requests. Using "ureq" consistently resulted in errors as soon as the number of
+    /// concurrent tasks increased significantly.
+    async fn batch_request(&self, obj: Vec<JsonRequest>) -> anyhow::Result<String> {
+        let result = surf::post(self.base_el_endpoint.clone())
+            .middleware(Retry::default())
+            .body_json(&json!(obj))
+            .map_err(|e| anyhow!("Unable to construct json post request: {e:?}"))?
+            .header("Content-Type", "application/json".to_string())
+            .header("CF-Access-Client-Id", self.client_id.clone())
+            .header("CF-Access-Client-Secret", self.client_secret.clone())
+            .recv_string()
+            .await;
+
+        result.map_err(|err| anyhow!("Unable to request execution batch from pandaops: {err:?}"))
+    }
+
+    #[allow(dead_code)] // FIXME: Remove this once we have a use case for this function (e.g. requesting consensus data)
+    pub(crate) async fn request(&self, endpoint: String) -> anyhow::Result<String> {
+        let result = surf::get(endpoint)
+            .header("Content-Type", "application/json".to_string())
+            .header("CF-Access-Client-Id", self.client_id.clone())
+            .header("CF-Access-Client-Secret", self.client_secret.clone())
+            .recv_string()
+            .await;
+        result.map_err(|err| anyhow!("Unable to request consensus block from pandaops: {err:?}"))
+    }
+
+    pub(crate) async fn get_trusted_receipts(
+        &self,
+        tx_hashes: &[H256],
+    ) -> anyhow::Result<Receipts> {
+        let request: Vec<JsonRequest> = tx_hashes
+            .iter()
+            .enumerate()
+            .map(|(id, tx_hash)| {
+                let tx_hash = hex_encode(tx_hash);
+                let params = Params::Array(vec![json!(tx_hash)]);
+                let method = "eth_getTransactionReceipt".to_string();
+                JsonRequest::new(method, params, id as u32)
+            })
+            .collect();
+        let response = self.batch_request(request).await?;
+        Ok(serde_json::from_str(&response)?)
+    }
+
+    pub(crate) async fn get_latest_block_number(&self) -> anyhow::Result<u64> {
+        let params = Params::Array(vec![json!("latest"), json!(false)]);
+        let method = "eth_getBlockByNumber".to_string();
+        let request = JsonRequest::new(method, params, 1);
+        let response = self.batch_request(vec![request]).await?;
+        let response: Vec<Value> = serde_json::from_str(&response)?;
+        let result = response[0]
+            .get("result")
+            .ok_or_else(|| anyhow!("Unable to fetch latest block"))?;
+        let header: Header = serde_json::from_value(result.clone())?;
+        Ok(header.number)
+    }
+
+    pub(crate) async fn get_trusted_uncles(&self, hashes: &[H256]) -> anyhow::Result<Vec<Header>> {
+        let batch_request = hashes
+            .iter()
+            .enumerate()
+            .map(|(id, uncle)| {
+                let uncle_hash = hex_encode(uncle);
+                let params = Params::Array(vec![json!(uncle_hash), json!(false)]);
+                let method = "eth_getBlockByHash".to_string();
+                JsonRequest::new(method, params, id as u32)
+            })
+            .collect();
+        let response = self.batch_request(batch_request).await?;
+        let response: Vec<Value> = serde_json::from_str(&response).map_err(|e| anyhow!(e))?;
+        // single responses are in an array, since we batch them...
+        let mut headers = vec![];
+        for res in response {
+            if res["result"].as_object().is_none() {
+                bail!("unable to find uncle header");
+            }
+            let header: Header = serde_json::from_value(res.clone())?;
+            headers.push(header)
+        }
+        Ok(headers)
+    }
+
+    pub(crate) async fn get_header(&self, height: u64) -> anyhow::Result<FullHeader> {
+        // Geth requires block numbers to be formatted using the following padding.
+        let block_param = format!("0x{height:01X}");
+        let params = Params::Array(vec![json!(block_param), json!(true)]);
+        let batch_request = vec![JsonRequest::new(
+            "eth_getBlockByNumber".to_string(),
+            params,
+            height as u32,
+        )];
+        let response = self.batch_request(batch_request).await?;
+        let batch: FullHeaderBatch = serde_json::from_str(&response)?;
+        if batch.headers.len() != 1 {
+            bail!("Expected 1 header, got {:#?}", batch.headers.len());
+        }
+        Ok(batch.headers[0].clone())
+    }
+}


### PR DESCRIPTION
### What was wrong?

trin-bridge should provide data for more than one overlay subnetwork. Some refactoring is necessary to enable more solid architecture for adding support for the beacon and state overlay data.

### How was it fixed?
Create a Pandaops middleware structure and encapsulate requesting the data from the DevOps nodes. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x]  Test this PR live when PandaOps nodes are back online
- [x] Clean up commit history
