### PR TITLE
Alias bootnodes

### DIFF
--- a/ethportal-api/src/types/bootnodes.rs
+++ b/ethportal-api/src/types/bootnodes.rs
@@ -4,45 +4,103 @@ use anyhow::anyhow;
 
 use crate::types::enr::Enr;
 
-lazy_static! {
-    pub static ref DEFAULT_BOOTNODES: Vec<Enr> = vec![
-        // https://github.com/ethereum/portal-network-specs/blob/master/testnet.md
-        // Trin bootstrap nodes
-        // trin-ams3-1
-        Enr::from_str("enr:-I24QDy_atpK3KlPjl6X5yIrK7FosdHI1cW0I0MeiaIVuYg3AEEH9tRSTyFb2k6lpUiFsqxt8uTW3jVMUzoSlQf5OXYBY4d0IDAuMS4wgmlkgnY0gmlwhKEjVaWJc2VjcDI1NmsxoQOSGugH1jSdiE_fRK1FIBe9oLxaWH8D_7xXSnaOVBe-SYN1ZHCCIyg").expect("Parsing static bootnode enr to work"),
-        // trin-nyc1-1
-        Enr::from_str("enr:-I24QIdQtNSyUNcoyR4R7pWLfGj0YuX550Qld0HuInYo_b7JE9CIzmi2TF9hPg-OFL3kebYgLjnPkRu17niXB6xKQugBY4d0IDAuMS4wgmlkgnY0gmlwhJO2oc6Jc2VjcDI1NmsxoQJal-rNlNBoOMikJ7PcGk1h6Mlt_XtTWihHwOKmFVE-GoN1ZHCCIyg").expect("Parsing static bootnode enr to work"),
-        // trin-sgp1-1
-        Enr::from_str("enr:-I24QI_QC3IsdxHUX_jk8udbQ4U2bv-Gncsdg9GzgaPU95ayHdAwnH7mY22A6ggd_aZegFiBBOAPamkP2pyHbjNH61sBY4d0IDAuMS4wgmlkgnY0gmlwhJ31OTWJc2VjcDI1NmsxoQMo_DLYhV1nqAVC1ayEIwrhoFCcHvWuhC_J-w-n_4aHP4N1ZHCCIyg").expect("Parsing static bootnode enr to work"),
-
-        // Fluffy bootstrap nodes
-        Enr::from_str("enr:-IS4QGeIshGTdA7EpUV9SYYKUWxzMg1mihWOEg-_Kf1lndQRTYY5jXRIiZnL8XJ-wnwuUXnZvwLjhbaXfOAhf_qNkUUBgmlkgnY0gmlwhEFsKgOJc2VjcDI1NmsxoQPlKmIWSMXPn_FgUiVnopQ_Y0T64f7zKIAu26T8BhVPdIN1ZHCCI40").expect("Parsing static bootnode enr to work"),
-        Enr::from_str("enr:-IS4QBDo5n39042MrxWU8tOmGgleD2tc42ODP-EMoUEdFBXxchTyNRVjlcxfajOwnUmi9Ro-BS5_Z5JwpWW58kUarLwBgmlkgnY0gmlwhEFsKgOJc2VjcDI1NmsxoQLj_0Y6aW4yEhZolYwQRW6Tya10jVB_UB1vplJzC4o0hYN1ZHCCI44").expect("Parsing static bootnode enr to work"),
-        Enr::from_str("enr:-IS4QFzPZ7Cc7BGYSQBlWdkPyep8XASIVlviHbi-ZzcCdvkcE382unsRq8Tb_dYQFNZFWLqhJsJljdgJ7WtWP830Gq0BgmlkgnY0gmlwhEFsKq6Jc2VjcDI1NmsxoQPjz2Y1Hsa0edvzvn6-OADS3re-FOkSiJSmBB7DVrsAXIN1ZHCCI40").expect("Parsing static bootnode enr to work"),
-        Enr::from_str("enr:-IS4QHA1PJCdmESyKkQsBmMUhSkRDgwKjwTtPZYMcbMiqCb8I1Xt-Xyh9Nj0yWeIN4S3sOpP9nxI6qCCR1Nf4LjY0IABgmlkgnY0gmlwhEFsKq6Jc2VjcDI1NmsxoQLMWRNAgXVdGc0Ij9RZCPsIyrrL67eYfE9PPwqwRvmZooN1ZHCCI44").expect("Parsing static bootnode enr to work"),
-
-        // Ultralight bootstrap nodes
-        Enr::from_str("enr:-IS4QFV_wTNknw7qiCGAbHf6LxB-xPQCktyrCEZX-b-7PikMOIKkBg-frHRBkfwhI3XaYo_T-HxBYmOOQGNwThkBBHYDgmlkgnY0gmlwhKRc9_OJc2VjcDI1NmsxoQKHPt5CQ0D66ueTtSUqwGjfhscU_LiwS28QvJ0GgJFd-YN1ZHCCE4k").expect("Parsing static bootnode enr to work"),
-        Enr::from_str("enr:-IS4QDpUz2hQBNt0DECFm8Zy58Hi59PF_7sw780X3qA0vzJEB2IEd5RtVdPUYZUbeg4f0LMradgwpyIhYUeSxz2Tfa8DgmlkgnY0gmlwhKRc9_OJc2VjcDI1NmsxoQJd4NAVKOXfbdxyjSOUJzmA4rjtg43EDeEJu1f8YRhb_4N1ZHCCE4o").expect("Parsing static bootnode enr to work"),
-        Enr::from_str("enr:-IS4QGG6moBhLW1oXz84NaKEHaRcim64qzFn1hAG80yQyVGNLoKqzJe887kEjthr7rJCNlt6vdVMKMNoUC9OCeNK-EMDgmlkgnY0gmlwhKRc9-KJc2VjcDI1NmsxoQLJhXByb3LmxHQaqgLDtIGUmpANXaBbFw3ybZWzGqb9-IN1ZHCCE4k").expect("Parsing static bootnode enr to work"),
-        Enr::from_str("enr:-IS4QA5hpJikeDFf1DD1_Le6_ylgrLGpdwn3SRaneGu9hY2HUI7peHep0f28UUMzbC0PvlWjN8zSfnqMG07WVcCyBhADgmlkgnY0gmlwhKRc9-KJc2VjcDI1NmsxoQJMpHmGj1xSP1O-Mffk_jYIHVcg6tY5_CjmWVg1gJEsPIN1ZHCCE4o").expect("Parsing static bootnode enr to work"),
-            ];
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Bootnode {
+    pub enr: Enr,
+    pub alias: String,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+lazy_static! {
+    pub static ref DEFAULT_BOOTNODES: Vec<Bootnode> = vec![
+        // https://github.com/ethereum/portal-network-specs/blob/master/testnet.md
+        // Trin bootstrap nodes
+        Bootnode{
+            enr: Enr::from_str("enr:-I24QDy_atpK3KlPjl6X5yIrK7FosdHI1cW0I0MeiaIVuYg3AEEH9tRSTyFb2k6lpUiFsqxt8uTW3jVMUzoSlQf5OXYBY4d0IDAuMS4wgmlkgnY0gmlwhKEjVaWJc2VjcDI1NmsxoQOSGugH1jSdiE_fRK1FIBe9oLxaWH8D_7xXSnaOVBe-SYN1ZHCCIyg").expect("Parsing static bootnode enr to work"),
+            alias: "trin-ams3-1".to_string()
+        },
+        Bootnode{
+            enr: Enr::from_str("enr:-I24QIdQtNSyUNcoyR4R7pWLfGj0YuX550Qld0HuInYo_b7JE9CIzmi2TF9hPg-OFL3kebYgLjnPkRu17niXB6xKQugBY4d0IDAuMS4wgmlkgnY0gmlwhJO2oc6Jc2VjcDI1NmsxoQJal-rNlNBoOMikJ7PcGk1h6Mlt_XtTWihHwOKmFVE-GoN1ZHCCIyg").expect("Parsing static bootnode enr to work"),
+            alias: "trin-nyc1-1".to_string()
+        },
+        Bootnode{
+        enr: Enr::from_str("enr:-I24QI_QC3IsdxHUX_jk8udbQ4U2bv-Gncsdg9GzgaPU95ayHdAwnH7mY22A6ggd_aZegFiBBOAPamkP2pyHbjNH61sBY4d0IDAuMS4wgmlkgnY0gmlwhJ31OTWJc2VjcDI1NmsxoQMo_DLYhV1nqAVC1ayEIwrhoFCcHvWuhC_J-w-n_4aHP4N1ZHCCIyg").expect("Parsing static bootnode enr to work"),
+            alias: "trin-sgp1-1".to_string()
+        },
+
+        // Fluffy bootstrap nodes
+        Bootnode{
+            enr:
+        Enr::from_str("enr:-IS4QGeIshGTdA7EpUV9SYYKUWxzMg1mihWOEg-_Kf1lndQRTYY5jXRIiZnL8XJ-wnwuUXnZvwLjhbaXfOAhf_qNkUUBgmlkgnY0gmlwhEFsKgOJc2VjcDI1NmsxoQPlKmIWSMXPn_FgUiVnopQ_Y0T64f7zKIAu26T8BhVPdIN1ZHCCI40").expect("Parsing static bootnode enr to work"),
+            alias: "fluffy-1".to_string()
+        },
+        Bootnode{
+            enr:
+        Enr::from_str("enr:-IS4QBDo5n39042MrxWU8tOmGgleD2tc42ODP-EMoUEdFBXxchTyNRVjlcxfajOwnUmi9Ro-BS5_Z5JwpWW58kUarLwBgmlkgnY0gmlwhEFsKgOJc2VjcDI1NmsxoQLj_0Y6aW4yEhZolYwQRW6Tya10jVB_UB1vplJzC4o0hYN1ZHCCI44").expect("Parsing static bootnode enr to work"),
+            alias: "fluffy-2".to_string()
+        },
+        Bootnode{
+            enr:
+        Enr::from_str("enr:-IS4QFzPZ7Cc7BGYSQBlWdkPyep8XASIVlviHbi-ZzcCdvkcE382unsRq8Tb_dYQFNZFWLqhJsJljdgJ7WtWP830Gq0BgmlkgnY0gmlwhEFsKq6Jc2VjcDI1NmsxoQPjz2Y1Hsa0edvzvn6-OADS3re-FOkSiJSmBB7DVrsAXIN1ZHCCI40").expect("Parsing static bootnode enr to work"),
+            alias: "fluffy-3".to_string()
+        },
+        Bootnode{
+            enr:
+        Enr::from_str("enr:-IS4QHA1PJCdmESyKkQsBmMUhSkRDgwKjwTtPZYMcbMiqCb8I1Xt-Xyh9Nj0yWeIN4S3sOpP9nxI6qCCR1Nf4LjY0IABgmlkgnY0gmlwhEFsKq6Jc2VjcDI1NmsxoQLMWRNAgXVdGc0Ij9RZCPsIyrrL67eYfE9PPwqwRvmZooN1ZHCCI44").expect("Parsing static bootnode enr to work"),
+            alias: "fluffy-4".to_string()
+        },
+
+        // Ultralight bootstrap nodes
+        Bootnode{
+            enr:
+        Enr::from_str("enr:-IS4QFV_wTNknw7qiCGAbHf6LxB-xPQCktyrCEZX-b-7PikMOIKkBg-frHRBkfwhI3XaYo_T-HxBYmOOQGNwThkBBHYDgmlkgnY0gmlwhKRc9_OJc2VjcDI1NmsxoQKHPt5CQ0D66ueTtSUqwGjfhscU_LiwS28QvJ0GgJFd-YN1ZHCCE4k").expect("Parsing static bootnode enr to work"),
+            alias: "ultralight-1".to_string()
+        },
+        Bootnode{
+            enr:
+        Enr::from_str("enr:-IS4QDpUz2hQBNt0DECFm8Zy58Hi59PF_7sw780X3qA0vzJEB2IEd5RtVdPUYZUbeg4f0LMradgwpyIhYUeSxz2Tfa8DgmlkgnY0gmlwhKRc9_OJc2VjcDI1NmsxoQJd4NAVKOXfbdxyjSOUJzmA4rjtg43EDeEJu1f8YRhb_4N1ZHCCE4o").expect("Parsing static bootnode enr to work"),
+            alias: "ultralight-2".to_string()
+        },
+        Bootnode{
+            enr:
+        Enr::from_str("enr:-IS4QGG6moBhLW1oXz84NaKEHaRcim64qzFn1hAG80yQyVGNLoKqzJe887kEjthr7rJCNlt6vdVMKMNoUC9OCeNK-EMDgmlkgnY0gmlwhKRc9-KJc2VjcDI1NmsxoQLJhXByb3LmxHQaqgLDtIGUmpANXaBbFw3ybZWzGqb9-IN1ZHCCE4k").expect("Parsing static bootnode enr to work"),
+            alias: "ultralight-3".to_string()
+        },
+        Bootnode{
+            enr:
+        Enr::from_str("enr:-IS4QA5hpJikeDFf1DD1_Le6_ylgrLGpdwn3SRaneGu9hY2HUI7peHep0f28UUMzbC0PvlWjN8zSfnqMG07WVcCyBhADgmlkgnY0gmlwhKRc9-KJc2VjcDI1NmsxoQJMpHmGj1xSP1O-Mffk_jYIHVcg6tY5_CjmWVg1gJEsPIN1ZHCCE4o").expect("Parsing static bootnode enr to work"),
+            alias: "ultralight-4".to_string()
+        }];
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum Bootnodes {
+    #[default]
     Default,
     // use explicit None here instead of Option<Bootnodes>, since default value is DEFAULT_BOOTNODES
     None,
-    Custom(Vec<Enr>),
+    Custom(Vec<Bootnode>),
+}
+
+impl From<Enr> for Bootnode {
+    fn from(enr: Enr) -> Self {
+        for bootnode in DEFAULT_BOOTNODES.clone().into_iter() {
+            if bootnode.enr == enr {
+                return bootnode;
+            }
+        }
+        Bootnode {
+            enr,
+            alias: "custom".to_string(),
+        }
+    }
 }
 
 impl From<Bootnodes> for Vec<Enr> {
     fn from(bootnodes: Bootnodes) -> Self {
         match bootnodes {
-            Bootnodes::Default => DEFAULT_BOOTNODES.to_vec(),
+            Bootnodes::Default => DEFAULT_BOOTNODES.iter().map(|bn| bn.enr.clone()).collect(),
             Bootnodes::None => vec![],
-            Bootnodes::Custom(bootnodes) => bootnodes,
+            Bootnodes::Custom(bootnodes) => bootnodes.iter().map(|bn| bn.enr.clone()).collect(),
         }
     }
 }
@@ -57,7 +115,10 @@ impl FromStr for Bootnodes {
             _ => {
                 let bootnodes: Result<Vec<Enr>, _> = s.split(',').map(Enr::from_str).collect();
                 match bootnodes {
-                    Ok(val) => Ok(Bootnodes::Custom(val)),
+                    Ok(val) => {
+                        let bootnodes = val.into_iter().map(|enr| enr.into()).collect();
+                        Ok(Bootnodes::Custom(bootnodes))
+                    }
                     Err(_) => Err(anyhow!("Invalid bootnode argument")),
                 }
             }

--- a/newsfragments/773.fixed.md
+++ b/newsfragments/773.fixed.md
@@ -1,0 +1,1 @@
+Add alias to bootnode enrs.

--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -114,7 +114,8 @@ impl Discovery {
         let discv5 = Discv5::new(enr, enr_key, discv5_config)
             .map_err(|e| format!("Failed to create discv5 instance: {e}"))?;
 
-        for enr in portal_config.bootnode_enrs {
+        let bootnode_enrs: Vec<Enr> = portal_config.bootnodes.into();
+        for enr in bootnode_enrs {
             discv5
                 .add_enr(enr)
                 .map_err(|e| format!("Failed to add bootnode enr: {e}"))?;

--- a/portalnet/src/types/messages.rs
+++ b/portalnet/src/types/messages.rs
@@ -16,6 +16,7 @@ use ssz_types::{typenum, BitList};
 use thiserror::Error;
 use validator::ValidationError;
 
+use ethportal_api::types::bootnodes::Bootnodes;
 use ethportal_api::types::bytes::ByteList;
 use ethportal_api::types::content_key::RawContentKey;
 use ethportal_api::types::distance::Distance;
@@ -162,7 +163,7 @@ pub struct PortalnetConfig {
     pub external_addr: Option<SocketAddr>,
     pub private_key: H256,
     pub listen_port: u16,
-    pub bootnode_enrs: Vec<Enr>,
+    pub bootnodes: Bootnodes,
     pub data_radius: Distance,
     pub internal_ip: bool,
     pub no_stun: bool,
@@ -175,7 +176,7 @@ impl Default for PortalnetConfig {
             external_addr: None,
             private_key: H256::random(),
             listen_port: 4242,
-            bootnode_enrs: Vec::<Enr>::new(),
+            bootnodes: Bootnodes::default(),
             data_radius: Distance::MAX,
             internal_ip: false,
             no_stun: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub async fn run_trin(
         private_key,
         listen_port: trin_config.discovery_port,
         no_stun: trin_config.no_stun,
-        bootnode_enrs: trin_config.bootnodes.clone().into(),
+        bootnodes: trin_config.bootnodes.clone(),
         ..Default::default()
     };
 

--- a/trin-beacon/src/lib.rs
+++ b/trin-beacon/src/lib.rs
@@ -18,6 +18,7 @@ use utp_rs::socket::UtpSocket;
 
 use crate::network::BeaconNetwork;
 use crate::{events::BeaconEvents, jsonrpc::BeaconRequestHandler};
+use ethportal_api::types::enr::Enr;
 use ethportal_api::types::jsonrpc::request::BeaconJsonRpcRequest;
 use portalnet::{
     discovery::{Discovery, UtpEnr},
@@ -76,15 +77,10 @@ pub fn spawn_beacon_network(
     portalnet_config: PortalnetConfig,
     beacon_event_rx: mpsc::UnboundedReceiver<TalkRequest>,
 ) -> JoinHandle<()> {
-    let bootnodes: Vec<String> = portalnet_config
-        .bootnode_enrs
-        .iter()
-        .map(|enr| format!("{{ {}, Encoded ENR: {} }}", enr, enr.to_base64()))
-        .collect();
-    let bootnodes = bootnodes.join(", ");
+    let bootnode_enrs: Vec<Enr> = portalnet_config.bootnodes.into();
     info!(
-        "About to spawn Beacon Network with boot nodes: {}",
-        bootnodes
+        "About to spawn Beacon Network with {} boot nodes.",
+        bootnode_enrs.len()
     );
 
     tokio::spawn(async move {

--- a/trin-beacon/src/network.rs
+++ b/trin-beacon/src/network.rs
@@ -7,6 +7,7 @@ use utp_rs::socket::UtpSocket;
 use crate::validation::BeaconValidator;
 use ethportal_api::types::content_key::BeaconContentKey;
 use ethportal_api::types::distance::XorMetric;
+use ethportal_api::types::enr::Enr;
 use portalnet::{
     discovery::{Discovery, UtpEnr},
     overlay::{OverlayConfig, OverlayProtocol},
@@ -29,8 +30,9 @@ impl BeaconNetwork {
         portal_config: PortalnetConfig,
         header_oracle: Arc<RwLock<HeaderOracle>>,
     ) -> anyhow::Result<Self> {
+        let bootnode_enrs: Vec<Enr> = portal_config.bootnodes.into();
         let config = OverlayConfig {
-            bootnode_enrs: portal_config.bootnode_enrs.clone(),
+            bootnode_enrs,
             ..Default::default()
         };
         let storage = Arc::new(PLRwLock::new(PortalStorage::new(

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -19,6 +19,7 @@ use tracing::info;
 use utp_rs::socket::UtpSocket;
 
 use crate::{events::HistoryEvents, jsonrpc::HistoryRequestHandler};
+use ethportal_api::types::enr::Enr;
 use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
 use portalnet::{
     discovery::{Discovery, UtpEnr},
@@ -78,15 +79,10 @@ pub fn spawn_history_network(
     portalnet_config: PortalnetConfig,
     history_event_rx: mpsc::UnboundedReceiver<TalkRequest>,
 ) -> JoinHandle<()> {
-    let bootnodes: Vec<String> = portalnet_config
-        .bootnode_enrs
-        .iter()
-        .map(|enr| format!("{{ {}, Encoded ENR: {} }}", enr, enr.to_base64()))
-        .collect();
-    let bootnodes = bootnodes.join(", ");
+    let bootnode_enrs: Vec<Enr> = portalnet_config.bootnodes.into();
     info!(
-        "About to spawn History Network with boot nodes: {}",
-        bootnodes
+        "About to spawn History Network with {} boot nodes",
+        bootnode_enrs.len()
     );
 
     tokio::spawn(async move {

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -5,6 +5,7 @@ use tokio::sync::RwLock;
 use utp_rs::socket::UtpSocket;
 
 use ethportal_api::types::distance::XorMetric;
+use ethportal_api::types::enr::Enr;
 use ethportal_api::HistoryContentKey;
 use portalnet::{
     discovery::{Discovery, UtpEnr},
@@ -31,8 +32,9 @@ impl HistoryNetwork {
         portal_config: PortalnetConfig,
         header_oracle: Arc<RwLock<HeaderOracle>>,
     ) -> anyhow::Result<Self> {
+        let bootnode_enrs: Vec<Enr> = portal_config.bootnodes.into();
         let config = OverlayConfig {
-            bootnode_enrs: portal_config.bootnode_enrs.clone(),
+            bootnode_enrs,
             ..Default::default()
         };
         let storage = Arc::new(PLRwLock::new(PortalStorage::new(

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -12,6 +12,7 @@ use tracing::info;
 use utp_rs::socket::UtpSocket;
 
 use crate::{events::StateEvents, jsonrpc::StateRequestHandler};
+use ethportal_api::types::enr::Enr;
 use ethportal_api::types::jsonrpc::request::StateJsonRpcRequest;
 use portalnet::{
     discovery::{Discovery, UtpEnr},
@@ -69,15 +70,10 @@ pub fn spawn_state_network(
     portalnet_config: PortalnetConfig,
     state_event_rx: mpsc::UnboundedReceiver<TalkRequest>,
 ) -> JoinHandle<()> {
-    let bootnodes: Vec<String> = portalnet_config
-        .bootnode_enrs
-        .iter()
-        .map(|enr| format!("{{ {}, Encoded ENR: {} }}", enr, enr.to_base64()))
-        .collect();
-    let bootnodes = bootnodes.join(", ");
+    let bootnode_enrs: Vec<Enr> = portalnet_config.bootnodes.into();
     info!(
-        "About to spawn State Network with boot nodes: {}",
-        bootnodes
+        "About to spawn State Network with {} boot nodes.",
+        bootnode_enrs.len()
     );
 
     tokio::spawn(async move {

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -6,6 +6,7 @@ use tokio::sync::RwLock;
 use utp_rs::socket::UtpSocket;
 
 use ethportal_api::types::distance::XorMetric;
+use ethportal_api::types::enr::Enr;
 use ethportal_api::StateContentKey;
 use portalnet::{
     discovery::{Discovery, UtpEnr},
@@ -41,8 +42,9 @@ impl StateNetwork {
             ProtocolId::State,
         )?));
         let validator = Arc::new(StateValidator { header_oracle });
+        let bootnode_enrs: Vec<Enr> = portal_config.bootnodes.into();
         let config = OverlayConfig {
-            bootnode_enrs: portal_config.bootnode_enrs.clone(),
+            bootnode_enrs,
             ..Default::default()
         };
         let overlay = OverlayProtocol::new(


### PR DESCRIPTION
### What was wrong?
I'm not a fan of outputting all 11 of our bootnode enrs on startup & each individual enr on success/failed bonding with said bootnode. It's not very useful information & really clutters the logs.

Before...
```shell
2023-06-09T18:15:01.077921Z  INFO portalnet::overlay_service: Starting overlay service protocol=History
2023-06-09T18:15:01.078302Z  INFO trin_history: About to spawn History Network with boot nodes: { enr:-I24QDy_atpK3KlPjl6X5yIrK7FosdHI1cW0I0MeiaIVuYg3AEEH9tRSTyFb2k6lpUiFsqxt8uTW3jVMUzoSlQf5OXYBY4d0IDAuMS4wgmlkgnY0gmlwhKEjVaWJc2VjcDI1NmsxoQOSGugH1jSdiE_fRK1FIBe9oLxaWH8D_7xXSnaOVBe-SYN1ZHCCIyg, Encoded ENR: enr:-I24QDy_atpK3KlPjl6X5yIrK7FosdHI1cW0I0MeiaIVuYg3AEEH9tRSTyFb2k6lpUiFsqxt8uTW3jVMUzoSlQf5OXYBY4d0IDAuMS4wgmlkgnY0gmlwhKEjVaWJc2VjcDI1NmsxoQOSGugH1jSdiE_fRK1FIBe9oLxaWH8D_7xXSnaOVBe-SYN1ZHCCIyg }, { enr:-I24QIdQtNSyUNcoyR4R7pWLfGj0YuX550Qld0HuInYo_b7JE9CIzmi2TF9hPg-OFL3kebYgLjnPkRu17niXB6xKQugBY4d0IDAuMS4wgmlkgnY0gmlwhJO2oc6Jc2VjcDI1NmsxoQJal-rNlNBoOMikJ7PcGk1h6Mlt_XtTWihHwOKmFVE-GoN1ZHCCIyg, Encoded ENR: enr:-I24QIdQtNSyUNcoyR4R7pWLfGj0YuX550Qld0HuInYo_b7JE9CIzmi2TF9hPg-OFL3kebYgLjnPkRu17niXB6xKQugBY4d0IDAuMS4wgmlkgnY0gmlwhJO2oc6Jc2VjcDI1NmsxoQJal-rNlNBoOMikJ7PcGk1h6Mlt_XtTWihHwOKmFVE-GoN1ZHCCIyg }, { enr:-I24QI_QC3IsdxHUX_jk8udbQ4U2bv-Gncsdg9GzgaPU95ayHdAwnH7mY22A6ggd_aZegFiBBOAPamkP2pyHbjNH61sBY4d0IDAuMS4wgmlkgnY0gmlwhJ31OTWJc2VjcDI1NmsxoQMo_DLYhV1nqAVC1ayEIwrhoFCcHvWuhC_J-w-n_4aHP4N1ZHCCIyg, Encoded ENR: enr:-I24QI_QC3IsdxHUX_jk8udbQ4U2bv-Gncsdg9GzgaPU95ayHdAwnH7mY22A6ggd_aZegFiBBOAPamkP2pyHbjNH61sBY4d0IDAuMS4wgmlkgnY0gmlwhJ31OTWJc2VjcDI1NmsxoQMo_DLYhV1nqAVC1ayEIwrhoFCcHvWuhC_J-w-n_4aHP4N1ZHCCIyg }, { enr:-IS4QGeIshGTdA7EpUV9SYYKUWxzMg1mihWOEg-_Kf1lndQRTYY5jXRIiZnL8XJ-wnwuUXnZvwLjhbaXfOAhf_qNkUUBgmlkgnY0gmlwhEFsKgOJc2VjcDI1NmsxoQPlKmIWSMXPn_FgUiVnopQ_Y0T64f7zKIAu26T8BhVPdIN1ZHCCI40, Encoded ENR: enr:-IS4QGeIshGTdA7EpUV9SYYKUWxzMg1mihWOEg-_Kf1lndQRTYY5jXRIiZnL8XJ-wnwuUXnZvwLjhbaXfOAhf_qNkUUBgmlkgnY0gmlwhEFsKgOJc2VjcDI1NmsxoQPlKmIWSMXPn_FgUiVnopQ_Y0T64f7zKIAu26T8BhVPdIN1ZHCCI40 }, { enr:-IS4QBDo5n39042MrxWU8tOmGgleD2tc42ODP-EMoUEdFBXxchTyNRVjlcxfajOwnUmi9Ro-BS5_Z5JwpWW58kUarLwBgmlkgnY0gmlwhEFsKgOJc2VjcDI1NmsxoQLj_0Y6aW4yEhZolYwQRW6Tya10jVB_UB1vplJzC4o0hYN1ZHCCI44, Encoded ENR: enr:-IS4QBDo5n39042MrxWU8tOmGgleD2tc42ODP-EMoUEdFBXxchTyNRVjlcxfajOwnUmi9Ro-BS5_Z5JwpWW58kUarLwBgmlkgnY0gmlwhEFsKgOJc2VjcDI1NmsxoQLj_0Y6aW4yEhZolYwQRW6Tya10jVB_UB1vplJzC4o0hYN1ZHCCI44 }, { enr:-IS4QFzPZ7Cc7BGYSQBlWdkPyep8XASIVlviHbi-ZzcCdvkcE382unsRq8Tb_dYQFNZFWLqhJsJljdgJ7WtWP830Gq0BgmlkgnY0gmlwhEFsKq6Jc2VjcDI1NmsxoQPjz2Y1Hsa0edvzvn6-OADS3re-FOkSiJSmBB7DVrsAXIN1ZHCCI40, Encoded ENR: enr:-IS4QFzPZ7Cc7BGYSQBlWdkPyep8XASIVlviHbi-ZzcCdvkcE382unsRq8Tb_dYQFNZFWLqhJsJljdgJ7WtWP830Gq0BgmlkgnY0gmlwhEFsKq6Jc2VjcDI1NmsxoQPjz2Y1Hsa0edvzvn6-OADS3re-FOkSiJSmBB7DVrsAXIN1ZHCCI40 }, { enr:-IS4QHA1PJCdmESyKkQsBmMUhSkRDgwKjwTtPZYMcbMiqCb8I1Xt-Xyh9Nj0yWeIN4S3sOpP9nxI6qCCR1Nf4LjY0IABgmlkgnY0gmlwhEFsKq6Jc2VjcDI1NmsxoQLMWRNAgXVdGc0Ij9RZCPsIyrrL67eYfE9PPwqwRvmZooN1ZHCCI44, Encoded ENR: enr:-IS4QHA1PJCdmESyKkQsBmMUhSkRDgwKjwTtPZYMcbMiqCb8I1Xt-Xyh9Nj0yWeIN4S3sOpP9nxI6qCCR1Nf4LjY0IABgmlkgnY0gmlwhEFsKq6Jc2VjcDI1NmsxoQLMWRNAgXVdGc0Ij9RZCPsIyrrL67eYfE9PPwqwRvmZooN1ZHCCI44 }, { enr:-IS4QFV_wTNknw7qiCGAbHf6LxB-xPQCktyrCEZX-b-7PikMOIKkBg-frHRBkfwhI3XaYo_T-HxBYmOOQGNwThkBBHYDgmlkgnY0gmlwhKRc9_OJc2VjcDI1NmsxoQKHPt5CQ0D66ueTtSUqwGjfhscU_LiwS28QvJ0GgJFd-YN1ZHCCE4k, Encoded ENR: enr:-IS4QFV_wTNknw7qiCGAbHf6LxB-xPQCktyrCEZX-b-7PikMOIKkBg-frHRBkfwhI3XaYo_T-HxBYmOOQGNwThkBBHYDgmlkgnY0gmlwhKRc9_OJc2VjcDI1NmsxoQKHPt5CQ0D66ueTtSUqwGjfhscU_LiwS28QvJ0GgJFd-YN1ZHCCE4k }, { enr:-IS4QDpUz2hQBNt0DECFm8Zy58Hi59PF_7sw780X3qA0vzJEB2IEd5RtVdPUYZUbeg4f0LMradgwpyIhYUeSxz2Tfa8DgmlkgnY0gmlwhKRc9_OJc2VjcDI1NmsxoQJd4NAVKOXfbdxyjSOUJzmA4rjtg43EDeEJu1f8YRhb_4N1ZHCCE4o, Encoded ENR: enr:-IS4QDpUz2hQBNt0DECFm8Zy58Hi59PF_7sw780X3qA0vzJEB2IEd5RtVdPUYZUbeg4f0LMradgwpyIhYUeSxz2Tfa8DgmlkgnY0gmlwhKRc9_OJc2VjcDI1NmsxoQJd4NAVKOXfbdxyjSOUJzmA4rjtg43EDeEJu1f8YRhb_4N1ZHCCE4o }, { enr:-IS4QGG6moBhLW1oXz84NaKEHaRcim64qzFn1hAG80yQyVGNLoKqzJe887kEjthr7rJCNlt6vdVMKMNoUC9OCeNK-EMDgmlkgnY0gmlwhKRc9-KJc2VjcDI1NmsxoQLJhXByb3LmxHQaqgLDtIGUmpANXaBbFw3ybZWzGqb9-IN1ZHCCE4k, Encoded ENR: enr:-IS4QGG6moBhLW1oXz84NaKEHaRcim64qzFn1hAG80yQyVGNLoKqzJe887kEjthr7rJCNlt6vdVMKMNoUC9OCeNK-EMDgmlkgnY0gmlwhKRc9-KJc2VjcDI1NmsxoQLJhXByb3LmxHQaqgLDtIGUmpANXaBbFw3ybZWzGqb9-IN1ZHCCE4k }, { enr:-IS4QA5hpJikeDFf1DD1_Le6_ylgrLGpdwn3SRaneGu9hY2HUI7peHep0f28UUMzbC0PvlWjN8zSfnqMG07WVcCyBhADgmlkgnY0gmlwhKRc9-KJc2VjcDI1NmsxoQJMpHmGj1xSP1O-Mffk_jYIHVcg6tY5_CjmWVg1gJEsPIN1ZHCCE4o, Encoded ENR: enr:-IS4QA5hpJikeDFf1DD1_Le6_ylgrLGpdwn3SRaneGu9hY2HUI7peHep0f28UUMzbC0PvlWjN8zSfnqMG07WVcCyBhADgmlkgnY0gmlwhKRc9-KJc2VjcDI1NmsxoQJMpHmGj1xSP1O-Mffk_jYIHVcg6tY5_CjmWVg1gJEsPIN1ZHCCE4o }
2023-06-09T18:15:01.080090Z  INFO trin_history: reports~ data: radius=46% content=100.0/100mb #=1867 disk=45.3mb; msgs: offers=0/0, accepts=0/0
2023-06-09T18:15:02.793091Z  INFO portalnet::overlay: Bonded with bootnode bootnode.enr=enr:-IS4QGG6moBhLW1oXz84NaKEHaRcim64qzFn1hAG80yQyVGNLoKqzJe887kEjthr7rJCNlt6vdVMKMNoUC9OCeNK-EMDgmlkgnY0gmlwhKRc9-KJc2VjcDI1NmsxoQLJhXByb3LmxHQaqgLDtIGUmpANXaBbFw3ybZWzGqb9-IN1ZHCCE4k
2023-06-09T18:15:12.544408Z  INFO portalnet::overlay: Bonded with bootnode bootnode.enr=enr:-IS4QHA1PJCdmESyKkQsBmMUhSkRDgwKjwTtPZYMcbMiqCb8I1Xt-Xyh9Nj0yWeIN4S3sOpP9nxI6qCCR1Nf4LjY0IABgmlkgnY0gmlwhEFsKq6Jc2VjcDI1NmsxoQLMWRNAgXVdGc0Ij9RZCPsIyrrL67eYfE9PPwqwRvmZooN1ZHCCI44
2023-06-09T18:15:13.076000Z  INFO portalnet::overlay: Bonded with bootnode bootnode.enr=enr:-IS4QA5hpJikeDFf1DD1_Le6_ylgrLGpdwn3SRaneGu9hY2HUI7peHep0f28UUMzbC0PvlWjN8zSfnqMG07WVcCyBhADgmlkgnY0gmlwhKRc9-KJc2VjcDI1NmsxoQJMpHmGj1xSP1O-Mffk_jYIHVcg6tY5_CjmWVg1gJEsPIN1ZHCCE4o
2023-06-09T18:15:14.079765Z ERROR portalnet::overlay: Error bonding with bootnode protocol=History error=The request timed out bootnode.enr=enr:-IS4QDpUz2hQBNt0DECFm8Zy58Hi59PF_7sw780X3qA0vzJEB2IEd5RtVdPUYZUbeg4f0LMradgwpyIhYUeSxz2Tfa8DgmlkgnY0gmlwhKRc9_OJc2VjcDI1NmsxoQJd4NAVKOXfbdxyjSOUJzmA4rjtg43EDeEJu1f8YRhb_4N1ZHCCE4o
2023-06-09T18:15:15.083819Z ERROR portalnet::overlay: Error bonding with bootnode protocol=History error=The request timed out bootnode.enr=enr:-I24QIdQtNSyUNcoyR4R7pWLfGj0YuX550Qld0HuInYo_b7JE9CIzmi2TF9hPg-OFL3kebYgLjnPkRu17niXB6xKQugBY4d0IDAuMS4wgmlkgnY0gmlwhJO2oc6Jc2VjcDI1NmsxoQJal-rNlNBoOMikJ7PcGk1h6Mlt_XtTWihHwOKmFVE-GoN1ZHCCIyg
2023-06-09T18:15:16.088706Z ERROR portalnet::overlay: Error bonding with bootnode protocol=History error=The request timed out bootnode.enr=enr:-I24QI_QC3IsdxHUX_jk8udbQ4U2bv-Gncsdg9GzgaPU95ayHdAwnH7mY22A6ggd_aZegFiBBOAPamkP2pyHbjNH61sBY4d0IDAuMS4wgmlkgnY0gmlwhJ31OTWJc2VjcDI1NmsxoQMo_DLYhV1nqAVC1ayEIwrhoFCcHvWuhC_J-w-n_4aHP4N1ZHCCIyg
```

After ...
```shell
2023-06-09T18:16:23.750547Z  INFO trin_history: About to spawn History Network with 11 boot nodes
2023-06-09T18:16:23.750603Z  INFO portalnet::overlay_service: Starting overlay service protocol=History
2023-06-09T18:16:23.752140Z  INFO trin_history: reports~ data: radius=46% content=100.0/100mb #=1867 disk=45.3mb; msgs: offers=0/0, accepts=0/0
2023-06-09T18:16:25.382009Z  INFO portalnet::overlay: Bonded with bootnode alias=ultralight-3

2023-06-09T18:16:34.061523Z  INFO portalnet::overlay: Bonded with bootnode alias=fluffy-4
2023-06-09T18:16:35.158583Z  INFO portalnet::overlay: Bonded with bootnode alias=ultralight-4
2023-06-09T18:16:36.164566Z ERROR portalnet::overlay: Error bonding with bootnode alias=ultralight-2 protocol=History error=The request timed out
2023-06-09T18:16:37.170793Z ERROR portalnet::overlay: Error bonding with bootnode alias=trin-nyc1-1 protocol=History error=The request timed out
2023-06-09T18:16:38.178902Z ERROR portalnet::overlay: Error bonding with bootnode alias=trin-sgp1-1 protocol=History error=The request timed out
2023-06-09T18:16:39.182898Z ERROR portalnet::overlay: Error bonding with bootnode alias=fluffy-2 protocol=History error=The request timed out
```

### How was it fixed?
I added some aliases to the bootnodes to help easily identify them and clean up the logs. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
