### PR TITLE
Add catch for bootnode self-update

### DIFF
--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -116,6 +116,10 @@ impl Discovery {
 
         let bootnode_enrs: Vec<Enr> = portal_config.bootnodes.into();
         for enr in bootnode_enrs {
+            if enr.node_id() == discv5.local_enr().node_id() {
+                warn!("Bootnode ENR is the same as the local ENR. Skipping.");
+                continue;
+            }
             discv5
                 .add_enr(enr)
                 .map_err(|e| format!("Failed to add bootnode enr: {e}"))?;


### PR DESCRIPTION
### What was wrong?
If a network bootnode uses the default bootnode list to bootstrap itself into the network, it will inevitably try to connect with itself, which will throw an `invalid self update` error.

### How was it fixed?
This clause checks to make sure that a node never attempts to add itself to its routing table.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
