### PR TITLE
Add validate_content jsonrpc

### DIFF
--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -95,6 +95,14 @@ pub trait BeaconNetworkApi {
         content_value: Option<BeaconContentValue>,
     ) -> RpcResult<AcceptInfo>;
 
+    /// Returns true or false depending on if the client was able to validate a given history content key and content data.
+    #[method(name = "historyValidateContent")]
+    async fn validate_content(
+        &self,
+        content_key: BeaconContentKey,
+        content_value: BeaconContentValue,
+    ) -> RpcResult<bool>;
+
     /// Store content key with a content data to the local database.
     #[method(name = "beaconStore")]
     async fn store(

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -98,6 +98,14 @@ pub trait HistoryNetworkApi {
         content_value: Option<HistoryContentValue>,
     ) -> RpcResult<AcceptInfo>;
 
+    /// Returns true or false depending on if the client was able to validate a given history content key and content data.
+    #[method(name = "historyValidateContent")]
+    async fn validate_content(
+        &self,
+        content_key: HistoryContentKey,
+        content_value: HistoryContentValue,
+    ) -> RpcResult<bool>;
+
     /// Store content key with a content data to the local database.
     #[method(name = "historyStore")]
     async fn store(

--- a/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -47,6 +47,8 @@ pub enum HistoryEndpoint {
     Gossip(HistoryContentKey, HistoryContentValue),
     /// params: [enr, content_key]
     Offer(Enr, HistoryContentKey, Option<HistoryContentValue>),
+    /// params: [content_key, content_value]
+    ValidateContent(HistoryContentKey, HistoryContentValue),
     /// params: [enr]
     Ping(Enr),
     /// params: content_key
@@ -87,6 +89,8 @@ pub enum BeaconEndpoint {
     Gossip(BeaconContentKey, BeaconContentValue),
     /// params: [enr, content_key]
     Offer(Enr, BeaconContentKey, Option<BeaconContentValue>),
+    /// params: [content_key, content_value]
+    ValidateContent(BeaconContentKey, BeaconContentValue),
     /// params: enr
     Ping(Enr),
     /// params: content_key

--- a/ethportal-peertest/src/scenarios/validation.rs
+++ b/ethportal-peertest/src/scenarios/validation.rs
@@ -118,3 +118,51 @@ pub async fn test_validate_pre_merge_receipts(peertest: &Peertest, target: &Clie
         _ => panic!("Content value's should match"),
     }
 }
+
+pub async fn test_validate_content_rpc_pre_merge_header_with_proof(target: &Client) {
+    info!("Test validate content rpc pre-merge header-with-proof");
+    let header_with_proof_content_key: HistoryContentKey =
+        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_KEY)).unwrap();
+    let header_with_proof_content_value: HistoryContentValue =
+        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_VALUE)).unwrap();
+
+    let result = target
+        .validate_content(
+            header_with_proof_content_key,
+            header_with_proof_content_value,
+        )
+        .await
+        .unwrap();
+
+    assert!(result)
+}
+
+pub async fn test_validate_content_rpc_pre_merge_block_body(target: &Client) {
+    info!("Test validate content rpc pre-merge block body");
+    let block_body_content_key: HistoryContentKey =
+        serde_json::from_value(json!(BLOCK_BODY_CONTENT_KEY)).unwrap();
+    let block_body_content_value: HistoryContentValue =
+        serde_json::from_value(json!(BLOCK_BODY_CONTENT_VALUE)).unwrap();
+
+    let result = target
+        .validate_content(block_body_content_key, block_body_content_value)
+        .await
+        .unwrap();
+
+    assert!(result)
+}
+
+pub async fn test_validate_content_rpc_pre_merge_receipts(target: &Client) {
+    info!("Test validate content rpc pre-merge receipts");
+    let receipts_content_key: HistoryContentKey =
+        serde_json::from_value(json!(RECEIPTS_CONTENT_KEY)).unwrap();
+    let receipts_content_value: HistoryContentValue =
+        serde_json::from_value(json!(RECEIPTS_CONTENT_VALUE)).unwrap();
+
+    let result = target
+        .validate_content(receipts_content_key, receipts_content_value)
+        .await
+        .unwrap();
+
+    assert!(result)
+}

--- a/newsfragments/782.added.md
+++ b/newsfragments/782.added.md
@@ -1,0 +1,1 @@
+Add validate_content jsonrpc

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -541,6 +541,30 @@ where
         }
     }
 
+    /// Validate Content request
+    pub async fn validate_content(
+        &self,
+        content_key: RawContentKey,
+        content_value: Vec<u8>,
+    ) -> Result<bool, OverlayRequestError> {
+        let content_key = TContentKey::try_from(content_key).map_err(|err| {
+            OverlayRequestError::FailedValidation(format!(
+                "Error decoding content key for received utp content: {err}"
+            ))
+        })?;
+        match self
+            .validator
+            .validate_content(&content_key, &content_value)
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(msg) => Err(OverlayRequestError::FailedValidation(format!(
+                "Network: {:?}, Reason: {:?}",
+                self.protocol, msg
+            ))),
+        }
+    }
+
     pub async fn lookup_node(&self, target: NodeId) -> Vec<Enr> {
         if target == self.local_enr().node_id() {
             return vec![self.local_enr()];

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -201,6 +201,18 @@ impl BeaconNetworkApiServer for BeaconNetworkApi {
         Ok(result)
     }
 
+    /// Returns true or false depending on if the client was able to validate a given history content key and content data.
+    async fn validate_content(
+        &self,
+        content_key: BeaconContentKey,
+        content_value: BeaconContentValue,
+    ) -> RpcResult<bool> {
+        let endpoint = BeaconEndpoint::ValidateContent(content_key, content_value);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: bool = from_value(result)?;
+        Ok(result)
+    }
+
     /// Store content key with a content data to the local database.
     async fn store(
         &self,

--- a/rpc/src/history_rpc.rs
+++ b/rpc/src/history_rpc.rs
@@ -200,6 +200,18 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
         Ok(result)
     }
 
+    /// Returns true or false depending on if the client was able to validate a given history content key and content data.
+    async fn validate_content(
+        &self,
+        content_key: HistoryContentKey,
+        content_value: HistoryContentValue,
+    ) -> RpcResult<bool> {
+        let endpoint = HistoryEndpoint::ValidateContent(content_key, content_value);
+        let result = self.proxy_query_to_history_subnet(endpoint).await?;
+        let result: bool = from_value(result)?;
+        Ok(result)
+    }
+
     /// Store content key with a content data to the local database.
     async fn store(
         &self,

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -80,6 +80,14 @@ mod test {
         peertest::scenarios::validation::test_validate_pre_merge_block_body(&peertest, &target)
             .await;
         peertest::scenarios::validation::test_validate_pre_merge_receipts(&peertest, &target).await;
+        peertest::scenarios::validation::test_validate_content_rpc_pre_merge_header_with_proof(
+            &target,
+        )
+        .await;
+        peertest::scenarios::validation::test_validate_content_rpc_pre_merge_block_body(&target)
+            .await;
+        peertest::scenarios::validation::test_validate_content_rpc_pre_merge_receipts(&target)
+            .await;
 
         peertest.exit_all_nodes();
         test_client_rpc_handle.stop().unwrap();

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -69,6 +69,9 @@ async fn complete_request(network: Arc<RwLock<BeaconNetwork>>, request: BeaconJs
         BeaconEndpoint::Offer(enr, content_key, content_value) => {
             offer(network, enr, content_key, content_value).await
         }
+        BeaconEndpoint::ValidateContent(content_key, content_value) => {
+            validate_content(network, content_key, content_value).await
+        }
         BeaconEndpoint::Ping(enr) => ping(network, enr).await,
         BeaconEndpoint::RoutingTableInfo => Ok(json!("Not implemented")), // TODO: implement this when refactor trin_history utils
         BeaconEndpoint::RecursiveFindNodes(node_id) => recursive_find_nodes(network, node_id).await,
@@ -297,6 +300,22 @@ async fn offer(
             })),
             Err(msg) => Err(format!("Offer request timeout: {msg:?}")),
         }
+    }
+}
+
+/// Constructs a JSON call for the Validate Content method.
+async fn validate_content(
+    network: Arc<RwLock<BeaconNetwork>>,
+    content_key: BeaconContentKey,
+    content_value: BeaconContentValue,
+) -> Result<Value, String> {
+    let overlay = network.read().await.overlay.clone();
+    match overlay
+        .validate_content(content_key.into(), content_value.encode())
+        .await
+    {
+        Ok(bool) => Ok(json!(bool)),
+        Err(msg) => Err(format!("Validate Content request timeout: {msg:?}")),
     }
 }
 


### PR DESCRIPTION
### What was wrong?
There wasn't a good way to validate if you had data other then push it onto the network and try and fetch it again. We should have a way for a user to validate data they have throw jsonrpc
### How was it fixed?
Add ``validate_content`` json rpc
### To-Do

### Use cases?

- debugging
- when we settle how we are going to handle verification https://github.com/ethereum/trin/issues/755
If someone chooses ``loose`` it might be useful for a user to check if we were able to validate the data for important information to them?
- Direct access to validate if a users data is valid instead of having to store then findcontent. Assuming they already have the data

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
