### PR TITLE
ethportal-api: Change `node_id` field of `NodeInfo` to `String`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,7 +2276,7 @@ checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
 
 [[package]]
 name = "ethportal-api"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64 0.13.1",

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethportal-api"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Definitions for various Ethereum Portal Network JSONRPC APIs"
 license = "GPL-3.0"

--- a/ethportal-api/src/types/discv5.rs
+++ b/ethportal-api/src/types/discv5.rs
@@ -23,7 +23,7 @@ pub struct KBucketsTable {
 #[serde(rename_all = "camelCase")]
 pub struct NodeInfo {
     pub enr: Enr,
-    pub node_id: NodeId,
+    pub node_id: String,
     pub ip: Option<String>,
 }
 

--- a/newsfragments/784.changed.md
+++ b/newsfragments/784.changed.md
@@ -1,0 +1,1 @@
+ethportal-api: Change `node_id` field of `NodeInfo` to `String`.

--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -206,7 +206,7 @@ impl Discovery {
         Ok(NodeInfo {
             enr: Enr::from_str(&self.discv5.local_enr().to_base64())
                 .map_err(|err| anyhow!("{err}"))?,
-            node_id: self.discv5.local_enr().node_id(),
+            node_id: hex_encode(self.discv5.local_enr().node_id().raw()),
             ip: self
                 .discv5
                 .local_enr()


### PR DESCRIPTION
### What was wrong?
The `NodeId `type as a `NodeInfo` field is incompatible with Fluffy and Ultralight and doesn't follow the json-rpc specs. This causes `portal-hive` tests to fail.

### How was it fixed?
Change node id field type to `String`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
