### PR TITLE
Add support for fluffy-bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7182,6 +7182,7 @@ dependencies = [
  "futures 0.3.28",
  "jsonrpsee 0.16.2",
  "lazy_static",
+ "portalnet",
  "rstest 0.11.0",
  "serde",
  "serde_json",
@@ -7192,6 +7193,7 @@ dependencies = [
  "tracing-subscriber",
  "trin-utils",
  "trin-validation",
+ "url",
 ]
 
 [[package]]

--- a/newsfragments/785.fixed.md
+++ b/newsfragments/785.fixed.md
@@ -1,0 +1,1 @@
+Add support for fluffy inside bridge.

--- a/trin-bridge/Cargo.toml
+++ b/trin-bridge/Cargo.toml
@@ -24,6 +24,7 @@ eth2_ssz_types = "0.2.1"
 futures = "0.3.21"
 jsonrpsee = {version="0.16.2", features = ["async-client", "client", "macros", "server"]}
 lazy_static = "1.4.0"
+portalnet = { path = "../portalnet" }
 serde = { version = "1.0.150", features = ["derive", "rc"] }
 serde_json = "1.0.89"
 surf = "2.3.2"
@@ -32,6 +33,7 @@ tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 trin-utils = { path = "../trin-utils" }
 trin-validation = { path = "../trin-validation" }
+url = "2.3.1"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/trin-bridge/README.md
+++ b/trin-bridge/README.md
@@ -3,5 +3,5 @@ Process to feed the portal network by gossiping data retrieved from a trusted pr
 
 ex.
 ```
-cargo run -p trin-bridge -- --node-count 1 --executable-path ./target/debug/trin --epoch-accumulator-path ./portal-accumulators
+cargo run -p trin-bridge -- --node-count 1 --executable-path ./target/debug/trin --epoch-accumulator-path ./portal-accumulators trin
 ```

--- a/trin-bridge/src/cli.rs
+++ b/trin-bridge/src/cli.rs
@@ -1,7 +1,10 @@
+use crate::client_handles::{fluffy_handle, trin_handle};
 use crate::types::NetworkKind;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 use std::str::FromStr;
+use tokio::process::Child;
+use url::Url;
 
 // max value of 16 b/c...
 // - reliably calculate spaced private keys in a reasonable time
@@ -11,7 +14,7 @@ use std::str::FromStr;
 pub const MAX_NODE_COUNT: u8 = 16;
 const DEFAULT_SUBNETWORK: &str = "history";
 
-#[derive(Parser, Debug, PartialEq)]
+#[derive(Parser, Debug, PartialEq, Clone)]
 #[command(name = "Trin Bridge", about = "Feed the network")]
 pub struct BridgeConfig {
     #[arg(
@@ -44,6 +47,12 @@ pub struct BridgeConfig {
         use_value_delimiter = true
     )]
     pub network: Vec<NetworkKind>,
+
+    #[arg(long, help = "Url for metrics reporting")]
+    pub metrics_url: Option<Url>,
+
+    #[command(subcommand)]
+    pub client_type: ClientType,
 }
 
 fn check_node_count(val: &str) -> Result<u8, String> {
@@ -98,6 +107,38 @@ impl FromStr for BridgeMode {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Subcommand)]
+pub enum ClientType {
+    Fluffy,
+    Trin,
+}
+
+impl FromStr for ClientType {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "fluffy" => Ok(ClientType::Fluffy),
+            "trin" => Ok(ClientType::Trin),
+            _ => Err("Invalid client type"),
+        }
+    }
+}
+
+impl ClientType {
+    pub fn build_handle(
+        &self,
+        private_key: String,
+        rpc_port: u16,
+        udp_port: u16,
+        bridge_config: BridgeConfig,
+    ) -> anyhow::Result<Child> {
+        match self {
+            ClientType::Fluffy => fluffy_handle(private_key, rpc_port, udp_port, bridge_config),
+            ClientType::Trin => trin_handle(private_key, rpc_port, udp_port, bridge_config),
+        }
+    }
+}
 #[cfg(test)]
 mod test {
     use super::*;
@@ -108,7 +149,7 @@ mod test {
         const EXECUTABLE_PATH: &str = "path/to/executable";
         const EPOCH_ACC_PATH: &str = "path/to/epoch/accumulator";
         let bridge_config = BridgeConfig::parse_from([
-            "test",
+            "bridge",
             "--node-count",
             NODE_COUNT,
             "--executable-path",
@@ -117,6 +158,7 @@ mod test {
             EPOCH_ACC_PATH,
             "--network",
             "history,beacon",
+            "trin",
         ]);
         assert_eq!(bridge_config.node_count, 1);
         assert_eq!(
@@ -138,7 +180,7 @@ mod test {
         const EPOCH_ACC_PATH: &str = "path/to/epoch/accumulator";
         const EPOCH: &str = "e100";
         let bridge_config = BridgeConfig::parse_from([
-            "test",
+            "bridge",
             "--node-count",
             NODE_COUNT,
             "--executable-path",
@@ -147,6 +189,7 @@ mod test {
             EPOCH_ACC_PATH,
             "--mode",
             EPOCH,
+            "trin",
         ]);
         assert_eq!(bridge_config.node_count, 1);
         assert_eq!(
@@ -165,13 +208,14 @@ mod test {
         const EXECUTABLE_PATH: &str = "path/to/executable";
         const EPOCH_ACC_PATH: &str = "path/to/epoch/accumulator";
         let bridge_config = BridgeConfig::parse_from([
-            "test",
+            "bridge",
             "--node-count",
             node_count,
             "--executable-path",
             EXECUTABLE_PATH,
             "--epoch-accumulator-path",
             EPOCH_ACC_PATH,
+            "trin",
         ]);
         assert_eq!(bridge_config.node_count, 16);
         assert_eq!(
@@ -188,6 +232,21 @@ mod test {
         expected = "Invalid network arg. Expected either 'beacon', 'history' or 'state'"
     )]
     fn test_invalid_network_arg() {
-        BridgeConfig::try_parse_from(["test", "--network", "das"].iter()).unwrap();
+        BridgeConfig::try_parse_from(["bridge", "--network", "das", "trin"].iter()).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "MissingSubcommand")]
+    fn test_config_requires_client_type_subcommand() {
+        BridgeConfig::try_parse_from([
+            "bridge",
+            "--node-count",
+            "1",
+            "--executable-path",
+            "path/to/executable",
+            "--epoch-accumulator-path",
+            "path/to/epoch/accumulator",
+        ])
+        .unwrap();
     }
 }

--- a/trin-bridge/src/client_handles.rs
+++ b/trin-bridge/src/client_handles.rs
@@ -1,0 +1,68 @@
+use crate::cli::BridgeConfig;
+use anyhow::bail;
+use portalnet::socket::stun_for_external;
+use std::net::SocketAddr;
+use tokio::process::{Child, Command};
+
+pub fn fluffy_handle(
+    private_key: String,
+    rpc_port: u16,
+    udp_port: u16,
+    bridge_config: BridgeConfig,
+) -> anyhow::Result<Child> {
+    let mut command = Command::new(bridge_config.executable_path);
+    let listen_all_ips = SocketAddr::new("0.0.0.0".parse().expect("to parse ip"), udp_port);
+    let ip = stun_for_external(&listen_all_ips).expect("to stun for external ip");
+    command
+        .kill_on_drop(true)
+        .arg("--storage-size:0")
+        .arg("--rpc")
+        .arg(format!("--rpc-port:{rpc_port}"))
+        .arg(format!("--udp-port:{udp_port}"))
+        .arg(format!("--nat:extip:{}", ip.ip()))
+        .arg("--network:testnet0")
+        .arg("--table-ip-limit:1024")
+        .arg("--bucket-ip-limit:24")
+        .arg(format!("--netkey-unsafe:{private_key}"));
+    if let Some(metrics_url) = bridge_config.metrics_url {
+        let address = match metrics_url.host_str() {
+            Some(address) => address,
+            None => bail!("Invalid metrics url address"),
+        };
+        let port = match metrics_url.port() {
+            Some(port) => port,
+            None => bail!("Invalid metrics url port"),
+        };
+        command
+            .arg("--metrics")
+            .arg(format!("--metrics-address:{address}"))
+            .arg(format!("--metrics-port:{port}"));
+    }
+    Ok(command.spawn()?)
+}
+
+pub fn trin_handle(
+    private_key: String,
+    rpc_port: u16,
+    udp_port: u16,
+    bridge_config: BridgeConfig,
+) -> anyhow::Result<Child> {
+    let mut command = Command::new(bridge_config.executable_path);
+    command
+        .kill_on_drop(true)
+        .args(["--ephemeral"])
+        .args(["--mb", "0"])
+        .args(["--web3-transport", "http"])
+        .args(["--unsafe-private-key", &private_key])
+        .args([
+            "--web3-http-address",
+            &format!("http://127.0.0.1:{rpc_port}"),
+        ])
+        .args(["--discovery-port", &format!("{udp_port}")])
+        .args(["--bootnodes", "default"]);
+    if let Some(metrics_url) = bridge_config.metrics_url {
+        let url: String = metrics_url.into();
+        command.args(["--enable-metrics-with-url", &url]);
+    }
+    Ok(command.spawn()?)
+}

--- a/trin-bridge/src/lib.rs
+++ b/trin-bridge/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod bridge;
 pub mod cli;
+pub mod client_handles;
 pub mod constants;
 pub mod full_header;
 pub mod pandaops;


### PR DESCRIPTION
### What was wrong?
Add support for trin-bridge to use fluffy as the client it uses to gossip out data to the network.

### How was it fixed?
Added a subcommand to the `trin-bridge` command that requires a user to specify what kind of client is located at `--executable-path` 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
