### PR TITLE
fixed minor typos in book's dev/quick_setup

### DIFF
--- a/book/src/developers/quick_setup.md
+++ b/book/src/developers/quick_setup.md
@@ -107,8 +107,6 @@ In a python shell:
 >>> w3 = Web3(Web3.IPCProvider("/tmp/trin-jsonrpc.ipc"))
 >>> w3.client_version
 'trin 0.0.1-alpha'
->>> w3.eth.block_number
-11870768
 ```
 
 To request a custom jsonrpc endpoint, provide the endpoint and array of params. eg:
@@ -137,8 +135,6 @@ Then, in a python shell:
 >>> w3 = Web3(Web3.HTTPProvider("http://127.0.0.1:8545"))
 >>> w3.client_version
 'trin 0.0.1-alpha'
->>> w3.eth.block_number
-11870768
 ```
 
 The client version responds immediately, from the trin client. The block number is retrieved more slowly, by proxying to Infura.

--- a/book/src/developers/quick_setup.md
+++ b/book/src/developers/quick_setup.md
@@ -105,9 +105,9 @@ In a python shell:
 ```py
 >>> from web3 import Web3
 >>> w3 = Web3(Web3.IPCProvider("/tmp/trin-jsonrpc.ipc"))
->>> w3.clientVersion
+>>> w3.client_version
 'trin 0.0.1-alpha'
->>> w3.eth.blockNumber
+>>> w3.eth.block_number
 11870768
 ```
 
@@ -135,9 +135,9 @@ Then, in a python shell:
 ```py
 >>> from web3 import Web3
 >>> w3 = Web3(Web3.HTTPProvider("http://127.0.0.1:8545"))
->>> w3.clientVersion
+>>> w3.client_version
 'trin 0.0.1-alpha'
->>> w3.eth.blockNumber
+>>> w3.eth.block_number
 11870768
 ```
 


### PR DESCRIPTION
### What was wrong?
In the section 3.1 of the book, it shares following snippet to interact with trin using python web3 lib:

```sh
>>> from web3 import Web3
>>> w3 = Web3(Web3.IPCProvider("/tmp/trin-jsonrpc.ipc"))
>>> w3.clientVersion
'trin 0.0.1-alpha'
>>> w3.eth.blockNumber
11870768
```
However, clientVersion and eth.blockNumber do not exist on w3. 

### How was it fixed?
I have changed them to block_number and client_version. 
More info here: https://web3py.readthedocs.io/en/latest/examples.html#getting-the-latest-block
