### PR TITLE
Fixed depends install typo in trin books linux install guide

### DIFF
--- a/book/src/users/installation/linux.md
+++ b/book/src/users/installation/linux.md
@@ -6,7 +6,7 @@ These steps are for setting up a Trin node as a service on Ubuntu.
 
 ## Installation
 ```sh
-$ sudo apt install libssl-dev librocksdb-dev libclang-dev pkg-config build-essentials
+$ sudo apt install libssl-dev librocksdb-dev libclang-dev pkg-config build-essential
 ```
 Install Trin:
 > Tip: If you intend to submit code changes to trin, first fork the repo and


### PR DESCRIPTION
### What was wrong?
Typo
### How was it fixed?
Removing the s
