### PR TITLE
Introduce an event stream to `OverlayService`

### DIFF
--- a/newsfragments/793.added.md
+++ b/newsfragments/793.added.md
@@ -1,0 +1,1 @@
+Introduce an event stream to `OverlayService`.

--- a/portalnet/src/events.rs
+++ b/portalnet/src/events.rs
@@ -1,4 +1,5 @@
 use std::str::FromStr;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use discv5::TalkRequest;
 use tokio::sync::mpsc;
@@ -109,4 +110,87 @@ impl PortalnetEvents {
 pub enum OverlayEvent {
     LightClientOptimisticUpdate,
     LightClientFinalityUpdate,
+}
+
+/// Timestamp of an overlay event.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Timestamp {
+    /// Timestamp not available.
+    NotAvailable,
+    /// Event creation time.
+    CreateTime(i64),
+}
+
+impl Timestamp {
+    /// Convert the timestamp to milliseconds since epoch.
+    pub fn to_millis(self) -> Option<i64> {
+        match self {
+            Timestamp::NotAvailable | Timestamp::CreateTime(-1) => None,
+            Timestamp::CreateTime(t) => Some(t),
+        }
+    }
+
+    /// Creates a new `Timestamp::CreateTime` representing the current time.
+    pub fn now() -> Timestamp {
+        Timestamp::from(SystemTime::now())
+    }
+}
+
+impl From<i64> for Timestamp {
+    fn from(system_time: i64) -> Timestamp {
+        Timestamp::CreateTime(system_time)
+    }
+}
+
+impl From<SystemTime> for Timestamp {
+    fn from(system_time: SystemTime) -> Timestamp {
+        Timestamp::CreateTime(millis_to_epoch(system_time))
+    }
+}
+
+/// A wrapper around an overlay event that includes additional metadata.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct EventEnvelope {
+    pub timestamp: Timestamp,
+    pub payload: OverlayEvent,
+}
+
+impl EventEnvelope {
+    pub fn new(payload: OverlayEvent) -> Self {
+        let timestamp = Timestamp::now();
+        Self { timestamp, payload }
+    }
+}
+
+/// Converts the given time to the number of milliseconds since the Unix epoch.
+pub fn millis_to_epoch(time: SystemTime) -> i64 {
+    time.duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| Duration::from_secs(0))
+        .as_millis() as i64
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::time::SystemTime;
+
+    #[test]
+    fn test_timestamp_creation() {
+        let now = SystemTime::now();
+        let t1 = Timestamp::now();
+        let t2 = Timestamp::from(now);
+        let expected = Timestamp::CreateTime(millis_to_epoch(now));
+
+        assert_eq!(t2, expected);
+        assert!(t1.to_millis().unwrap() - t2.to_millis().unwrap() < 10);
+    }
+
+    #[test]
+    fn test_timestamp_conversion() {
+        assert_eq!(Timestamp::CreateTime(100).to_millis(), Some(100));
+        assert_eq!(Timestamp::CreateTime(-1).to_millis(), None);
+        assert_eq!(Timestamp::NotAvailable.to_millis(), None);
+        let t: Timestamp = 100.into();
+        assert_eq!(t, Timestamp::CreateTime(100));
+    }
 }

--- a/portalnet/src/events.rs
+++ b/portalnet/src/events.rs
@@ -103,3 +103,10 @@ impl PortalnetEvents {
         }
     }
 }
+
+/// Events that can be produced by the `OverlayProtocol` event stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OverlayEvent {
+    LightClientOptimisticUpdate,
+    LightClientFinalityUpdate,
+}

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -47,7 +47,7 @@ use ethportal_api::utils::bytes::hex_encode;
 use ethportal_api::OverlayContentKey;
 use trin_validation::validator::Validator;
 
-use crate::events::OverlayEvent;
+use crate::events::EventEnvelope;
 use ethportal_api::types::query_trace::QueryTrace;
 
 /// Configuration parameters for the overlay network.
@@ -710,7 +710,7 @@ where
     /// Creates an event stream channel which can be polled to receive overlay events.
     pub fn event_stream(
         &self,
-    ) -> impl Future<Output = anyhow::Result<mpsc::Receiver<OverlayEvent>>> + 'static {
+    ) -> impl Future<Output = anyhow::Result<mpsc::Receiver<EventEnvelope>>> + 'static {
         let channel = self.command_tx.clone();
 
         async move {
@@ -723,7 +723,7 @@ where
 
             callback_recv
                 .await
-                .map_err(|_| anyhow!("The Overlay Service channel has been closed early."))
+                .map_err(|_| anyhow!("The Overlay Service callback channel has been closed early."))
         }
     }
 }

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -237,3 +237,15 @@ async fn overlay() {
         }
     }
 }
+
+#[tokio::test]
+async fn overlay_event_stream() {
+    let portal_config = PortalnetConfig {
+        no_stun: true,
+        ..Default::default()
+    };
+    let discovery = Arc::new(Discovery::new(portal_config).unwrap());
+    let overlay = init_overlay(discovery, ProtocolId::Beacon).await;
+
+    overlay.event_stream().await.unwrap();
+}

--- a/trin-beacon/src/network.rs
+++ b/trin-beacon/src/network.rs
@@ -50,6 +50,8 @@ impl BeaconNetwork {
         )
         .await;
 
+        let _ = overlay.event_stream().await?;
+
         Ok(Self {
             overlay: Arc::new(overlay),
         })


### PR DESCRIPTION
### What was wrong?

 We want to introduce a separate Beacon network service that takes care of the light client mechanics and keeps the node in sync with the tip of the chain. This service needs to listen for the latest `LightClientFinality` and `LIghtClientOptimistic` content updates. Currently, there is no way to listen for an event from the overlay service.

### How was it fixed?

IMO, listening for an event is best done by an event stream. This PR adds an event stream to the `OverlayService` which can emit light client updates events or any other kind of events. As discussed in Boulder, this event stream can be also used for testing and debugging.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
