### PR TITLE
Prevent lookup_enr failing prematurely if internal FindNodes fails

### DIFF
--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -344,11 +344,12 @@ where
 
         // try to find more up to date enr
         if let Ok(enr) = enr.clone() {
-            let nodes = self.send_find_nodes(enr, vec![0]).await?;
-            let enr_highest_seq = nodes.enrs.into_iter().max_by(|a, b| a.seq().cmp(&b.seq()));
+            if let Ok(nodes) = self.send_find_nodes(enr, vec![0]).await {
+                let enr_highest_seq = nodes.enrs.into_iter().max_by(|a, b| a.seq().cmp(&b.seq()));
 
-            if let Some(enr_highest_seq) = enr_highest_seq {
-                return Ok(enr_highest_seq.into());
+                if let Some(enr_highest_seq) = enr_highest_seq {
+                    return Ok(enr_highest_seq.into());
+                }
             }
         }
 


### PR DESCRIPTION
### What was wrong?
lookup_enr can prematurely fail if FindNodes errors out. It shouldn't be errored if that is the case, it should continue trying the other ways of finding an enr
### How was it fixed?
by using a if let Ok instead of using a ? (a try statement in rust). This prevents the potential case of lookup_enr failing prematurely
