### PR TITLE
Fix FindContent Enr failing to serialize and add test

### DIFF
--- a/ethportal-api/src/types/enr.rs
+++ b/ethportal-api/src/types/enr.rs
@@ -2,6 +2,7 @@ use discv5::enr::CombinedKey;
 use discv5::enr::EnrBuilder;
 use rand::Rng;
 use rlp::Encodable;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use ssz::DecodeError;
 use std::net::Ipv4Addr;
@@ -11,7 +12,7 @@ use validator::ValidationError;
 
 pub type Enr = discv5::enr::Enr<CombinedKey>;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct SszEnr(pub Enr);
 
 impl SszEnr {

--- a/newsfragments/797.fixed.md
+++ b/newsfragments/797.fixed.md
@@ -1,0 +1,1 @@
+Fix FindContent Enr failing to serialize and add test

--- a/portalnet/src/types/messages.rs
+++ b/portalnet/src/types/messages.rs
@@ -542,7 +542,7 @@ impl TryInto<Value> for Content {
         } else if let Content::Content(val) = self {
             Ok(serde_json::json!({ "content": hex_encode(val) }))
         } else if let Content::Enrs(val) = self {
-            Ok(serde_json::json!({ "enrs": format!("{:?}", val) }))
+            Ok(serde_json::json!({ "enrs": val }))
         } else {
             Err(MessageDecodeError::Type)
         }

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -46,11 +46,12 @@ mod test {
         .unwrap();
 
         let test_client_rpc_handle = trin::run_trin(trin_config).await.unwrap();
-        peertest::scenarios::paginate::test_paginate_local_storage(&peertest).await;
         let target = reth_ipc::client::IpcClientBuilder::default()
             .build(DEFAULT_WEB3_IPC_PATH)
             .await
             .unwrap();
+
+        peertest::scenarios::paginate::test_paginate_local_storage(&peertest).await;
         peertest::scenarios::basic::test_web3_client_version(&target).await;
         peertest::scenarios::basic::test_discv5_node_info(&peertest).await;
         peertest::scenarios::basic::test_discv5_routing_table_info(&target).await;
@@ -67,6 +68,7 @@ mod test {
         peertest::scenarios::basic::test_history_local_content_absent(&target).await;
         peertest::scenarios::offer_accept::test_unpopulated_offer(&peertest, &target).await;
         peertest::scenarios::offer_accept::test_populated_offer(&peertest, &target).await;
+        peertest::scenarios::find::test_find_content_return_enr(&target, &peertest).await;
         peertest::scenarios::find::test_recursive_find_nodes_self(&peertest).await;
         peertest::scenarios::find::test_recursive_find_nodes_peer(&peertest).await;
         peertest::scenarios::find::test_recursive_find_nodes_random(&peertest).await;


### PR DESCRIPTION
### What was wrong?
I was trying to write tests for portal-hive https://github.com/ethereum/portal-hive/pull/61

And I notice FindContent returning ENRS would fail everytime
### How was it fixed?
I did some debugging and found out it was an issue with serializing. So I used serde derivied serialization and it worked like a charm.
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
