### PR TITLE
Update discv5 version to 0.3.1 (Fixing NodeId Serialization)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,9 +1639,9 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "discv5"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f32d27968ba86689e3f0eccba0383414348a6fc5918b0a639c98dd81e20ed6"
+checksum = "98c05fa26996c6141f78ac4fafbe297a7fa69690565ba4e0d1f2e60bde5ce501"
 dependencies = [
  "aes 0.7.5",
  "aes-gcm 0.9.4",
@@ -1789,11 +1789,11 @@ dependencies = [
 
 [[package]]
 name = "enr"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf56acd72bb22d2824e66ae8e9e5ada4d0de17a69c7fd35569dde2ada8ec9116"
+checksum = "0be7b2ac146c1f99fe245c02d16af0696450d8e06c135db75e10eeb9e642c20d"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes 1.4.0",
  "ed25519-dalek",
  "hex",
@@ -1802,6 +1802,7 @@ dependencies = [
  "rand 0.8.5",
  "rlp 0.5.2",
  "serde",
+ "serde-hex",
  "sha3 0.10.7",
  "zeroize",
 ]
@@ -5910,6 +5911,17 @@ checksum = "c3dfe1b7eb6f9dcf011bd6fad169cdeaae75eda0d61b1a99a3f015b41b0cae39"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "serde-hex"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca37e3e4d1b39afd7ff11ee4e947efae85adfddf4841787bfa47c470e96dc26d"
+dependencies = [
+ "array-init",
+ "serde",
+ "smallvec 0.6.14",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ description = "A Rust implementation of the Ethereum Portal Network"
 [dependencies]
 anyhow = "1.0.68"
 clap = { version = "4.2.1", features = ["derive"] }
-discv5 = { version = "0.3.0", features = ["serde"] }
+discv5 = { version = "0.3.1", features = ["serde"] }
 eth2_ssz = "0.4.0"
 ethereum-types = "0.12.1"
 ethportal-api = { path = "ethportal-api" }

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.68"
 base64 = "0.13.0"
 bytes = "1.3.0"
 clap = { version = "4.2.1", features = ["derive"] }
-discv5 = { version = "0.3.0", features = ["serde"]}
+discv5 = { version = "0.3.1", features = ["serde"]}
 eth_trie = "0.1.0"
 eth2_ssz = "0.4.0"
 eth2_ssz_derive = "0.3.0"

--- a/ethportal-api/src/types/enr.rs
+++ b/ethportal-api/src/types/enr.rs
@@ -61,7 +61,7 @@ impl ssz::Decode for SszEnr {
     }
 
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        let string = base64::encode_config(bytes, base64::URL_SAFE);
+        let string = base64::encode_config(bytes, base64::URL_SAFE_NO_PAD);
         Ok(SszEnr(
             Enr::from_str(&string).map_err(DecodeError::BytesInvalid)?,
         ))

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
-discv5 = { version = "0.3.0", features = ["serde"]}
+discv5 = { version = "0.3.1", features = ["serde"]}
 eth2_ssz = "0.4.0"
 ethereum-types = "0.12.1"
 ethportal-api = { path="../ethportal-api"}

--- a/newsfragments/800.fixed.md
+++ b/newsfragments/800.fixed.md
@@ -1,0 +1,1 @@
+Update discv5 version to 0.3.1/Fix NodeId Serialization

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 anyhow = "1.0.68"
 async-trait = "0.1.68"
 clap = { version = "4.2.1", features = ["derive"] }
-discv5 = { version = "0.3.0", features = ["serde"]}
+discv5 = { version = "0.3.1", features = ["serde"]}
 ethportal-api = { path = "../ethportal-api" }
 ethereum-types = "0.12.1"
 eth2_ssz = "0.4.0"

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -17,7 +17,7 @@ base64 = "0.13.0"
 bytes = "1.3.0"
 delay_map = "0.1.1"
 directories = "3.0"
-discv5 = { version = "0.3.0", features = ["serde"]}
+discv5 = { version = "0.3.1", features = ["serde"]}
 eth2_ssz = "0.4.0"
 eth2_ssz_derive = "0.3.0"
 eth2_ssz_types = "0.2.1"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
-discv5 = { version = "0.3.0", features = ["serde"] }
+discv5 = { version = "0.3.1", features = ["serde"] }
 ethportal-api = { path = "../ethportal-api"}
 portalnet = { path = "../portalnet"}
 tracing = "0.1.27"

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 async-trait = "0.1.53"
-discv5 = { version = "0.3.0", features = ["serde"]}
+discv5 = { version = "0.3.1", features = ["serde"]}
 ethportal-api = {path = "../ethportal-api"}
 eth2_ssz = "0.4.0"
 parking_lot = "0.11.2"

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 async-trait = "0.1.53"
-discv5 = { version = "0.3.0", features = ["serde"]}
+discv5 = { version = "0.3.1", features = ["serde"]}
 eth2_ssz = "0.4.0"
 ethereum-types = "0.12.1"
 ethportal-api = {path = "../ethportal-api"}

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 async-trait = "0.1.53"
-discv5 = { version = "0.3.0", features = ["serde"]}
+discv5 = { version = "0.3.1", features = ["serde"]}
 ethereum-types = "0.12.1"
 ethportal-api = { path = "../ethportal-api" }
 eth_trie = "0.1.0"

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
-discv5 = { version = "0.3.0", features = ["serde"]}
+discv5 = { version = "0.3.1", features = ["serde"]}
 ethportal-api = { path="../ethportal-api"}
 jsonrpsee = {version = "0.15.1", features = ["full"]}
 portalnet = { path = "../portalnet" }


### PR DESCRIPTION
### What was wrong?
Update discv5 version which has fixes for NodeID serialiation
### How was it fixed?
By updating the dependency.

``let string = base64::encode_config(bytes, base64::URL_SAFE);`` was switched to ``let string = base64::encode_config(bytes, base64::URL_SAFE_NO_PAD);`` since we just used a wrapped of sigp/enr Enr::from_str which uses "URL_SAFE_NO_PAD" I am not sure why we used URL_SAFE, but regardless if ``Enr::from_str()`` doesn't use URL_SAFE us using it will indeed throw an error, so if we want that we have to implement ``Enr::from_str()`` ourselves