### PR TITLE
Filters disconnected nodes before beginning queries

### DIFF
--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -2194,6 +2194,33 @@ where
         Ok(closest_nodes)
     }
 
+    /// Returns a vector of ENRs of the `max_nodes` closest connected nodes to the target from our routing table.
+    fn closest_connected_nodes(&self, target_key: &Key<NodeId>, max_nodes: usize) -> Vec<Enr> {
+        // Filter out all disconnected nodes
+        let kbuckets = self.kbuckets.read();
+        let mut all_nodes: Vec<&kbucket::Node<NodeId, Node>> = kbuckets
+            .buckets_iter()
+            .flat_map(|kbucket| {
+                kbucket
+                    .iter()
+                    .filter(|node| node.status.is_connected())
+                    .collect::<Vec<&kbucket::Node<NodeId, Node>>>()
+            })
+            .collect();
+
+        all_nodes.sort_by(|a, b| {
+            let a_distance = a.key.distance(target_key);
+            let b_distance = b.key.distance(target_key);
+            a_distance.cmp(&b_distance)
+        });
+
+        all_nodes
+            .iter()
+            .take(max_nodes)
+            .map(|closest| closest.value.enr.clone())
+            .collect()
+    }
+
     /// Starts a FindNode query to find nodes with IDs closest to `target`.
     fn init_find_nodes_query(
         &mut self,
@@ -2201,19 +2228,23 @@ where
         callback: Option<oneshot::Sender<Vec<Enr>>>,
     ) -> Option<QueryId> {
         let target_key = Key::from(*target);
-        let mut closest_enrs: Vec<Enr> = self
-            .kbuckets
-            .write()
-            .closest_values(&target_key)
-            .map(|closest| closest.value.enr)
-            .collect();
 
-        // `closest_enrs` will be empty if `target` is our local node ID
-        // due to the behavior of `closest_values`. In this case, set closest_enrs
-        // to be all ENRs in routing table.
+        let mut closest_enrs = self.closest_connected_nodes(&target_key, self.query_num_results);
+
+        // All nodes may be disconnected at boot, before they respond to pings.
+        // If no connected nodes, use the closest nodes regardless of connectivity.
         if closest_enrs.is_empty() {
-            let mut all_enrs: Vec<Enr> = self.table_entries_enr();
-            closest_enrs.append(&mut all_enrs);
+            closest_enrs = self
+                .kbuckets
+                .write()
+                .closest_values(&target_key)
+                .map(|closest| closest.value.enr)
+                .take(self.query_num_results)
+                .collect();
+            // `closest_values` return is empty if querying our own Node ID
+            if closest_enrs.is_empty() {
+                closest_enrs = self.table_entries_enr();
+            }
         }
 
         let query_config = QueryConfig {
@@ -2270,39 +2301,7 @@ where
             peer_timeout: self.query_peer_timeout,
         };
 
-        // Filter out all disconnected nodes
-        let kbuckets = self.kbuckets.read();
-        let mut all_nodes: Vec<&kbucket::Node<NodeId, Node>> = kbuckets
-            .buckets_iter()
-            .flat_map(|kbucket| {
-                kbucket
-                    .iter()
-                    .filter(|node| node.status.is_connected())
-                    .collect::<Vec<&kbucket::Node<NodeId, Node>>>()
-            })
-            .collect();
-
-        all_nodes.sort_by(|a, b| {
-            let a_distance = a.key.distance(&target_key);
-            let b_distance = b.key.distance(&target_key);
-            a_distance.cmp(&b_distance)
-        });
-
-        let closest_enrs: Vec<Enr> = all_nodes
-            .iter()
-            .take(query_config.num_results)
-            .map(|closest| closest.value.enr.clone())
-            .collect();
-
-        // Look up the closest ENRs to the target.
-        // Limit the number of ENRs according to the query config.
-        // let closest_enrs: Vec<Enr> = self
-        //     .kbuckets
-        //     .write()
-        //     .closest_values(&target_key)
-        //     .map(|closest| closest.value.enr)
-        //     .take(query_config.num_results)
-        //     .collect();
+        let closest_enrs = self.closest_connected_nodes(&target_key, query_config.num_results);
 
         let trace: Option<QueryTrace> = {
             if is_trace {


### PR DESCRIPTION
### What was wrong?

`sigp/discv5` provides the `kbucket::closest_values` method, but the `ClosestValue` output of this method does not include information about the connection state of the nodes on which we can filter. So we haven't been filtering disconnected nodes.

Currently out of the 16 nodes that our queries begin with, only an average of 3 respond, which is  **19%**

### How was it fixed?

Iterating over the kbuckets directly and filtering out disconnected nodes, sorting, then taking the top 16.

After this change, an average of 13 / 16 respond which is **81%** 

Testing was done manually using a local glados instance and comparing batches of audit trace results with and without the change.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Breakout into a function and use the same function in find nodes
- [x] Clean up commit history
