### PR TITLE
Don't include source enr in find_content return

### DIFF
--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -1063,6 +1063,7 @@ where
                 let enrs = self.find_nodes_close_to_content(content_key);
                 match enrs {
                     Ok(mut val) => {
+                        val.retain(|x| source != &x.node_id());
                         pop_while_ssz_bytes_len_gt(&mut val, MAX_PORTAL_CONTENT_PAYLOAD_SIZE);
                         Ok(Content::Enrs(val))
                     }


### PR DESCRIPTION
### What was wrong?
fixes https://github.com/ethereum/trin/issues/804
### How was it fixed?
we add the requesting nodes enr to our table just before we handle it, there is nothing wrong with this.
But find_content should never return the requesting nodes enr in this request
