### PR TITLE
Handle utp connection id for recursive find content lookups

### DIFF
--- a/ethportal-peertest/src/scenarios/validation.rs
+++ b/ethportal-peertest/src/scenarios/validation.rs
@@ -54,6 +54,22 @@ pub async fn test_validate_pre_merge_header_with_proof(peertest: &Peertest, targ
 
 pub async fn test_validate_pre_merge_block_body(peertest: &Peertest, target: &Client) {
     info!("Test validating a pre-merge block body");
+    // store header_with_proof to validate block body
+    let header_with_proof_content_key: HistoryContentKey =
+        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_KEY)).unwrap();
+    let header_with_proof_content_value: HistoryContentValue =
+        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_VALUE)).unwrap();
+
+    let store_result = target
+        .store(
+            header_with_proof_content_key.clone(),
+            header_with_proof_content_value.clone(),
+        )
+        .await
+        .unwrap();
+
+    assert!(store_result);
+
     // store block body
     let block_body_content_key: HistoryContentKey =
         serde_json::from_value(json!(BLOCK_BODY_CONTENT_KEY)).unwrap();

--- a/newsfragments/809.fixed.md
+++ b/newsfragments/809.fixed.md
@@ -1,0 +1,1 @@
+Add support for handling connection id responses to a find content request.

--- a/portalnet/src/find/iterators/findcontent.rs
+++ b/portalnet/src/find/iterators/findcontent.rs
@@ -32,6 +32,7 @@ use super::query::{Query, QueryConfig, QueryPeer, QueryPeerState, QueryProgress}
 pub enum FindContentQueryResponse<TNodeId> {
     ClosestNodes(Vec<TNodeId>),
     Content(Vec<u8>),
+    ConnectionId(u16),
 }
 
 #[derive(Debug)]
@@ -39,13 +40,31 @@ pub enum FindContentQueryResult<TNodeId> {
     ClosestNodes(Vec<TNodeId>),
     Content {
         content: Vec<u8>,
-        closest_nodes: Vec<TNodeId>,
+        nodes_to_poke: Vec<TNodeId>,
+    },
+    Utp {
+        connection_id: u16,
+        nodes_to_poke: Vec<TNodeId>,
+        // peer used to create utp stream
+        peer: TNodeId,
     },
 }
 
 #[derive(Debug, Clone)]
-struct ContentAndPeer<TNodeId> {
+enum ContentAndPeer<TNodeId> {
+    Content(ContentAndPeerDetails<TNodeId>),
+    Utp(UtpAndPeerDetails<TNodeId>),
+}
+
+#[derive(Debug, Clone)]
+struct ContentAndPeerDetails<TNodeId> {
     content: Vec<u8>,
+    peer: TNodeId,
+}
+
+#[derive(Debug, Clone)]
+struct UtpAndPeerDetails<TNodeId> {
+    connection_id: u16,
     peer: TNodeId,
 }
 
@@ -166,11 +185,16 @@ where
                 };
             }
             FindContentQueryResponse::Content(content) => {
-                // Incorporate the found content into the query.
-                self.content = Some(ContentAndPeer {
+                self.content = Some(ContentAndPeer::Content(ContentAndPeerDetails {
                     content,
                     peer: peer.clone(),
-                });
+                }));
+            }
+            FindContentQueryResponse::ConnectionId(connection_id) => {
+                self.content = Some(ContentAndPeer::Utp(UtpAndPeerDetails {
+                    connection_id: u16::from_be(connection_id),
+                    peer: peer.clone(),
+                }));
             }
         }
     }
@@ -292,36 +316,30 @@ where
     }
 
     fn into_result(self) -> Self::Result {
-        match self.content {
-            Some(content) => {
-                let closest_nodes = self
-                    .closest_peers
-                    .into_values()
-                    .filter_map(|peer| {
-                        if let QueryPeerState::Succeeded = peer.state() {
-                            // Do not include the peer who returned the content.
-                            if *peer.key().preimage() == content.peer {
-                                None
-                            } else {
-                                Some(peer.key().clone().into_preimage())
-                            }
-                        } else {
-                            None
-                        }
-                    })
-                    .take(self.config.num_results)
-                    .collect();
-
-                FindContentQueryResult::Content {
-                    content: content.content,
-                    closest_nodes,
+        match self.content.clone() {
+            Some(content) => match content {
+                ContentAndPeer::Content(val) => {
+                    let nodes_to_poke = self.get_nodes_to_poke(&val.peer);
+                    FindContentQueryResult::Content {
+                        content: val.content,
+                        nodes_to_poke,
+                    }
                 }
-            }
+                ContentAndPeer::Utp(val) => {
+                    let nodes_to_poke = self.get_nodes_to_poke(&val.peer);
+                    FindContentQueryResult::Utp {
+                        connection_id: val.connection_id,
+                        nodes_to_poke,
+                        peer: val.peer,
+                    }
+                }
+            },
             None => {
                 let closest_nodes = self
                     .closest_peers
                     .into_values()
                     .filter_map(|peer| {
+                        // we don't filter out the source peer when returning the closest nodes
                         if let QueryPeerState::Succeeded = peer.state() {
                             Some(peer.key().clone().into_preimage())
                         } else {
@@ -388,6 +406,26 @@ where
             QueryProgress::Iterating { .. } => self.num_waiting >= self.config.parallelism,
             QueryProgress::Finished => true,
         }
+    }
+
+    /// Returns the nodes to poke after a successful query.
+    /// Do not include the peer who returned the content.
+    fn get_nodes_to_poke(&self, source_peer: &TNodeId) -> Vec<TNodeId> {
+        self.closest_peers
+            .iter()
+            .filter_map(|(_, peer)| {
+                if let QueryPeerState::Succeeded = peer.state() {
+                    if peer.key().preimage() == source_peer {
+                        None
+                    } else {
+                        Some(peer.key().clone().into_preimage())
+                    }
+                } else {
+                    None
+                }
+            })
+            .take(self.config.num_results)
+            .collect()
     }
 }
 
@@ -459,13 +497,11 @@ mod tests {
 
         let result = query.into_result();
         match result {
-            FindContentQueryResult::Content { .. } => {
-                panic!("Unexpected result variant from new query")
-            }
             FindContentQueryResult::ClosestNodes(closest_nodes) => assert!(
                 closest_nodes.is_empty(),
                 "Unexpected closest peers in new query"
             ),
+            _ => panic!("Unexpected result variant from new query"),
         }
     }
 
@@ -571,17 +607,16 @@ mod tests {
             match result {
                 FindContentQueryResult::Content {
                     content,
-                    closest_nodes,
+                    nodes_to_poke,
                 } => {
-                    let closest_nodes =
-                        closest_nodes.into_iter().map(Key::from).collect::<Vec<_>>();
-                    assert!(sorted(&target_key, &closest_nodes));
+                    let nodes_to_poke =
+                        nodes_to_poke.into_iter().map(Key::from).collect::<Vec<_>>();
+                    assert!(sorted(&target_key, &nodes_to_poke));
 
                     let content_peer = content_peer.unwrap();
 
-                    // The peer who returned the content should not be included in the closest
-                    // nodes.
-                    assert!(!closest_nodes.contains(&content_peer));
+                    // The peer who returned the content should not be included in the poke nodes
+                    assert!(!nodes_to_poke.contains(&content_peer));
 
                     assert_eq!(content, found_content);
                 }
@@ -602,6 +637,7 @@ mod tests {
                         assert_eq!(num_results, closest_nodes.len(), "Too  many results.");
                     }
                 }
+                _ => panic!("Unexpected result."),
             }
         }
 
@@ -707,9 +743,7 @@ mod tests {
                     FindContentQueryResult::ClosestNodes(closest) => {
                         assert!(closest.is_empty());
                     }
-                    FindContentQueryResult::Content { .. } => {
-                        panic!("Unexpected query result variant")
-                    }
+                    _ => panic!("Unexpected query result variant"),
                 }
             } else {
                 // Unresponsive peers can still deliver results while the iterator
@@ -718,9 +752,7 @@ mod tests {
                     FindContentQueryResult::ClosestNodes(closest) => {
                         assert_eq!(closest, vec![peer]);
                     }
-                    FindContentQueryResult::Content { .. } => {
-                        panic!("Unexpected query result variant")
-                    }
+                    _ => panic!("Unexpected query result variant"),
                 }
             }
             true

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -284,9 +284,9 @@ pub struct OverlayService<TContentKey, TMetric, TValidator, TStore> {
     /// A map of active outgoing requests.
     active_outgoing_requests: Arc<RwLock<HashMap<OverlayRequestId, ActiveOutgoingRequest>>>,
     /// A query pool that manages find node queries.
-    find_node_query_pool: QueryPool<NodeId, FindNodeQuery<NodeId>, TContentKey>,
+    find_node_query_pool: Arc<RwLock<QueryPool<NodeId, FindNodeQuery<NodeId>, TContentKey>>>,
     /// A query pool that manages find content queries.
-    find_content_query_pool: QueryPool<NodeId, FindContentQuery<NodeId>, TContentKey>,
+    find_content_query_pool: Arc<RwLock<QueryPool<NodeId, FindContentQuery<NodeId>, TContentKey>>>,
     /// Timeout after which a peer in an ongoing query is marked unresponsive.
     query_peer_timeout: Duration,
     /// Number of peers to request data from in parallel for a single query.
@@ -370,8 +370,8 @@ where
                 command_rx,
                 command_tx: internal_command_tx,
                 active_outgoing_requests: Arc::new(RwLock::new(HashMap::new())),
-                find_node_query_pool: QueryPool::new(query_timeout),
-                find_content_query_pool: QueryPool::new(query_timeout),
+                find_node_query_pool: Arc::new(RwLock::new(QueryPool::new(query_timeout))),
+                find_content_query_pool: Arc::new(RwLock::new(QueryPool::new(query_timeout))),
                 query_peer_timeout,
                 query_parallelism,
                 query_num_results,
@@ -507,11 +507,11 @@ where
                 }
                 Some(response) = self.response_rx.recv() => {
                     // Look up active request that corresponds to the response.
-                    let optional_active_request = self.active_outgoing_requests.write().remove(&response.request_id);
-                    if let Some(active_request) = optional_active_request {
+                    let active_request = self.active_outgoing_requests.write().remove(&response.request_id);
+                    if let Some(request) = active_request {
 
                         // Send response to responder if present.
-                        if let Some(responder) = active_request.responder {
+                        if let Some(responder) = request.responder {
                             let _ = responder.send(response.response.clone());
                         }
 
@@ -519,9 +519,9 @@ where
                         match response.response {
                             Ok(response) => {
                                 self.metrics.report_inbound_response(&response);
-                                self.process_response(response, active_request.destination, active_request.request, active_request.query_id)
+                                self.process_response(response, request.destination, request.request, request.query_id)
                             }
-                            Err(error) => self.process_request_failure(response.request_id, active_request.destination, error),
+                            Err(error) => self.process_request_failure(response.request_id, request.destination, error),
                         }
 
                     } else {
@@ -536,11 +536,11 @@ where
                         self.peers_to_ping.insert(node_id);
                     }
                 }
-                query_event = OverlayService::<TContentKey, TMetric, TValidator, TStore>::query_event_poll(&mut self.find_node_query_pool) => {
+                query_event = OverlayService::<TContentKey, TMetric, TValidator, TStore>::query_event_poll(self.find_node_query_pool.clone()) => {
                     self.handle_find_nodes_query_event(query_event);
                 }
                 // Handle query events for queries in the find content query pool.
-                query_event = OverlayService::<TContentKey, TMetric, TValidator, TStore>::query_event_poll(&mut self.find_content_query_pool) => {
+                query_event = OverlayService::<TContentKey, TMetric, TValidator, TStore>::query_event_poll(self.find_content_query_pool.clone()) => {
                     self.handle_find_content_query_event(query_event);
                 }
                 _ = OverlayService::<TContentKey, TMetric, TValidator, TStore>::bucket_maintenance_poll(self.protocol.clone(), &self.kbuckets) => {}
@@ -624,11 +624,11 @@ where
     /// Maintains the query pool.
     /// Returns a `QueryEvent` when the `QueryPoolState` updates.
     /// This happens when a query needs to send a request to a node, when a query has completed,
-    // or when a query has timed out.
+    /// or when a query has timed out.
     async fn query_event_poll<TQuery: Query<NodeId>>(
-        queries: &mut QueryPool<NodeId, TQuery, TContentKey>,
+        queries: Arc<RwLock<QueryPool<NodeId, TQuery, TContentKey>>>,
     ) -> QueryEvent<TQuery, TContentKey> {
-        future::poll_fn(move |_cx| match queries.poll() {
+        future::poll_fn(move |_cx| match queries.write().poll() {
             QueryPoolState::Finished(query_id, query_info, query) => {
                 Poll::Ready(QueryEvent::Finished(query_id, query_info, query))
             }
@@ -679,7 +679,7 @@ where
                         query.id = %query_id,
                         "Cannot query peer with unknown ENR",
                     );
-                    if let Some((_, query)) = self.find_node_query_pool.get_mut(query_id) {
+                    if let Some((_, query)) = self.find_node_query_pool.write().get_mut(query_id) {
                         query.on_failure(&node_id);
                     }
                 }
@@ -758,58 +758,152 @@ where
                         query.id = %query_id,
                         "Cannot query peer with unknown ENR"
                     );
-                    if let Some((_, query)) = self.find_node_query_pool.get_mut(query_id) {
+                    if let Some((_, query)) = self.find_node_query_pool.write().get_mut(query_id) {
                         query.on_failure(&node_id);
                     }
                 }
             }
-            QueryEvent::Finished(query_id, query_info, query)
-            | QueryEvent::TimedOut(query_id, query_info, query) => {
-                let result = query.into_result();
-                let (content, closest_nodes) = match result {
-                    FindContentQueryResult::ClosestNodes(closest_nodes) => (None, closest_nodes),
-                    FindContentQueryResult::Content {
-                        content,
-                        closest_nodes,
-                    } => (Some(content), closest_nodes),
+            QueryEvent::Finished(_, query_info, query)
+            | QueryEvent::TimedOut(_, query_info, query) => {
+                let (callback, content_key) = match query_info.query_type {
+                    QueryType::FindContent { callback, target } => (callback, target),
+                    _ => {
+                        error!(
+                            "Only FindContent queries trigger a Finished or TimedOut event, but this is a {:?}",
+                            query_info.query_type
+                        );
+                        return;
+                    }
                 };
 
-                if let QueryType::FindContent {
-                    callback: Some(callback),
-                    target: content_key,
-                } = query_info.query_type
-                {
-                    let response = (content.clone(), query_info.trace);
-                    // Send (possibly `None`) content on callback channel.
-                    if let Err(err) = callback.send(response) {
-                        error!(
-                            query.id = %query_id,
-                            error = ?err,
-                            "Error sending FindContent query result to callback",
-                        );
+                match query.into_result() {
+                    FindContentQueryResult::ClosestNodes(_closest_nodes) => {
+                        if let Some(responder) = callback {
+                            let _ = responder.send((None, query_info.trace));
+                        }
                     }
+                    FindContentQueryResult::Content {
+                        content,
+                        nodes_to_poke,
+                    } => {
+                        let validator = self.validator.clone();
+                        let store = self.store.clone();
+                        let kbuckets = self.kbuckets.clone();
+                        let command_tx = self.command_tx.clone();
+                        tokio::spawn(async move {
+                            Self::process_received_content(
+                                kbuckets,
+                                command_tx,
+                                validator,
+                                store,
+                                (content.clone(), true),
+                                content_key,
+                                callback,
+                                query_info.trace,
+                                nodes_to_poke,
+                            )
+                            .await;
+                        });
+                    }
+                    FindContentQueryResult::Utp {
+                        connection_id,
+                        peer,
+                        nodes_to_poke,
+                    } => {
+                        let metrics = self.metrics.clone();
+                        let utp = self.utp_socket.clone();
+                        let source = match self.find_enr(&peer) {
+                            Some(enr) => enr,
+                            _ => {
+                                warn!("Received uTP payload from unknown {peer}");
+                                return;
+                            }
+                        };
+                        let cid = utp_rs::cid::ConnectionId {
+                            recv: connection_id,
+                            send: connection_id.wrapping_add(1),
+                            peer: crate::discovery::UtpEnr(source),
+                        };
+                        let validator = self.validator.clone();
+                        let store = self.store.clone();
+                        let kbuckets = self.kbuckets.clone();
+                        let command_tx = self.command_tx.clone();
+                        tokio::spawn(async move {
+                            metrics.report_utp_active_inc(UtpDirectionLabel::Inbound);
+                            let mut stream = match utp
+                                .connect_with_cid(cid.clone(), UTP_CONN_CFG)
+                                .await
+                            {
+                                Ok(stream) => stream,
+                                Err(err) => {
+                                    metrics.report_utp_outcome(
+                                        UtpDirectionLabel::Inbound,
+                                        UtpOutcomeLabel::FailedConnection,
+                                    );
+                                    warn!(
+                                        %err,
+                                        cid.send,
+                                        cid.recv,
+                                        peer = ?cid.peer.client(),
+                                        "Unable to establish uTP conn based on Content response",
+                                    );
+                                    return;
+                                }
+                            };
 
-                    // If content was found, then offer the content to the closest nodes who did
-                    // not possess the content.
-                    if let Some(content) = content {
-                        self.poke_content(content_key, content, closest_nodes);
+                            let mut data = vec![];
+                            if let Err(err) = stream.read_to_eof(&mut data).await {
+                                metrics.report_utp_outcome(
+                                    UtpDirectionLabel::Inbound,
+                                    UtpOutcomeLabel::FailedDataTx,
+                                );
+                                error!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), "error reading data from uTP stream, while handling a FindContent request.");
+                                return;
+                            }
+
+                            // report utp tx as successful, even if we go on to fail to process the payload
+                            metrics.report_utp_outcome(
+                                UtpDirectionLabel::Inbound,
+                                UtpOutcomeLabel::Success,
+                            );
+
+                            let trace = query_info.trace;
+                            Self::process_received_content(
+                                kbuckets,
+                                command_tx,
+                                validator,
+                                store,
+                                (data, true),
+                                content_key,
+                                callback,
+                                trace,
+                                nodes_to_poke,
+                            )
+                            .await;
+                        });
                     }
-                }
+                };
             }
         }
     }
 
     /// Submits outgoing requests to offer `content` to the closest known nodes whose radius
     /// contains `content_key`.
-    fn poke_content(&self, content_key: TContentKey, content: Vec<u8>, closest_nodes: Vec<NodeId>) {
+    fn poke_content(
+        kbuckets: Arc<RwLock<KBucketsTable<NodeId, Node>>>,
+        command_tx: UnboundedSender<OverlayCommand<TContentKey>>,
+        content_key: TContentKey,
+        content: Vec<u8>,
+        nodes_to_poke: Vec<NodeId>,
+    ) {
         let content_id = content_key.content_id();
 
         // Offer content to closest nodes with sufficient radius.
-        for node_id in closest_nodes.iter() {
+        for node_id in nodes_to_poke.iter() {
             // Look up node in the routing table. We need the ENR and the radius. If we can't find
             // the node, then move on to the next.
             let key = kbucket::Key::from(*node_id);
-            let node = match self.kbuckets.write().entry(&key) {
+            let node = match kbuckets.write().entry(&key) {
                 kbucket::Entry::Present(entry, _) => entry.value().clone(),
                 kbucket::Entry::Pending(mut entry, _) => entry.value().clone(),
                 _ => continue,
@@ -831,9 +925,8 @@ where
                     None,
                 );
 
-                if let Ok(..) = self.command_tx.send(OverlayCommand::Request(request)) {
+                if let Ok(..) = command_tx.send(OverlayCommand::Request(request)) {
                     trace!(
-                        protocol = %self.protocol,
                         content.id = %hex_encode_compact(content_id),
                         content.key = %content_key,
                         peer.node_id = %node_id,
@@ -1170,7 +1263,7 @@ where
             if let Err(err) = stream.read_to_eof(&mut data).await {
                 metrics
                     .report_utp_outcome(UtpDirectionLabel::Inbound, UtpOutcomeLabel::FailedDataTx);
-                error!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), "error reading data from uTP stream");
+                error!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), "error reading data from uTP stream, while handling an Offer request.");
                 return;
             }
 
@@ -1376,19 +1469,7 @@ where
         match response {
             Response::Pong(pong) => self.process_pong(pong, source),
             Response::Nodes(nodes) => self.process_nodes(nodes, source, query_id),
-            Response::Content(content) => {
-                let find_content_request = match request {
-                    Request::FindContent(find_content) => find_content,
-                    _ => {
-                        error!(
-                            response.source = %source.node_id(),
-                            "Content response associated with non-FindContent request"
-                        );
-                        return;
-                    }
-                };
-                self.process_content(content, source, find_content_request, query_id)
-            }
+            Response::Content(content) => self.process_content(content, source, query_id),
             Response::Accept(accept) => {
                 if let Err(err) = self.process_accept(accept, source, request) {
                     error!(response.error = %err, "Error processing ACCEPT message")
@@ -1692,27 +1773,19 @@ where
     }
 
     /// Processes a Content response.
-    fn process_content(
-        &mut self,
-        content: Content,
-        source: Enr,
-        request: FindContent,
-        query_id: Option<QueryId>,
-    ) {
+    fn process_content(&mut self, content: Content, source: Enr, query_id: Option<QueryId>) {
         trace!(
             protocol = %self.protocol,
             response.source = %source.node_id(),
             "Processing Content message",
         );
         match content {
-            Content::ConnectionId(id) => debug!(
-                protocol = %self.protocol,
-                "Skipping processing for content connection ID {}",
-                u16::from_be(id)
-            ),
+            Content::ConnectionId(id) => {
+                if let Some(query_id) = query_id {
+                    self.advance_find_content_query_with_connection_id(&query_id, source, id);
+                }
+            }
             Content::Content(content) => {
-                self.process_received_content(content.clone(), request);
-                // TODO: Should we only advance the query if the content has been validated?
                 if let Some(query_id) = query_id {
                     self.advance_find_content_query_with_content(&query_id, source, content);
                 }
@@ -1727,67 +1800,69 @@ where
         }
     }
 
-    fn process_received_content(&mut self, content: Vec<u8>, request: FindContent) {
-        let content_key = match TContentKey::try_from(request.content_key) {
-            Ok(val) => val,
-            Err(msg) => {
-                error!(
-                    protocol = %self.protocol,
-                    error = ?msg,
-                    "Error decoding content key requested by local node"
+    // This method should be used in a non-blocking thread to allow for
+    // requests to this/other overlay services.
+    #[allow(clippy::too_many_arguments)]
+    async fn process_received_content(
+        kbuckets: Arc<RwLock<KBucketsTable<NodeId, Node>>>,
+        command_tx: UnboundedSender<OverlayCommand<TContentKey>>,
+        validator: Arc<TValidator>,
+        store: Arc<RwLock<TStore>>,
+        content: (Vec<u8>, bool),
+        content_key: TContentKey,
+        responder: Option<oneshot::Sender<FindContentResult>>,
+        trace: Option<QueryTrace>,
+        nodes_to_poke: Vec<NodeId>,
+    ) {
+        let (mut content, _utp_transfer) = content;
+        // Operate under assumption that all content in the store is valid
+        let local_value = store.read().get(&content_key);
+        if let Ok(Some(val)) = local_value {
+            // todo validate & replace content value if different & punish bad peer
+            warn!("Stored content doesn't match expected value");
+            content = val;
+        } else {
+            let content_id = content_key.content_id();
+            if let Err(err) = validator.validate_content(&content_key, &content).await {
+                warn!(
+                    error = ?err,
+                    content.id = %hex_encode_compact(content_id),
+                    content.key = %content_key,
+                    "Error validating content"
                 );
+                if let Some(responder) = responder {
+                    let _ = responder.send((None, trace));
+                }
                 return;
-            }
-        };
-        let content_id = content_key.content_id();
+            };
 
-        match self
-            .store
-            .read()
-            .is_key_within_radius_and_unavailable(&content_key)
-        {
-            Ok(true) => {
-                let validator = Arc::clone(&self.validator);
-                let store = Arc::clone(&self.store);
-                // Spawn task that validates content before storing.
-                // Allows for non-blocking requests to this/other overlay services.
-                tokio::spawn(async move {
-                    if let Err(err) = validator.validate_content(&content_key, &content).await {
-                        warn!(
-                            error = ?err,
-                            content.id = %hex_encode_compact(content_id),
-                            content.key = %content_key,
-                            "Error validating content"
-                        );
-                        return;
-                    };
-
-                    if let Err(err) = store.write().put(content_key.clone(), content) {
-                        error!(
-                            error = %err,
-                            content.id = %hex_encode_compact(content_id),
-                            content.key = %content_key,
-                            "Error storing content"
-                        );
-                    }
-                });
-            }
-            Ok(false) => {
-                debug!(
-                    content.id = %hex_encode_compact(content_id),
-                    content.key = %content_key,
-                    "Content not stored (key outside radius or already stored)"
-                );
-            }
-            Err(err) => {
-                error!(
-                    error = %err,
-                    content.id = %hex_encode_compact(content_id),
-                    content.key = %content_key,
-                    "Error storing content"
-                );
+            // skip storing if the content is already stored
+            // or if there's an error reading the store
+            let should_store = match store
+                .read()
+                .is_key_within_radius_and_unavailable(&content_key)
+            {
+                Ok(val) => val,
+                Err(msg) => {
+                    error!("Unable to read store: {}", msg);
+                    false
+                }
+            };
+            if should_store {
+                if let Err(err) = store.write().put(content_key.clone(), content.clone()) {
+                    error!(
+                        error = %err,
+                        content.id = %hex_encode_compact(content_id),
+                        content.key = %content_key,
+                        "Error storing content"
+                    );
+                }
             }
         }
+        if let Some(responder) = responder {
+            let _ = responder.send((Some(content.clone()), trace));
+        }
+        Self::poke_content(kbuckets, command_tx, content_key, content, nodes_to_poke);
     }
 
     /// Processes a collection of discovered nodes.
@@ -1920,7 +1995,7 @@ where
         // Check whether this request was sent on behalf of a query.
         // If so, advance the query with the returned data.
         let local_node_id = self.local_enr().node_id();
-        if let Some((query_info, query)) = self.find_node_query_pool.get_mut(query_id) {
+        if let Some((query_info, query)) = self.find_node_query_pool.write().get_mut(query_id) {
             for enr_ref in enrs.iter() {
                 if !query_info
                     .untrusted_enrs
@@ -1945,7 +2020,7 @@ where
         enrs: Vec<Enr>,
     ) {
         let local_node_id = self.local_enr().node_id();
-        if let Some((query_info, query)) = self.find_content_query_pool.get_mut(*query_id) {
+        if let Some((query_info, query)) = self.find_content_query_pool.write().get_mut(*query_id) {
             // If an ENR is not present in the query's untrusted ENRs, then add the ENR.
             // Ignore the local node's ENR.
             let mut new_enrs: Vec<&Enr> = vec![];
@@ -1977,6 +2052,25 @@ where
         }
     }
 
+    /// Advances a find content query (if one exists for `query_id`) with a connection id.
+    fn advance_find_content_query_with_connection_id(
+        &mut self,
+        query_id: &QueryId,
+        source: Enr,
+        utp: u16,
+    ) {
+        if let Some((query_info, query)) = self.find_content_query_pool.write().get_mut(*query_id) {
+            if let Some(trace) = &mut query_info.trace {
+                trace.node_responded_with_content(&source);
+            }
+            // Mark the query successful for the source of the response with the connection id.
+            query.on_success(
+                &source.node_id(),
+                FindContentQueryResponse::ConnectionId(utp),
+            );
+        }
+    }
+
     /// Advances a find content query (if one exists for `query_id`) with content.
     fn advance_find_content_query_with_content(
         &mut self,
@@ -1984,7 +2078,8 @@ where
         source: Enr,
         content: Vec<u8>,
     ) {
-        if let Some((query_info, query)) = self.find_content_query_pool.get_mut(*query_id) {
+        let mut pool = self.find_content_query_pool.write();
+        if let Some((query_info, query)) = pool.get_mut(*query_id) {
             if let Some(trace) = &mut query_info.trace {
                 trace.node_responded_with_content(&source);
             }
@@ -2278,6 +2373,7 @@ where
                 FindNodeQuery::with_config(query_config, query_info.key(), known_closest_peers);
             Some(
                 self.find_node_query_pool
+                    .write()
                     .add_query(query_info, find_nodes_query),
             )
         }
@@ -2335,7 +2431,11 @@ where
             None
         } else {
             let query = FindContentQuery::with_config(query_config, target_key, closest_enrs);
-            Some(self.find_content_query_pool.add_query(query_info, query))
+            Some(
+                self.find_content_query_pool
+                    .write()
+                    .add_query(query_info, query),
+            )
         }
     }
 
@@ -2348,7 +2448,7 @@ where
         }
 
         // Check the existing find node queries for the ENR.
-        for (query_info, _) in self.find_node_query_pool.iter() {
+        for (query_info, _) in self.find_node_query_pool.write().iter() {
             if let Some(enr) = query_info
                 .untrusted_enrs
                 .iter()
@@ -2359,7 +2459,7 @@ where
         }
 
         // Check the existing find content queries for the ENR.
-        for (query_info, _) in self.find_content_query_pool.iter() {
+        for (query_info, _) in self.find_content_query_pool.write().iter() {
             if let Some(enr) = query_info
                 .untrusted_enrs
                 .iter()
@@ -2611,8 +2711,12 @@ mod tests {
             command_tx,
             command_rx,
             active_outgoing_requests,
-            find_node_query_pool: QueryPool::new(overlay_config.query_timeout),
-            find_content_query_pool: QueryPool::new(overlay_config.query_timeout),
+            find_node_query_pool: Arc::new(RwLock::new(QueryPool::new(
+                overlay_config.query_timeout,
+            ))),
+            find_content_query_pool: Arc::new(RwLock::new(QueryPool::new(
+                overlay_config.query_timeout,
+            ))),
             query_peer_timeout: overlay_config.query_peer_timeout,
             query_parallelism: overlay_config.query_parallelism,
             query_num_results: overlay_config.query_num_results,
@@ -2977,7 +3081,13 @@ mod tests {
         let peer_node_ids: Vec<NodeId> = vec![peer.enr.node_id()];
 
         // Node has maximum radius, so there should be one offer in the channel.
-        service.poke_content(content_key, content, peer_node_ids);
+        OverlayService::<IdentityContentKey, XorMetric, MockValidator, MemoryContentStore>::poke_content(
+            service.kbuckets.clone(),
+            service.command_tx.clone(),
+            content_key,
+            content,
+            peer_node_ids,
+        );
         let cmd = assert_ready!(poll_command_rx!(service));
         let cmd = cmd.unwrap();
         if let OverlayCommand::Request(req) = cmd {
@@ -3008,7 +3118,13 @@ mod tests {
         let peer_node_ids: Vec<NodeId> = peers.iter().map(|p| p.node_id()).collect();
 
         // No nodes in the routing table, so no commands should be in the channel.
-        service.poke_content(content_key, content, peer_node_ids);
+        OverlayService::<IdentityContentKey, XorMetric, MockValidator, MemoryContentStore>::poke_content(
+            service.kbuckets.clone(),
+            service.command_tx.clone(),
+            content_key,
+            content,
+            peer_node_ids,
+        );
         assert_pending!(poll_command_rx!(service));
     }
 
@@ -3053,7 +3169,13 @@ mod tests {
         let peer_node_ids: Vec<NodeId> = peers.iter().map(|p| p.enr.node_id()).collect();
 
         // One offer should be in the channel for the maximum radius node.
-        service.poke_content(content_key, content, peer_node_ids);
+        OverlayService::<IdentityContentKey, XorMetric, MockValidator, MemoryContentStore>::poke_content(
+            service.kbuckets.clone(),
+            service.command_tx.clone(),
+            content_key,
+            content,
+            peer_node_ids,
+        );
         let cmd = assert_ready!(poll_command_rx!(service));
         let cmd = cmd.unwrap();
         if let OverlayCommand::Request(req) = cmd {
@@ -3282,15 +3404,16 @@ mod tests {
         let (_, target_enr) = generate_random_remote_enr();
         let target_node_id = target_enr.node_id();
 
-        assert_eq!(service.find_node_query_pool.iter().count(), 0);
+        assert_eq!(service.find_node_query_pool.read().iter().count(), 0);
 
         service.add_bootnodes(bootnodes);
 
         // Initialize the query and call `poll` so that it starts
         service.init_find_nodes_query(&target_node_id, None);
-        let _ = service.find_node_query_pool.poll();
+        let _ = service.find_node_query_pool.write().poll();
 
-        let (query_info, query) = service.find_node_query_pool.iter().next().unwrap();
+        let pool = service.find_node_query_pool.read();
+        let (query_info, query) = pool.iter().next().unwrap();
 
         assert!(query_info.untrusted_enrs.contains(&bootnode1));
         assert!(query_info.untrusted_enrs.contains(&bootnode2));
@@ -3333,7 +3456,7 @@ mod tests {
             XorMetric,
             MockValidator,
             MemoryContentStore,
-        >::query_event_poll(&mut service.find_node_query_pool)
+        >::query_event_poll(service.find_node_query_pool.clone())
         .await;
         match event {
             QueryEvent::Waiting(query_id, node_id, request) => {
@@ -3369,7 +3492,7 @@ mod tests {
             XorMetric,
             MockValidator,
             MemoryContentStore,
-        >::query_event_poll(&mut service.find_node_query_pool)
+        >::query_event_poll(service.find_node_query_pool.clone())
         .await;
 
         // Check that the request is being sent to either node 1 or node 2. Keep track of which.
@@ -3386,7 +3509,7 @@ mod tests {
             XorMetric,
             MockValidator,
             MemoryContentStore,
-        >::query_event_poll(&mut service.find_node_query_pool)
+        >::query_event_poll(service.find_node_query_pool.clone())
         .await;
 
         // Check that a request is being sent to the other node.
@@ -3410,7 +3533,7 @@ mod tests {
             XorMetric,
             MockValidator,
             MemoryContentStore,
-        >::query_event_poll(&mut service.find_node_query_pool)
+        >::query_event_poll(service.find_node_query_pool.clone())
         .await;
 
         match event {
@@ -3453,7 +3576,7 @@ mod tests {
             XorMetric,
             MockValidator,
             MemoryContentStore,
-        >::query_event_poll(&mut service.find_node_query_pool)
+        >::query_event_poll(service.find_node_query_pool.clone())
         .await;
 
         let (_, enr1) = generate_random_remote_enr();
@@ -3508,8 +3631,9 @@ mod tests {
         let query_id = service.init_find_content_query(target_content_key.clone(), None, false);
         let query_id = query_id.expect("Query ID for new find content query is `None`");
 
-        let (query_info, query) = service
-            .find_content_query_pool
+        let pool = service.find_content_query_pool.clone();
+        let mut pool = pool.write();
+        let (query_info, query) = pool
             .get_mut(query_id)
             .expect("Query pool does not contain query");
 
@@ -3562,14 +3686,17 @@ mod tests {
         let query_id = service.init_find_content_query(target_content_key, None, false);
         let query_id = query_id.expect("Query ID for new find content query is `None`");
 
-        let (_, query) = service
-            .find_content_query_pool
-            .get_mut(query_id)
-            .expect("Query pool does not contain query");
-
-        // Poll query to put into waiting state. Otherwise, `on_success` has no effect on the
-        // query.
-        query.poll(Instant::now());
+        // update query in own span so mut ref is dropped after poll
+        {
+            let pool = service.find_content_query_pool.clone();
+            let mut pool = pool.write();
+            let (_, query) = pool
+                .get_mut(query_id)
+                .expect("Query pool does not contain query");
+            // Poll query to put into waiting state. Otherwise, `on_success` has no effect on the
+            // query.
+            query.poll(Instant::now());
+        }
 
         // Simulate a response from the bootnode.
         let (_, enr) = generate_random_remote_enr();
@@ -3579,8 +3706,8 @@ mod tests {
             vec![enr.clone()],
         );
 
-        let (query_info, query) = service
-            .find_content_query_pool
+        let mut pool = service.find_content_query_pool.write();
+        let (query_info, query) = pool
             .get_mut(query_id)
             .expect("Query pool does not contain query");
 
@@ -3627,21 +3754,25 @@ mod tests {
         let query_id = service.init_find_content_query(target_content_key, None, false);
         let query_id = query_id.expect("Query ID for new find content query is `None`");
 
-        let (_, query) = service
-            .find_content_query_pool
-            .get_mut(query_id)
-            .expect("Query pool does not contain query");
+        // update query in own span so mut ref is dropped after poll
+        {
+            let pool = service.find_content_query_pool.clone();
+            let mut pool = pool.write();
+            let (_, query) = pool
+                .get_mut(query_id)
+                .expect("Query pool does not contain query");
 
-        // Poll query to put into waiting state. Otherwise, `on_success` has no effect on the
-        // query.
-        query.poll(Instant::now());
+            // Poll query to put into waiting state. Otherwise, `on_success` has no effect on the
+            // query.
+            query.poll(Instant::now());
+        }
 
         // Simulate a response from the bootnode.
         let content: Vec<u8> = vec![0, 1, 2, 3];
         service.advance_find_content_query_with_content(&query_id, bootnode_enr, content.clone());
 
-        let (_, query) = service
-            .find_content_query_pool
+        let mut pool = service.find_content_query_pool.write();
+        let (_, query) = pool
             .get_mut(query_id)
             .expect("Query pool does not contain query");
 
@@ -3652,6 +3783,71 @@ mod tests {
                 ..
             } => {
                 assert_eq!(result_content, content);
+            }
+            _ => panic!("Unexpected find content query result"),
+        }
+    }
+
+    #[tokio::test]
+    async fn advance_find_content_query_with_connection_id() {
+        let mut service = task::spawn(build_service());
+
+        let (_, bootnode_enr) = generate_random_remote_enr();
+        let bootnode_node_id = bootnode_enr.node_id();
+        let bootnode_key = kbucket::Key::from(bootnode_node_id);
+
+        let data_radius = Distance::MAX;
+        let bootnode = Node {
+            enr: bootnode_enr.clone(),
+            data_radius,
+        };
+
+        let connection_direction = ConnectionDirection::Outgoing;
+        let status = NodeStatus {
+            state: ConnectionState::Connected,
+            direction: connection_direction,
+        };
+
+        let _ = service
+            .kbuckets
+            .write()
+            .insert_or_update(&bootnode_key, bootnode, status);
+
+        let target_content = NodeId::random();
+        let target_content_key = IdentityContentKey::new(target_content.raw());
+
+        let query_id = service.init_find_content_query(target_content_key, None, false);
+        let query_id = query_id.expect("Query ID for new find content query is `None`");
+
+        // update query in own span so mut ref is dropped after poll
+        {
+            let pool = service.find_content_query_pool.clone();
+            let mut pool = pool.write();
+            let (_, query) = pool
+                .get_mut(query_id)
+                .expect("Query pool does not contain query");
+            // Poll query to put into waiting state. Otherwise, `on_success` has no effect on the
+            // query.
+            query.poll(Instant::now());
+        }
+
+        // Simulate a response from the bootnode.
+        let actual_connection_id = 1;
+        service.advance_find_content_query_with_connection_id(
+            &query_id,
+            bootnode_enr,
+            actual_connection_id,
+        );
+
+        let mut pool = service.find_content_query_pool.write();
+        let (_, query) = pool
+            .get_mut(query_id)
+            .expect("Query pool does not contain query");
+
+        // Query result should contain content.
+        match query.clone().into_result() {
+            FindContentQueryResult::Utp { connection_id, .. } => {
+                assert_eq!(u16::from_be(connection_id), actual_connection_id);
             }
             _ => panic!("Unexpected find content query result"),
         }
@@ -3692,7 +3888,7 @@ mod tests {
 
         let query_event =
             OverlayService::<_, XorMetric, MockValidator, MemoryContentStore>::query_event_poll(
-                &mut service.find_content_query_pool,
+                service.find_content_query_pool.clone(),
             )
             .await;
 
@@ -3731,7 +3927,7 @@ mod tests {
 
         let query_event =
             OverlayService::<_, XorMetric, MockValidator, MemoryContentStore>::query_event_poll(
-                &mut service.find_content_query_pool,
+                service.find_content_query_pool.clone(),
             )
             .await;
 

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -83,6 +83,7 @@ mod test {
         peertest::scenarios::validation::test_validate_pre_merge_block_body(&peertest, &target)
             .await;
         peertest::scenarios::validation::test_validate_pre_merge_receipts(&peertest, &target).await;
+        peertest::scenarios::find::test_recursive_utp(&peertest).await;
 
         peertest.exit_all_nodes();
         test_client_rpc_handle.stop().unwrap();


### PR DESCRIPTION
### What was wrong?
We weren't handling find content responses that required utp.

### How was it fixed?
- Validate data that's received from a `Content` response
- asyncify some `OverlayService` methods so that they can be used across threads.
  - `process_received_content`
  - `poke_content`
- Some modifications to the query pool
  - Handle all content processing (validation / storing) in the final stage of a find content query lifecycle
- Added some tests

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history

#### in follow up prs

- [ ] boot peer if content validation fails
- [x] add utpTransfer field to return type
- [ ] add validation status to return type (?) 
- [ ] rename overlay_service -> service & protocol
- [x] unique content values for each test run
  - [x] add test recursive utp with trace scenario
- [ ] remove utp handling from protocol 
- [ ] prepend node id to peertest logs
 - https://github.com/ethereum/utp/blob/be858a8665276a4cff1c0c9bb78f55a1d87d0809/src/stream.rs#L42
- [ ] remove rwlock usage in favor of channels (see comment)
- [ ] https://github.com/ethereum/trin/pull/809/files#r1278470587
- [ ] https://github.com/ethereum/trin/pull/809/files/c4bff3fff4c683ec9cf4d0e1c2fa9ccd20463bac#r1278472910


