### PR TITLE
Add utp transfer to find content return

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,5 +56,6 @@ members = [
     "trin-history",
     "trin-state",
     "trin-utils",
+    "trin-validation",
     "utp-testing",
 ]

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -62,7 +62,7 @@ pub trait HistoryNetworkApi {
     async fn recursive_find_content(
         &self,
         content_key: HistoryContentKey,
-    ) -> RpcResult<PossibleHistoryContentValue>;
+    ) -> RpcResult<ContentInfo>;
 
     /// Lookup a target content key in the network. Return tracing info.
     #[method(name = "historyTraceRecursiveFindContent")]

--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -34,7 +34,10 @@ pub enum ContentInfo {
     #[serde(rename_all = "camelCase")]
     ConnectionId { connection_id: u16 },
     #[serde(rename_all = "camelCase")]
-    Content { content: HistoryContentValue },
+    Content {
+        content: HistoryContentValue,
+        utp_transfer: bool,
+    },
     #[serde(rename_all = "camelCase")]
     Enrs { enrs: Vec<Enr> },
 }
@@ -54,6 +57,7 @@ pub struct AcceptInfo {
 #[serde(rename_all = "camelCase")]
 pub struct TraceContentInfo {
     pub content: PossibleHistoryContentValue,
+    pub utp_transfer: bool,
     pub trace: QueryTrace,
 }
 

--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -1,6 +1,6 @@
 use crate::types::enr::Enr;
 use crate::HistoryContentKey;
-use crate::{HistoryContentValue, PossibleHistoryContentValue};
+use crate::PossibleHistoryContentValue;
 use serde::{Deserialize, Serialize};
 use ssz_types::{typenum, BitList};
 
@@ -27,7 +27,7 @@ pub struct PongInfo {
 
 pub type FindNodesInfo = Vec<Enr>;
 
-/// Response for FindContent endpoint
+/// Response for FindContent & RecursiveFindContent endpoints
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ContentInfo {
@@ -35,7 +35,7 @@ pub enum ContentInfo {
     ConnectionId { connection_id: u16 },
     #[serde(rename_all = "camelCase")]
     Content {
-        content: HistoryContentValue,
+        content: PossibleHistoryContentValue,
         utp_transfer: bool,
     },
     #[serde(rename_all = "camelCase")]

--- a/ethportal-peertest/src/scenarios/validation.rs
+++ b/ethportal-peertest/src/scenarios/validation.rs
@@ -47,7 +47,13 @@ pub async fn test_validate_pre_merge_header_with_proof(peertest: &Peertest, targ
         .unwrap();
 
     match result {
-        ContentInfo::Content { content } => assert_eq!(content, header_with_proof_content_value),
+        ContentInfo::Content {
+            content,
+            utp_transfer,
+        } => {
+            assert_eq!(content, header_with_proof_content_value);
+            assert!(!utp_transfer);
+        }
         _ => panic!("Content value's should match"),
     }
 }
@@ -98,7 +104,13 @@ pub async fn test_validate_pre_merge_block_body(peertest: &Peertest, target: &Cl
         .unwrap();
 
     match result {
-        ContentInfo::Content { content } => assert_eq!(content, block_body_content_value),
+        ContentInfo::Content {
+            content,
+            utp_transfer,
+        } => {
+            assert_eq!(content, block_body_content_value);
+            assert!(utp_transfer);
+        }
         _ => panic!("Content value's should match"),
     }
 }
@@ -130,7 +142,13 @@ pub async fn test_validate_pre_merge_receipts(peertest: &Peertest, target: &Clie
         .unwrap();
 
     match result {
-        ContentInfo::Content { content } => assert_eq!(content, receipts_content_value),
+        ContentInfo::Content {
+            content,
+            utp_transfer,
+        } => {
+            assert_eq!(content, receipts_content_value);
+            assert!(utp_transfer);
+        }
         _ => panic!("Content value's should match"),
     }
 }

--- a/ethportal-peertest/src/scenarios/validation.rs
+++ b/ethportal-peertest/src/scenarios/validation.rs
@@ -2,7 +2,7 @@ use ethportal_api::types::enr::Enr;
 use ethportal_api::types::portal::ContentInfo;
 use ethportal_api::{
     jsonrpsee::async_client::Client, HistoryContentKey, HistoryContentValue,
-    HistoryNetworkApiClient,
+    HistoryNetworkApiClient, PossibleHistoryContentValue,
 };
 use serde_json::json;
 use std::str::FromStr;
@@ -51,10 +51,13 @@ pub async fn test_validate_pre_merge_header_with_proof(peertest: &Peertest, targ
             content,
             utp_transfer,
         } => {
-            assert_eq!(content, header_with_proof_content_value);
+            assert_eq!(
+                content,
+                PossibleHistoryContentValue::ContentPresent(header_with_proof_content_value)
+            );
             assert!(!utp_transfer);
         }
-        _ => panic!("Content value's should match"),
+        _ => panic!("Content values should match"),
     }
 }
 
@@ -108,10 +111,13 @@ pub async fn test_validate_pre_merge_block_body(peertest: &Peertest, target: &Cl
             content,
             utp_transfer,
         } => {
-            assert_eq!(content, block_body_content_value);
+            assert_eq!(
+                content,
+                PossibleHistoryContentValue::ContentPresent(block_body_content_value)
+            );
             assert!(utp_transfer);
         }
-        _ => panic!("Content value's should match"),
+        _ => panic!("Content values should match"),
     }
 }
 
@@ -146,9 +152,12 @@ pub async fn test_validate_pre_merge_receipts(peertest: &Peertest, target: &Clie
             content,
             utp_transfer,
         } => {
-            assert_eq!(content, receipts_content_value);
+            assert_eq!(
+                content,
+                PossibleHistoryContentValue::ContentPresent(receipts_content_value)
+            );
             assert!(utp_transfer);
         }
-        _ => panic!("Content value's should match"),
+        _ => panic!("Content values should match"),
     }
 }

--- a/newsfragments/812.added.md
+++ b/newsfragments/812.added.md
@@ -1,0 +1,1 @@
+Add support for `utp_transfer` field in find content results.

--- a/portalnet/src/find/query_info.rs
+++ b/portalnet/src/find/query_info.rs
@@ -4,7 +4,7 @@ use smallvec::SmallVec;
 
 use crate::{
     find::query_pool::TargetKey,
-    types::messages::{FindContent, FindNodes, Request},
+    types::messages::{Content, FindContent, FindNodes, Request},
 };
 use ethportal_api::types::query_trace::QueryTrace;
 use ethportal_api::OverlayContentKey;
@@ -22,7 +22,15 @@ pub struct QueryInfo<TContentKey> {
 }
 
 // Content, utp_transfer, trace
-pub type FindContentResult = (Option<Vec<u8>>, bool, Option<QueryTrace>);
+// Content is Option<Vec<u8>> because it can be None if the content is not found
+// in a recursive find content query.
+pub type RecursiveFindContentResult = (Option<Vec<u8>>, bool, Option<QueryTrace>);
+// Content, utp_transfer
+// Content is Content type because the response to a simple find content query
+// cannot be None and must be a valid Content response, to account for the
+// possibility of returning Enrs / ConnectionIds (although in practice we never
+// return ConnectionIds in favor of executing the utp transfer).
+pub type FindContentResult = (Content, bool);
 
 /// Additional information about the query.
 #[derive(Debug)]
@@ -44,7 +52,7 @@ pub enum QueryType<TContentKey> {
         target: TContentKey,
 
         /// A callback channel for the result of the query.
-        callback: Option<oneshot::Sender<FindContentResult>>,
+        callback: Option<oneshot::Sender<RecursiveFindContentResult>>,
     },
 }
 

--- a/portalnet/src/find/query_info.rs
+++ b/portalnet/src/find/query_info.rs
@@ -21,7 +21,8 @@ pub struct QueryInfo<TContentKey> {
     pub trace: Option<QueryTrace>,
 }
 
-pub type FindContentResult = (Option<Vec<u8>>, Option<QueryTrace>);
+// Content, utp_transfer, trace
+pub type FindContentResult = (Option<Vec<u8>>, bool, Option<QueryTrace>);
 
 /// Additional information about the query.
 #[derive(Debug)]

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -25,6 +25,7 @@ use utp_rs::socket::UtpSocket;
 
 use crate::{
     discovery::{Discovery, UtpEnr},
+    find::query_info::FindContentResult,
     metrics::overlay::OverlayMetrics,
     overlay_service::{
         OverlayCommand, OverlayRequest, OverlayRequestError, OverlayService, RequestDirection,
@@ -48,7 +49,6 @@ use ethportal_api::RawContentKey;
 use trin_validation::validator::Validator;
 
 use crate::events::EventEnvelope;
-use ethportal_api::types::query_trace::QueryTrace;
 
 /// Configuration parameters for the overlay network.
 #[derive(Clone)]
@@ -593,11 +593,7 @@ where
 
     /// Performs a content lookup for `target`.
     /// Returns the target content along with the peers traversed during content lookup.
-    pub async fn lookup_content(
-        &self,
-        target: TContentKey,
-        is_trace: bool,
-    ) -> (Option<Vec<u8>>, Option<QueryTrace>) {
+    pub async fn lookup_content(&self, target: TContentKey, is_trace: bool) -> FindContentResult {
         let (tx, rx) = oneshot::channel();
         let content_id = target.content_id();
 
@@ -612,7 +608,7 @@ where
                 content.id = %hex_encode(content_id),
                 "Error submitting FindContent query to service"
             );
-            return (None, None);
+            return (None, false, None);
         }
 
         rx.await.unwrap_or_else(|err| {
@@ -622,7 +618,7 @@ where
                 content.id = %hex_encode(content_id),
                 "Error receiving content from service",
             );
-            (None, None)
+            (None, false, None)
         })
     }
 

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -43,7 +43,7 @@ use crate::{
             findnodes::FindNodeQuery,
             query::{Query, QueryConfig},
         },
-        query_info::{FindContentResult, QueryInfo, QueryType},
+        query_info::{QueryInfo, QueryType, RecursiveFindContentResult},
         query_pool::{QueryId, QueryPool, QueryPoolState, TargetKey},
     },
     metrics::{
@@ -112,7 +112,7 @@ pub enum OverlayCommand<TContentKey> {
         /// The query target.
         target: TContentKey,
         /// A callback channel to transmit the result of the query.
-        callback: oneshot::Sender<FindContentResult>,
+        callback: oneshot::Sender<RecursiveFindContentResult>,
         /// Whether or not a trace for the content query should be kept and returned.
         is_trace: bool,
     },
@@ -1814,7 +1814,7 @@ where
         content: Vec<u8>,
         utp_transfer: bool,
         content_key: TContentKey,
-        responder: Option<oneshot::Sender<FindContentResult>>,
+        responder: Option<oneshot::Sender<RecursiveFindContentResult>>,
         trace: Option<QueryTrace>,
         nodes_to_poke: Vec<NodeId>,
     ) {
@@ -2387,7 +2387,7 @@ where
     fn init_find_content_query(
         &mut self,
         target: TContentKey,
-        callback: Option<oneshot::Sender<FindContentResult>>,
+        callback: Option<oneshot::Sender<RecursiveFindContentResult>>,
         is_trace: bool,
     ) -> Option<QueryId> {
         info!("Starting query for content key: {}", target);
@@ -2452,7 +2452,7 @@ where
         }
 
         // Check the existing find node queries for the ENR.
-        for (query_info, _) in self.find_node_query_pool.write().iter() {
+        for (query_info, _) in self.find_node_query_pool.read().iter() {
             if let Some(enr) = query_info
                 .untrusted_enrs
                 .iter()
@@ -2463,7 +2463,7 @@ where
         }
 
         // Check the existing find content queries for the ENR.
-        for (query_info, _) in self.find_content_query_pool.write().iter() {
+        for (query_info, _) in self.find_content_query_pool.read().iter() {
             if let Some(enr) = query_info
                 .untrusted_enrs
                 .iter()

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -204,8 +204,11 @@ async fn overlay() {
         .send_find_content(overlay_one.local_enr(), content_key.into())
         .await
     {
-        Ok(content) => match content {
-            Content::Enrs(enrs) => enrs,
+        Ok((content, utp_transfer)) => match content {
+            Content::Enrs(enrs) => {
+                assert!(!utp_transfer);
+                enrs
+            }
             other => panic!("Unexpected response to find content: {other:?}"),
         },
         Err(err) => panic!("Unable to respond to find content: {err}"),

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -229,10 +229,11 @@ async fn overlay() {
         .put(content_key.clone(), &content)
         .expect("Unable to store content");
     match overlay_one.lookup_content(content_key, false).await {
-        (Some(found_content), _) => {
+        (Some(found_content), utp_transfer, _) => {
             assert_eq!(found_content, content);
+            assert!(!utp_transfer);
         }
-        (None, _) => {
+        (None, _, _) => {
             panic!("Unable to find content stored with peer");
         }
     }

--- a/rpc/src/history_rpc.rs
+++ b/rpc/src/history_rpc.rs
@@ -140,14 +140,17 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
     async fn recursive_find_content(
         &self,
         content_key: HistoryContentKey,
-    ) -> RpcResult<PossibleHistoryContentValue> {
+    ) -> RpcResult<ContentInfo> {
         let endpoint = HistoryEndpoint::RecursiveFindContent(content_key);
         let result = self.proxy_query_to_history_subnet(endpoint).await?;
         if result == serde_json::Value::String(CONTENT_ABSENT.to_string()) {
-            return Ok(PossibleHistoryContentValue::ContentAbsent);
+            return Ok(ContentInfo::Content {
+                content: PossibleHistoryContentValue::ContentAbsent,
+                utp_transfer: false,
+            });
         };
-        let result: HistoryContentValue = from_value(result)?;
-        Ok(PossibleHistoryContentValue::ContentPresent(result))
+        let result: ContentInfo = from_value(result)?;
+        Ok(result)
     }
 
     /// Lookup a target content key in the network. Return tracing info.

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -9,8 +9,8 @@ use ethportal_api::types::{
 use ethportal_api::utils::bytes::hex_encode;
 use ethportal_api::OverlayContentKey;
 use ethportal_api::{
-    types::portal::{AcceptInfo, FindNodesInfo, PongInfo, TraceContentInfo},
-    HistoryContentKey, RawContentKey,
+    types::portal::{AcceptInfo, ContentInfo, FindNodesInfo, PongInfo, TraceContentInfo},
+    ContentValue, {HistoryContentKey, OverlayContentKey},
 };
 use portalnet::storage::ContentStore;
 use serde_json::{json, Value};
@@ -103,7 +103,7 @@ async fn recursive_find_content(
             None
         }
     };
-    let (possible_content_bytes, trace) = match local_content {
+    let (possible_content_bytes, utp_transfer, trace) = match local_content {
         Some(val) => {
             let local_enr = overlay.local_enr();
             let mut trace = QueryTrace::new(
@@ -111,7 +111,7 @@ async fn recursive_find_content(
                 NodeId::new(&content_key.content_id()).into(),
             );
             trace.node_responded_with_content(&local_enr);
-            (Some(val), if is_trace { Some(trace) } else { None })
+            (Some(val), false, if is_trace { Some(trace) } else { None })
         }
         None => overlay.lookup_content(content_key.clone(), is_trace).await,
     };
@@ -124,11 +124,15 @@ async fn recursive_find_content(
 
     // If tracing is not required, return content.
     if !is_trace {
-        return Ok(content_response_string);
+        return Ok(json!(ContentInfo::Content {
+            content: serde_json::from_value(content_response_string).map_err(|e| e.to_string())?,
+            utp_transfer,
+        }));
     }
     if let Some(trace) = trace {
         Ok(json!(TraceContentInfo {
             content: serde_json::from_value(content_response_string).map_err(|e| e.to_string())?,
+            utp_transfer,
             trace,
         }))
     } else {

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -49,7 +49,7 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
                     .header_oracle
                     .write()
                     .await
-                    .recursive_find_hwp(H256::from(key.block_hash))
+                    .recursive_find_header_with_proof(H256::from(key.block_hash))
                     .await?
                     .header;
                 let actual_uncles_root = block_body.uncles_root()?;
@@ -78,7 +78,7 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
                     .header_oracle
                     .write()
                     .await
-                    .recursive_find_hwp(H256::from(key.block_hash))
+                    .recursive_find_header_with_proof(H256::from(key.block_hash))
                     .await?
                     .header;
                 let actual_receipts_root = receipts.root()?;


### PR DESCRIPTION
### What was wrong?
Add support for boolean `utpTransfer` field in json responses to find content & recursive find content jsonrpc requests.

### How was it fixed?
Repurpose `ContentInfo` response type to accommodate both find content and recursive find content responses. As well as adding the `utp_transfer` field.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] support inside `trin-beacon`
- [x] add new field to spec (https://github.com/ethereum/portal-network-specs/pull/221)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
