### PR TITLE
Validate find_content result in non-utp transfers & use fresh testnet for each peertest scenario

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7168,6 +7168,7 @@ dependencies = [
  "ethereum-types 0.12.1",
  "ethportal-api",
  "ethportal-peertest",
+ "jsonrpsee 0.16.2",
  "parking_lot 0.11.2",
  "portalnet",
  "prometheus_exporter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ discv5 = { version = "0.3.1", features = ["serde"] }
 eth2_ssz = "0.4.0"
 ethereum-types = "0.12.1"
 ethportal-api = { path = "ethportal-api" }
+jsonrpsee = "0.16.2"
 parking_lot = "0.11.2"
 portalnet = { path = "portalnet" }
 prometheus_exporter = "0.8.4"

--- a/ethportal-peertest/src/constants.rs
+++ b/ethportal-peertest/src/constants.rs
@@ -1,3 +1,46 @@
+use ethportal_api::{HistoryContentKey, HistoryContentValue};
+use serde_json::json;
+
+/// History HeaderWithProof content key & value
+/// Block #1000010
+pub fn fixture_header_with_proof_1000010() -> (HistoryContentKey, HistoryContentValue) {
+    let content_key: HistoryContentKey =
+        serde_json::from_value(json!(HISTORY_CONTENT_KEY)).unwrap();
+    let content_value: HistoryContentValue =
+        serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).unwrap();
+    (content_key, content_value)
+}
+
+/// History HeaderWithProof content key & value
+/// Block #14764013 (pre-merge)
+pub fn fixture_header_with_proof() -> (HistoryContentKey, HistoryContentValue) {
+    let content_key: HistoryContentKey =
+        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_KEY)).unwrap();
+    let content_value: HistoryContentValue =
+        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_VALUE)).unwrap();
+    (content_key, content_value)
+}
+
+/// History BlockBody content key & value
+/// Block #14764013 (pre-merge)
+pub fn fixture_block_body() -> (HistoryContentKey, HistoryContentValue) {
+    let content_key: HistoryContentKey =
+        serde_json::from_value(json!(BLOCK_BODY_CONTENT_KEY)).unwrap();
+    let content_value: HistoryContentValue =
+        serde_json::from_value(json!(BLOCK_BODY_CONTENT_VALUE)).unwrap();
+    (content_key, content_value)
+}
+
+/// History Receipts content key & value
+/// Block #14764013 (pre-merge)
+pub fn fixture_receipts() -> (HistoryContentKey, HistoryContentValue) {
+    let content_key: HistoryContentKey =
+        serde_json::from_value(json!(RECEIPTS_CONTENT_KEY)).unwrap();
+    let content_value: HistoryContentValue =
+        serde_json::from_value(json!(RECEIPTS_CONTENT_VALUE)).unwrap();
+    (content_key, content_value)
+}
+
 /// History HeaderWithProof content key & value
 /// Block #1000010
 pub const HISTORY_CONTENT_KEY: &str =

--- a/ethportal-peertest/src/lib.rs
+++ b/ethportal-peertest/src/lib.rs
@@ -6,14 +6,13 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
 use std::{thread, time};
 
+use ethportal_api::types::cli::TrinConfig;
+use ethportal_api::types::enr::Enr;
+use ethportal_api::utils::bytes::hex_encode;
 use ethportal_api::Discv5ApiClient;
 use futures::future;
 use jsonrpsee::async_client::Client;
 use rpc::RpcServerHandle;
-
-use ethportal_api::types::cli::TrinConfig;
-use ethportal_api::types::enr::Enr;
-use ethportal_api::utils::bytes::hex_encode;
 
 pub struct PeertestNode {
     pub enr: Enr,

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -1,12 +1,12 @@
-use crate::constants::{HISTORY_CONTENT_KEY, HISTORY_CONTENT_VALUE};
+use crate::constants::fixture_header_with_proof;
 use crate::Peertest;
-use ethereum_types::U256;
+use ethereum_types::{H256, U256};
 use ethportal_api::types::distance::Distance;
-use ethportal_api::HistoryContentKey;
-use ethportal_api::{Discv5ApiClient, HistoryNetworkApiClient, Web3ApiClient};
-use ethportal_api::{HistoryContentValue, PossibleHistoryContentValue};
+use ethportal_api::{
+    BlockHeaderKey, Discv5ApiClient, HistoryContentKey, HistoryNetworkApiClient,
+    PossibleHistoryContentValue, Web3ApiClient,
+};
 use jsonrpsee::async_client::Client;
-use serde_json::json;
 use ssz::Encode;
 use tracing::info;
 use trin_utils::version::get_trin_version;
@@ -107,12 +107,7 @@ pub async fn test_history_find_nodes_zero_distance(target: &Client, peertest: &P
 
 pub async fn test_history_store(target: &Client) {
     info!("Testing portal_historyStore");
-
-    let content_key: HistoryContentKey =
-        serde_json::from_value(json!(HISTORY_CONTENT_KEY)).unwrap();
-    let content_value: HistoryContentValue =
-        serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).unwrap();
-
+    let (content_key, content_value) = fixture_header_with_proof();
     let result = target.store(content_key, content_value).await.unwrap();
     assert!(result);
 }
@@ -130,11 +125,9 @@ pub async fn test_history_routing_table_info(target: &Client) {
 
 pub async fn test_history_local_content_absent(target: &Client) {
     info!("Testing portal_historyLocalContent absent");
-
-    let content_key: HistoryContentKey = serde_json::from_value(json!(
-        "0x00cb5cab7266694daa0d28cbf40496c08dd30bf732c41e0455e7ad389c10d79f4f"
-    ))
-    .unwrap();
+    let content_key = HistoryContentKey::BlockHeaderWithProof(BlockHeaderKey {
+        block_hash: H256::random().into(),
+    });
     let result = target.local_content(content_key).await.unwrap();
 
     if let PossibleHistoryContentValue::ContentPresent(_) = result {

--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -1,12 +1,10 @@
-use crate::constants::{HISTORY_CONTENT_KEY, HISTORY_CONTENT_VALUE};
+use crate::constants::fixture_header_with_proof_1000010;
 use crate::utils::wait_for_content;
 use crate::Peertest;
 use ethportal_api::jsonrpsee::http_client::HttpClient;
 use ethportal_api::PossibleHistoryContentValue;
-use ethportal_api::{HistoryContentKey, HistoryContentValue};
 use portal_bridge::bridge::Bridge;
 use portal_bridge::mode::BridgeMode;
-use serde_json::json;
 use tokio::time::{sleep, Duration};
 use trin_validation::accumulator::MasterAccumulator;
 use trin_validation::oracle::HeaderOracle;
@@ -21,12 +19,7 @@ pub async fn test_bridge(peertest: &Peertest, target: &HttpClient) {
     sleep(Duration::from_secs(1)).await;
     let bridge = Bridge::new(mode, portal_clients, header_oracle, epoch_acc_path);
     bridge.launch().await;
-
-    let content_key: HistoryContentKey =
-        serde_json::from_value(json!(HISTORY_CONTENT_KEY)).unwrap();
-    let content_value: HistoryContentValue =
-        serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).unwrap();
-
+    let (content_key, content_value) = fixture_header_with_proof_1000010();
     // Check if the stored content value in bootnode's DB matches the offered
     let response = wait_for_content(&peertest.bootnode.ipc_client, content_key).await;
     let received_content_value = match response {

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -1,24 +1,16 @@
-use crate::constants::{
-    BLOCK_BODY_CONTENT_KEY, BLOCK_BODY_CONTENT_VALUE, HEADER_WITH_PROOF_CONTENT_KEY,
-    HEADER_WITH_PROOF_CONTENT_VALUE, HISTORY_CONTENT_VALUE,
-};
+use crate::constants::fixture_header_with_proof;
 use crate::Peertest;
 use discv5::enr::NodeId;
-use ethportal_api::types::content_value::ContentValue;
 use ethportal_api::types::portal::{ContentInfo, TraceContentInfo};
 use ethportal_api::utils::bytes::hex_decode;
-use ethportal_api::{
-    HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient, PossibleHistoryContentValue,
-};
+use ethportal_api::{HistoryNetworkApiClient, PossibleHistoryContentValue};
 use jsonrpsee::async_client::Client;
-use serde_json::json;
 use tracing::info;
 
 pub async fn test_find_content_return_enr(target: &Client, peertest: &Peertest) {
     info!("Testing find content returns enrs properly");
 
-    let header_with_proof_key: HistoryContentKey =
-        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_KEY)).unwrap();
+    let (content_key, _) = fixture_header_with_proof();
 
     // check if we can fetch data from routing table
     match HistoryNetworkApiClient::get_enr(
@@ -36,7 +28,7 @@ pub async fn test_find_content_return_enr(target: &Client, peertest: &Peertest) 
     }
 
     let result = target
-        .find_content(peertest.bootnode.enr.clone(), header_with_proof_key.clone())
+        .find_content(peertest.bootnode.enr.clone(), content_key.clone())
         .await;
 
     let enrs = if let Ok(ContentInfo::Enrs { enrs }) = result {
@@ -52,7 +44,7 @@ pub async fn test_find_content_return_enr(target: &Client, peertest: &Peertest) 
 }
 
 pub async fn test_recursive_find_nodes_self(peertest: &Peertest) {
-    info!("Testing trace recursive find nodes self");
+    info!("Testing recursive find nodes self");
     let target_enr = peertest.bootnode.enr.clone();
     let target_node_id = NodeId::from(target_enr.node_id().raw());
     let result = peertest
@@ -65,7 +57,7 @@ pub async fn test_recursive_find_nodes_self(peertest: &Peertest) {
 }
 
 pub async fn test_recursive_find_nodes_peer(peertest: &Peertest) {
-    info!("Testing trace recursive find nodes peer");
+    info!("Testing recursive find nodes peer");
     let target_enr = peertest.nodes[0].enr.clone();
     let target_node_id = NodeId::from(target_enr.node_id().raw());
     let result = peertest
@@ -78,7 +70,7 @@ pub async fn test_recursive_find_nodes_peer(peertest: &Peertest) {
 }
 
 pub async fn test_recursive_find_nodes_random(peertest: &Peertest) {
-    info!("Testing trace recursive find nodes random");
+    info!("Testing recursive find nodes random");
     let mut bytes = [0u8; 32];
     let random_node_id =
         hex_decode("0xcac75e7e776d84fba55a3104bdccfd716537bca3ad8465113f67f04d62694183").unwrap();
@@ -93,75 +85,13 @@ pub async fn test_recursive_find_nodes_random(peertest: &Peertest) {
     assert_eq!(result.len(), 3);
 }
 
-pub async fn test_recursive_utp(peertest: &Peertest) {
-    info!("Test recursive utp");
-
-    // store header_with_proof to validate block body
-    let header_with_proof_content_key: HistoryContentKey =
-        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_KEY)).unwrap();
-    let header_with_proof_content_value: HistoryContentValue =
-        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_VALUE)).unwrap();
-
-    let store_result = peertest.nodes[0]
-        .ipc_client
-        .store(
-            header_with_proof_content_key.clone(),
-            header_with_proof_content_value.clone(),
-        )
-        .await
-        .unwrap();
-
-    assert!(store_result);
-
-    let history_content_key: HistoryContentKey =
-        serde_json::from_value(json!(BLOCK_BODY_CONTENT_KEY)).unwrap();
-    let hex_data = hex_decode(BLOCK_BODY_CONTENT_VALUE).unwrap();
-    let history_content_value: HistoryContentValue =
-        HistoryContentValue::decode(&hex_data).unwrap();
-
-    let store_result = peertest
-        .bootnode
-        .ipc_client
-        .store(history_content_key.clone(), history_content_value.clone())
-        .await
-        .unwrap();
-
-    assert!(store_result);
-
-    let content_info = peertest.nodes[0]
-        .ipc_client
-        .recursive_find_content(history_content_key)
-        .await
-        .unwrap();
-
-    if let ContentInfo::Content {
-        content,
-        utp_transfer,
-    } = content_info
-    {
-        assert_eq!(
-            content,
-            PossibleHistoryContentValue::ContentPresent(history_content_value)
-        );
-        assert!(utp_transfer);
-    } else {
-        panic!("Error: Unexpected content info response");
-    }
-}
-
 pub async fn test_trace_recursive_find_content(peertest: &Peertest) {
-    let uniq_content_key =
-        "\"0x0015b11b918355b1ef9c5db810302ebad0bf2544255b530cdce90674d5887bb286\"";
-    let history_content_key: HistoryContentKey = serde_json::from_str(uniq_content_key).unwrap();
-
-    let hex_data = hex_decode(HISTORY_CONTENT_VALUE).unwrap();
-    let history_content_value: HistoryContentValue =
-        HistoryContentValue::decode(&hex_data).unwrap();
-
+    info!("Testing trace recursive find content");
+    let (content_key, content_value) = fixture_header_with_proof();
     let store_result = peertest
         .bootnode
         .ipc_client
-        .store(history_content_key.clone(), history_content_value.clone())
+        .store(content_key.clone(), content_value.clone())
         .await
         .unwrap();
 
@@ -169,7 +99,7 @@ pub async fn test_trace_recursive_find_content(peertest: &Peertest) {
 
     let trace_content_info: TraceContentInfo = peertest.nodes[0]
         .ipc_client
-        .trace_recursive_find_content(history_content_key)
+        .trace_recursive_find_content(content_key)
         .await
         .unwrap();
 
@@ -179,7 +109,7 @@ pub async fn test_trace_recursive_find_content(peertest: &Peertest) {
 
     assert_eq!(
         content,
-        PossibleHistoryContentValue::ContentPresent(history_content_value)
+        PossibleHistoryContentValue::ContentPresent(content_value)
     );
 
     let query_origin_node: NodeId = peertest.nodes[0].enr.node_id();
@@ -208,16 +138,10 @@ pub async fn test_trace_recursive_find_content(peertest: &Peertest) {
 // This test ensures that when content is not found the correct response is returned.
 pub async fn test_trace_recursive_find_content_for_absent_content(peertest: &Peertest) {
     let client = &peertest.nodes[0].ipc_client;
-
-    // Different key to other test (final character).
-    let uniq_content_key =
-        "\"0x0015b11b918355b1ef9c5db810302ebad0bf2544255b530cdce90674d5887bb287\"";
-    // Do not store content to offer in the testnode db
-
-    let history_content_key: HistoryContentKey = serde_json::from_str(uniq_content_key).unwrap();
+    let (content_key, _) = fixture_header_with_proof();
 
     let result = client
-        .trace_recursive_find_content(history_content_key)
+        .trace_recursive_find_content(content_key)
         .await
         .unwrap();
 
@@ -228,19 +152,12 @@ pub async fn test_trace_recursive_find_content_for_absent_content(peertest: &Pee
 }
 
 pub async fn test_trace_recursive_find_content_local_db(peertest: &Peertest) {
-    let uniq_content_key =
-        "\"0x0025b11b918355b1ef9c5db810302ebad0bf2544255b530cdce90674d5887bb286\"";
-
-    let history_content_key: HistoryContentKey = serde_json::from_str(uniq_content_key).unwrap();
-
-    let hex_data = hex_decode(HISTORY_CONTENT_VALUE).unwrap();
-    let history_content_value: HistoryContentValue =
-        HistoryContentValue::decode(&hex_data).unwrap();
+    let (content_key, content_value) = fixture_header_with_proof();
 
     let store_result = peertest
         .bootnode
         .ipc_client
-        .store(history_content_key.clone(), history_content_value.clone())
+        .store(content_key.clone(), content_value.clone())
         .await
         .unwrap();
 
@@ -249,13 +166,13 @@ pub async fn test_trace_recursive_find_content_local_db(peertest: &Peertest) {
     let trace_content_info: TraceContentInfo = peertest
         .bootnode
         .ipc_client
-        .trace_recursive_find_content(history_content_key)
+        .trace_recursive_find_content(content_key)
         .await
         .unwrap();
     assert!(!trace_content_info.utp_transfer);
     assert_eq!(
         trace_content_info.content,
-        PossibleHistoryContentValue::ContentPresent(history_content_value)
+        PossibleHistoryContentValue::ContentPresent(content_value)
     );
 
     let origin = trace_content_info.trace.origin;

--- a/ethportal-peertest/src/scenarios/mod.rs
+++ b/ethportal-peertest/src/scenarios/mod.rs
@@ -3,4 +3,5 @@ pub mod bridge;
 pub mod find;
 pub mod offer_accept;
 pub mod paginate;
+pub mod utp;
 pub mod validation;

--- a/ethportal-peertest/src/scenarios/offer_accept.rs
+++ b/ethportal-peertest/src/scenarios/offer_accept.rs
@@ -1,29 +1,17 @@
 use std::str::FromStr;
 
-use serde_json::json;
 use tracing::info;
 
-use ethportal_api::types::enr::Enr;
-use ethportal_api::utils::bytes::hex_encode;
+use crate::{constants::fixture_header_with_proof, utils::wait_for_content, Peertest};
 use ethportal_api::{
-    jsonrpsee::async_client::Client, HistoryContentKey, HistoryContentValue,
+    jsonrpsee::async_client::Client, types::enr::Enr, utils::bytes::hex_encode,
     HistoryNetworkApiClient, PossibleHistoryContentValue,
-};
-
-use crate::{
-    constants::{HISTORY_CONTENT_KEY, HISTORY_CONTENT_VALUE},
-    utils::wait_for_content,
-    Peertest,
 };
 
 pub async fn test_unpopulated_offer(peertest: &Peertest, target: &Client) {
     info!("Testing Unpopulated OFFER/ACCEPT flow");
 
-    let content_key: HistoryContentKey =
-        serde_json::from_value(json!(HISTORY_CONTENT_KEY)).unwrap();
-    let content_value: HistoryContentValue =
-        serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).unwrap();
-
+    let (content_key, content_value) = fixture_header_with_proof();
     // Store content to offer in the testnode db
     let store_result = target
         .store(content_key.clone(), content_value.clone())
@@ -60,14 +48,7 @@ pub async fn test_unpopulated_offer(peertest: &Peertest, target: &Client) {
 pub async fn test_populated_offer(peertest: &Peertest, target: &Client) {
     info!("Testing Populated Offer/ACCEPT flow");
 
-    // Offer unique content key to bootnode
-    let content_key: HistoryContentKey = serde_json::from_value(json!(
-        "0x00cb5cab7266694daa0d28cbf40496c08dd30bf732c41e0455e7ad389c10d79f4f"
-    ))
-    .unwrap();
-    let content_value: HistoryContentValue =
-        serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).unwrap();
-
+    let (content_key, content_value) = fixture_header_with_proof();
     let result = target
         .offer(
             Enr::from_str(&peertest.bootnode.enr.to_base64()).unwrap(),

--- a/ethportal-peertest/src/scenarios/paginate.rs
+++ b/ethportal-peertest/src/scenarios/paginate.rs
@@ -1,10 +1,7 @@
-use ethportal_api::HistoryContentValue;
 use ethportal_api::HistoryNetworkApiClient;
 use ethportal_api::{BlockHeaderKey, HistoryContentKey};
-use serde_json::json;
 
-use crate::constants::HISTORY_CONTENT_VALUE;
-use crate::Peertest;
+use crate::{constants::fixture_header_with_proof, Peertest};
 
 pub async fn test_paginate_local_storage(peertest: &Peertest) {
     let ipc_client = &peertest.bootnode.ipc_client;
@@ -21,15 +18,13 @@ pub async fn test_paginate_local_storage(peertest: &Peertest) {
             .unwrap()
         })
         .collect();
-
+    let (_, content_value) = fixture_header_with_proof();
     for content_key in content_keys.clone().into_iter() {
         // Store content to offer in the testnode db
-        let dummy_content_value: HistoryContentValue =
-            serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).unwrap();
         let store_result = ipc_client
             .store(
                 serde_json::from_str(&content_key).unwrap(),
-                dummy_content_value,
+                content_value.clone(),
             )
             .await
             .unwrap();

--- a/ethportal-peertest/src/scenarios/utp.rs
+++ b/ethportal-peertest/src/scenarios/utp.rs
@@ -1,0 +1,113 @@
+use crate::{
+    constants::{fixture_block_body, fixture_header_with_proof},
+    Peertest,
+};
+use discv5::enr::NodeId;
+use ethportal_api::types::portal::{ContentInfo, TraceContentInfo};
+use ethportal_api::{HistoryNetworkApiClient, PossibleHistoryContentValue};
+use tracing::info;
+
+pub async fn test_recursive_utp(peertest: &Peertest) {
+    info!("Test recursive utp");
+
+    // store header_with_proof to validate block body
+    let (content_key, content_value) = fixture_header_with_proof();
+    let store_result = peertest.nodes[0]
+        .ipc_client
+        .store(content_key.clone(), content_value.clone())
+        .await
+        .unwrap();
+    assert!(store_result);
+
+    let (content_key, content_value) = fixture_block_body();
+
+    let store_result = peertest
+        .bootnode
+        .ipc_client
+        .store(content_key.clone(), content_value.clone())
+        .await
+        .unwrap();
+
+    assert!(store_result);
+
+    let content_info = peertest.nodes[0]
+        .ipc_client
+        .recursive_find_content(content_key)
+        .await
+        .unwrap();
+
+    if let ContentInfo::Content {
+        content,
+        utp_transfer,
+    } = content_info
+    {
+        assert_eq!(
+            content,
+            PossibleHistoryContentValue::ContentPresent(content_value)
+        );
+        assert!(utp_transfer);
+    } else {
+        panic!("Error: Unexpected content info response");
+    }
+}
+
+pub async fn test_trace_recursive_utp(peertest: &Peertest) {
+    info!("Test trace recursive utp");
+
+    // store header_with_proof to validate block body
+    let (content_key, content_value) = fixture_header_with_proof();
+    let store_result = peertest.nodes[0]
+        .ipc_client
+        .store(content_key.clone(), content_value.clone())
+        .await
+        .unwrap();
+
+    assert!(store_result);
+
+    let (content_key, content_value) = fixture_block_body();
+
+    let store_result = peertest
+        .bootnode
+        .ipc_client
+        .store(content_key.clone(), content_value.clone())
+        .await
+        .unwrap();
+
+    assert!(store_result);
+
+    let trace_content_info: TraceContentInfo = peertest.nodes[0]
+        .ipc_client
+        .trace_recursive_find_content(content_key)
+        .await
+        .unwrap();
+
+    let content = trace_content_info.content;
+    let trace = trace_content_info.trace;
+
+    assert_eq!(
+        content,
+        PossibleHistoryContentValue::ContentPresent(content_value)
+    );
+
+    let query_origin_node: NodeId = peertest.nodes[0].enr.node_id();
+    let node_with_content: NodeId = peertest.bootnode.enr.node_id();
+
+    // Test that `origin` is set correctly
+    let origin = trace.origin;
+    assert_eq!(origin, ethportal_api::NodeId::from(query_origin_node));
+
+    // Test that `received_content_from_node` is set correctly
+    let received_content_from_node = trace.received_content_from_node.unwrap();
+    assert_eq!(
+        ethportal_api::NodeId::from(node_with_content),
+        received_content_from_node
+    );
+
+    let responses = trace.responses;
+
+    // Test that origin response has `responses` containing `received_content_from_node` node
+    let origin_response = responses.get(&origin).unwrap();
+    assert!(origin_response
+        .responded_with
+        .contains(&received_content_from_node));
+}

--- a/ethportal-peertest/src/utils.rs
+++ b/ethportal-peertest/src/utils.rs
@@ -1,7 +1,6 @@
 use tracing::error;
 
-use ethportal_api::PossibleHistoryContentValue;
-use ethportal_api::{HistoryContentKey, HistoryNetworkApiClient};
+use ethportal_api::{HistoryContentKey, HistoryNetworkApiClient, PossibleHistoryContentValue};
 
 /// Wait for the content to be transferred
 pub async fn wait_for_content<P: HistoryNetworkApiClient + std::marker::Sync>(

--- a/newsfragments/814.fixed.md
+++ b/newsfragments/814.fixed.md
@@ -1,0 +1,1 @@
+Validate find_content result in non-utp transfers & use fresh testnet for each peertest scenario.

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -1,24 +1,176 @@
 #[cfg(test)]
 mod test {
+    use rpc::RpcServerHandle;
     use std::env;
     use std::net::{IpAddr, Ipv4Addr};
 
     use ethportal_api::types::cli::{TrinConfig, DEFAULT_WEB3_HTTP_ADDRESS, DEFAULT_WEB3_IPC_PATH};
     use ethportal_peertest as peertest;
+    use jsonrpsee::async_client::Client;
     use serial_test::serial;
     use tokio::time::{sleep, Duration};
-    use trin_utils::log::init_tracing_logger;
 
     // Logs don't show up when trying to use test_log here, maybe because of multi_thread
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn test_launches() {
-        init_tracing_logger();
+    async fn peertest_stateless() {
+        // These tests are stateless with regards to the content database,
+        // so they can all be run against the same set of peertest nodes
+        // without needing to reset the database between tests.
+        // If a scenario is testing the state of the content database,
+        // it should be added to its own test function.
+        let (peertest, target, handle) = setup_peertest().await;
+        peertest::scenarios::paginate::test_paginate_local_storage(&peertest).await;
+        peertest::scenarios::basic::test_web3_client_version(&target).await;
+        peertest::scenarios::basic::test_discv5_node_info(&peertest).await;
+        peertest::scenarios::basic::test_discv5_routing_table_info(&target).await;
+        peertest::scenarios::basic::test_history_radius(&target).await;
+        peertest::scenarios::basic::test_history_add_enr(&target, &peertest).await;
+        peertest::scenarios::basic::test_history_get_enr(&target, &peertest).await;
+        peertest::scenarios::basic::test_history_delete_enr(&target, &peertest).await;
+        peertest::scenarios::basic::test_history_lookup_enr(&peertest).await;
+        peertest::scenarios::basic::test_history_ping(&target, &peertest).await;
+        peertest::scenarios::basic::test_history_find_nodes(&target, &peertest).await;
+        peertest::scenarios::basic::test_history_find_nodes_zero_distance(&target, &peertest).await;
+        peertest::scenarios::basic::test_history_store(&target).await;
+        peertest::scenarios::basic::test_history_routing_table_info(&target).await;
+        peertest::scenarios::basic::test_history_local_content_absent(&target).await;
+        peertest::scenarios::find::test_recursive_find_nodes_self(&peertest).await;
+        peertest::scenarios::find::test_recursive_find_nodes_peer(&peertest).await;
+        peertest::scenarios::find::test_recursive_find_nodes_random(&peertest).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
 
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_populated_offer() {
+        let (peertest, target, handle) = setup_peertest().await;
+        peertest::scenarios::offer_accept::test_populated_offer(&peertest, &target).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_unpopulated_offer() {
+        let (peertest, target, handle) = setup_peertest().await;
+        peertest::scenarios::offer_accept::test_unpopulated_offer(&peertest, &target).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_find_content_return_enr() {
+        let (peertest, target, handle) = setup_peertest().await;
+        peertest::scenarios::find::test_find_content_return_enr(&target, &peertest).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_trace_recursive_find_content_local_db() {
+        let (peertest, _target, handle) = setup_peertest().await;
+        peertest::scenarios::find::test_trace_recursive_find_content_local_db(&peertest).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_trace_recursive_find_content_for_absent_content() {
+        let (peertest, _target, handle) = setup_peertest().await;
+        peertest::scenarios::find::test_trace_recursive_find_content_for_absent_content(&peertest)
+            .await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_trace_recursive_find_content() {
+        let (peertest, _target, handle) = setup_peertest().await;
+        peertest::scenarios::find::test_trace_recursive_find_content(&peertest).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_validate_pre_merge_header_with_proof() {
+        let (peertest, target, handle) = setup_peertest().await;
+        peertest::scenarios::validation::test_validate_pre_merge_header_with_proof(
+            &peertest, &target,
+        )
+        .await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_invalidate_header_by_hash() {
+        let (peertest, target, handle) = setup_peertest().await;
+        peertest::scenarios::validation::test_invalidate_header_by_hash(&peertest, &target).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_validate_block_body() {
+        let (peertest, target, handle) = setup_peertest().await;
+        peertest::scenarios::validation::test_validate_pre_merge_block_body(&peertest, &target)
+            .await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_validate_receipts() {
+        let (peertest, target, handle) = setup_peertest().await;
+        peertest::scenarios::validation::test_validate_pre_merge_receipts(&peertest, &target).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_recursive_utp() {
+        let (peertest, _target, handle) = setup_peertest().await;
+        peertest::scenarios::utp::test_recursive_utp(&peertest).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_trace_recursive_utp() {
+        let (peertest, _target, handle) = setup_peertest().await;
+        peertest::scenarios::utp::test_trace_recursive_utp(&peertest).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    // sets the global tracing subscriber on the first peertest run, which is used by all other tests
+    fn init_tracing() {
+        let subscriber = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_ansi(trin_utils::log::detect_ansi_support())
+            .finish();
+        // returns err if already set, which is fine and we just ignore the err
+        let _ = tracing::subscriber::set_global_default(subscriber);
+    }
+
+    async fn setup_peertest() -> (peertest::Peertest, Client, RpcServerHandle) {
+        init_tracing();
         // Run a client, as a buddy peer for ping tests, etc.
         let peertest = peertest::launch_peertest_nodes(2).await;
         // Short sleep to make sure all peertest nodes can connect
-        sleep(Duration::from_secs(1)).await;
+        sleep(Duration::from_millis(100)).await;
 
         let test_ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
         // Use an uncommon port for the peertest to avoid clashes.
@@ -50,52 +202,16 @@ mod test {
             .build(DEFAULT_WEB3_IPC_PATH)
             .await
             .unwrap();
-
-        peertest::scenarios::paginate::test_paginate_local_storage(&peertest).await;
-        peertest::scenarios::basic::test_web3_client_version(&target).await;
-        peertest::scenarios::basic::test_discv5_node_info(&peertest).await;
-        peertest::scenarios::basic::test_discv5_routing_table_info(&target).await;
-        peertest::scenarios::basic::test_history_radius(&target).await;
-        peertest::scenarios::basic::test_history_add_enr(&target, &peertest).await;
-        peertest::scenarios::basic::test_history_get_enr(&target, &peertest).await;
-        peertest::scenarios::basic::test_history_delete_enr(&target, &peertest).await;
-        peertest::scenarios::basic::test_history_lookup_enr(&peertest).await;
-        peertest::scenarios::basic::test_history_ping(&target, &peertest).await;
-        peertest::scenarios::basic::test_history_find_nodes(&target, &peertest).await;
-        peertest::scenarios::basic::test_history_find_nodes_zero_distance(&target, &peertest).await;
-        peertest::scenarios::basic::test_history_store(&target).await;
-        peertest::scenarios::basic::test_history_routing_table_info(&target).await;
-        peertest::scenarios::basic::test_history_local_content_absent(&target).await;
-        peertest::scenarios::offer_accept::test_unpopulated_offer(&peertest, &target).await;
-        peertest::scenarios::offer_accept::test_populated_offer(&peertest, &target).await;
-        peertest::scenarios::find::test_find_content_return_enr(&target, &peertest).await;
-        peertest::scenarios::find::test_recursive_find_nodes_self(&peertest).await;
-        peertest::scenarios::find::test_recursive_find_nodes_peer(&peertest).await;
-        peertest::scenarios::find::test_recursive_find_nodes_random(&peertest).await;
-        peertest::scenarios::find::test_trace_recursive_find_content(&peertest).await;
-        peertest::scenarios::find::test_trace_recursive_find_content_local_db(&peertest).await;
-        peertest::scenarios::find::test_trace_recursive_find_content_for_absent_content(&peertest)
-            .await;
-        peertest::scenarios::validation::test_validate_pre_merge_header_with_proof(
-            &peertest, &target,
-        )
-        .await;
-        peertest::scenarios::validation::test_validate_pre_merge_block_body(&peertest, &target)
-            .await;
-        peertest::scenarios::validation::test_validate_pre_merge_receipts(&peertest, &target).await;
-        peertest::scenarios::find::test_recursive_utp(&peertest).await;
-
-        peertest.exit_all_nodes();
-        test_client_rpc_handle.stop().unwrap();
+        (peertest, target, test_client_rpc_handle)
     }
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn test_bridge() {
+    async fn peertest_bridge() {
         // Run a client, as a buddy peer for ping tests, etc.
         let peertest = peertest::launch_peertest_nodes(1).await;
         // Short sleep to make sure all peertest nodes can connect
-        sleep(Duration::from_secs(1)).await;
+        sleep(Duration::from_millis(100)).await;
 
         let test_ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
         // Use an uncommon port for the peertest to avoid clashes.
@@ -133,7 +249,6 @@ mod test {
             .build(DEFAULT_WEB3_HTTP_ADDRESS)
             .unwrap();
         peertest::scenarios::bridge::test_bridge(&peertest, &target).await;
-
         test_client_rpc_handle.stop().unwrap();
     }
 }

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -13,7 +13,7 @@ use ethportal_api::types::execution::{
     header::{Header, HeaderWithProof},
     receipts::Receipts,
 };
-use ethportal_api::HistoryContentKey;
+use ethportal_api::{utils::bytes::hex_encode, HistoryContentKey};
 use trin_validation::{oracle::HeaderOracle, validator::Validator};
 
 pub struct ChainHistoryValidator {
@@ -31,11 +31,18 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
         HistoryContentKey: 'async_trait,
     {
         match content_key {
-            HistoryContentKey::BlockHeaderWithProof(_key) => {
+            HistoryContentKey::BlockHeaderWithProof(key) => {
                 let header_with_proof =
                     HeaderWithProof::from_ssz_bytes(content).map_err(|err| {
                         anyhow!("Header with proof content has invalid encoding: {err:?}")
                     })?;
+                let header_hash = header_with_proof.header.hash();
+                if header_hash != H256::from(key.block_hash) {
+                    return Err(anyhow!(
+                        "Content validation failed: Invalid header hash. Found: {header_hash:?} - Expected: {:?}",
+                        hex_encode(key.block_hash)
+                    ));
+                }
                 self.header_oracle
                     .write()
                     .await

--- a/trin-utils/src/log.rs
+++ b/trin-utils/src/log.rs
@@ -7,7 +7,7 @@ pub fn init_tracing_logger() {
         .init();
 }
 
-fn detect_ansi_support() -> bool {
+pub fn detect_ansi_support() -> bool {
     #[cfg(windows)]
     {
         use ansi_term::enable_ansi_support;


### PR DESCRIPTION
### What was wrong?
Our testing setup for peertest was not ideal. We spin up a small testnet of nodes and use the same testnet for every scenario. This makes testing difficult & non-intuitive, when side-affects from certain scenarios can affect the outcome of later scenarios. Especially relevant for find content tests. 

Initially, I thought that it would be better to simply use unique test values for each scenario. However, this is an unsustainable approach, as we will need to continually generate new test values for each scenario we add. It turns out that the time overhead for spinning up a new peertest for each scenario is really not that bad, and avoids the unneeded complexity of maintaining unique content key/values for each scenario.

### How was it fixed?
- Updated any relevant scenarios to use a fresh peertest testnet.
- Added validation for content retrieved via a simple `FindContent` request.
- Improved header validation to also validate that its hash matches the hashed content.
- Added some test scenarios


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] bridge pandaops batch limit of 100
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
