### PR TITLE
Add unwrap_used lint warning to all workspaces

### DIFF
--- a/ethportal-peertest/src/lib.rs
+++ b/ethportal-peertest/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::unwrap_used)]
+
 pub mod constants;
 pub mod scenarios;
 pub mod utils;

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -13,29 +13,36 @@ use trin_utils::version::get_trin_version;
 
 pub async fn test_web3_client_version(target: &Client) {
     info!("Testing web3_clientVersion");
-    let result = target.client_version().await.unwrap();
+    let result = target.client_version().await.expect("operation failed");
     let expected_version = format!("trin v{}", get_trin_version());
     assert_eq!(result, expected_version);
 }
 
 pub async fn test_discv5_node_info(peertest: &Peertest) {
     info!("Testing discv5_nodeInfo");
-    let result = peertest.bootnode.ipc_client.node_info().await.unwrap();
+    let result = peertest
+        .bootnode
+        .ipc_client
+        .node_info()
+        .await
+        .expect("operation failed");
     assert_eq!(result.enr, peertest.bootnode.enr);
 }
 
 pub async fn test_discv5_routing_table_info(target: &Client) {
     info!("Testing discv5_routingTableInfo");
-    let result = Discv5ApiClient::routing_table_info(target).await.unwrap();
-    let local_key = result.get("localNodeId").unwrap();
+    let result = Discv5ApiClient::routing_table_info(target)
+        .await
+        .expect("operation failed");
+    let local_key = result.get("localNodeId").expect("index not found");
     assert!(local_key.is_string());
-    assert!(local_key.as_str().unwrap().starts_with("0x"));
-    assert!(result.get("buckets").unwrap().is_array());
+    assert!(local_key.as_str().expect("self is none").starts_with("0x"));
+    assert!(result.get("buckets").expect("index not found").is_array());
 }
 
 pub async fn test_history_radius(target: &Client) {
     info!("Testing portal_historyRadius");
-    let result = target.radius().await.unwrap();
+    let result = target.radius().await.expect("operation failed");
     assert_eq!(
         result,
         U256::from_big_endian(Distance::MAX.as_ssz_bytes().as_slice())
@@ -46,7 +53,7 @@ pub async fn test_history_add_enr(target: &Client, peertest: &Peertest) {
     info!("Testing portal_historyAddEnr");
     let result = HistoryNetworkApiClient::add_enr(target, peertest.bootnode.enr.clone())
         .await
-        .unwrap();
+        .expect("operation failed");
     assert!(result);
 }
 
@@ -54,7 +61,7 @@ pub async fn test_history_get_enr(target: &Client, peertest: &Peertest) {
     info!("Testing portal_historyGetEnr");
     let result = HistoryNetworkApiClient::get_enr(target, peertest.bootnode.enr.node_id())
         .await
-        .unwrap();
+        .expect("operation failed");
     assert_eq!(result, peertest.bootnode.enr);
 }
 
@@ -62,7 +69,7 @@ pub async fn test_history_delete_enr(target: &Client, peertest: &Peertest) {
     info!("Testing portal_historyDeleteEnr");
     let result = HistoryNetworkApiClient::delete_enr(target, peertest.bootnode.enr.node_id())
         .await
-        .unwrap();
+        .expect("operation failed");
     assert!(result);
 }
 
@@ -73,13 +80,16 @@ pub async fn test_history_lookup_enr(peertest: &Peertest) {
         peertest.nodes[0].enr.node_id(),
     )
     .await
-    .unwrap();
+    .expect("operation failed");
     assert_eq!(result, peertest.nodes[0].enr);
 }
 
 pub async fn test_history_ping(target: &Client, peertest: &Peertest) {
     info!("Testing portal_historyPing");
-    let result = target.ping(peertest.bootnode.enr.clone()).await.unwrap();
+    let result = target
+        .ping(peertest.bootnode.enr.clone())
+        .await
+        .expect("operation failed");
     assert_eq!(
         result.data_radius,
         U256::from_big_endian(Distance::MAX.as_ssz_bytes().as_slice())
@@ -92,7 +102,7 @@ pub async fn test_history_find_nodes(target: &Client, peertest: &Peertest) {
     let result = target
         .find_nodes(peertest.bootnode.enr.clone(), vec![256])
         .await
-        .unwrap();
+        .expect("operation failed");
     assert!(result.contains(&peertest.nodes[0].enr));
 }
 
@@ -101,7 +111,7 @@ pub async fn test_history_find_nodes_zero_distance(target: &Client, peertest: &P
     let result = target
         .find_nodes(peertest.bootnode.enr.clone(), vec![0])
         .await
-        .unwrap();
+        .expect("operation failed");
     assert!(result.contains(&peertest.bootnode.enr));
 }
 
@@ -109,11 +119,14 @@ pub async fn test_history_store(target: &Client) {
     info!("Testing portal_historyStore");
 
     let content_key: HistoryContentKey =
-        serde_json::from_value(json!(HISTORY_CONTENT_KEY)).unwrap();
+        serde_json::from_value(json!(HISTORY_CONTENT_KEY)).expect("conversion failed");
     let content_value: HistoryContentValue =
-        serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).unwrap();
+        serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).expect("conversion failed");
 
-    let result = target.store(content_key, content_value).await.unwrap();
+    let result = target
+        .store(content_key, content_value)
+        .await
+        .expect("operation failed");
     assert!(result);
 }
 
@@ -121,11 +134,14 @@ pub async fn test_history_routing_table_info(target: &Client) {
     info!("Testing portal_historyRoutingTableInfo");
     let result = HistoryNetworkApiClient::routing_table_info(target)
         .await
-        .unwrap();
-    assert!(result.get("buckets").unwrap().is_object());
-    assert!(result.get("numBuckets").unwrap().is_u64());
-    assert!(result.get("numNodes").unwrap().is_u64());
-    assert!(result.get("numConnected").unwrap().is_u64());
+        .expect("operation failed");
+    assert!(result.get("buckets").expect("index not found").is_object());
+    assert!(result.get("numBuckets").expect("index not found").is_u64());
+    assert!(result.get("numNodes").expect("index not found").is_u64());
+    assert!(result
+        .get("numConnected")
+        .expect("index not found")
+        .is_u64());
 }
 
 pub async fn test_history_local_content_absent(target: &Client) {
@@ -134,8 +150,11 @@ pub async fn test_history_local_content_absent(target: &Client) {
     let content_key: HistoryContentKey = serde_json::from_value(json!(
         "0x00cb5cab7266694daa0d28cbf40496c08dd30bf732c41e0455e7ad389c10d79f4f"
     ))
-    .unwrap();
-    let result = target.local_content(content_key).await.unwrap();
+    .expect("conversion failed");
+    let result = target
+        .local_content(content_key)
+        .await
+        .expect("operation failed");
 
     if let PossibleHistoryContentValue::ContentPresent(_) = result {
         panic!("Expected absent content");

--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -23,9 +23,9 @@ pub async fn test_bridge(peertest: &Peertest, target: &HttpClient) {
     bridge.launch().await;
 
     let content_key: HistoryContentKey =
-        serde_json::from_value(json!(HISTORY_CONTENT_KEY)).unwrap();
+        serde_json::from_value(json!(HISTORY_CONTENT_KEY)).expect("conversion failed");
     let content_value: HistoryContentValue =
-        serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).unwrap();
+        serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).expect("conversion failed");
 
     // Check if the stored content value in bootnode's DB matches the offered
     let response = wait_for_content(&peertest.bootnode.ipc_client, content_key).await;

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -18,7 +18,7 @@ pub async fn test_find_content_return_enr(target: &Client, peertest: &Peertest) 
     info!("Testing find content returns enrs properly");
 
     let header_with_proof_key: HistoryContentKey =
-        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_KEY)).unwrap();
+        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_KEY)).expect("conversion failed");
 
     // check if we can fetch data from routing table
     match HistoryNetworkApiClient::get_enr(
@@ -60,7 +60,7 @@ pub async fn test_recursive_find_nodes_self(peertest: &Peertest) {
         .ipc_client
         .recursive_find_nodes(target_node_id)
         .await
-        .unwrap();
+        .expect("operation failed");
     assert_eq!(result, vec![target_enr]);
 }
 
@@ -73,7 +73,7 @@ pub async fn test_recursive_find_nodes_peer(peertest: &Peertest) {
         .ipc_client
         .recursive_find_nodes(target_node_id)
         .await
-        .unwrap();
+        .expect("operation failed");
     assert_eq!(result, vec![target_enr]);
 }
 
@@ -81,7 +81,8 @@ pub async fn test_recursive_find_nodes_random(peertest: &Peertest) {
     info!("Testing trace recursive find nodes random");
     let mut bytes = [0u8; 32];
     let random_node_id =
-        hex_decode("0xcac75e7e776d84fba55a3104bdccfd716537bca3ad8465113f67f04d62694183").unwrap();
+        hex_decode("0xcac75e7e776d84fba55a3104bdccfd716537bca3ad8465113f67f04d62694183")
+            .expect("conversion failed");
     bytes.copy_from_slice(&random_node_id);
     let target_node_id = NodeId::from(bytes);
     let result = peertest
@@ -89,7 +90,7 @@ pub async fn test_recursive_find_nodes_random(peertest: &Peertest) {
         .ipc_client
         .recursive_find_nodes(target_node_id)
         .await
-        .unwrap();
+        .expect("operation failed");
     assert_eq!(result.len(), 3);
 }
 
@@ -98,9 +99,9 @@ pub async fn test_recursive_utp(peertest: &Peertest) {
 
     // store header_with_proof to validate block body
     let header_with_proof_content_key: HistoryContentKey =
-        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_KEY)).unwrap();
+        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_KEY)).expect("conversion failed");
     let header_with_proof_content_value: HistoryContentValue =
-        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_VALUE)).unwrap();
+        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_VALUE)).expect("conversion failed");
 
     let store_result = peertest.nodes[0]
         .ipc_client
@@ -109,22 +110,22 @@ pub async fn test_recursive_utp(peertest: &Peertest) {
             header_with_proof_content_value.clone(),
         )
         .await
-        .unwrap();
+        .expect("operation failed");
 
     assert!(store_result);
 
     let history_content_key: HistoryContentKey =
-        serde_json::from_value(json!(BLOCK_BODY_CONTENT_KEY)).unwrap();
-    let hex_data = hex_decode(BLOCK_BODY_CONTENT_VALUE).unwrap();
+        serde_json::from_value(json!(BLOCK_BODY_CONTENT_KEY)).expect("conversion failed");
+    let hex_data = hex_decode(BLOCK_BODY_CONTENT_VALUE).expect("conversion failed");
     let history_content_value: HistoryContentValue =
-        HistoryContentValue::decode(&hex_data).unwrap();
+        HistoryContentValue::decode(&hex_data).expect("conversion failed");
 
     let store_result = peertest
         .bootnode
         .ipc_client
         .store(history_content_key.clone(), history_content_value.clone())
         .await
-        .unwrap();
+        .expect("operation failed");
 
     assert!(store_result);
 
@@ -132,7 +133,7 @@ pub async fn test_recursive_utp(peertest: &Peertest) {
         .ipc_client
         .recursive_find_content(history_content_key)
         .await
-        .unwrap();
+        .expect("operation failed");
 
     if let ContentInfo::Content {
         content,
@@ -152,18 +153,19 @@ pub async fn test_recursive_utp(peertest: &Peertest) {
 pub async fn test_trace_recursive_find_content(peertest: &Peertest) {
     let uniq_content_key =
         "\"0x0015b11b918355b1ef9c5db810302ebad0bf2544255b530cdce90674d5887bb286\"";
-    let history_content_key: HistoryContentKey = serde_json::from_str(uniq_content_key).unwrap();
+    let history_content_key: HistoryContentKey =
+        serde_json::from_str(uniq_content_key).expect("conversion failed");
 
-    let hex_data = hex_decode(HISTORY_CONTENT_VALUE).unwrap();
+    let hex_data = hex_decode(HISTORY_CONTENT_VALUE).expect("conversion failed");
     let history_content_value: HistoryContentValue =
-        HistoryContentValue::decode(&hex_data).unwrap();
+        HistoryContentValue::decode(&hex_data).expect("conversion failed");
 
     let store_result = peertest
         .bootnode
         .ipc_client
         .store(history_content_key.clone(), history_content_value.clone())
         .await
-        .unwrap();
+        .expect("operation failed");
 
     assert!(store_result);
 
@@ -171,7 +173,7 @@ pub async fn test_trace_recursive_find_content(peertest: &Peertest) {
         .ipc_client
         .trace_recursive_find_content(history_content_key)
         .await
-        .unwrap();
+        .expect("operation failed");
 
     assert!(!trace_content_info.utp_transfer);
     let content = trace_content_info.content;
@@ -190,7 +192,7 @@ pub async fn test_trace_recursive_find_content(peertest: &Peertest) {
     assert_eq!(origin, ethportal_api::NodeId::from(query_origin_node));
 
     // Test that `received_content_from_node` is set correctly
-    let received_content_from_node = trace.received_content_from_node.unwrap();
+    let received_content_from_node = trace.received_content_from_node.expect("content not found");
     assert_eq!(
         ethportal_api::NodeId::from(node_with_content),
         received_content_from_node
@@ -199,7 +201,7 @@ pub async fn test_trace_recursive_find_content(peertest: &Peertest) {
     let responses = trace.responses;
 
     // Test that origin response has `responses` containing `received_content_from_node` node
-    let origin_response = responses.get(&origin).unwrap();
+    let origin_response = responses.get(&origin).expect("origin response not found");
     assert!(origin_response
         .responded_with
         .contains(&received_content_from_node));
@@ -214,12 +216,13 @@ pub async fn test_trace_recursive_find_content_for_absent_content(peertest: &Pee
         "\"0x0015b11b918355b1ef9c5db810302ebad0bf2544255b530cdce90674d5887bb287\"";
     // Do not store content to offer in the testnode db
 
-    let history_content_key: HistoryContentKey = serde_json::from_str(uniq_content_key).unwrap();
+    let history_content_key: HistoryContentKey =
+        serde_json::from_str(uniq_content_key).expect("conversion failed");
 
     let result = client
         .trace_recursive_find_content(history_content_key)
         .await
-        .unwrap();
+        .expect("operation failed");
 
     assert!(!result.utp_transfer);
     assert_eq!(result.content, PossibleHistoryContentValue::ContentAbsent);
@@ -231,18 +234,19 @@ pub async fn test_trace_recursive_find_content_local_db(peertest: &Peertest) {
     let uniq_content_key =
         "\"0x0025b11b918355b1ef9c5db810302ebad0bf2544255b530cdce90674d5887bb286\"";
 
-    let history_content_key: HistoryContentKey = serde_json::from_str(uniq_content_key).unwrap();
+    let history_content_key: HistoryContentKey =
+        serde_json::from_str(uniq_content_key).expect("conversion failed");
 
-    let hex_data = hex_decode(HISTORY_CONTENT_VALUE).unwrap();
+    let hex_data = hex_decode(HISTORY_CONTENT_VALUE).expect("conversion failed");
     let history_content_value: HistoryContentValue =
-        HistoryContentValue::decode(&hex_data).unwrap();
+        HistoryContentValue::decode(&hex_data).expect("conversion failed");
 
     let store_result = peertest
         .bootnode
         .ipc_client
         .store(history_content_key.clone(), history_content_value.clone())
         .await
-        .unwrap();
+        .expect("operation failed");
 
     assert!(store_result);
 
@@ -251,7 +255,7 @@ pub async fn test_trace_recursive_find_content_local_db(peertest: &Peertest) {
         .ipc_client
         .trace_recursive_find_content(history_content_key)
         .await
-        .unwrap();
+        .expect("operation failed");
     assert!(!trace_content_info.utp_transfer);
     assert_eq!(
         trace_content_info.content,
@@ -260,7 +264,10 @@ pub async fn test_trace_recursive_find_content_local_db(peertest: &Peertest) {
 
     let origin = trace_content_info.trace.origin;
     assert_eq!(
-        trace_content_info.trace.received_content_from_node.unwrap(),
+        trace_content_info
+            .trace
+            .received_content_from_node
+            .expect("content not found"),
         origin
     );
 

--- a/ethportal-peertest/src/scenarios/offer_accept.rs
+++ b/ethportal-peertest/src/scenarios/offer_accept.rs
@@ -20,27 +20,27 @@ pub async fn test_unpopulated_offer(peertest: &Peertest, target: &Client) {
     info!("Testing Unpopulated OFFER/ACCEPT flow");
 
     let content_key: HistoryContentKey =
-        serde_json::from_value(json!(HISTORY_CONTENT_KEY)).unwrap();
+        serde_json::from_value(json!(HISTORY_CONTENT_KEY)).expect("conversion failed");
     let content_value: HistoryContentValue =
-        serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).unwrap();
+        serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).expect("conversion failed");
 
     // Store content to offer in the testnode db
     let store_result = target
         .store(content_key.clone(), content_value.clone())
         .await
-        .unwrap();
+        .expect("operation failed");
 
     assert!(store_result);
 
     // Send unpopulated offer request from testnode to bootnode
     let result = target
         .offer(
-            Enr::from_str(&peertest.bootnode.enr.to_base64()).unwrap(),
+            Enr::from_str(&peertest.bootnode.enr.to_base64()).expect("conversion failed"),
             content_key.clone(),
             None,
         )
         .await
-        .unwrap();
+        .expect("operation failed");
 
     // Check that ACCEPT response sent by bootnode accepted the offered content
     assert_eq!(hex_encode(result.content_keys.into_bytes()), "0x03");
@@ -64,18 +64,18 @@ pub async fn test_populated_offer(peertest: &Peertest, target: &Client) {
     let content_key: HistoryContentKey = serde_json::from_value(json!(
         "0x00cb5cab7266694daa0d28cbf40496c08dd30bf732c41e0455e7ad389c10d79f4f"
     ))
-    .unwrap();
+    .expect("conversion failed");
     let content_value: HistoryContentValue =
-        serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).unwrap();
+        serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).expect("conversion failed");
 
     let result = target
         .offer(
-            Enr::from_str(&peertest.bootnode.enr.to_base64()).unwrap(),
+            Enr::from_str(&peertest.bootnode.enr.to_base64()).expect("conversion failed"),
             content_key.clone(),
             Some(content_value.clone()),
         )
         .await
-        .unwrap();
+        .expect("operation failed");
 
     // Check that ACCEPT response sent by bootnode accepted the offered content
     assert_eq!(hex_encode(result.content_keys.into_bytes()), "0x03");

--- a/ethportal-peertest/src/scenarios/paginate.rs
+++ b/ethportal-peertest/src/scenarios/paginate.rs
@@ -9,7 +9,10 @@ use crate::Peertest;
 pub async fn test_paginate_local_storage(peertest: &Peertest) {
     let ipc_client = &peertest.bootnode.ipc_client;
     // Test paginate with empty storage
-    let result = ipc_client.paginate_local_content_keys(0, 1).await.unwrap();
+    let result = ipc_client
+        .paginate_local_content_keys(0, 1)
+        .await
+        .expect("operation failed");
     assert_eq!(result.total_entries, 0);
     assert_eq!(result.content_keys.len(), 0);
 
@@ -18,44 +21,50 @@ pub async fn test_paginate_local_storage(peertest: &Peertest) {
             serde_json::to_string(&HistoryContentKey::BlockHeaderWithProof(BlockHeaderKey {
                 block_hash: rand::random(),
             }))
-            .unwrap()
+            .expect("conversion failed")
         })
         .collect();
 
     for content_key in content_keys.clone().into_iter() {
         // Store content to offer in the testnode db
         let dummy_content_value: HistoryContentValue =
-            serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).unwrap();
+            serde_json::from_value(json!(HISTORY_CONTENT_VALUE)).expect("conversion failed");
         let store_result = ipc_client
             .store(
-                serde_json::from_str(&content_key).unwrap(),
+                serde_json::from_str(&content_key).expect("conversion failed"),
                 dummy_content_value,
             )
             .await
-            .unwrap();
+            .expect("operation failed");
         assert!(store_result);
     }
     // Sort content keys to use for testing
     content_keys.sort();
 
     // Test paginate
-    let result = ipc_client.paginate_local_content_keys(0, 1).await.unwrap();
+    let result = ipc_client
+        .paginate_local_content_keys(0, 1)
+        .await
+        .expect("operation failed");
     assert_eq!(result.total_entries, 20);
 
     let paginated_content_keys: Vec<String> = result
         .content_keys
         .iter()
-        .map(|v| serde_json::to_string(v).unwrap())
+        .map(|v| serde_json::to_string(v).expect("conversion failed"))
         .collect();
     assert_eq!(paginated_content_keys, &content_keys[0..1]);
 
     // Test paginate with different offset & limit
-    let result = ipc_client.paginate_local_content_keys(5, 10).await.unwrap();
+    let result = ipc_client
+        .paginate_local_content_keys(5, 10)
+        .await
+        .expect("operation failed");
     assert_eq!(result.total_entries, 20);
     let paginated_content_keys: Vec<String> = result
         .content_keys
         .iter()
-        .map(|v| serde_json::to_string(v).unwrap())
+        .map(|v| serde_json::to_string(v).expect("conversion failed"))
         .collect();
     assert_eq!(paginated_content_keys, &content_keys[5..15]);
 
@@ -63,13 +72,13 @@ pub async fn test_paginate_local_storage(peertest: &Peertest) {
     let result = ipc_client
         .paginate_local_content_keys(19, 20)
         .await
-        .unwrap();
+        .expect("operation failed");
 
     assert_eq!(result.total_entries, 20);
     let paginated_content_keys: Vec<String> = result
         .content_keys
         .iter()
-        .map(|v| serde_json::to_string(v).unwrap())
+        .map(|v| serde_json::to_string(v).expect("conversion failed"))
         .collect();
     assert_eq!(paginated_content_keys, &content_keys[19..]);
 
@@ -77,12 +86,12 @@ pub async fn test_paginate_local_storage(peertest: &Peertest) {
     let result = ipc_client
         .paginate_local_content_keys(21, 10)
         .await
-        .unwrap();
+        .expect("operation failed");
     assert_eq!(result.total_entries, 20);
     assert!(result
         .content_keys
         .iter()
-        .map(|v| serde_json::to_string(v).unwrap())
+        .map(|v| serde_json::to_string(v).expect("conversion failed"))
         .next()
         .is_none());
 }

--- a/ethportal-peertest/src/scenarios/validation.rs
+++ b/ethportal-peertest/src/scenarios/validation.rs
@@ -21,9 +21,9 @@ pub async fn test_validate_pre_merge_header_with_proof(peertest: &Peertest, targ
 
     // store header_with_proof
     let header_with_proof_content_key: HistoryContentKey =
-        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_KEY)).unwrap();
+        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_KEY)).expect("conversion failed");
     let header_with_proof_content_value: HistoryContentValue =
-        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_VALUE)).unwrap();
+        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_VALUE)).expect("conversion failed");
 
     let store_result = peertest
         .bootnode
@@ -33,18 +33,18 @@ pub async fn test_validate_pre_merge_header_with_proof(peertest: &Peertest, targ
             header_with_proof_content_value.clone(),
         )
         .await
-        .unwrap();
+        .expect("operation failed");
 
     assert!(store_result);
 
     // calling find_content since it only returns the found data if validation was successful
     let result = target
         .find_content(
-            Enr::from_str(&peertest.bootnode.enr.to_base64()).unwrap(),
+            Enr::from_str(&peertest.bootnode.enr.to_base64()).expect("conversion failed"),
             header_with_proof_content_key.clone(),
         )
         .await
-        .unwrap();
+        .expect("operation failed");
 
     match result {
         ContentInfo::Content {
@@ -65,9 +65,9 @@ pub async fn test_validate_pre_merge_block_body(peertest: &Peertest, target: &Cl
     info!("Test validating a pre-merge block body");
     // store header_with_proof to validate block body
     let header_with_proof_content_key: HistoryContentKey =
-        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_KEY)).unwrap();
+        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_KEY)).expect("conversion failed");
     let header_with_proof_content_value: HistoryContentValue =
-        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_VALUE)).unwrap();
+        serde_json::from_value(json!(HEADER_WITH_PROOF_CONTENT_VALUE)).expect("conversion failed");
 
     let store_result = target
         .store(
@@ -75,15 +75,15 @@ pub async fn test_validate_pre_merge_block_body(peertest: &Peertest, target: &Cl
             header_with_proof_content_value.clone(),
         )
         .await
-        .unwrap();
+        .expect("operation failed");
 
     assert!(store_result);
 
     // store block body
     let block_body_content_key: HistoryContentKey =
-        serde_json::from_value(json!(BLOCK_BODY_CONTENT_KEY)).unwrap();
+        serde_json::from_value(json!(BLOCK_BODY_CONTENT_KEY)).expect("conversion failed");
     let block_body_content_value: HistoryContentValue =
-        serde_json::from_value(json!(BLOCK_BODY_CONTENT_VALUE)).unwrap();
+        serde_json::from_value(json!(BLOCK_BODY_CONTENT_VALUE)).expect("conversion failed");
 
     let store_result = peertest
         .bootnode
@@ -93,18 +93,18 @@ pub async fn test_validate_pre_merge_block_body(peertest: &Peertest, target: &Cl
             block_body_content_value.clone(),
         )
         .await
-        .unwrap();
+        .expect("operation failed");
 
     assert!(store_result);
 
     // calling find_content since it only returns the found data if validation was successful
     let result = target
         .find_content(
-            Enr::from_str(&peertest.bootnode.enr.to_base64()).unwrap(),
+            Enr::from_str(&peertest.bootnode.enr.to_base64()).expect("conversin failed"),
             block_body_content_key.clone(),
         )
         .await
-        .unwrap();
+        .expect("operation failed");
 
     match result {
         ContentInfo::Content {
@@ -125,27 +125,27 @@ pub async fn test_validate_pre_merge_receipts(peertest: &Peertest, target: &Clie
     info!("Test validating pre-merge receipts");
     // store receipts
     let receipts_content_key: HistoryContentKey =
-        serde_json::from_value(json!(RECEIPTS_CONTENT_KEY)).unwrap();
+        serde_json::from_value(json!(RECEIPTS_CONTENT_KEY)).expect("operatioin failed");
     let receipts_content_value: HistoryContentValue =
-        serde_json::from_value(json!(RECEIPTS_CONTENT_VALUE)).unwrap();
+        serde_json::from_value(json!(RECEIPTS_CONTENT_VALUE)).expect("operatioin failed");
 
     let store_result = peertest
         .bootnode
         .ipc_client
         .store(receipts_content_key.clone(), receipts_content_value.clone())
         .await
-        .unwrap();
+        .expect("operation failed");
 
     assert!(store_result);
 
     // calling find_content since it only returns the found data if validation was successful
     let result = target
         .find_content(
-            Enr::from_str(&peertest.bootnode.enr.to_base64()).unwrap(),
+            Enr::from_str(&peertest.bootnode.enr.to_base64()).expect("conversion failed"),
             receipts_content_key.clone(),
         )
         .await
-        .unwrap();
+        .expect("operation failed");
 
     match result {
         ContentInfo::Content {

--- a/ethportal-peertest/src/utils.rs
+++ b/ethportal-peertest/src/utils.rs
@@ -15,7 +15,9 @@ pub async fn wait_for_content<P: HistoryNetworkApiClient + std::marker::Sync>(
     // If content is absent an error will be returned.
     while counter < 5 {
         let message = match received_content_value {
-            x @ Ok(PossibleHistoryContentValue::ContentPresent(_)) => return x.unwrap(),
+            x @ Ok(PossibleHistoryContentValue::ContentPresent(_)) => {
+                return x.expect("operation failed")
+            }
             Ok(PossibleHistoryContentValue::ContentAbsent) => {
                 "absent content response received".to_string()
             }
@@ -27,5 +29,5 @@ pub async fn wait_for_content<P: HistoryNetworkApiClient + std::marker::Sync>(
         counter += 1;
     }
 
-    received_content_value.unwrap()
+    received_content_value.expect("operatin failed")
 }

--- a/light-client/src/client.rs
+++ b/light-client/src/client.rs
@@ -215,6 +215,7 @@ impl<DB: Database> Client<DB> {
 
         if let Err(err) = sync_res {
             match err {
+                #[allow(clippy::unwrap_used)]
                 NodeError::ConsensusSyncError(err) => match err.downcast_ref().unwrap() {
                     ConsensusError::CheckpointTooOld => {
                         warn!(

--- a/light-client/src/config/cli.rs
+++ b/light-client/src/config/cli.rs
@@ -31,7 +31,10 @@ impl CliConfig {
             user_dict.insert("rpc_port", Value::from(port));
         }
 
-        user_dict.insert("data_dir", Value::from(self.data_dir.to_str().unwrap()));
+        user_dict.insert(
+            "data_dir",
+            Value::from(self.data_dir.to_str().expect("conversion failed")),
+        );
 
         if let Some(fallback) = &self.fallback {
             user_dict.insert("fallback", Value::from(fallback.clone()));

--- a/light-client/src/config/networks.rs
+++ b/light-client/src/config/networks.rs
@@ -37,7 +37,7 @@ pub fn mainnet() -> BaseConfig {
         default_checkpoint: hex_str_to_bytes(
             "0x766647f3c4e1fc91c0db9a9374032ae038778411fbff222974e11f2e3ce7dadf",
         )
-        .unwrap(),
+        .expect("conversion failed"),
         rpc_port: 8545,
         consensus_rpc: Some("https://www.lightclientdata.org".to_string()),
         chain: ChainConfig {
@@ -46,24 +46,24 @@ pub fn mainnet() -> BaseConfig {
             genesis_root: hex_str_to_bytes(
                 "0x4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95",
             )
-            .unwrap(),
+            .expect("conversion failed"),
         },
         forks: Forks {
             genesis: Fork {
                 epoch: 0,
-                fork_version: hex_str_to_bytes("0x00000000").unwrap(),
+                fork_version: hex_str_to_bytes("0x00000000").expect("conversion failed"),
             },
             altair: Fork {
                 epoch: 74240,
-                fork_version: hex_str_to_bytes("0x01000000").unwrap(),
+                fork_version: hex_str_to_bytes("0x01000000").expect("conversion failed"),
             },
             bellatrix: Fork {
                 epoch: 144896,
-                fork_version: hex_str_to_bytes("0x02000000").unwrap(),
+                fork_version: hex_str_to_bytes("0x02000000").expect("conversion failed"),
             },
             capella: Fork {
                 epoch: 194048,
-                fork_version: hex_str_to_bytes("0x03000000").unwrap(),
+                fork_version: hex_str_to_bytes("0x03000000").expect("conversion failed"),
             },
         },
         max_checkpoint_age: 1_209_600, // 14 days
@@ -75,7 +75,7 @@ pub fn goerli() -> BaseConfig {
         default_checkpoint: hex_str_to_bytes(
             "0xd4344682866dbede543395ecf5adf9443a27f423a4b00f270458e7932686ced1",
         )
-        .unwrap(),
+        .expect("conversion failed"),
         rpc_port: 8545,
         consensus_rpc: None,
         chain: ChainConfig {
@@ -84,24 +84,24 @@ pub fn goerli() -> BaseConfig {
             genesis_root: hex_str_to_bytes(
                 "0x043db0d9a83813551ee2f33450d23797757d430911a9320530ad8a0eabc43efb",
             )
-            .unwrap(),
+            .expect("conversion failed"),
         },
         forks: Forks {
             genesis: Fork {
                 epoch: 0,
-                fork_version: hex_str_to_bytes("0x00001020").unwrap(),
+                fork_version: hex_str_to_bytes("0x00001020").expect("conversion failed"),
             },
             altair: Fork {
                 epoch: 36660,
-                fork_version: hex_str_to_bytes("0x01001020").unwrap(),
+                fork_version: hex_str_to_bytes("0x01001020").expect("conversion failed"),
             },
             bellatrix: Fork {
                 epoch: 112260,
-                fork_version: hex_str_to_bytes("0x02001020").unwrap(),
+                fork_version: hex_str_to_bytes("0x02001020").expect("conversion failed"),
             },
             capella: Fork {
                 epoch: 162304,
-                fork_version: hex_str_to_bytes("0x03000000").unwrap(),
+                fork_version: hex_str_to_bytes("0x03000000").expect("conversion failed"),
             },
         },
         max_checkpoint_age: 1_209_600, // 14 days

--- a/light-client/src/config/utils.rs
+++ b/light-client/src/config/utils.rs
@@ -3,7 +3,7 @@ where
     D: serde::Deserializer<'de>,
 {
     let bytes: String = serde::Deserialize::deserialize(deserializer)?;
-    Ok(hex_str_to_bytes(&bytes).unwrap())
+    Ok(hex_str_to_bytes(&bytes).expect("conversion failed"))
 }
 
 pub fn bytes_serialize<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
@@ -20,7 +20,7 @@ where
 {
     let bytes_opt: Option<String> = serde::Deserialize::deserialize(deserializer)?;
     if let Some(bytes) = bytes_opt {
-        Ok(Some(hex_str_to_bytes(&bytes).unwrap()))
+        Ok(Some(hex_str_to_bytes(&bytes).expect("conversion failed")))
     } else {
         Ok(None)
     }

--- a/light-client/src/consensus/consensus_client.rs
+++ b/light-client/src/consensus/consensus_client.rs
@@ -123,7 +123,7 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
             let mut updates = self.rpc.get_updates(current_period, 1).await?;
 
             if updates.len() == 1 {
-                let update = updates.get_mut(0).unwrap();
+                let update = updates.get_mut(0).expect("operation failed");
                 let res = self.verify_update(update);
 
                 if res.is_ok() {
@@ -226,8 +226,8 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
         if update.finalized_header.is_some() && update.finality_branch.is_some() {
             let is_valid = is_finality_proof_valid(
                 &update.attested_header,
-                &mut update.finalized_header.clone().unwrap(),
-                &update.finality_branch.clone().unwrap(),
+                &mut update.finalized_header.clone().unwrap_or_default(),
+                &update.finality_branch.clone().unwrap_or_default(),
             );
 
             if !is_valid {
@@ -238,8 +238,11 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
         if update.next_sync_committee.is_some() && update.next_sync_committee_branch.is_some() {
             let is_valid = is_next_committee_proof_valid(
                 &update.attested_header,
-                &mut update.next_sync_committee.clone().unwrap(),
-                &update.next_sync_committee_branch.clone().unwrap(),
+                &mut update.next_sync_committee.clone().unwrap_or_default(),
+                &update
+                    .next_sync_committee_branch
+                    .clone()
+                    .unwrap_or_default(),
             );
 
             if !is_valid {
@@ -250,7 +253,10 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
         let sync_committee = if update_sig_period == store_period {
             &self.store.current_sync_committee
         } else {
-            self.store.next_sync_committee.as_ref().unwrap()
+            self.store
+                .next_sync_committee
+                .as_ref()
+                .expect("operation failed")
         };
 
         let pks =
@@ -331,7 +337,8 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
                 self.store.next_sync_committee = update.next_sync_committee.clone();
             } else if update_finalized_period == store_period + 1 {
                 info!("sync committee updated");
-                self.store.current_sync_committee = self.store.next_sync_committee.clone().unwrap();
+                self.store.current_sync_committee =
+                    self.store.next_sync_committee.clone().unwrap_or_default();
                 self.store.next_sync_committee = update.next_sync_committee.clone();
                 self.store.previous_max_active_participants =
                     self.store.current_max_active_participants;
@@ -339,7 +346,7 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
             }
 
             if update_finalized_slot > self.store.finalized_header.slot {
-                self.store.finalized_header = update.finalized_header.clone().unwrap();
+                self.store.finalized_header = update.finalized_header.clone().unwrap_or_default();
                 self.log_finality_update(update);
 
                 if self.store.finalized_header.slot % 32 == 0 {
@@ -444,7 +451,7 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
     }
 
     fn compute_committee_sign_root(&self, header: Bytes32, slot: u64) -> Result<Node> {
-        let genesis_root = self.config.chain.genesis_root.to_vec().try_into().unwrap();
+        let genesis_root = self.config.chain.genesis_root.to_vec().try_into()?;
 
         let domain_type = &hex::decode("07000000")?[..];
         let fork_version = Vector::from_iter(self.config.fork_version(slot));
@@ -454,13 +461,17 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
 
     fn age(&self, slot: u64) -> Duration {
         let expected_time = self.slot_timestamp(slot);
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Timestamp passed is later than self");
         let delay = now - std::time::Duration::from_secs(expected_time);
-        chrono::Duration::from_std(delay).unwrap()
+        chrono::Duration::from_std(delay).expect("delay is out of range")
     }
 
     pub fn expected_current_slot(&self) -> u64 {
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Timestamp passed is later than self");
         let genesis_time = self.config.chain.genesis_time;
         let since_genesis = now - std::time::Duration::from_secs(genesis_time);
 
@@ -480,7 +491,7 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
 
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .expect("Timestamp passed is later than self")
             .as_secs();
 
         let time_to_next_slot = next_slot_timestamp - now;
@@ -509,7 +520,7 @@ fn get_participating_keys(
     bitfield.iter().enumerate().for_each(|(i, bit)| {
         if bit == true {
             let pk = &committee.pubkeys[i];
-            let pk = PublicKey::from_bytes_unchecked(pk).unwrap();
+            let pk = PublicKey::from_bytes_unchecked(pk).expect("conversion failed");
             pks.push(pk);
         }
     });

--- a/light-client/src/consensus/types.rs
+++ b/light-client/src/consensus/types.rs
@@ -517,7 +517,7 @@ where
     D: serde::Deserializer<'de>,
 {
     let val: String = serde::Deserialize::deserialize(deserializer)?;
-    Ok(val.parse().unwrap())
+    Ok(val.parse().expect("conversion failed"))
 }
 
 fn u256_deserialize<'de, D>(deserializer: D) -> Result<U256, D::Error>
@@ -536,8 +536,9 @@ where
     D: serde::Deserializer<'de>,
 {
     let bytes: String = serde::Deserialize::deserialize(deserializer)?;
-    let bytes = hex::decode(bytes.strip_prefix("0x").unwrap()).unwrap();
-    Ok(bytes.to_vec().try_into().unwrap())
+    let bytes =
+        hex::decode(bytes.strip_prefix("0x").expect("prefix not found")).expect("decoding failed");
+    Ok(bytes.to_vec().try_into().expect("conversion failed"))
 }
 
 fn logs_bloom_deserialize<'de, D>(deserializer: D) -> Result<LogsBloom, D::Error>
@@ -545,8 +546,9 @@ where
     D: serde::Deserializer<'de>,
 {
     let bytes: String = serde::Deserialize::deserialize(deserializer)?;
-    let bytes = hex::decode(bytes.strip_prefix("0x").unwrap()).unwrap();
-    Ok(bytes.to_vec().try_into().unwrap())
+    let bytes =
+        hex::decode(bytes.strip_prefix("0x").expect("prefix not found")).expect("decoding failed");
+    Ok(bytes.to_vec().try_into().expect("conversion failed"))
 }
 
 fn address_deserialize<'de, D>(deserializer: D) -> Result<Address, D::Error>
@@ -554,8 +556,9 @@ where
     D: serde::Deserializer<'de>,
 {
     let bytes: String = serde::Deserialize::deserialize(deserializer)?;
-    let bytes = hex::decode(bytes.strip_prefix("0x").unwrap()).unwrap();
-    Ok(bytes.to_vec().try_into().unwrap())
+    let bytes =
+        hex::decode(bytes.strip_prefix("0x").expect("prefix not found")).expect("decoding failed");
+    Ok(bytes.to_vec().try_into().expect("conversion failed"))
 }
 
 fn extra_data_deserialize<'de, D>(deserializer: D) -> Result<List<u8, 32>, D::Error>
@@ -563,8 +566,9 @@ where
     D: serde::Deserializer<'de>,
 {
     let bytes: String = serde::Deserialize::deserialize(deserializer)?;
-    let bytes = hex::decode(bytes.strip_prefix("0x").unwrap()).unwrap();
-    Ok(bytes.to_vec().try_into().unwrap())
+    let bytes =
+        hex::decode(bytes.strip_prefix("0x").expect("prefix not found")).expect("decoding failed");
+    Ok(bytes.to_vec().try_into().expect("conversion failed"))
 }
 
 fn transactions_deserialize<'de, D>(deserializer: D) -> Result<List<Transaction, 1048576>, D::Error>
@@ -575,7 +579,7 @@ where
     let transactions = transactions
         .iter()
         .map(|tx| {
-            let tx = hex_str_to_bytes(tx).unwrap();
+            let tx = hex_str_to_bytes(tx).expect("conversion failed");
             let tx: Transaction = List::from_iter(tx);
             tx
         })
@@ -590,7 +594,7 @@ where
     let attesting_indices: Vec<String> = serde::Deserialize::deserialize(deserializer)?;
     let attesting_indices = attesting_indices
         .iter()
-        .map(|i| i.parse().unwrap())
+        .map(|i| i.parse().unwrap_or_default())
         .collect::<List<u64, 2048>>();
 
     Ok(attesting_indices)

--- a/light-client/src/consensus/utils.rs
+++ b/light-client/src/consensus/utils.rs
@@ -70,7 +70,7 @@ pub fn compute_domain(
     let start = domain_type;
     let end = &fork_data_root.as_bytes()[..28];
     let d = [start, end].concat();
-    Ok(d.to_vec().try_into().unwrap())
+    Ok(d.to_vec().try_into()?)
 }
 
 fn compute_fork_data_root(

--- a/light-client/src/lib.rs
+++ b/light-client/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::unwrap_used)]
+
 mod client;
 pub use crate::client::*;
 

--- a/light-client/src/node.rs
+++ b/light-client/src/node.rs
@@ -25,7 +25,7 @@ pub struct Node {
 impl Node {
     pub fn new(config: Arc<Config>) -> Result<Self, NodeError> {
         let consensus_rpc = &config.consensus_rpc;
-        let checkpoint_hash = &config.checkpoint.as_ref().unwrap();
+        let checkpoint_hash = &config.checkpoint.as_ref().expect("operation failed");
 
         let consensus = ConsensusLightClient::new(consensus_rpc, checkpoint_hash, config.clone())
             .map_err(NodeError::ConsensusClientCreationError)?;
@@ -65,7 +65,7 @@ impl Node {
         self.consensus
             .duration_until_next_update()
             .to_std()
-            .unwrap()
+            .expect("duration is less than zero")
     }
 
     pub fn get_block_transaction_count_by_hash(&self, hash: &Vec<u8>) -> Result<u64> {

--- a/light-client/src/rpc.rs
+++ b/light-client/src/rpc.rs
@@ -127,7 +127,7 @@ impl EthRpcServer for RpcInner {
 
     async fn get_coinbase(&self) -> Result<Address, Error> {
         let node = self.node.read().await;
-        Ok(node.get_coinbase().unwrap())
+        Ok(node.get_coinbase().expect("coinbase not found"))
     }
 
     async fn syncing(&self) -> Result<SyncingStatus, Error> {
@@ -170,7 +170,7 @@ fn format_hex(num: &U256) -> String {
     let stripped = num
         .encode_hex()
         .strip_prefix("0x")
-        .unwrap()
+        .expect("prefix not found")
         .trim_start_matches('0')
         .to_string();
 

--- a/trin-utils/src/lib.rs
+++ b/trin-utils/src/lib.rs
@@ -1,2 +1,4 @@
+#![warn(clippy::unwrap_used)]
+
 pub mod log;
 pub mod version;

--- a/trin-validation/src/lib.rs
+++ b/trin-validation/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::unwrap_used)]
+
 pub mod accumulator;
 pub mod constants;
 pub mod merkle;

--- a/utp-testing/src/bin/test_app.rs
+++ b/utp-testing/src/bin/test_app.rs
@@ -15,7 +15,7 @@ async fn main() {
     let config = TestAppConfig::from_args();
 
     let udp_listen_address = format!("{}:{}", config.udp_listen_address, config.udp_port);
-    let udp_listen_address = SocketAddr::from_str(&udp_listen_address).unwrap();
+    let udp_listen_address = SocketAddr::from_str(&udp_listen_address).expect("conversion failed");
     let (rpc_addr, enr, _handle) = run_test_app(
         config.udp_port,
         udp_listen_address,
@@ -23,7 +23,7 @@ async fn main() {
         config.rpc_port,
     )
     .await
-    .unwrap();
+    .expect("operation failed");
 
     info!("uTP test app started. RPC address: {rpc_addr}, Enr: {enr}");
 

--- a/utp-testing/src/bin/test_suite.rs
+++ b/utp-testing/src/bin/test_suite.rs
@@ -23,11 +23,11 @@ async fn send_10k_bytes() -> anyhow::Result<()> {
     println!("Sending 10k bytes uTP payload from client to server...");
     let client_url = format!("http://{CLIENT_ADDR}");
     let client_rpc = HttpClientBuilder::default().build(client_url)?;
-    let client_enr: String = client_rpc.request("local_enr", None).await.unwrap();
+    let client_enr: String = client_rpc.request("local_enr", None).await?;
 
     let server_url = format!("http://{SERVER_ADDR}");
     let server_rpc = HttpClientBuilder::default().build(server_url)?;
-    let server_enr: String = server_rpc.request("local_enr", None).await.unwrap();
+    let server_enr: String = server_rpc.request("local_enr", None).await?;
 
     let client_cid_recv: u16 = thread_rng().gen();
     let client_cid_send = client_cid_recv.wrapping_add(1);
@@ -38,7 +38,7 @@ async fn send_10k_bytes() -> anyhow::Result<()> {
 
     // Add client enr to allowed server uTP connections
     let params = rpc_params!(client_enr, server_cid_send, server_cid_recv);
-    let response: String = server_rpc.request("prepare_to_recv", params).await.unwrap();
+    let response: String = server_rpc.request("prepare_to_recv", params).await?;
     assert_eq!(response, "true");
 
     // Send uTP payload from client to server
@@ -50,10 +50,7 @@ async fn send_10k_bytes() -> anyhow::Result<()> {
         client_cid_recv,
         payload.clone()
     );
-    let response: String = client_rpc
-        .request("send_utp_payload", params)
-        .await
-        .unwrap();
+    let response: String = client_rpc.request("send_utp_payload", params).await?;
 
     assert_eq!(response, "true");
 
@@ -61,7 +58,7 @@ async fn send_10k_bytes() -> anyhow::Result<()> {
     tokio::time::sleep(Duration::from_secs(16)).await;
 
     // Verify received uTP payload
-    let utp_payload: String = server_rpc.request("get_utp_payload", None).await.unwrap();
+    let utp_payload: String = server_rpc.request("get_utp_payload", None).await?;
     let expected_payload = hex_encode(payload);
 
     assert_eq!(expected_payload, utp_payload);

--- a/utp-testing/src/lib.rs
+++ b/utp-testing/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::unwrap_used)]
+
 extern crate core;
 
 pub mod cli;


### PR DESCRIPTION
### What was wrong?
https://github.com/ethereum/trin/issues/687

### How was it fixed?
I added `#![warn(clippy::unwrap_used)]` to the `lib.rs` of all the work spaces that didn't already have it

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
