### PR TITLE
Fix header_oracle deadlocking on history validation

### DIFF
--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -37,7 +37,7 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
                         anyhow!("Header with proof content has invalid encoding: {err:?}")
                     })?;
                 self.header_oracle
-                    .write()
+                    .read()
                     .await
                     .master_acc
                     .validate_header_with_proof(&header_with_proof)
@@ -47,7 +47,7 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
                     .map_err(|msg| anyhow!("Block Body content has invalid encoding: {:?}", msg))?;
                 let trusted_header: Header = self
                     .header_oracle
-                    .write()
+                    .read()
                     .await
                     .recursive_find_header_with_proof(H256::from(key.block_hash))
                     .await?
@@ -76,7 +76,7 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
                 })?;
                 let trusted_header: Header = self
                     .header_oracle
-                    .write()
+                    .read()
                     .await
                     .recursive_find_header_with_proof(H256::from(key.block_hash))
                     .await?


### PR DESCRIPTION
### What was wrong?
When trying to validate a blockbody or receipt we didn't have the header with proof for. ``header_oracle`` would deadlock trying to find the header with proof through a RECURSIVE_FIND_CONTENT request
### How was it fixed?
By changing ``header_oracle.write()`` to ``header_oracle.read()`` where ``write`` wasn't needed

Portal Hive test results with fix

```
INFO[08-10|11:55:26] building image                           image=hive/hiveproxy nocache=false pull=false
INFO[08-10|11:55:26] building 1 clients... 
INFO[08-10|11:55:26] building image                           image=hive/clients/trin:latest dir=clients/trin nocache=false pull=false
INFO[08-10|11:55:29] building 1 simulators... 
INFO[08-10|11:55:29] building image                           image=hive/simulators/portal-interop:latest dir=simulators/portal-interop nocache=false pull=false
INFO[08-10|12:03:11] creating output directory                folder=workspace/logs
INFO[08-10|12:03:11] running simulation: portal-interop 
INFO[08-10|12:03:12] hiveproxy started                        container=5a913123110c addr=172.17.0.2:8081
INFO[08-10|12:03:12] API: suite started                       suite=0 name=portal-interop
INFO[08-10|12:03:12] API: test started                        suite=0 test=1 name="Portal Network interop"
INFO[08-10|12:03:12] API: test started                        suite=0 test=2 name="RECURSIVE_FIND_CONTENT Receipts over uTP trin --> trin"
INFO[08-10|12:03:13] API: client trin started                 suite=0 test=2 container=e96b8f01
INFO[08-10|12:03:13] API: client trin started                 suite=0 test=2 container=8e231a7e
INFO[08-10|12:03:14] API: test ended                          suite=0 test=2 pass=true
INFO[08-10|12:03:14] API: test started                        suite=0 test=3 name="FIND_CONTENT Receipts over uTP trin --> trin"
INFO[08-10|12:03:14] API: client trin started                 suite=0 test=3 container=3ce64ca1
INFO[08-10|12:03:14] API: client trin started                 suite=0 test=3 container=a0cce913
INFO[08-10|12:03:15] API: test ended                          suite=0 test=3 pass=true
INFO[08-10|12:03:15] API: test ended                          suite=0 test=1 pass=true
INFO[08-10|12:03:15] API: suite ended                         suite=0
INFO[08-10|12:03:16] simulation portal-interop finished       suites=1 tests=3 failed=0
```


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
