### PR TITLE
Upgrade utp-rs to v0.1.0-alpha.6 & remove mutex on discv5 transport layer for utp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7459,12 +7459,12 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utp-rs"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29f56696d12604e7ce844c299a2f4807583480836201ac1a46d8639ade963c6"
+checksum = "ecba6a54e3c37e15bc6320a4aa63fd057eea9c34b06743f09b5d4eea65746c2e"
 dependencies = [
  "async-trait",
- "delay_map 0.1.2",
+ "delay_map 0.3.0",
  "futures 0.3.28",
  "rand 0.8.5",
  "tokio",

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -47,7 +47,7 @@ trin-utils = { path="../trin-utils" }
 trin-validation = { path="../trin-validation" }
 validator = { version = "0.13.0", features = ["derive"] }
 url = "2.3.1"
-utp-rs = "0.1.0-alpha.5"
+utp-rs = "0.1.0-alpha.6"
 
 [target.'cfg(windows)'.dependencies]
 uds_windows = "1.0.1"

--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -314,7 +314,7 @@ impl ConnectionPeer for UtpEnr {}
 
 #[async_trait]
 impl AsyncUdpSocket<UtpEnr> for Discv5UdpSocket {
-    async fn send_to(&self, buf: &[u8], target: &UtpEnr) -> io::Result<usize> {
+    async fn send_to(&mut self, buf: &[u8], target: &UtpEnr) -> io::Result<usize> {
         let discv5 = Arc::clone(&self.discv5);
         let target = target.0.clone();
         let data = buf.to_vec();
@@ -332,7 +332,7 @@ impl AsyncUdpSocket<UtpEnr> for Discv5UdpSocket {
         Ok(buf.len())
     }
 
-    async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, UtpEnr)> {
+    async fn recv_from(&mut self, buf: &mut [u8]) -> io::Result<(usize, UtpEnr)> {
         let mut talk_reqs = self.talk_reqs.lock().await;
         match talk_reqs.recv().await {
             Some(talk_req) => {

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -1588,7 +1588,7 @@ where
             }
 
             // close uTP connection
-            if let Err(err) = stream.shutdown() {
+            if let Err(err) = stream.close().await {
                 if !utp_tx_recorded {
                     metrics.report_utp_outcome(
                         UtpDirectionLabel::Outbound,

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -24,4 +24,4 @@ tokio = {version = "1.14.0", features = ["full"]}
 tracing = "0.1.36"
 trin-validation = { path = "../trin-validation" }
 trin-utils = { path = "../trin-utils" }
-utp-rs = "0.1.0-alpha.5"
+utp-rs = "0.1.0-alpha.6"

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -25,7 +25,7 @@ tracing = "0.1.36"
 tree_hash = "0.4.0"
 trin-utils = { path = "../trin-utils" }
 trin-validation = { path = "../trin-validation" }
-utp-rs = "0.1.0-alpha.5"
+utp-rs = "0.1.0-alpha.6"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -23,7 +23,7 @@ rocksdb = "0.18.0"
 tracing = "0.1.36"
 tokio = {version = "1.14.0", features = ["full"]}
 trin-validation = { path = "../trin-validation" }
-utp-rs = "0.1.0-alpha.5"
+utp-rs = "0.1.0-alpha.6"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -22,7 +22,7 @@ tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 trin-utils = { path = "../trin-utils" }
 tokio = {version = "1.14.0", features = ["full"]}
-utp-rs = "0.1.0-alpha.4"
+utp-rs = "0.1.0-alpha.6"
 
 [[bin]]
 name = "utp-test-app"

--- a/utp-testing/src/lib.rs
+++ b/utp-testing/src/lib.rs
@@ -74,7 +74,7 @@ impl RpcServer for TestApp {
 
             tracing::info!("read {n} bytes from uTP stream");
 
-            conn.shutdown().unwrap();
+            conn.close().await.unwrap();
 
             payload_store.write().await.push(data);
         });
@@ -110,7 +110,7 @@ impl RpcServer for TestApp {
 
             conn.write(&payload).await.unwrap();
 
-            conn.shutdown().unwrap();
+            conn.close().await.unwrap();
         });
 
         Ok("true".to_string())


### PR DESCRIPTION
Handle new APIs:
- &mut self in socket trait methods
- shutdown() -> async close()

### What was wrong?

Fix #827 

utp library recently had a new release: https://github.com/ethereum/utp/releases/tag/v0.1.0-alpha.6

A (now) unnecessary mutex is wrapped around the discv5 talkreqs in the utp transport layer.

### How was it fixed?

Upgrade utp-rs, fix compile errors related to breaking changes. Also remove the mutex.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
- [x] Remove the mutex
