### PR TITLE
Add GenerateTestData to Portal-Bridge

### DIFF
--- a/portal-bridge/src/utils.rs
+++ b/portal-bridge/src/utils.rs
@@ -51,6 +51,11 @@ pub struct TestAssets(pub Vec<Asset>);
 pub struct Asset {
     pub content_key: HistoryContentKey,
     pub content_value: HistoryContentValue,
+
+    // Comments are only supported by yaml. We don't de/serialize them for json, but only serialize
+    // them for yaml through our write yaml file code
+    #[serde(skip_serializing, skip_deserializing)]
+    pub comment: String,
 }
 
 pub fn read_test_assets_from_file(test_path: PathBuf) -> TestAssets {


### PR DESCRIPTION
### What was wrong?
Portal-Bridge should be able to generate the test data it needs since it already supports 99% of the logic to create it. I was going to make a python script for this but then did a double take when I realized I would be reimplementing all of portal bridge and portal validation. As well as realizing if we support running bridge with test data it should be able to generate the files we need (manually making test files is no simple task)
### How was it fixed?
Refactoring ``constructor_and_gossip_*`` to only do construction and move the gossip part up stream so we can use constructor for more then just gossiping data to the network like in creating test data.

I also decided to make ``launch_generate_test_data`` handle creating the testfile  and collecting the data instead of using putting the logic through the serve function like backfill does. Serve was written with throughput as a goal where as I want the test data I am creating to be linear from block x to y. This is also good since then it isolates this code instead of leaching the test generation code in every function.

We can generate the test data in both json and yaml format's. When creating tests I believe yaml should be the preference since it allows comments