### PR TITLE
Remove redundant empty-check in content query initialization

### DIFF
--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -2403,14 +2403,12 @@ where
         }
 
         if closest_enrs.is_empty() {
-            // If there are no nodes in the routing table the query cannot proceed.
+            // If there are no nodes whatsoever in the routing table the query cannot proceed.
             warn!("No nodes in routing table, query cannot proceed.");
-            if closest_enrs.is_empty() {
-                if let Some(callback) = callback {
-                    let _ = callback.send((None, false, None));
-                }
-                return None;
+            if let Some(callback) = callback {
+                let _ = callback.send((None, false, None));
             }
+            return None;
         }
 
         // Convert ENRs into k-bucket keys.


### PR DESCRIPTION
### What was wrong?

In `init_find_content_query`, `closest_enrs.is_empty()` was being checked redundantly. 

### How was it fixed?

Removed redundancy

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
