### PR TITLE
Responds to query if utp peer enr is unknown instead of dropping oneshot

### DIFF
--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -818,6 +818,9 @@ where
                             Some(enr) => enr,
                             _ => {
                                 warn!("Received uTP payload from unknown {peer}");
+                                if let Some(responder) = callback {
+                                    let _ = responder.send((None, true, query_info.trace));
+                                };
                                 return;
                             }
                         };

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -852,6 +852,9 @@ where
                                         peer = ?cid.peer.client(),
                                         "Unable to establish uTP conn based on Content response",
                                     );
+                                    if let Some(responder) = callback {
+                                        let _ = responder.send((None, true, query_info.trace));
+                                    };
                                     return;
                                 }
                             };
@@ -863,6 +866,9 @@ where
                                     UtpOutcomeLabel::FailedDataTx,
                                 );
                                 error!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), "error reading data from uTP stream, while handling a FindContent request.");
+                                if let Some(responder) = callback {
+                                    let _ = responder.send((None, true, query_info.trace));
+                                };
                                 return;
                             }
 


### PR DESCRIPTION
### What was wrong?

When a utp connection ID is received at the end of a content query, trin uses `OverlayService::find_enr` to lookup the sender's ENR by its node ID. Currently if it can't find anything it just throws a warning and lets the oneshot get canceled so the query never completes.

### How was it fixed?

The best thing would be for `find_enr` to find the ENR, which I'm working on. In the meantime this PR just has trin send a response back so that the query completes and we can at least see the trace.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
