### PR TITLE
fix: bump rocksdb version to 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.3.12"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bf394cfbbe876f0ac67b13b6ca819f9c9f2fb9ec67223cceb1555fbab1c31a"
+checksum = "62b74f44609f0f91493e3082d3734d98497e094777144380ea4db9f9905dd5b6"
 dependencies = [
  "brotli",
  "flate2",
@@ -602,12 +602,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -3773,9 +3767,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.6.3+6.28.2"
+version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "184ce2a189a817be2731070775ad053b6804a340fee05c6686d711db27455917"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -3783,6 +3777,7 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
+ "lz4-sys",
  "zstd-sys",
 ]
 
@@ -3892,6 +3887,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -5207,7 +5212,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/paradigmxyz/reth.git#bdcc56bbf667d562da2715f232a2e70da36250c6"
+source = "git+https://github.com/paradigmxyz/reth.git#6edbc0eeaf30aa9cc2e12a03ab93167be8e809e8"
 dependencies = [
  "async-trait",
  "bytes 1.4.0",
@@ -5303,9 +5308,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.18.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620f4129485ff1a7128d184bc687470c21c7951b64779ebc9cfdad3dcd920290"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -5774,9 +5779,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -6866,12 +6871,12 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8bd22a874a2d0b70452d5597b12c537331d49060824a95f49f108994f94aa4c"
+checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
 dependencies = [
  "async-compression",
- "base64 0.20.0",
+ "base64 0.21.2",
  "bitflags 2.4.0",
  "bytes 1.4.0",
  "futures-core",
@@ -7738,9 +7743,9 @@ checksum = "d419259aba16b663966e29e6d7c6ecfa0bb8425818bb96f6f1f3c3eb71a6e7b9"
 
 [[package]]
 name = "winnow"
-version = "0.5.10"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5504cc7644f4b593cbc05c4a55bf9bd4e94b867c3c0bd440934174d50482427d"
+checksum = "83817bbecf72c73bad717ee86820ebf286203d2e04c3951f3cd538869c897364"
 dependencies = [
  "memchr",
 ]
@@ -7826,18 +7831,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.10.2+zstd.1.5.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4a6bd64f22b5e3e94b4e238669ff9f10815c27a5180108b849d24174a83847"
+checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.6+zstd.1.5.2"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b61c51bb270702d6167b8ce67340d2754b088d0c091b06e593aa772c3ee9bb"
+checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -7845,10 +7850,11 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.3+zstd.1.5.2"
+version = "2.0.8+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ prometheus_exporter = "0.8.4"
 rand = "0.8.4"
 reth-ipc = { version = "0.1.0-alpha.6", git = "https://github.com/paradigmxyz/reth.git"}
 rlp = "0.5.0"
-rocksdb = "0.18.0"
+rocksdb = "0.21.0"
 rpc = { path = "rpc"}
 serde_json = {version = "1.0.89", features = ["preserve_order"]}
 sha3 = "0.9.1"

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -23,7 +23,7 @@ hyper = { version = "0.14", features = ["full"] }
 jsonrpsee = {version="0.20.0", features = ["async-client", "client", "macros", "server"]}
 rand = "0.8.4"
 reth-ipc = { version = "0.1.0-alpha.6", git = "https://github.com/paradigmxyz/reth.git"}
-rocksdb = "0.18.0"
+rocksdb = "0.21.0"
 rpc = { path = "../rpc" }
 serde_json = "1.0.89"
 tempfile = "3.3.0"

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -31,7 +31,7 @@ parking_lot = "0.11.2"
 prometheus_exporter = "0.8.4"
 rand = "0.8.4"
 rlp = "0.5.0"
-rocksdb = "0.18.0"
+rocksdb = "0.21.0"
 rusqlite = { version = "0.26.3", features = ["bundled"] }
 r2d2 = "0.8.9"
 r2d2_sqlite = "0.19.0"

--- a/src/bin/purge_db.rs
+++ b/src/bin/purge_db.rs
@@ -48,7 +48,8 @@ pub fn main() -> Result<()> {
     let iter = config.db.iterator(IteratorMode::Start);
     let mut item_count = 0;
     let mut remove_count = 0;
-    for (id, value) in iter {
+    for element in iter {
+        let (id, value) = element?;
         item_count += 1;
         let mut content_id = [0u8; 32];
         content_id.copy_from_slice(&id);

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -19,7 +19,7 @@ ethportal-api = { path = "../ethportal-api" }
 eth_trie = "0.1.0"
 parking_lot = "0.11.2"
 portalnet = { path = "../portalnet" }
-rocksdb = "0.18.0"
+rocksdb = "0.21.0"
 tracing = "0.1.36"
 tokio = {version = "1.14.0", features = ["full"]}
 trin-validation = { path = "../trin-validation" }


### PR DESCRIPTION
### What was wrong?

An [error](https://gist.github.com/danielrachi/376f43eac9fda2e8f07996a25302ddb0) appeared when building on systems with gcc 13.

### How was it fixed?

Bumped rocksdb version from 0.18.0 to 0.21.0, on all crates.

It was necessary to also update a for loop in `src/bin/purge_db.rs` for trin to compile with the updated rocksdb.

### To-Do

N/A
