### PR TITLE
Remove restriction on closeness of nodes returned on FindContent

### DIFF
--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -2283,7 +2283,6 @@ where
         let closest_nodes = nodes_with_distance
             .into_iter()
             .take(FIND_CONTENT_MAX_NODES)
-            .filter(|node_record| node_record.0 < self_distance)
             .map(|node_record| SszEnr::new(node_record.1))
             .collect();
 

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -2269,8 +2269,6 @@ where
         content_key: impl OverlayContentKey,
     ) -> Result<Vec<SszEnr>, OverlayRequestError> {
         let content_id = content_key.content_id();
-        let self_node_id = self.local_enr().node_id();
-        let self_distance = TMetric::distance(&content_id, &self_node_id.raw());
 
         let mut nodes_with_distance: Vec<(Distance, Enr)> = self
             .table_entries_enr()

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -2263,7 +2263,7 @@ where
         nodes_to_send
     }
 
-    /// Returns list of nodes closer to content than self, sorted by distance.
+    /// Returns list of nodes closest to content, sorted by distance.
     fn find_nodes_close_to_content(
         &self,
         content_key: impl OverlayContentKey,


### PR DESCRIPTION
**blocked till https://github.com/ethereum/portal-network-specs/pull/222 is merged**

### What was wrong?
There is a update to the spec where we no longer ``list of ENR records of nodes that are closer than the recipient is to the requested content.`` and instead do ``list of ENR records of nodes that are closest to the requested content.``
### How was it fixed?
By removing the filter that compared if a nodes distance was closer then our distance or not