### PR TITLE
Bump to discv5 experimental branch for concurrent requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ name = "amcl"
 version = "0.3.0"
 source = "git+https://github.com/Snowfork/milagro_bls#7d1776edb42870b006430ece9741c15811e4c9e3"
 dependencies = [
- "parity-scale-codec 3.6.8",
+ "parity-scale-codec 3.6.5",
  "scale-info",
 ]
 
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d495b6dc0184693324491a5ac05f559acc97bf937ab31d7a1c33dd0016be6d2b"
+checksum = "bb42b2197bf15ccb092b62c74515dbd8b86d0effd934795f6687c93b6e679a2c"
 dependencies = [
  "brotli",
  "flate2",
@@ -1336,8 +1336,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "discv5"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c05fa26996c6141f78ac4fafbe297a7fa69690565ba4e0d1f2e60bde5ce501"
+source = "git+https://github.com/njgheorghita/discv5.git?rev=09262ead2882e062de1a6a45df9ea61917eb8465#09262ead2882e062de1a6a45df9ea61917eb8465"
 dependencies = [
  "aes 0.7.5",
  "aes-gcm 0.9.4",
@@ -2638,7 +2637,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
- "parity-scale-codec 3.6.8",
+ "parity-scale-codec 3.6.5",
 ]
 
 [[package]]
@@ -3338,7 +3337,7 @@ dependencies = [
  "amcl",
  "hex",
  "lazy_static",
- "parity-scale-codec 3.6.8",
+ "parity-scale-codec 3.6.5",
  "rand 0.8.5",
  "scale-info",
  "zeroize",
@@ -3663,15 +3662,15 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.8"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88eaac72ead1b9bd4ce747d577dbd2ad31fb0a56a9a20c611bf27bd1b97fbed"
+checksum = "0dec8a8073036902368c2cdc0387e85ff9a37054d7e7c98e592145e0c92cd4fb"
 dependencies = [
  "arrayvec",
  "bitvec 1.0.1",
  "byte-slice-cast",
  "impl-trait-for-tuples",
- "parity-scale-codec-derive 3.6.8",
+ "parity-scale-codec-derive 3.6.5",
  "serde",
 ]
 
@@ -3689,9 +3688,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.8"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33bdcd446e9400b6ad9fc85b4aea68846c258b07c3efb994679ae82707b133f0"
+checksum = "312270ee71e1cd70289dacf597cab7b207aa107d2f28191c2ae45b2ece18a260"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4557,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "0.1.0-alpha.8"
-source = "git+https://github.com/paradigmxyz/reth.git#660ea0c9376c4b03793995f700ee36182cfdf781"
+source = "git+https://github.com/paradigmxyz/reth.git#261a9f949996eb2f6129cf7f17469d5134c09761"
 dependencies = [
  "async-trait",
  "bytes 1.5.0",
@@ -4836,7 +4835,7 @@ checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.4",
+ "rustls-webpki 0.101.5",
  "sct",
 ]
 
@@ -4873,9 +4872,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.4"
+version = "0.101.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
 dependencies = [
  "ring",
  "untrusted",
@@ -4911,7 +4910,7 @@ dependencies = [
  "bitvec 1.0.1",
  "cfg-if 1.0.0",
  "derive_more",
- "parity-scale-codec 3.6.8",
+ "parity-scale-codec 3.6.5",
  "scale-info-derive",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ description = "A Rust implementation of the Ethereum Portal Network"
 [dependencies]
 anyhow = "1.0.68"
 clap = { version = "4.2.1", features = ["derive"] }
-discv5 = { version = "0.3.1", features = ["serde"] }
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
 eth2_ssz = "0.4.0"
 ethereum-types = "0.12.1"
 ethportal-api = { path = "ethportal-api" }

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.68"
 base64 = "0.13.0"
 bytes = "1.3.0"
 clap = { version = "4.2.1", features = ["derive"] }
-discv5 = { version = "0.3.1", features = ["serde"]}
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
 eth_trie = "0.3.0"
 eth2_ssz = "0.4.0"
 eth2_ssz_derive = "0.3.0"

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
-discv5 = { version = "0.3.1", features = ["serde"]}
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
 eth2_ssz = "0.4.0"
 ethereum-types = "0.12.1"
 ethportal-api = { path="../ethportal-api"}

--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -53,7 +53,7 @@ pub async fn test_beacon_bridge(peertest: &Peertest, target: &HttpClient) {
     let mode = BridgeMode::Test("./test_assets/portalnet/beacon_bridge_data.yaml".into());
     // Wait for bootnode to start
     sleep(Duration::from_secs(1)).await;
-    let consensus_api = ConsensusApi::new(Default::default());
+    let consensus_api = ConsensusApi::default();
     let bridge = BeaconBridge::new(consensus_api, mode, portal_clients);
     bridge.launch().await;
 

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -24,7 +24,7 @@ pub async fn test_find_content_return_enr(target: &Client, peertest: &Peertest) 
                 panic!("Response from GetEnr didn't return expected Enr");
             }
         }
-        Err(err) => panic!("{}", &err.to_string()),
+        Err(err) => panic!("{err}"),
     }
 
     let result = target

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0.68"
 async-trait = "0.1.68"
 chrono = "0.4.26"
 clap = { version = "4.2.1", features = ["derive"] }
-discv5 = { version = "0.3.1", features = ["serde"]}
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
 ethportal-api = { path = "../ethportal-api" }
 ethereum-types = "0.12.1"
 eth2_ssz = "0.4.0"

--- a/portal-bridge/src/consensus_api.rs
+++ b/portal-bridge/src/consensus_api.rs
@@ -2,7 +2,7 @@ use crate::pandaops::PandaOpsMiddleware;
 use std::fmt::Display;
 
 /// Implements endpoints from the Beacon API to access data from the consensus layer.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ConsensusApi {
     middleware: PandaOpsMiddleware,
 }

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -17,7 +17,7 @@ base64 = "0.13.0"
 bytes = "1.3.0"
 delay_map = "0.1.1"
 directories = "3.0"
-discv5 = { version = "0.3.1", features = ["serde"]}
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
 eth2_ssz = "0.4.0"
 eth2_ssz_derive = "0.3.0"
 eth2_ssz_types = "0.2.1"

--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -2,7 +2,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use discv5::{
     enr::{CombinedKey, EnrBuilder, NodeId},
-    Discv5, Discv5ConfigBuilder, Discv5Event, ListenConfig, RequestError, TalkRequest,
+    ConfigBuilder, Discv5, Event, ListenConfig, RequestError, TalkRequest,
 };
 use lru::LruCache;
 use parking_lot::RwLock;
@@ -110,7 +110,7 @@ impl Discovery {
             port: portal_config.listen_port,
         };
 
-        let discv5_config = Discv5ConfigBuilder::new(listen_config).build();
+        let discv5_config = ConfigBuilder::new(listen_config).build();
         let discv5 = Discv5::new(enr, enr_key, discv5_config)
             .map_err(|e| format!("Failed to create discv5 instance: {e}"))?;
 
@@ -162,11 +162,11 @@ impl Discovery {
         tokio::spawn(async move {
             while let Some(event) = event_rx.recv().await {
                 match event {
-                    Discv5Event::TalkRequest(talk_req) => {
+                    Event::TalkRequest(talk_req) => {
                         // Forward all TALKREQ messages.
                         let _ = talk_req_tx.send(talk_req).await;
                     }
-                    Discv5Event::SessionEstablished(enr, socket_addr) => {
+                    Event::SessionEstablished(enr, socket_addr) => {
                         if let Some(old) = node_addr_cache.write().put(
                             enr.node_id(),
                             NodeAddress {

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -685,12 +685,12 @@ where
             })
             .collect();
         for bootnode in bootnodes {
-            debug!(alias = %bootnode.alias, "Attempting to bond with bootnode");
+            debug!(alias = %bootnode.alias, protocol = %self.protocol, "Attempting to bond with bootnode");
             let ping_result = self.send_ping(bootnode.enr.clone()).await;
 
             match ping_result {
                 Ok(_) => {
-                    info!(alias = %bootnode.alias, "Bonded with bootnode");
+                    info!(alias = %bootnode.alias, protocol = %self.protocol, "Bonded with bootnode");
                     successfully_bonded_bootnode = true;
                 }
                 Err(err) => {

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
-discv5 = { version = "0.3.1", features = ["serde"] }
+discv5 = { git = "https://github.com/njgheorghita/discv5.git",  rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
 ethportal-api = { path = "../ethportal-api"}
 ethereum-types = "0.12.1"
 portalnet = { path = "../portalnet"}

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 async-trait = "0.1.53"
-discv5 = { version = "0.3.1", features = ["serde"]}
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
 ethportal-api = {path = "../ethportal-api"}
 eth2_ssz = "0.4.0"
 parking_lot = "0.11.2"

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 async-trait = "0.1.53"
-discv5 = { version = "0.3.1", features = ["serde"]}
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
 eth2_ssz = "0.4.0"
 ethereum-types = "0.12.1"
 ethportal-api = {path = "../ethportal-api"}

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 async-trait = "0.1.53"
-discv5 = { version = "0.3.1", features = ["serde"]}
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
 ethereum-types = "0.12.1"
 ethportal-api = { path = "../ethportal-api" }
 eth_trie = "0.3.0"

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 clap = { version = "4.2.1", features = ["derive"] }
-discv5 = { version = "0.3.1", features = ["serde"]}
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
 ethportal-api = { path="../ethportal-api"}
 jsonrpsee = {version = "0.20.0", features = ["full"]}
 portalnet = { path = "../portalnet" }


### PR DESCRIPTION
### What was wrong?
Bump discv5 dependency to branch that contains support for concurrent requests.

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
