### PR TITLE
portal-bridge: Serve light client bootstrap data

### DIFF
--- a/ethportal-api/src/types/content_value/beacon.rs
+++ b/ethportal-api/src/types/content_value/beacon.rs
@@ -100,6 +100,15 @@ pub struct ForkVersionedLightClientBootstrap {
     pub bootstrap: LightClientBootstrap,
 }
 
+impl From<LightClientBootstrapCapella> for ForkVersionedLightClientBootstrap {
+    fn from(bootstrap: LightClientBootstrapCapella) -> Self {
+        Self {
+            fork_name: ForkName::Capella,
+            bootstrap: LightClientBootstrap::Capella(bootstrap),
+        }
+    }
+}
+
 impl ForkVersionedLightClientBootstrap {
     pub fn encode(&self) -> Vec<u8> {
         let fork_digest = self.fork_name.as_fork_digest();
@@ -282,6 +291,15 @@ pub struct ForkVersionedLightClientOptimisticUpdate {
     pub update: LightClientOptimisticUpdate,
 }
 
+impl From<LightClientOptimisticUpdateCapella> for ForkVersionedLightClientOptimisticUpdate {
+    fn from(update: LightClientOptimisticUpdateCapella) -> Self {
+        Self {
+            fork_name: ForkName::Capella,
+            update: LightClientOptimisticUpdate::Capella(update),
+        }
+    }
+}
+
 impl ForkVersionedLightClientOptimisticUpdate {
     fn encode(&self) -> Vec<u8> {
         let fork_digest = self.fork_name.as_fork_digest();
@@ -345,6 +363,15 @@ impl Encode for ForkVersionedLightClientOptimisticUpdate {
 pub struct ForkVersionedLightClientFinalityUpdate {
     pub fork_name: ForkName,
     pub update: LightClientFinalityUpdate,
+}
+
+impl From<LightClientFinalityUpdateCapella> for ForkVersionedLightClientFinalityUpdate {
+    fn from(update: LightClientFinalityUpdateCapella) -> Self {
+        Self {
+            fork_name: ForkName::Capella,
+            update: LightClientFinalityUpdate::Capella(update),
+        }
+    }
 }
 
 impl ForkVersionedLightClientFinalityUpdate {

--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -12,6 +12,7 @@ use portal_bridge::execution_api::ExecutionApi;
 use portal_bridge::mode::BridgeMode;
 use portal_bridge::pandaops::PandaOpsMiddleware;
 use serde_json::Value;
+use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 use trin_validation::accumulator::MasterAccumulator;
 use trin_validation::oracle::HeaderOracle;
@@ -48,7 +49,7 @@ pub async fn test_history_bridge(peertest: &Peertest, target: &HttpClient) {
 }
 
 pub async fn test_beacon_bridge(peertest: &Peertest, target: &HttpClient) {
-    let portal_clients = vec![target.clone()];
+    let portal_clients = Arc::new(vec![target.clone()]);
     let mode = BridgeMode::Test("./test_assets/portalnet/beacon_bridge_data.yaml".into());
     // Wait for bootnode to start
     sleep(Duration::from_secs(1)).await;

--- a/portal-bridge/src/consensus_api.rs
+++ b/portal-bridge/src/consensus_api.rs
@@ -1,4 +1,5 @@
 use crate::pandaops::PandaOpsMiddleware;
+use std::fmt::Display;
 
 /// Implements endpoints from the Beacon API to access data from the consensus layer.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -12,10 +13,27 @@ impl ConsensusApi {
     }
 
     /// Requests the `LightClientBootstrap` structure corresponding to a given post-Altair beacon block root.
-    pub async fn get_lc_bootstrap(&self, block_root: String) -> anyhow::Result<String> {
+    pub async fn get_lc_bootstrap<S: AsRef<str> + Display>(
+        &self,
+        block_root: S,
+    ) -> anyhow::Result<String> {
         let endpoint = format!(
             "{}/eth/v1/beacon/light_client/bootstrap/{}",
             self.middleware.base_cl_endpoint, block_root
+        );
+        self.middleware.request(endpoint).await
+    }
+
+    /// Retrieves hashTreeRoot of `BeaconBlock/BeaconBlockHeader`
+    /// Block identifier can be one of: "head" (canonical head in node's view),
+    /// "genesis", "finalized", <slot>, <hex encoded blockRoot with 0x prefix>.
+    pub async fn get_beacon_block_root<S: AsRef<str> + Display>(
+        &self,
+        block_id: S,
+    ) -> anyhow::Result<String> {
+        let endpoint = format!(
+            "{}/eth/v1/beacon/blocks/{}/root",
+            self.middleware.base_cl_endpoint, block_id
         );
         self.middleware.request(endpoint).await
     }


### PR DESCRIPTION
### What was wrong?

Closes #849 

### How was it fixed?

For every slot, we request the latest finalized block root, if a new finalized block root is available, request and serve new `LightClientBootstrap` data.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
