### PR TITLE
Add github stale issues action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 42
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          exempt-issue-labels: "shelf-stable"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What was wrong?
As I'm combing through our issues list, I'm finding that we don't have the best track record with tracking issues after they've been opened. I've seen a fair number of duplicate issues, outdated bug reports, and issues that were solved but never close. 

The [Stale Issues Action](https://github.com/actions/stale), introduced here will...
- Run daily
- Add a label "Stale" on issues and pull requests after 60 days of inactivity and comment on them
- Close the stale issues and pull requests after 14 days of inactivity
- If an update/comment occur on stale issues or pull requests, the stale label will be removed and the timer will restart

The action itself is very customizable, but imo this default is sufficient to start with and we can adjust it as we see fit.

### How was it fixed?
Introduced github action

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history

![flamingo](https://www.tampabay.com/resizer/MmT8PcDei6NqimiKoLZok6Zo2RE=/1200x1200/smart/cloudfront-us-east-1.images.arcpublishing.com/tbt/4RZEKHLSZ5E3THKIFJGTJWVTW4.jpg)