### PR TITLE
Adds random method to NodeId type

### DIFF
--- a/ethportal-api/src/types/node_id.rs
+++ b/ethportal-api/src/types/node_id.rs
@@ -28,6 +28,12 @@ pub fn generate_random_node_id(target_bucket_idx: u8, local_node_id: EnrNodeId) 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct NodeId(#[serde(with = "SerHex::<StrictPfx>")] pub RawNodeId);
 
+impl NodeId {
+    pub fn random() -> Self {
+        NodeId(rand::random())
+    }
+}
+
 impl From<&Enr> for NodeId {
     fn from(enr: &Enr) -> Self {
         NodeId(enr.node_id().raw())


### PR DESCRIPTION
### What was wrong?

`ethportal-api`'s `NodeId` implementation was missing `random()` method, this was causing problems for glados which was using this method in testing

### How was it fixed?

Implements `NodeId::random()`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
