### PR TITLE
Update ethportal-api to v0.2.2

### DIFF
--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethportal-api"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Definitions for various Ethereum Portal Network JSONRPC APIs"
 license = "GPL-3.0"


### PR DESCRIPTION
### What was wrong?

PR #867 added a method to `NodeId` within `ethportal-api` but should have also bumped the ethportal-api version number to make the crate publishable

### How was it fixed?

bumped to v0.2.2

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
