### PR TITLE
feat: define concrete type for RoutingTableInfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6735,7 +6735,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.9",
+ "tokio-util 0.7.10",
 ]
 
 [[package]]

--- a/ethportal-api/src/types/discv5.rs
+++ b/ethportal-api/src/types/discv5.rs
@@ -28,6 +28,7 @@ pub struct NodeInfo {
     pub ip: Option<String>,
 }
 
+/// Information about a discv5/overlay network's routing table.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RoutingTableInfo {

--- a/ethportal-api/src/types/discv5.rs
+++ b/ethportal-api/src/types/discv5.rs
@@ -1,20 +1,21 @@
 use super::enr::Enr;
+use crate::utils::bytes::hex_encode;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 use discv5::enr::NodeId;
 
 /// Discv5 bucket
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Bucket {
-    #[serde(flatten)]
-    pub node_ids: Vec<NodeId>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub node_ids: Vec<String>,
 }
 
 /// Represents a discv5 kbuckets table
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct KBucketsTable {
-    #[serde(flatten)]
     pub buckets: Vec<Bucket>,
 }
 
@@ -27,4 +28,25 @@ pub struct NodeInfo {
     pub ip: Option<String>,
 }
 
-pub type RoutingTableInfo = Value;
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoutingTableInfo {
+    pub local_node_id: String,
+    pub buckets: KBucketsTable,
+}
+
+impl<TVal: Eq> From<discv5::kbucket::KBucketsTable<NodeId, TVal>> for KBucketsTable {
+    fn from(table: discv5::kbucket::KBucketsTable<NodeId, TVal>) -> Self {
+        let buckets = table
+            .buckets_iter()
+            .map(|bucket| Bucket {
+                node_ids: bucket
+                    .iter()
+                    .map(|node| hex_encode(*node.key.preimage()))
+                    .collect(),
+            })
+            .collect();
+
+        KBucketsTable { buckets }
+    }
+}

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -111,8 +111,10 @@ pub async fn test_history_store(target: &Client) {
 
 pub async fn test_history_routing_table_info(target: &Client) {
     info!("Testing portal_historyRoutingTableInfo");
-    let result = HistoryNetworkApiClient::routing_table_info(target).await;
-    assert!(result.is_ok());
+    let result = HistoryNetworkApiClient::routing_table_info(target)
+        .await
+        .unwrap();
+    assert!(result.local_node_id.starts_with("0x"));
 }
 
 pub async fn test_history_local_content_absent(target: &Client) {

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -27,10 +27,7 @@ pub async fn test_discv5_node_info(peertest: &Peertest) {
 pub async fn test_discv5_routing_table_info(target: &Client) {
     info!("Testing discv5_routingTableInfo");
     let result = Discv5ApiClient::routing_table_info(target).await.unwrap();
-    let local_key = result.get("localNodeId").unwrap();
-    assert!(local_key.is_string());
-    assert!(local_key.as_str().unwrap().starts_with("0x"));
-    assert!(result.get("buckets").unwrap().is_array());
+    assert!(result.local_node_id.starts_with("0x"));
 }
 
 pub async fn test_history_radius(target: &Client) {
@@ -114,13 +111,8 @@ pub async fn test_history_store(target: &Client) {
 
 pub async fn test_history_routing_table_info(target: &Client) {
     info!("Testing portal_historyRoutingTableInfo");
-    let result = HistoryNetworkApiClient::routing_table_info(target)
-        .await
-        .unwrap();
-    assert!(result.get("buckets").unwrap().is_object());
-    assert!(result.get("numBuckets").unwrap().is_u64());
-    assert!(result.get("numNodes").unwrap().is_u64());
-    assert!(result.get("numConnected").unwrap().is_u64());
+    let result = HistoryNetworkApiClient::routing_table_info(target).await;
+    assert!(result.is_ok());
 }
 
 pub async fn test_history_local_content_absent(target: &Client) {

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -43,6 +43,7 @@ use crate::{
     },
 };
 use ethportal_api::types::bootnodes::Bootnode;
+use ethportal_api::types::discv5::RoutingTableInfo;
 use ethportal_api::types::distance::{Distance, Metric};
 use ethportal_api::types::enr::Enr;
 use ethportal_api::utils::bytes::hex_encode;
@@ -265,6 +266,14 @@ where
             .iter()
             .map(|entry| entry.node.value.enr())
             .collect()
+    }
+
+    /// Returns the node-id and a nested array of node-ids to represent this node's k-buckets table.
+    pub fn routing_table_info(&self) -> RoutingTableInfo {
+        RoutingTableInfo {
+            local_node_id: hex_encode(self.local_enr().node_id().raw()),
+            buckets: self.kbuckets.read().clone().into(),
+        }
     }
 
     /// Returns a map (BTree for its ordering guarantees) with:

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -75,7 +75,10 @@ async fn complete_request(network: Arc<RwLock<BeaconNetwork>>, request: BeaconJs
             offer(network, enr, content_key, content_value).await
         }
         BeaconEndpoint::Ping(enr) => ping(network, enr).await,
-        BeaconEndpoint::RoutingTableInfo => Ok(json!("Not implemented")), // TODO: implement this when refactor trin_history utils
+        BeaconEndpoint::RoutingTableInfo => {
+            serde_json::to_value(network.read().await.overlay.routing_table_info())
+                .map_err(|err| err.to_string())
+        }
         BeaconEndpoint::RecursiveFindNodes(node_id) => recursive_find_nodes(network, node_id).await,
     };
     let _ = request.resp.send(response);


### PR DESCRIPTION
### What was wrong?
Loosely defined RoutingTableInfo type.

Closes #862

### How was it fixed?
Changed RoutingTableInfo to a struct according to the specification. The Routing table consists of a `localNodeId` field and a `buckets` field which is represented as a nested array of node-ids, with each inner array representing a single bucket in the k-buckets table. 

The serializable types represent node_id as a `String`(hex-encoded) so as to conform to the serialization and deserialization scheme proposed by the specs. This is a workaround for the fact that the `NodeId` type exported by the enr crate only supports default serialization and deserialization to and from a `bytes32`, which is possibly a reason why `RoutingTableInfo` was defined as a `Value` in the first place(#862).



### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
