### PR TITLE
Impose limit on batch request size

### DIFF
--- a/portal-bridge/src/execution_api.rs
+++ b/portal-bridge/src/execution_api.rs
@@ -30,7 +30,7 @@ impl ExecutionApi {
                 JsonRequest::new(method, params, id as u32)
             })
             .collect();
-        let response = self.middleware.batch_request(request).await?;
+        let response = self.middleware.batch_requests(request).await?;
         Ok(serde_json::from_str(&response)?)
     }
 
@@ -38,7 +38,7 @@ impl ExecutionApi {
         let params = Params::Array(vec![json!("latest"), json!(false)]);
         let method = "eth_getBlockByNumber".to_string();
         let request = JsonRequest::new(method, params, 1);
-        let response = self.middleware.batch_request(vec![request]).await?;
+        let response = self.middleware.batch_requests(vec![request]).await?;
         let response: Vec<Value> = serde_json::from_str(&response)?;
         let result = response[0]
             .get("result")
@@ -58,7 +58,7 @@ impl ExecutionApi {
                 JsonRequest::new(method, params, id as u32)
             })
             .collect();
-        let response = self.middleware.batch_request(batch_request).await?;
+        let response = self.middleware.batch_requests(batch_request).await?;
         let response: Vec<Value> = serde_json::from_str(&response).map_err(|e| anyhow!(e))?;
         // single responses are in an array, since we batch them...
         let mut headers = vec![];
@@ -81,7 +81,7 @@ impl ExecutionApi {
             params,
             height as u32,
         )];
-        let response = self.middleware.batch_request(batch_request).await?;
+        let response = self.middleware.batch_requests(batch_request).await?;
         let batch: FullHeaderBatch = serde_json::from_str(&response)?;
         if batch.headers.len() != 1 {
             bail!("Expected 1 header, got {:#?}", batch.headers.len());

--- a/portal-bridge/src/pandaops.rs
+++ b/portal-bridge/src/pandaops.rs
@@ -3,7 +3,13 @@ use crate::constants::{BASE_CL_ENDPOINT, BASE_EL_ENDPOINT};
 use crate::{PANDAOPS_CLIENT_ID, PANDAOPS_CLIENT_SECRET};
 use anyhow::anyhow;
 use ethportal_api::types::jsonrpc::request::JsonRequest;
-use serde_json::json;
+use futures::future::join_all;
+use serde_json::{json, Value};
+use tracing::warn;
+
+/// Limit the number of requests in a single batch to avoid exceeding the
+/// provider's batch size limit configuration of 100.
+const BATCH_LIMIT: usize = 100;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PandaOpsMiddleware {
@@ -44,18 +50,39 @@ impl PandaOpsMiddleware {
     /// Used the "surf" library here instead of "ureq" since "surf" is much more capable of handling
     /// multiple async requests. Using "ureq" consistently resulted in errors as soon as the number of
     /// concurrent tasks increased significantly.
-    pub async fn batch_request(&self, obj: Vec<JsonRequest>) -> anyhow::Result<String> {
+    pub async fn batch_requests(&self, obj: Vec<JsonRequest>) -> anyhow::Result<String> {
+        let batched_request_futures = obj
+            .chunks(BATCH_LIMIT)
+            .map(|chunk| self.send_batch_request(chunk.to_vec()))
+            .collect::<Vec<_>>();
+        match join_all(batched_request_futures)
+            .await
+            .into_iter()
+            .try_fold(Vec::new(), |mut acc, next| {
+                acc.extend_from_slice(&next?);
+                Ok::<Vec<Value>, Box<dyn std::error::Error>>(acc)
+            }) {
+            Ok(val) => Ok(serde_json::to_string(&val)?),
+            Err(err) => Err(anyhow!("Unable to flatten batch request: {err:?}")),
+        }
+    }
+
+    async fn send_batch_request(&self, requests: Vec<JsonRequest>) -> anyhow::Result<Vec<Value>> {
+        if requests.len() > BATCH_LIMIT {
+            warn!("Attempting to send requests outnumbering pandaops limit")
+        }
         let result = surf::post(self.base_el_endpoint.clone())
             .middleware(Retry::default())
-            .body_json(&json!(obj))
+            .body_json(&json!(requests))
             .map_err(|e| anyhow!("Unable to construct json post request: {e:?}"))?
             .header("Content-Type", "application/json".to_string())
             .header("CF-Access-Client-Id", self.client_id.clone())
             .header("CF-Access-Client-Secret", self.client_secret.clone())
             .recv_string()
-            .await;
-
-        result.map_err(|err| anyhow!("Unable to request execution batch from pandaops: {err:?}"))
+            .await
+            .map_err(|err| anyhow!("Unable to request execution batch from pandaops: {err:?}"));
+        serde_json::from_str::<Vec<Value>>(&result?)
+            .map_err(|err| anyhow!("Unable to parse execution batch from pandaops: {err:?}"))
     }
 
     pub async fn request(&self, endpoint: String) -> anyhow::Result<String> {


### PR DESCRIPTION
### What was wrong?
Fixes #830 

Batch requests to a panda-ops provider of > 100 were failing as those clients are configured to handle a max of 100 batch requests at a time.

This bug was the reason why our bridge has not been pumping out receipts. Can confirm that bridge now gossips receipts as expected.

### How was it fixed?
Add a limit to haw many pandaops requests can be batched into a single request.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
