### PR TITLE
Filter out source node from Nodes response

### DIFF
--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -82,7 +82,7 @@ pub async fn test_recursive_find_nodes_random(peertest: &Peertest) {
         .recursive_find_nodes(target_node_id)
         .await
         .unwrap();
-    assert_eq!(result.len(), 3);
+    assert_eq!(result.len(), 2);
 }
 
 pub async fn test_trace_recursive_find_content(peertest: &Peertest) {

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -1057,7 +1057,14 @@ where
         );
 
         let distances64: Vec<u64> = request.distances.iter().map(|x| (*x).into()).collect();
-        let mut enrs = self.nodes_by_distance(distances64);
+        let mut enrs = self
+            .nodes_by_distance(distances64)
+            .into_iter()
+            .filter(|enr| {
+                // Filter out the source node.
+                &enr.node_id() != source
+            })
+            .collect();
 
         // Limit the ENRs so that their summed sizes do not surpass the max TALKREQ packet size.
         pop_while_ssz_bytes_len_gt(&mut enrs, MAX_PORTAL_NODES_ENRS_SIZE);

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -183,9 +183,8 @@ async fn overlay() {
     {
         Ok(nodes) => {
             assert_eq!(1, nodes.total);
-            assert_eq!(2, nodes.enrs.len());
+            assert_eq!(1, nodes.enrs.len());
             assert!(nodes.enrs.contains(&SszEnr::new(overlay_two.local_enr())));
-            assert!(nodes.enrs.contains(&SszEnr::new(overlay_three.local_enr())));
         }
         Err(err) => panic!("Unable to respond to find nodes: {err}"),
     }


### PR DESCRIPTION
### What was wrong?
While I was debugging the flakiness in #851, I noticed that quite often we see the error ~ `Unable to insert node into routing table, invalid self update`. Indicating that a node is trying to add itself to its own routing table, since it is present in the `Nodes` response from a peer. 

This pr follows the spec update in https://github.com/ethereum/portal-network-specs/pull/230. It filters the "requesting" node out from a `FindNodes` response. We already filter out the "requesting" node from a `FindContent::Enrs` response in https://github.com/ethereum/trin/blob/master/portalnet/src/overlay_service.rs#L1148 & "responding" nodes are automatically omitted from that list

### How was it fixed?
Filter out source node from a `Nodes` response.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
