### PR TITLE
chore: Update tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rocksdb = "0.21.0"
 rpc = { path = "rpc"}
 serde_json = {version = "1.0.89", features = ["preserve_order"]}
 sha3 = "0.9.1"
-tempfile = "3.3.0"
+tempfile = "3.8.0"
 tokio = { version = "1.32.0", features = ["full"] }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rpc = { path = "rpc"}
 serde_json = {version = "1.0.89", features = ["preserve_order"]}
 sha3 = "0.9.1"
 tempfile = "3.3.0"
-tokio = { version = "1.14.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 trin-beacon = { path = "trin-beacon" }

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 anyhow = "1.0.68"
 base64 = "0.13.0"
 bytes = "1.3.0"
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "4.4.2", features = ["derive"] }
 discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
 eth_trie = "0.3.0"
 eth2_ssz = "0.4.0"

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -43,7 +43,7 @@ stremio-serde-hex = "0.1.0"
 thiserror = "1.0.40"
 tree_hash = "0.4.0"
 tree_hash_derive = "0.4.0"
-tokio = { version = "1.14.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 ureq = { version = "2.5.0", features = ["json"] }
 url = "2.3.1"
 validator = { version = "0.13.0", features = ["derive"] }

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -28,7 +28,7 @@ rpc = { path = "../rpc" }
 serde_json = "1.0.89"
 serde_yaml = "0.9.25"
 tempfile = "3.3.0"
-tokio = {version = "1.14.0", features = ["full"]}
+tokio = {version = "1.32.0", features = ["full"]}
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 tree_hash = "0.4.0"

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -27,7 +27,7 @@ rocksdb = "0.21.0"
 rpc = { path = "../rpc" }
 serde_json = "1.0.89"
 serde_yaml = "0.9.25"
-tempfile = "3.3.0"
+tempfile = "3.8.0"
 tokio = {version = "1.32.0", features = ["full"]}
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1.0.150", features = ["derive", "rc"] }
 serde_json = "1.0.89"
 serde_yaml = "0.9"
 surf = "2.3.2"
-tokio = { version = "1.14.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 trin-utils = { path = "../trin-utils" }

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -42,7 +42,7 @@ smallvec = "1.8.0"
 stunclient = "0.1.2"
 tempfile = "3.3.0"
 thiserror = "1.0.29"
-tokio = { version = "1.14.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 tracing = "0.1.36"
 trin-utils = { path="../trin-utils" }
 trin-validation = { path="../trin-validation" }

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -11,7 +11,7 @@ description = "Core library for Trin."
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-anyhow = "1.0.68"
+anyhow = "1.0.75"
 async-trait = "0.1.64"
 base64 = "0.13.0"
 bytes = "1.3.0"
@@ -40,7 +40,7 @@ serde = { version = "1.0.150", features = ["derive"] }
 serde_json = "1.0.89"
 smallvec = "1.8.0"
 stunclient = "0.1.2"
-tempfile = "3.3.0"
+tempfile = "3.8.0"
 thiserror = "1.0.29"
 tokio = { version = "1.32.0", features = ["full"] }
 tracing = "0.1.36"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -18,7 +18,7 @@ ethereum-types = "0.12.1"
 portalnet = { path = "../portalnet"}
 tracing = "0.1.27"
 trin-utils = { path = "../trin-utils"}
-tokio = { version = "1.14.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 hyper = "0.14"
 reth-ipc = { version = "0.1.0-alpha.6", git = "https://github.com/paradigmxyz/reth.git"}
 url = "2.3.1"

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -20,7 +20,7 @@ eth2_ssz = "0.4.0"
 parking_lot = "0.11.2"
 portalnet = { path = "../portalnet" }
 serde_json = "1.0.89"
-tokio = {version = "1.14.0", features = ["full"]}
+tokio = {version = "1.32.0", features = ["full"]}
 tracing = "0.1.36"
 trin-validation = { path = "../trin-validation" }
 trin-utils = { path = "../trin-utils" }

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -20,7 +20,7 @@ ethportal-api = {path = "../ethportal-api"}
 parking_lot = "0.11.2"
 portalnet = { path = "../portalnet" }
 serde_json = "1.0.89"
-tokio = { version = "1.14.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 tracing = "0.1.36"
 tree_hash = "0.4.0"
 trin-utils = { path = "../trin-utils" }

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -21,7 +21,7 @@ parking_lot = "0.11.2"
 portalnet = { path = "../portalnet" }
 rocksdb = "0.21.0"
 tracing = "0.1.36"
-tokio = {version = "1.14.0", features = ["full"]}
+tokio = {version = "1.32.0", features = ["full"]}
 trin-validation = { path = "../trin-validation" }
 utp-rs = "0.1.0-alpha.7"
 

--- a/trin-validation/Cargo.toml
+++ b/trin-validation/Cargo.toml
@@ -23,7 +23,7 @@ lazy_static = "1.4.0"
 rust-embed="6.6.1"
 serde = { version = "1.0.150", features = ["derive"] }
 serde_json = "1.0.89"
-tokio = { version = "1.14.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 tree_hash = "0.4.0"
 tree_hash_derive = "0.4.0"
 

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -21,7 +21,7 @@ rand = "0.8.4"
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 trin-utils = { path = "../trin-utils" }
-tokio = {version = "1.14.0", features = ["full"]}
+tokio = {version = "1.32.0", features = ["full"]}
 utp-rs = "0.1.0-alpha.7"
 
 [[bin]]


### PR DESCRIPTION
### What was wrong?

`cargo outdated` shows a few top-level crates have compatible updates available

### How was it fixed?

### To-Do

- [ ] Add more updates

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
