### PR TITLE
Adds preliminary Bridge-Infura integration

### DIFF
--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -50,6 +50,13 @@ pub struct BridgeConfig {
     )]
     pub network: Vec<NetworkKind>,
 
+    #[arg(
+        long = "infura",
+        help = "Use Infura as the execution layer provider",
+        default_value = "false"
+    )]
+    pub infura: bool,
+
     #[arg(long, help = "Url for metrics reporting")]
     pub metrics_url: Option<Url>,
 

--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -13,6 +13,9 @@ pub const BASE_EL_ENDPOINT: &str = "https://archive.mainnet.eu1.ethpandaops.io";
 /// We use Nimbus as the CL client, because it supports light client data by default.
 pub const BASE_CL_ENDPOINT: &str = "https://nimbus.mainnet.ethpandaops.io";
 
+/// Endpoint for Infura, which can be used instead of PandaOps via the --infura flag.
+pub const INFURA_BASE_URL: &str = "https://mainnet.infura.io/v3/";
+
 /// History * content key & value
 pub const HEADER_WITH_PROOF_CONTENT_KEY: &str =
     "0x006251d65b8a8668efabe2f89c96a5b6332d83b3bbe585089ea6b2ab9b6754f5e9";

--- a/portal-bridge/src/lib.rs
+++ b/portal-bridge/src/lib.rs
@@ -21,4 +21,6 @@ lazy_static! {
         env::var("PANDAOPS_CLIENT_ID").expect("PANDAOPS_CLIENT_ID env var not set.");
     static ref PANDAOPS_CLIENT_SECRET: String =
         env::var("PANDAOPS_CLIENT_SECRET").expect("PANDAOPS_CLIENT_SECRET env var not set.");
+    static ref INFURA_CLIENT_ID: String =
+        env::var("TRIN_INFURA_PROJECT_ID").expect("TRIN_INFURA_PROJECT_ID env var not set.");
 }

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -71,7 +71,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let bridge_handle = tokio::spawn(async move {
             let master_acc = MasterAccumulator::default();
             let header_oracle = HeaderOracle::new(master_acc);
-            let pandaops_middleware = PandaOpsMiddleware::default();
+            let pandaops_middleware = match bridge_config.infura {
+                true => PandaOpsMiddleware::infura(),
+                false => PandaOpsMiddleware::default(),
+            };
             let execution_api = ExecutionApi::new(pandaops_middleware);
 
             let bridge = Bridge::new(


### PR DESCRIPTION
### What was wrong?

PandaOps down meant `portal-bridge` couldn't work.

### How was it fixed?

`--infura` option added to `portal-bridge`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
