### PR TITLE
feat: add base eth_* rpc & eth_chainID is always 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures 0.3.28",
+ "pharos",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +496,18 @@ dependencies = [
  "hermit-abi 0.1.19",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -755,6 +778,9 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bzip2-sys"
@@ -915,6 +941,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
 dependencies = [
  "crossbeam-utils 0.8.16",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08849ed393c907c90016652a01465a12d86361cd38ad2a7de026c56a520cc259"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures 0.2.9",
+ "hex",
+ "serde",
 ]
 
 [[package]]
@@ -1506,7 +1544,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "948e343aa022785c07193f41ed37adfd9dd0350368060803b8302c7f798e8306"
 dependencies = [
- "ethereum-types",
+ "ethereum-types 0.12.1",
  "smallvec 1.11.0",
 ]
 
@@ -1542,12 +1580,29 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891f5a47ac0f4c111c46c77a3480b1b36da7b3ef7074ea23e4faaad377d6080d"
 dependencies = [
- "ethereum-types",
+ "ethereum-types 0.12.1",
  "hashbrown 0.14.0",
  "keccak-hash 0.10.0",
  "log",
  "parking_lot 0.12.1",
  "rlp",
+]
+
+[[package]]
+name = "ethabi"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
+dependencies = [
+ "ethereum-types 0.14.1",
+ "hex",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha3 0.10.8",
+ "thiserror",
+ "uint",
 ]
 
 [[package]]
@@ -1559,7 +1614,22 @@ dependencies = [
  "crunchy",
  "fixed-hash 0.7.0",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.3.2",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
+dependencies = [
+ "crunchy",
+ "fixed-hash 0.8.0",
+ "impl-codec 0.6.0",
+ "impl-rlp",
+ "impl-serde 0.4.0",
+ "scale-info",
  "tiny-keccak",
 ]
 
@@ -1569,12 +1639,93 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
 dependencies = [
- "ethbloom",
+ "ethbloom 0.11.1",
  "fixed-hash 0.7.0",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.3.2",
  "primitive-types 0.10.1",
  "uint",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
+dependencies = [
+ "ethbloom 0.13.0",
+ "fixed-hash 0.8.0",
+ "impl-codec 0.6.0",
+ "impl-rlp",
+ "impl-serde 0.4.0",
+ "primitive-types 0.12.1",
+ "scale-info",
+ "uint",
+]
+
+[[package]]
+name = "ethers-core"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a17f0708692024db9956b31d7a20163607d2745953f5ae8125ab368ba280ad"
+dependencies = [
+ "arrayvec",
+ "bytes 1.5.0",
+ "chrono",
+ "const-hex",
+ "elliptic-curve",
+ "ethabi",
+ "generic-array",
+ "k256",
+ "num_enum",
+ "open-fastrlp",
+ "rand 0.8.5",
+ "rlp",
+ "serde",
+ "serde_json",
+ "strum 0.25.0",
+ "tempfile",
+ "thiserror",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "ethers-providers"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6838fa110e57d572336178b7c79e94ff88ef976306852d8cb87d9e5b1fc7c0b5"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "base64 0.21.4",
+ "bytes 1.5.0",
+ "const-hex",
+ "enr",
+ "ethers-core",
+ "futures-channel",
+ "futures-core",
+ "futures-timer",
+ "futures-util",
+ "hashers",
+ "http",
+ "instant",
+ "jsonwebtoken",
+ "once_cell",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winapi 0.3.9",
+ "ws_stream_wasm",
 ]
 
 [[package]]
@@ -1597,7 +1748,7 @@ dependencies = [
  "eth2_ssz_derive",
  "eth2_ssz_types",
  "eth_trie",
- "ethereum-types",
+ "ethereum-types 0.12.1",
  "ethnum",
  "hex",
  "jsonrpsee",
@@ -1637,7 +1788,7 @@ dependencies = [
  "anyhow",
  "discv5",
  "eth2_ssz",
- "ethereum-types",
+ "ethereum-types 0.12.1",
  "ethportal-api",
  "futures 0.3.28",
  "hex",
@@ -1756,6 +1907,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
  "static_assertions",
 ]
 
@@ -1949,7 +2103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 dependencies = [
  "gloo-timers",
- "send_wrapper",
+ "send_wrapper 0.4.0",
 ]
 
 [[package]]
@@ -1968,6 +2122,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -2137,6 +2300,15 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 dependencies = [
  "ahash 0.8.3",
  "allocator-api2",
+]
+
+[[package]]
+name = "hashers"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
+dependencies = [
+ "fxhash",
 ]
 
 [[package]]
@@ -2461,6 +2633,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec 3.6.8",
+]
+
+[[package]]
 name = "impl-rlp"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,6 +2655,15 @@ name = "impl-serde"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
  "serde",
 ]
@@ -2827,6 +3017,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+dependencies = [
+ "base64 0.21.4",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3014,7 +3218,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
- "ethereum-types",
+ "ethereum-types 0.12.1",
  "eyre",
  "figment",
  "futures 0.3.28",
@@ -3327,6 +3531,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3346,6 +3571,31 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "open-fastrlp"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes 1.5.0",
+ "ethereum-types 0.14.1",
+ "open-fastrlp-derive",
+]
+
+[[package]]
+name = "open-fastrlp-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
+dependencies = [
+ "bytes 1.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "openssl"
@@ -3573,6 +3823,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3586,6 +3845,16 @@ checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
  "indexmap 2.0.0",
+]
+
+[[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures 0.3.28",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -3703,7 +3972,7 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
- "ethereum-types",
+ "ethereum-types 0.12.1",
  "ethportal-api",
  "futures 0.3.28",
  "jsonrpsee",
@@ -3738,7 +4007,7 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
- "ethereum-types",
+ "ethereum-types 0.12.1",
  "ethportal-api",
  "fnv",
  "futures 0.3.28",
@@ -3803,9 +4072,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash 0.7.0",
- "impl-codec",
+ "impl-codec 0.5.1",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.3.2",
  "uint",
 ]
 
@@ -3816,6 +4085,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
  "fixed-hash 0.8.0",
+ "impl-codec 0.6.0",
+ "impl-rlp",
+ "impl-serde 0.4.0",
+ "scale-info",
  "uint",
 ]
 
@@ -4333,6 +4606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes 1.5.0",
+ "rlp-derive",
  "rustc-hex",
 ]
 
@@ -4369,6 +4643,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "discv5",
+ "ethereum-types 0.12.1",
  "ethportal-api",
  "hyper",
  "portalnet",
@@ -4382,6 +4657,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "trin-utils",
+ "trin-validation",
  "url",
 ]
 
@@ -4750,6 +5026,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+
+[[package]]
 name = "serde"
 version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5007,6 +5289,18 @@ name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time 0.3.28",
+]
 
 [[package]]
 name = "siphasher"
@@ -5954,7 +6248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9c8a86fad3169a65aad2265d3c6a8bc119d0b771046af3c1b2fb0e9b12182b"
 dependencies = [
  "eth2_hashing",
- "ethereum-types",
+ "ethereum-types 0.12.1",
  "smallvec 1.11.0",
 ]
 
@@ -5977,7 +6271,9 @@ dependencies = [
  "clap",
  "discv5",
  "eth2_ssz",
- "ethereum-types",
+ "ethereum-types 0.12.1",
+ "ethers-core",
+ "ethers-providers",
  "ethportal-api",
  "ethportal-peertest",
  "jsonrpsee",
@@ -6034,7 +6330,7 @@ dependencies = [
  "env_logger 0.9.3",
  "eth2_ssz",
  "eth2_ssz_types",
- "ethereum-types",
+ "ethereum-types 0.12.1",
  "ethportal-api",
  "httpmock",
  "parking_lot 0.11.2",
@@ -6061,7 +6357,7 @@ dependencies = [
  "discv5",
  "env_logger 0.9.3",
  "eth_trie",
- "ethereum-types",
+ "ethereum-types 0.12.1",
  "ethportal-api",
  "parking_lot 0.11.2",
  "portalnet",
@@ -6093,7 +6389,7 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
- "ethereum-types",
+ "ethereum-types 0.12.1",
  "ethportal-api",
  "lazy_static",
  "quickcheck",
@@ -6622,6 +6918,25 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
+dependencies = [
+ "async_io_stream",
+ "futures 0.3.28",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version 0.4.0",
+ "send_wrapper 0.6.0",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ trin-validation = { path = "trin-validation" }
 utp-rs = "0.1.0-alpha.7"
 
 [dev-dependencies]
+ethers-core = { version = "2.0", default-features = false}
+ethers-providers = { version = "2.0", default-features = false, features = ["ipc"] }
 ethportal-peertest = { path = "ethportal-peertest" }
 serial_test = "0.5.1"
 ureq = { version = "2.5.0", features = ["json"] }

--- a/ethportal-api/src/eth.rs
+++ b/ethportal-api/src/eth.rs
@@ -1,0 +1,9 @@
+use ethereum_types::U256;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
+/// Web3 JSON-RPC endpoints
+#[rpc(client, server, namespace = "eth")]
+pub trait EthApi {
+    #[method(name = "chainId")]
+    async fn chain_id(&self) -> RpcResult<U256>;
+}

--- a/ethportal-api/src/lib.rs
+++ b/ethportal-api/src/lib.rs
@@ -9,6 +9,7 @@ extern crate lazy_static;
 mod beacon;
 mod dashboard;
 pub mod discv5;
+mod eth;
 mod history;
 pub mod types;
 pub mod utils;
@@ -16,6 +17,7 @@ mod web3;
 
 pub use crate::discv5::{Discv5ApiClient, Discv5ApiServer};
 pub use beacon::{BeaconNetworkApiClient, BeaconNetworkApiServer};
+pub use eth::{EthApiClient, EthApiServer};
 pub use history::{HistoryNetworkApiClient, HistoryNetworkApiServer};
 pub use web3::{Web3ApiClient, Web3ApiServer};
 

--- a/ethportal-peertest/src/scenarios/eth_rpc.rs
+++ b/ethportal-peertest/src/scenarios/eth_rpc.rs
@@ -1,0 +1,15 @@
+use ethereum_types::U256;
+use tracing::info;
+
+use ethportal_api::EthApiClient;
+use trin_validation::constants::CHAIN_ID;
+
+use crate::Peertest;
+
+pub async fn test_eth_chain_id(peertest: &Peertest) {
+    info!("Testing eth_chainId");
+    let target = &peertest.bootnode.ipc_client;
+    let chain_id = target.chain_id().await.unwrap();
+    // For now, the chain ID is always 1 -- portal only supports mainnet Ethereum
+    assert_eq!(chain_id, U256::from(CHAIN_ID));
+}

--- a/ethportal-peertest/src/scenarios/mod.rs
+++ b/ethportal-peertest/src/scenarios/mod.rs
@@ -1,5 +1,6 @@
 pub mod basic;
 pub mod bridge;
+pub mod eth_rpc;
 pub mod find;
 pub mod offer_accept;
 pub mod paginate;

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -670,7 +670,7 @@ where
         let mut successfully_bonded_bootnode = false;
         let enrs = self.discovery.table_entries_enr();
         if enrs.is_empty() {
-            error!(
+            info!(
                 protocol = %self.protocol,
                 "No bootnodes provided to join portal network",
             );

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -14,6 +14,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 anyhow = "1.0.68"
 discv5 = { version = "0.3.1", features = ["serde"] }
 ethportal-api = { path = "../ethportal-api"}
+ethereum-types = "0.12.1"
 portalnet = { path = "../portalnet"}
 tracing = "0.1.27"
 trin-utils = { path = "../trin-utils"}
@@ -26,4 +27,5 @@ serde_json = "1.0.95"
 strum = { version = "0.24.1", features = ["derive"] }
 tower-http = { version = "0.4", features = ["full"] }
 tower = { version = "0.4", features = ["full"] }
+trin-validation = { path="../trin-validation" }
 thiserror = "1.0"

--- a/rpc/src/builder.rs
+++ b/rpc/src/builder.rs
@@ -1,12 +1,12 @@
 use crate::errors::{RpcError, WsHttpSamePortError};
 use crate::jsonrpsee::{Methods, RpcModule};
 use crate::rpc_server::{RpcServerConfig, RpcServerHandle};
-use crate::{BeaconNetworkApi, Discv5Api, HistoryNetworkApi, Web3Api};
+use crate::{BeaconNetworkApi, Discv5Api, EthApi, HistoryNetworkApi, Web3Api};
 use ethportal_api::types::jsonrpc::request::{
     BeaconJsonRpcRequest, HistoryJsonRpcRequest, StateJsonRpcRequest,
 };
 use ethportal_api::{
-    BeaconNetworkApiServer, Discv5ApiServer, HistoryNetworkApiServer, Web3ApiServer,
+    BeaconNetworkApiServer, Discv5ApiServer, EthApiServer, HistoryNetworkApiServer, Web3ApiServer,
 };
 use portalnet::discovery::Discovery;
 use serde::Deserialize;
@@ -27,6 +27,8 @@ pub enum PortalRpcModule {
     Beacon,
     /// `discv5_` module
     Discv5,
+    /// `eth_` module
+    Eth,
     /// `portal_history` module
     History,
     /// `web3_` module
@@ -148,10 +150,11 @@ pub enum RpcModuleSelection {
 }
 
 impl RpcModuleSelection {
-    /// The standard modules to instantiate by default `discv5`, `history`, `web3` and `beacon`.
-    pub const STANDARD_MODULES: [PortalRpcModule; 4] = [
+    /// The standard modules to instantiate by default
+    pub const STANDARD_MODULES: [PortalRpcModule; 5] = [
         PortalRpcModule::Beacon,
         PortalRpcModule::Discv5,
+        PortalRpcModule::Eth,
         PortalRpcModule::History,
         PortalRpcModule::Web3,
     ];
@@ -399,6 +402,7 @@ impl RpcModuleBuilder {
                         PortalRpcModule::Discv5 => {
                             Discv5Api::new(self.discv5.clone()).into_rpc().into()
                         }
+                        PortalRpcModule::Eth => EthApi.into_rpc().into(),
                         PortalRpcModule::History => {
                             let history_tx = self
                                 .history_tx
@@ -467,6 +471,7 @@ mod tests {
             vec![
                 PortalRpcModule::Beacon,
                 PortalRpcModule::Discv5,
+                PortalRpcModule::Eth,
                 PortalRpcModule::History,
                 PortalRpcModule::Web3,
             ]

--- a/rpc/src/eth_rpc.rs
+++ b/rpc/src/eth_rpc.rs
@@ -1,0 +1,31 @@
+use crate::jsonrpsee::core::{async_trait, RpcResult};
+use ethereum_types::U256;
+use ethportal_api::EthApiServer;
+use trin_validation::constants::CHAIN_ID;
+
+pub struct EthApi;
+
+impl EthApi {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for EthApi {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl EthApiServer for EthApi {
+    async fn chain_id(&self) -> RpcResult<U256> {
+        Ok(U256::from(CHAIN_ID))
+    }
+}
+
+impl std::fmt::Debug for EthApi {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EthApi").finish_non_exhaustive()
+    }
+}

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -5,6 +5,7 @@ mod builder;
 mod cors;
 mod discv5_rpc;
 mod errors;
+mod eth_rpc;
 mod history_rpc;
 mod rpc_server;
 mod serde;
@@ -16,6 +17,7 @@ use beacon_rpc::BeaconNetworkApi;
 pub use builder::{PortalRpcModule, RpcModuleBuilder, TransportRpcModuleConfig};
 use discv5_rpc::Discv5Api;
 use errors::RpcError;
+use eth_rpc::EthApi;
 use ethportal_api::jsonrpsee;
 use ethportal_api::types::cli::{
     TrinConfig, Web3TransportType, BEACON_NETWORK, HISTORY_NETWORK, STATE_NETWORK,
@@ -46,6 +48,7 @@ pub async fn launch_jsonrpc_server(
         match network.as_str() {
             HISTORY_NETWORK => {
                 modules.push(PortalRpcModule::History);
+                modules.push(PortalRpcModule::Eth);
             }
             STATE_NETWORK => {
                 // not implemented

--- a/tests/rpc_server.rs
+++ b/tests/rpc_server.rs
@@ -1,0 +1,53 @@
+/// Test that a 3rd-party web3 client can understand our JSON-RPC API
+use std::net::{IpAddr, Ipv4Addr};
+
+use ethers_core::types::U256;
+use ethers_providers::*;
+use serial_test::serial;
+
+use ethportal_api::types::cli::{TrinConfig, DEFAULT_WEB3_IPC_PATH};
+use rpc::RpcServerHandle;
+
+mod utils;
+
+async fn setup_web3_server() -> (RpcServerHandle, Provider<Ipc>) {
+    utils::init_tracing();
+
+    let test_ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    // Use an uncommon port for the peertest to avoid clashes.
+    let test_discovery_port = 8999;
+    let external_addr = format!("{test_ip_addr}:{test_discovery_port}");
+
+    // Run a client, to be tested
+    let trin_config = TrinConfig::new_from(
+        [
+            "trin",
+            "--external-address",
+            external_addr.as_str(),
+            "--web3-ipc-path",
+            DEFAULT_WEB3_IPC_PATH,
+            "--ephemeral",
+            "--discovery-port",
+            &test_discovery_port.to_string(),
+            "--bootnodes",
+            "none",
+        ]
+        .iter(),
+    )
+    .unwrap();
+
+    let web3_server = trin::run_trin(trin_config).await.unwrap();
+    let web3_client = Provider::connect_ipc(DEFAULT_WEB3_IPC_PATH).await.unwrap();
+    (web3_server, web3_client)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn test_eth_chain_id() {
+    let (web3_server, web3_client) = setup_web3_server().await;
+    let chain_id = web3_client.get_chainid().await.unwrap();
+    web3_server.stop().unwrap();
+    // For now, the chain ID is always 1 -- Portal only supports mainnet Ethereum
+    // Intentionally testing against the magic number 1 so that a buggy constant value will fail
+    assert_eq!(chain_id, U256::from(1));
+}

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -1,272 +1,259 @@
-#[cfg(test)]
-mod test {
-    use rpc::RpcServerHandle;
-    use std::env;
-    use std::net::{IpAddr, Ipv4Addr};
+use rpc::RpcServerHandle;
+use std::env;
+use std::net::{IpAddr, Ipv4Addr};
 
-    use ethportal_api::types::cli::{TrinConfig, DEFAULT_WEB3_HTTP_ADDRESS, DEFAULT_WEB3_IPC_PATH};
-    use ethportal_peertest as peertest;
-    use ethportal_peertest::Peertest;
-    use jsonrpsee::async_client::Client;
-    use jsonrpsee::http_client::HttpClient;
-    use serial_test::serial;
-    use tokio::time::{sleep, Duration};
+use ethportal_api::types::cli::{TrinConfig, DEFAULT_WEB3_HTTP_ADDRESS, DEFAULT_WEB3_IPC_PATH};
+use ethportal_peertest as peertest;
+use ethportal_peertest::Peertest;
+use jsonrpsee::async_client::Client;
+use jsonrpsee::http_client::HttpClient;
+use serial_test::serial;
+use tokio::time::{sleep, Duration};
 
-    // Logs don't show up when trying to use test_log here, maybe because of multi_thread
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_stateless() {
-        // These tests are stateless with regards to the content database,
-        // so they can all be run against the same set of peertest nodes
-        // without needing to reset the database between tests.
-        // If a scenario is testing the state of the content database,
-        // it should be added to its own test function.
-        let (peertest, target, handle) = setup_peertest().await;
-        peertest::scenarios::paginate::test_paginate_local_storage(&peertest).await;
-        peertest::scenarios::basic::test_web3_client_version(&target).await;
-        peertest::scenarios::basic::test_discv5_node_info(&peertest).await;
-        peertest::scenarios::basic::test_discv5_routing_table_info(&target).await;
-        peertest::scenarios::basic::test_history_radius(&target).await;
-        peertest::scenarios::basic::test_history_add_enr(&target, &peertest).await;
-        peertest::scenarios::basic::test_history_get_enr(&target, &peertest).await;
-        peertest::scenarios::basic::test_history_delete_enr(&target, &peertest).await;
-        peertest::scenarios::basic::test_history_lookup_enr(&peertest).await;
-        peertest::scenarios::basic::test_history_ping(&target, &peertest).await;
-        peertest::scenarios::basic::test_history_find_nodes(&target, &peertest).await;
-        peertest::scenarios::basic::test_history_find_nodes_zero_distance(&target, &peertest).await;
-        peertest::scenarios::basic::test_history_store(&target).await;
-        peertest::scenarios::basic::test_history_routing_table_info(&target).await;
-        peertest::scenarios::basic::test_history_local_content_absent(&target).await;
-        peertest::scenarios::find::test_recursive_find_nodes_self(&peertest).await;
-        peertest::scenarios::find::test_recursive_find_nodes_peer(&peertest).await;
-        peertest::scenarios::find::test_recursive_find_nodes_random(&peertest).await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
+mod utils;
 
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_populated_offer() {
-        let (peertest, target, handle) = setup_peertest().await;
-        peertest::scenarios::offer_accept::test_populated_offer(&peertest, &target).await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
+// Logs don't show up when trying to use test_log here, maybe because of multi_thread
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_stateless() {
+    // These tests are stateless with regards to the content database,
+    // so they can all be run against the same set of peertest nodes
+    // without needing to reset the database between tests.
+    // If a scenario is testing the state of the content database,
+    // it should be added to its own test function.
+    let (peertest, target, handle) = setup_peertest().await;
+    peertest::scenarios::paginate::test_paginate_local_storage(&peertest).await;
+    peertest::scenarios::basic::test_web3_client_version(&target).await;
+    peertest::scenarios::basic::test_discv5_node_info(&peertest).await;
+    peertest::scenarios::basic::test_discv5_routing_table_info(&target).await;
+    peertest::scenarios::basic::test_history_radius(&target).await;
+    peertest::scenarios::basic::test_history_add_enr(&target, &peertest).await;
+    peertest::scenarios::basic::test_history_get_enr(&target, &peertest).await;
+    peertest::scenarios::basic::test_history_delete_enr(&target, &peertest).await;
+    peertest::scenarios::basic::test_history_lookup_enr(&peertest).await;
+    peertest::scenarios::basic::test_history_ping(&target, &peertest).await;
+    peertest::scenarios::basic::test_history_find_nodes(&target, &peertest).await;
+    peertest::scenarios::basic::test_history_find_nodes_zero_distance(&target, &peertest).await;
+    peertest::scenarios::basic::test_history_store(&target).await;
+    peertest::scenarios::basic::test_history_routing_table_info(&target).await;
+    peertest::scenarios::basic::test_history_local_content_absent(&target).await;
+    peertest::scenarios::find::test_recursive_find_nodes_self(&peertest).await;
+    peertest::scenarios::find::test_recursive_find_nodes_peer(&peertest).await;
+    peertest::scenarios::find::test_recursive_find_nodes_random(&peertest).await;
+    peertest::scenarios::eth_rpc::test_eth_chain_id(&peertest).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
 
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_unpopulated_offer() {
-        let (peertest, target, handle) = setup_peertest().await;
-        peertest::scenarios::offer_accept::test_unpopulated_offer(&peertest, &target).await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_populated_offer() {
+    let (peertest, target, handle) = setup_peertest().await;
+    peertest::scenarios::offer_accept::test_populated_offer(&peertest, &target).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
 
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_find_content_return_enr() {
-        let (peertest, target, handle) = setup_peertest().await;
-        peertest::scenarios::find::test_find_content_return_enr(&target, &peertest).await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_unpopulated_offer() {
+    let (peertest, target, handle) = setup_peertest().await;
+    peertest::scenarios::offer_accept::test_unpopulated_offer(&peertest, &target).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
 
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_trace_recursive_find_content_local_db() {
-        let (peertest, _target, handle) = setup_peertest().await;
-        peertest::scenarios::find::test_trace_recursive_find_content_local_db(&peertest).await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_find_content_return_enr() {
+    let (peertest, target, handle) = setup_peertest().await;
+    peertest::scenarios::find::test_find_content_return_enr(&target, &peertest).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
 
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_trace_recursive_find_content_for_absent_content() {
-        let (peertest, _target, handle) = setup_peertest().await;
-        peertest::scenarios::find::test_trace_recursive_find_content_for_absent_content(&peertest)
-            .await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_trace_recursive_find_content_local_db() {
+    let (peertest, _target, handle) = setup_peertest().await;
+    peertest::scenarios::find::test_trace_recursive_find_content_local_db(&peertest).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
 
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_trace_recursive_find_content() {
-        let (peertest, _target, handle) = setup_peertest().await;
-        peertest::scenarios::find::test_trace_recursive_find_content(&peertest).await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_validate_pre_merge_header_with_proof() {
-        let (peertest, target, handle) = setup_peertest().await;
-        peertest::scenarios::validation::test_validate_pre_merge_header_with_proof(
-            &peertest, &target,
-        )
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_trace_recursive_find_content_for_absent_content() {
+    let (peertest, _target, handle) = setup_peertest().await;
+    peertest::scenarios::find::test_trace_recursive_find_content_for_absent_content(&peertest)
         .await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
 
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_invalidate_header_by_hash() {
-        let (peertest, target, handle) = setup_peertest().await;
-        peertest::scenarios::validation::test_invalidate_header_by_hash(&peertest, &target).await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_trace_recursive_find_content() {
+    let (peertest, _target, handle) = setup_peertest().await;
+    peertest::scenarios::find::test_trace_recursive_find_content(&peertest).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
 
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_validate_block_body() {
-        let (peertest, target, handle) = setup_peertest().await;
-        peertest::scenarios::validation::test_validate_pre_merge_block_body(&peertest, &target)
-            .await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_validate_pre_merge_header_with_proof() {
+    let (peertest, target, handle) = setup_peertest().await;
+    peertest::scenarios::validation::test_validate_pre_merge_header_with_proof(&peertest, &target)
+        .await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
 
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_validate_receipts() {
-        let (peertest, target, handle) = setup_peertest().await;
-        peertest::scenarios::validation::test_validate_pre_merge_receipts(&peertest, &target).await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_invalidate_header_by_hash() {
+    let (peertest, target, handle) = setup_peertest().await;
+    peertest::scenarios::validation::test_invalidate_header_by_hash(&peertest, &target).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
 
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_recursive_utp() {
-        let (peertest, _target, handle) = setup_peertest().await;
-        peertest::scenarios::utp::test_recursive_utp(&peertest).await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_validate_block_body() {
+    let (peertest, target, handle) = setup_peertest().await;
+    peertest::scenarios::validation::test_validate_pre_merge_block_body(&peertest, &target).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
 
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_trace_recursive_utp() {
-        let (peertest, _target, handle) = setup_peertest().await;
-        peertest::scenarios::utp::test_trace_recursive_utp(&peertest).await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_validate_receipts() {
+    let (peertest, target, handle) = setup_peertest().await;
+    peertest::scenarios::validation::test_validate_pre_merge_receipts(&peertest, &target).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
 
-    // sets the global tracing subscriber on the first peertest run, which is used by all other tests
-    fn init_tracing() {
-        let subscriber = tracing_subscriber::fmt()
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-            .with_ansi(trin_utils::log::detect_ansi_support())
-            .finish();
-        // returns err if already set, which is fine and we just ignore the err
-        let _ = tracing::subscriber::set_global_default(subscriber);
-    }
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_recursive_utp() {
+    let (peertest, _target, handle) = setup_peertest().await;
+    peertest::scenarios::utp::test_recursive_utp(&peertest).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
 
-    async fn setup_peertest() -> (peertest::Peertest, Client, RpcServerHandle) {
-        init_tracing();
-        // Run a client, as a buddy peer for ping tests, etc.
-        let peertest = peertest::launch_peertest_nodes(2).await;
-        // Short sleep to make sure all peertest nodes can connect
-        sleep(Duration::from_millis(100)).await;
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_trace_recursive_utp() {
+    let (peertest, _target, handle) = setup_peertest().await;
+    peertest::scenarios::utp::test_trace_recursive_utp(&peertest).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
 
-        let test_ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-        // Use an uncommon port for the peertest to avoid clashes.
-        let test_discovery_port = 8999;
-        let external_addr = format!("{test_ip_addr}:{test_discovery_port}");
+async fn setup_peertest() -> (peertest::Peertest, Client, RpcServerHandle) {
+    utils::init_tracing();
+    // Run a client, as a buddy peer for ping tests, etc.
+    let peertest = peertest::launch_peertest_nodes(2).await;
+    // Short sleep to make sure all peertest nodes can connect
+    sleep(Duration::from_millis(100)).await;
 
-        // Run a client, to be tested
-        let trin_config = TrinConfig::new_from(
-            [
-                "trin",
-                "--networks",
-                "history,state",
-                "--external-address",
-                external_addr.as_str(),
-                "--web3-ipc-path",
-                DEFAULT_WEB3_IPC_PATH,
-                "--ephemeral",
-                "--discovery-port",
-                test_discovery_port.to_string().as_ref(),
-                "--bootnodes",
-                "none",
-            ]
-            .iter(),
-        )
+    let test_ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    // Use an uncommon port for the peertest to avoid clashes.
+    let test_discovery_port = 8999;
+    let external_addr = format!("{test_ip_addr}:{test_discovery_port}");
+
+    // Run a client, to be tested
+    let trin_config = TrinConfig::new_from(
+        [
+            "trin",
+            "--networks",
+            "history,state",
+            "--external-address",
+            external_addr.as_str(),
+            "--web3-ipc-path",
+            DEFAULT_WEB3_IPC_PATH,
+            "--ephemeral",
+            "--discovery-port",
+            test_discovery_port.to_string().as_ref(),
+            "--bootnodes",
+            "none",
+        ]
+        .iter(),
+    )
+    .unwrap();
+
+    let test_client_rpc_handle = trin::run_trin(trin_config).await.unwrap();
+    let target = reth_ipc::client::IpcClientBuilder::default()
+        .build(DEFAULT_WEB3_IPC_PATH)
+        .await
         .unwrap();
+    (peertest, target, test_client_rpc_handle)
+}
 
-        let test_client_rpc_handle = trin::run_trin(trin_config).await.unwrap();
-        let target = reth_ipc::client::IpcClientBuilder::default()
-            .build(DEFAULT_WEB3_IPC_PATH)
-            .await
-            .unwrap();
-        (peertest, target, test_client_rpc_handle)
-    }
+async fn setup_peertest_bridge() -> (Peertest, HttpClient, RpcServerHandle) {
+    utils::init_tracing();
+    // Run a client, as a buddy peer for ping tests, etc.
+    let peertest = peertest::launch_peertest_nodes(1).await;
+    // Short sleep to make sure all peertest nodes can connect
+    sleep(Duration::from_millis(100)).await;
 
-    async fn setup_peertest_bridge() -> (Peertest, HttpClient, RpcServerHandle) {
-        init_tracing();
-        // Run a client, as a buddy peer for ping tests, etc.
-        let peertest = peertest::launch_peertest_nodes(1).await;
-        // Short sleep to make sure all peertest nodes can connect
-        sleep(Duration::from_millis(100)).await;
+    let test_ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    // Use an uncommon port for the peertest to avoid clashes.
+    let test_discovery_port = 8999;
+    let external_addr = format!("{test_ip_addr}:{test_discovery_port}");
 
-        let test_ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-        // Use an uncommon port for the peertest to avoid clashes.
-        let test_discovery_port = 8999;
-        let external_addr = format!("{test_ip_addr}:{test_discovery_port}");
+    // add fake secrets for bridge activation
+    env::set_var("PANDAOPS_CLIENT_ID", "xxx");
+    env::set_var("PANDAOPS_CLIENT_SECRET", "xxx");
+    // Run a client, to be tested
+    let trin_config = TrinConfig::new_from(
+        [
+            "trin",
+            "--networks",
+            "history,beacon",
+            "--external-address",
+            external_addr.as_str(),
+            // Run bridge test with http, since bridge doesn't support ipc yet.
+            "--web3-transport",
+            "http",
+            "--web3-http-address",
+            DEFAULT_WEB3_HTTP_ADDRESS,
+            "--ephemeral",
+            "--discovery-port",
+            test_discovery_port.to_string().as_ref(),
+            "--bootnodes",
+            &peertest.bootnode.enr.to_base64(),
+        ]
+        .iter(),
+    )
+    .unwrap();
 
-        // add fake secrets for bridge activation
-        env::set_var("PANDAOPS_CLIENT_ID", "xxx");
-        env::set_var("PANDAOPS_CLIENT_SECRET", "xxx");
-        // Run a client, to be tested
-        let trin_config = TrinConfig::new_from(
-            [
-                "trin",
-                "--networks",
-                "history,beacon",
-                "--external-address",
-                external_addr.as_str(),
-                // Run bridge test with http, since bridge doesn't support ipc yet.
-                "--web3-transport",
-                "http",
-                "--web3-http-address",
-                DEFAULT_WEB3_HTTP_ADDRESS,
-                "--ephemeral",
-                "--discovery-port",
-                test_discovery_port.to_string().as_ref(),
-                "--bootnodes",
-                &peertest.bootnode.enr.to_base64(),
-            ]
-            .iter(),
-        )
+    let test_client_rpc_handle = trin::run_trin(trin_config).await.unwrap();
+    let target = ethportal_api::jsonrpsee::http_client::HttpClientBuilder::default()
+        .build(DEFAULT_WEB3_HTTP_ADDRESS)
         .unwrap();
+    (peertest, target, test_client_rpc_handle)
+}
 
-        let test_client_rpc_handle = trin::run_trin(trin_config).await.unwrap();
-        let target = ethportal_api::jsonrpsee::http_client::HttpClientBuilder::default()
-            .build(DEFAULT_WEB3_HTTP_ADDRESS)
-            .unwrap();
-        (peertest, target, test_client_rpc_handle)
-    }
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_history_bridge() {
+    let (peertest, target, handle) = setup_peertest_bridge().await;
+    peertest::scenarios::bridge::test_history_bridge(&peertest, &target).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
 
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_history_bridge() {
-        let (peertest, target, handle) = setup_peertest_bridge().await;
-        peertest::scenarios::bridge::test_history_bridge(&peertest, &target).await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_beacon_bridge() {
-        let (peertest, target, handle) = setup_peertest_bridge().await;
-        peertest::scenarios::bridge::test_beacon_bridge(&peertest, &target).await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_beacon_bridge() {
+    let (peertest, target, handle) = setup_peertest_bridge().await;
+    peertest::scenarios::bridge::test_beacon_bridge(&peertest, &target).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,0 +1,9 @@
+// sets the global tracing subscriber, to be used by all other tests
+pub fn init_tracing() {
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_ansi(trin_utils::log::detect_ansi_support())
+        .finish();
+    // returns err if already set, which is fine and we just ignore the err
+    let _ = tracing::subscriber::set_global_default(subscriber);
+}

--- a/trin-validation/src/constants.rs
+++ b/trin-validation/src/constants.rs
@@ -7,3 +7,6 @@ pub const EPOCH_SIZE: usize = 8192;
 
 // Max number of epochs = 2 ** 17
 // const MAX_HISTORICAL_EPOCHS: usize = 131072;
+
+// EIP-155 chain ID for Ethereum mainnet
+pub const CHAIN_ID: usize = 1;


### PR DESCRIPTION
### What was wrong?

Need the `eth_` namespace to accomplish #885 

### How was it fixed?

I think this is the minimal set of changes to implement a new RPC namespace. I'm not totally impressed, because it seems to sprawl a bit. I don't have any ideas for how to improve it yet, besides leaving this PR as a guide.

### To-Do

- [x] Clean up commit history
- [x] extract chain id constant
- [x] move duplicate tracing logic to a shared utility module
