### PR TITLE
Add header saturation delay for history bridge test mode

### DIFF
--- a/portal-bridge/src/bridge.rs
+++ b/portal-bridge/src/bridge.rs
@@ -86,9 +86,16 @@ impl Bridge {
             .expect("Error parsing history test assets.");
 
         for asset in assets.0.into_iter() {
-            Bridge::gossip_content(&self.portal_clients, asset.content_key, asset.content_value)
-                .await
-                .expect("Error serving block range in test mode.");
+            Bridge::gossip_content(
+                &self.portal_clients,
+                asset.content_key.clone(),
+                asset.content_value,
+            )
+            .await
+            .expect("Error serving block range in test mode.");
+            if let HistoryContentKey::BlockHeaderWithProof(_) = asset.content_key {
+                sleep(Duration::from_secs(HEADER_SATURATION_DELAY)).await;
+            }
         }
     }
 

--- a/portal-bridge/src/bridge.rs
+++ b/portal-bridge/src/bridge.rs
@@ -94,7 +94,7 @@ impl Bridge {
             .await
             .expect("Error serving block range in test mode.");
             if let HistoryContentKey::BlockHeaderWithProof(_) = asset.content_key {
-                sleep(Duration::from_secs(HEADER_SATURATION_DELAY)).await;
+                sleep(Duration::from_secs(1)).await;
             }
         }
     }

--- a/portal-bridge/src/bridge.rs
+++ b/portal-bridge/src/bridge.rs
@@ -94,7 +94,7 @@ impl Bridge {
             .await
             .expect("Error serving block range in test mode.");
             if let HistoryContentKey::BlockHeaderWithProof(_) = asset.content_key {
-                sleep(Duration::from_millis(100)).await;
+                sleep(Duration::from_millis(50)).await;
             }
         }
     }

--- a/portal-bridge/src/bridge.rs
+++ b/portal-bridge/src/bridge.rs
@@ -94,7 +94,7 @@ impl Bridge {
             .await
             .expect("Error serving block range in test mode.");
             if let HistoryContentKey::BlockHeaderWithProof(_) = asset.content_key {
-                sleep(Duration::from_secs(1)).await;
+                sleep(Duration::from_millis(100)).await;
             }
         }
     }


### PR DESCRIPTION
### What was wrong?
When using history bridge in test mode headers didn't have enough time to be propagated so block bodies and receipts would fail randomly.
### How was it fixed?
By adding the same delay used in the serve block code which was used for the same reason
