### PR TITLE
Better handle nodes in propagate gossip cross thread when none are connected

### DIFF
--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -2513,7 +2513,6 @@ pub fn propagate_gossip_cross_thread<TContentKey: OverlayContentKey>(
         .collect();
 
     if all_nodes.is_empty() {
-        // If there are no connected nodes, use the nodes regardless of connectivity.
         warn!("No connected nodes, using disconnected nodes for gossip.");
         all_nodes = kbuckets
             .buckets_iter()

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -2502,7 +2502,7 @@ pub fn propagate_gossip_cross_thread<TContentKey: OverlayContentKey>(
 ) -> usize {
     // Get all connected nodes from overlay routing table
     let kbuckets = kbuckets.read();
-    let all_nodes: Vec<&kbucket::Node<NodeId, Node>> = kbuckets
+    let mut all_nodes: Vec<&kbucket::Node<NodeId, Node>> = kbuckets
         .buckets_iter()
         .flat_map(|kbucket| {
             kbucket
@@ -2511,6 +2511,25 @@ pub fn propagate_gossip_cross_thread<TContentKey: OverlayContentKey>(
                 .collect::<Vec<&kbucket::Node<NodeId, Node>>>()
         })
         .collect();
+
+    if all_nodes.is_empty() {
+        // If there are no connected nodes, use the nodes regardless of connectivity.
+        warn!("No connected nodes, using disconnected nodes for gossip.");
+        all_nodes = kbuckets
+            .buckets_iter()
+            .flat_map(|kbucket| {
+                kbucket
+                    .iter()
+                    .collect::<Vec<&kbucket::Node<NodeId, Node>>>()
+            })
+            .collect();
+    }
+
+    if all_nodes.is_empty() {
+        // If there are no nodes whatsoever in the routing table the gossip cannot proceed.
+        warn!("No nodes in routing table, gossip cannot proceed.");
+        return 0;
+    }
 
     // HashMap to temporarily store all interested ENRs and the content.
     // Key is base64 string of node's ENR.


### PR DESCRIPTION
### What was wrong?
If there was no connected nodes, we would go into the forloop then our code would fail since it had no connected nodes which was confusing when trying to debug.
### How was it fixed?
I gave this function the same treatment Mike gave for ``init_find_content_query``. We shouldn't go into the forloop if we don't have any nodes to gossip to in the first place.
