### PR TITLE
Enable communication between overlays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4394,6 +4394,7 @@ dependencies = [
  "test-log",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-test",
  "tracing",
  "tracing-subscriber",
@@ -6623,6 +6624,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util 0.7.9",
 ]
 
 [[package]]

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -49,6 +49,7 @@ trin-validation = { path="../trin-validation" }
 validator = { version = "0.13.0", features = ["derive"] }
 url = "2.3.1"
 utp-rs = "0.1.0-alpha.8"
+tokio-stream = { version = "0.1.14", features = ["sync"] }
 
 [target.'cfg(windows)'.dependencies]
 uds_windows = "1.0.1"

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -2619,7 +2619,7 @@ where
     }
 
     /// Send `OverlayEvent` to the event stream.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // TODO: remove when used
     fn send_event(&self, event: OverlayEvent, to: Option<Vec<ProtocolId>>) {
         trace!(
             "Sending event={:?} to event-stream from protocol {}",

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -1009,6 +1009,7 @@ where
         }
     }
 
+    /// Process an event dispatched by another overlay on the discovery.
     fn process_event(&mut self, _event: EventEnvelope) {}
 
     /// Attempts to build a response for a request.
@@ -2619,13 +2620,13 @@ where
 
     /// Send `OverlayEvent` to the event stream.
     #[allow(dead_code)]
-    fn send_event(&self, event: OverlayEvent) {
+    fn send_event(&self, event: OverlayEvent, to: Option<Vec<ProtocolId>>) {
         trace!(
             "Sending event={:?} to event-stream from protocol {}",
             event,
             self.protocol
         );
-        let event = EventEnvelope::new(event, self.protocol);
+        let event = EventEnvelope::new(event, self.protocol, to);
         if let Err(err) = self.event_stream.send(event) {
             error!(
                 error = %err,
@@ -4008,7 +4009,7 @@ mod tests {
         let (sender, mut receiver) = broadcast::channel(1);
         service.event_stream = sender;
         // Emit LightClientUpdate event
-        service.send_event(OverlayEvent::LightClientOptimisticUpdate);
+        service.send_event(OverlayEvent::LightClientOptimisticUpdate, None);
         // Check that the event is received
         let event = receiver.recv().await.unwrap();
         assert_eq!(event.payload, OverlayEvent::LightClientOptimisticUpdate);

--- a/portalnet/src/types/messages.rs
+++ b/portalnet/src/types/messages.rs
@@ -161,7 +161,7 @@ pub enum ProtocolIdError {
 }
 
 /// Protocol identifiers
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ProtocolId {
     State,
     History,

--- a/tests/rpc_server.rs
+++ b/tests/rpc_server.rs
@@ -115,7 +115,9 @@ async fn test_eth_get_block_by_hash() {
         u64_to_ethers_u256(hwp.header.timestamp),
     );
 
-    let BlockBody::Shanghai(shanghai_body) = body.clone() else { panic!("expected shanghai body") };
+    let BlockBody::Shanghai(shanghai_body) = body.clone() else {
+        panic!("expected shanghai body")
+    };
 
     // Store header with proof in server
     let content_key = HistoryContentKey::BlockHeaderWithProof(block_hash.into());

--- a/trin-beacon/src/events.rs
+++ b/trin-beacon/src/events.rs
@@ -24,38 +24,43 @@ impl BeaconEvents {
         }
     }
 
-    /// Handle beacon network TalkRequest event
+    /// Handle beacon network OverlayRequest.
     fn handle_beacon_message(&self, msg: OverlayRequest) {
         let network = Arc::clone(&self.network);
         tokio::spawn(async move {
             match msg {
                 OverlayRequest::Talk(talk_request) => {
-                    let talk_request_id = talk_request.id().clone();
-                    let reply = match network
-                        .overlay
-                        .process_one_request(&talk_request)
-                        .instrument(tracing::info_span!("beacon_network", req = %talk_request_id))
-                        .await
-                    {
-                        Ok(response) => Message::from(response).into(),
-                        Err(error) => {
-                            error!(
-                                error = %error,
-                                request.discv5.id = %talk_request_id,
-                                "Error processing portal beacon request, responding with empty TALKRESP"
-                            );
-                            // Return an empty TALKRESP if there was an error executing the request
-                            "".into()
-                        }
-                    };
-                    if let Err(error) = talk_request.respond(reply) {
-                        warn!(error = %error, request.discv5.id = %talk_request_id, "Error responding to TALKREQ");
-                    }
+                    Self::handle_talk_request(talk_request, &network).await
                 }
                 OverlayRequest::Event(event) => {
                     let _ = network.overlay.process_one_event(event).await;
                 }
             }
         });
+    }
+
+    /// Handle beacon network TALKREQ message.
+    async fn handle_talk_request(request: discv5::TalkRequest, network: &Arc<BeaconNetwork>) {
+        let talk_request_id = request.id().clone();
+        let reply = match network
+            .overlay
+            .process_one_request(&request)
+            .instrument(tracing::info_span!("beacon_network", req = %talk_request_id))
+            .await
+        {
+            Ok(response) => Message::from(response).into(),
+            Err(error) => {
+                error!(
+                    error = %error,
+                    request.discv5.id = %talk_request_id,
+                    "Error processing portal beacon request, responding with empty TALKRESP"
+                );
+                // Return an empty TALKRESP if there was an error executing the request
+                "".into()
+            }
+        };
+        if let Err(error) = request.respond(reply) {
+            warn!(error = %error, request.discv5.id = %talk_request_id, "Error responding to TALKREQ");
+        }
     }
 }

--- a/trin-beacon/src/events.rs
+++ b/trin-beacon/src/events.rs
@@ -1,5 +1,5 @@
 use crate::network::BeaconNetwork;
-use discv5::TalkRequest;
+use portalnet::events::OverlayRequest;
 use portalnet::types::messages::Message;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -7,15 +7,15 @@ use tracing::{error, warn, Instrument};
 
 pub struct BeaconEvents {
     pub network: Arc<BeaconNetwork>,
-    pub event_rx: UnboundedReceiver<TalkRequest>,
+    pub message_rx: UnboundedReceiver<OverlayRequest>,
 }
 
 impl BeaconEvents {
     pub async fn start(mut self) {
         loop {
             tokio::select! {
-                Some(talk_request) = self.event_rx.recv() => {
-                    self.handle_beacon_talk_request(talk_request);
+                Some(msg) = self.message_rx.recv() => {
+                    self.handle_beacon_message(msg);
                 } else => {
                     error!("Beacon event channel closed, shutting down");
                     break;
@@ -25,29 +25,36 @@ impl BeaconEvents {
     }
 
     /// Handle beacon network TalkRequest event
-    fn handle_beacon_talk_request(&self, talk_request: TalkRequest) {
+    fn handle_beacon_message(&self, msg: OverlayRequest) {
         let network = Arc::clone(&self.network);
-        let talk_request_id = talk_request.id().clone();
         tokio::spawn(async move {
-            let reply = match network
-                .overlay
-                .process_one_request(&talk_request)
-                .instrument(tracing::info_span!("beacon_network", req = %talk_request_id))
-                .await
-            {
-                Ok(response) => Message::from(response).into(),
-                Err(error) => {
-                    error!(
-                        error = %error,
-                        request.discv5.id = %talk_request_id,
-                        "Error processing portal beacon request, responding with empty TALKRESP"
-                    );
-                    // Return an empty TALKRESP if there was an error executing the request
-                    "".into()
+            match msg {
+                OverlayRequest::Talk(talk_request) => {
+                    let talk_request_id = talk_request.id().clone();
+                    let reply = match network
+                        .overlay
+                        .process_one_request(&talk_request)
+                        .instrument(tracing::info_span!("beacon_network", req = %talk_request_id))
+                        .await
+                    {
+                        Ok(response) => Message::from(response).into(),
+                        Err(error) => {
+                            error!(
+                                error = %error,
+                                request.discv5.id = %talk_request_id,
+                                "Error processing portal beacon request, responding with empty TALKRESP"
+                            );
+                            // Return an empty TALKRESP if there was an error executing the request
+                            "".into()
+                        }
+                    };
+                    if let Err(error) = talk_request.respond(reply) {
+                        warn!(error = %error, request.discv5.id = %talk_request_id, "Error responding to TALKREQ");
+                    }
                 }
-            };
-            if let Err(error) = talk_request.respond(reply) {
-                warn!(error = %error, request.discv5.id = %talk_request_id, "Error responding to TALKREQ");
+                OverlayRequest::Event(event) => {
+                    let _ = network.overlay.process_one_event(event).await;
+                }
             }
         });
     }

--- a/trin-beacon/src/lib.rs
+++ b/trin-beacon/src/lib.rs
@@ -7,9 +7,8 @@ pub mod validation;
 
 use std::sync::Arc;
 
-use discv5::TalkRequest;
 use tokio::{
-    sync::{mpsc, Mutex, RwLock},
+    sync::{broadcast, mpsc, Mutex, RwLock},
     task::JoinHandle,
     time::{interval, Duration},
 };
@@ -23,14 +22,16 @@ use ethportal_api::types::jsonrpc::request::BeaconJsonRpcRequest;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
+    events::{EventEnvelope, OverlayRequest},
     storage::PortalStorageConfig,
 };
 use trin_validation::oracle::HeaderOracle;
 
 type BeaconHandler = Option<BeaconRequestHandler>;
 type BeaconNetworkTask = Option<JoinHandle<()>>;
-type BeaconEventTx = Option<mpsc::UnboundedSender<TalkRequest>>;
+type BeaconMessageTx = Option<mpsc::UnboundedSender<OverlayRequest>>;
 type BeaconJsonRpcTx = Option<mpsc::UnboundedSender<BeaconJsonRpcRequest>>;
+type BeaconEventStream = Option<broadcast::Receiver<EventEnvelope>>;
 
 pub async fn initialize_beacon_network(
     discovery: &Arc<Discovery>,
@@ -42,12 +43,13 @@ pub async fn initialize_beacon_network(
 ) -> anyhow::Result<(
     BeaconHandler,
     BeaconNetworkTask,
-    BeaconEventTx,
+    BeaconMessageTx,
     BeaconJsonRpcTx,
+    BeaconEventStream,
 )> {
     let (beacon_jsonrpc_tx, beacon_jsonrpc_rx) = mpsc::unbounded_channel::<BeaconJsonRpcRequest>();
     header_oracle.write().await.beacon_jsonrpc_tx = Some(beacon_jsonrpc_tx.clone());
-    let (beacon_event_tx, beacon_event_rx) = mpsc::unbounded_channel::<TalkRequest>();
+    let (beacon_message_tx, beacon_message_rx) = mpsc::unbounded_channel::<OverlayRequest>();
     let beacon_network = BeaconNetwork::new(
         Arc::clone(discovery),
         utp_socket,
@@ -56,26 +58,28 @@ pub async fn initialize_beacon_network(
         header_oracle,
     )
     .await?;
+    let beacon_event_stream = beacon_network.overlay.event_stream().await?;
     let beacon_handler = BeaconRequestHandler {
         network: Arc::new(RwLock::new(beacon_network.clone())),
         rpc_rx: Arc::new(Mutex::new(beacon_jsonrpc_rx)),
     };
     let beacon_network = Arc::new(beacon_network);
     let beacon_network_task =
-        spawn_beacon_network(beacon_network.clone(), portalnet_config, beacon_event_rx);
+        spawn_beacon_network(beacon_network.clone(), portalnet_config, beacon_message_rx);
     spawn_beacon_heartbeat(beacon_network);
     Ok((
         Some(beacon_handler),
         Some(beacon_network_task),
-        Some(beacon_event_tx),
+        Some(beacon_message_tx),
         Some(beacon_jsonrpc_tx),
+        Some(beacon_event_stream),
     ))
 }
 
 pub fn spawn_beacon_network(
     network: Arc<BeaconNetwork>,
     portalnet_config: PortalnetConfig,
-    beacon_event_rx: mpsc::UnboundedReceiver<TalkRequest>,
+    beacon_message_rx: mpsc::UnboundedReceiver<OverlayRequest>,
 ) -> JoinHandle<()> {
     let bootnode_enrs: Vec<Enr> = portalnet_config.bootnodes.into();
     info!(
@@ -86,7 +90,7 @@ pub fn spawn_beacon_network(
     tokio::spawn(async move {
         let beacon_events = BeaconEvents {
             network: Arc::clone(&network),
-            event_rx: beacon_event_rx,
+            message_rx: beacon_message_rx,
         };
 
         // Spawn beacon event handler

--- a/trin-history/src/events.rs
+++ b/trin-history/src/events.rs
@@ -1,5 +1,5 @@
 use crate::network::HistoryNetwork;
-use discv5::TalkRequest;
+use portalnet::events::OverlayRequest;
 use portalnet::types::messages::Message;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -7,15 +7,15 @@ use tracing::{error, warn, Instrument};
 
 pub struct HistoryEvents {
     pub network: Arc<HistoryNetwork>,
-    pub event_rx: UnboundedReceiver<TalkRequest>,
+    pub message_rx: UnboundedReceiver<OverlayRequest>,
 }
 
 impl HistoryEvents {
     pub async fn start(mut self) {
         loop {
             tokio::select! {
-                Some(talk_request) = self.event_rx.recv() => {
-                    self.handle_history_talk_request(talk_request);
+                Some(msg) = self.message_rx.recv() => {
+                    self.handle_history_message(msg);
                 } else => {
                     error!("History event channel closed, shutting down");
                     break;
@@ -25,29 +25,36 @@ impl HistoryEvents {
     }
 
     /// Handle history network TalkRequest event
-    fn handle_history_talk_request(&self, talk_request: TalkRequest) {
+    fn handle_history_message(&self, msg: OverlayRequest) {
         let network = Arc::clone(&self.network);
-        let talk_request_id = talk_request.id().clone();
         tokio::spawn(async move {
-            let reply = match network
-                .overlay
-                .process_one_request(&talk_request)
-                .instrument(tracing::info_span!("history_network", req = %talk_request_id))
-                .await
-            {
-                Ok(response) => Message::from(response).into(),
-                Err(error) => {
-                    error!(
-                        error = %error,
-                        request.discv5.id = %talk_request_id,
-                        "Error processing portal history request, responding with empty TALKRESP"
-                    );
-                    // Return an empty TALKRESP if there was an error executing the request
-                    "".into()
+            match msg {
+                OverlayRequest::Talk(talk_request) => {
+                    let talk_request_id = talk_request.id().clone();
+                    let reply = match network
+                        .overlay
+                        .process_one_request(&talk_request)
+                        .instrument(tracing::info_span!("history_network", req = %talk_request_id))
+                        .await
+                    {
+                        Ok(response) => Message::from(response).into(),
+                        Err(error) => {
+                            error!(
+                                error = %error,
+                                request.discv5.id = %talk_request_id,
+                                "Error processing portal history request, responding with empty TALKRESP"
+                            );
+                            // Return an empty TALKRESP if there was an error executing the request
+                            "".into()
+                        }
+                    };
+                    if let Err(error) = talk_request.respond(reply) {
+                        warn!(error = %error, request.discv5.id = %talk_request_id, "Error responding to TALKREQ");
+                    }
                 }
-            };
-            if let Err(error) = talk_request.respond(reply) {
-                warn!(error = %error, request.discv5.id = %talk_request_id, "Error responding to TALKREQ");
+                OverlayRequest::Event(event) => {
+                    let _ = network.overlay.process_one_event(event).await;
+                }
             }
         });
     }

--- a/trin-history/src/events.rs
+++ b/trin-history/src/events.rs
@@ -24,38 +24,43 @@ impl HistoryEvents {
         }
     }
 
-    /// Handle history network TalkRequest event
+    /// Handle history network OverlayRequest.
     fn handle_history_message(&self, msg: OverlayRequest) {
         let network = Arc::clone(&self.network);
         tokio::spawn(async move {
             match msg {
                 OverlayRequest::Talk(talk_request) => {
-                    let talk_request_id = talk_request.id().clone();
-                    let reply = match network
-                        .overlay
-                        .process_one_request(&talk_request)
-                        .instrument(tracing::info_span!("history_network", req = %talk_request_id))
-                        .await
-                    {
-                        Ok(response) => Message::from(response).into(),
-                        Err(error) => {
-                            error!(
-                                error = %error,
-                                request.discv5.id = %talk_request_id,
-                                "Error processing portal history request, responding with empty TALKRESP"
-                            );
-                            // Return an empty TALKRESP if there was an error executing the request
-                            "".into()
-                        }
-                    };
-                    if let Err(error) = talk_request.respond(reply) {
-                        warn!(error = %error, request.discv5.id = %talk_request_id, "Error responding to TALKREQ");
-                    }
+                    Self::handle_talk_request(talk_request, &network).await
                 }
                 OverlayRequest::Event(event) => {
                     let _ = network.overlay.process_one_event(event).await;
                 }
             }
         });
+    }
+
+    /// Handle history network TALKREQ message.
+    async fn handle_talk_request(request: discv5::TalkRequest, network: &Arc<HistoryNetwork>) {
+        let talk_request_id = request.id().clone();
+        let reply = match network
+            .overlay
+            .process_one_request(&request)
+            .instrument(tracing::info_span!("history_network", req = %talk_request_id))
+            .await
+        {
+            Ok(response) => Message::from(response).into(),
+            Err(error) => {
+                error!(
+                    error = %error,
+                    request.discv5.id = %talk_request_id,
+                    "Error processing portal history request, responding with empty TALKRESP"
+                );
+                // Return an empty TALKRESP if there was an error executing the request
+                "".into()
+            }
+        };
+        if let Err(error) = request.respond(reply) {
+            warn!(error = %error, request.discv5.id = %talk_request_id, "Error responding to TALKREQ");
+        }
     }
 }

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -8,10 +8,9 @@ pub mod validation;
 
 use std::sync::Arc;
 
-use discv5::TalkRequest;
 use network::HistoryNetwork;
 use tokio::{
-    sync::{mpsc, Mutex, RwLock},
+    sync::{broadcast, mpsc, Mutex, RwLock},
     task::JoinHandle,
     time::{interval, Duration},
 };
@@ -24,14 +23,16 @@ use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
+    events::{EventEnvelope, OverlayRequest},
     storage::PortalStorageConfig,
 };
 use trin_validation::oracle::HeaderOracle;
 
 type HistoryHandler = Option<HistoryRequestHandler>;
 type HistoryNetworkTask = Option<JoinHandle<()>>;
-type HistoryEventTx = Option<mpsc::UnboundedSender<TalkRequest>>;
+type HistoryMessageTx = Option<mpsc::UnboundedSender<OverlayRequest>>;
 type HistoryJsonRpcTx = Option<mpsc::UnboundedSender<HistoryJsonRpcRequest>>;
+type HistoryEventStream = Option<broadcast::Receiver<EventEnvelope>>;
 
 pub async fn initialize_history_network(
     discovery: &Arc<Discovery>,
@@ -43,13 +44,14 @@ pub async fn initialize_history_network(
 ) -> anyhow::Result<(
     HistoryHandler,
     HistoryNetworkTask,
-    HistoryEventTx,
+    HistoryMessageTx,
     HistoryJsonRpcTx,
+    HistoryEventStream,
 )> {
     let (history_jsonrpc_tx, history_jsonrpc_rx) =
         mpsc::unbounded_channel::<HistoryJsonRpcRequest>();
     header_oracle.write().await.history_jsonrpc_tx = Some(history_jsonrpc_tx.clone());
-    let (history_event_tx, history_event_rx) = mpsc::unbounded_channel::<TalkRequest>();
+    let (history_event_tx, history_event_rx) = mpsc::unbounded_channel::<OverlayRequest>();
     let history_network = HistoryNetwork::new(
         Arc::clone(discovery),
         utp_socket,
@@ -58,6 +60,7 @@ pub async fn initialize_history_network(
         header_oracle,
     )
     .await?;
+    let event_stream = history_network.overlay.event_stream().await?;
     let history_handler = HistoryRequestHandler {
         network: Arc::new(RwLock::new(history_network.clone())),
         history_rx: Arc::new(Mutex::new(history_jsonrpc_rx)),
@@ -71,13 +74,14 @@ pub async fn initialize_history_network(
         Some(history_network_task),
         Some(history_event_tx),
         Some(history_jsonrpc_tx),
+        Some(event_stream),
     ))
 }
 
 pub fn spawn_history_network(
     network: Arc<HistoryNetwork>,
     portalnet_config: PortalnetConfig,
-    history_event_rx: mpsc::UnboundedReceiver<TalkRequest>,
+    history_message_rx: mpsc::UnboundedReceiver<OverlayRequest>,
 ) -> JoinHandle<()> {
     let bootnode_enrs: Vec<Enr> = portalnet_config.bootnodes.into();
     info!(
@@ -88,7 +92,7 @@ pub fn spawn_history_network(
     tokio::spawn(async move {
         let history_events = HistoryEvents {
             network: Arc::clone(&network),
-            event_rx: history_event_rx,
+            message_rx: history_message_rx,
         };
 
         // Spawn history event handler

--- a/trin-state/src/events.rs
+++ b/trin-state/src/events.rs
@@ -1,5 +1,5 @@
 use crate::network::StateNetwork;
-use discv5::TalkRequest;
+use portalnet::events::OverlayRequest;
 use portalnet::types::messages::Message;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -7,15 +7,15 @@ use tracing::{error, warn, Instrument};
 
 pub struct StateEvents {
     pub network: Arc<StateNetwork>,
-    pub event_rx: UnboundedReceiver<TalkRequest>,
+    pub message_rx: UnboundedReceiver<OverlayRequest>,
 }
 
 impl StateEvents {
     pub async fn start(mut self) {
         loop {
             tokio::select! {
-                Some(talk_request) = self.event_rx.recv() => {
-                    self.handle_state_talk_request(talk_request);
+                Some(msg) = self.message_rx.recv() => {
+                    self.handle_state_message(msg);
                 } else => {
                     error!("State event channel closed, shutting down");
                     break;
@@ -25,29 +25,36 @@ impl StateEvents {
     }
 
     /// Handle state network TalkRequest event
-    fn handle_state_talk_request(&self, talk_request: TalkRequest) {
+    fn handle_state_message(&self, msg: OverlayRequest) {
         let network = Arc::clone(&self.network);
-        let talk_request_id = talk_request.id().clone();
         tokio::spawn(async move {
-            let reply = match network
-                .overlay
-                .process_one_request(&talk_request)
-                .instrument(tracing::info_span!("state_network"))
-                .await
-            {
-                Ok(response) => Message::from(response).into(),
-                Err(error) => {
-                    error!(
-                        error = %error,
-                        request.discv5.id = %talk_request_id,
-                        "Error processing portal state request, responding with empty TALKRESP."
-                    );
-                    // Return an empty TALKRESP if there was an error executing the request
-                    "".into()
+            match msg {
+                OverlayRequest::Talk(talk_request) => {
+                    let talk_request_id = talk_request.id().clone();
+                    let reply = match network
+                        .overlay
+                        .process_one_request(&talk_request)
+                        .instrument(tracing::info_span!("state_network", req = %talk_request_id))
+                        .await
+                    {
+                        Ok(response) => Message::from(response).into(),
+                        Err(error) => {
+                            error!(
+                                error = %error,
+                                request.discv5.id = %talk_request_id,
+                                "Error processing portal state request, responding with empty TALKRESP"
+                            );
+                            // Return an empty TALKRESP if there was an error executing the request
+                            "".into()
+                        }
+                    };
+                    if let Err(error) = talk_request.respond(reply) {
+                        warn!(error = %error, request.discv5.id = %talk_request_id, "Error responding to TALKREQ");
+                    }
                 }
-            };
-            if let Err(error) = talk_request.respond(reply) {
-                warn!(error = %error, request.discv5.id = %talk_request_id, "Error responding to TALKREQ");
+                OverlayRequest::Event(event) => {
+                    let _ = network.overlay.process_one_event(event).await;
+                }
             }
         });
     }

--- a/trin-state/src/events.rs
+++ b/trin-state/src/events.rs
@@ -24,38 +24,43 @@ impl StateEvents {
         }
     }
 
-    /// Handle state network TalkRequest event
+    /// Handle state network OverlayRequest.
     fn handle_state_message(&self, msg: OverlayRequest) {
         let network = Arc::clone(&self.network);
         tokio::spawn(async move {
             match msg {
                 OverlayRequest::Talk(talk_request) => {
-                    let talk_request_id = talk_request.id().clone();
-                    let reply = match network
-                        .overlay
-                        .process_one_request(&talk_request)
-                        .instrument(tracing::info_span!("state_network", req = %talk_request_id))
-                        .await
-                    {
-                        Ok(response) => Message::from(response).into(),
-                        Err(error) => {
-                            error!(
-                                error = %error,
-                                request.discv5.id = %talk_request_id,
-                                "Error processing portal state request, responding with empty TALKRESP"
-                            );
-                            // Return an empty TALKRESP if there was an error executing the request
-                            "".into()
-                        }
-                    };
-                    if let Err(error) = talk_request.respond(reply) {
-                        warn!(error = %error, request.discv5.id = %talk_request_id, "Error responding to TALKREQ");
-                    }
+                    Self::handle_talk_request(talk_request, &network).await
                 }
                 OverlayRequest::Event(event) => {
                     let _ = network.overlay.process_one_event(event).await;
                 }
             }
         });
+    }
+
+    /// Handle state network TALKREQ message.
+    async fn handle_talk_request(request: discv5::TalkRequest, network: &Arc<StateNetwork>) {
+        let talk_request_id = request.id().clone();
+        let reply = match network
+            .overlay
+            .process_one_request(&request)
+            .instrument(tracing::info_span!("state_network", req = %talk_request_id))
+            .await
+        {
+            Ok(response) => Message::from(response).into(),
+            Err(error) => {
+                error!(
+                    error = %error,
+                    request.discv5.id = %talk_request_id,
+                    "Error processing portal state request, responding with empty TALKRESP"
+                );
+                // Return an empty TALKRESP if there was an error executing the request
+                "".into()
+            }
+        };
+        if let Err(error) = request.respond(reply) {
+            warn!(error = %error, request.discv5.id = %talk_request_id, "Error responding to TALKREQ");
+        }
     }
 }

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -2,10 +2,9 @@
 
 use std::sync::Arc;
 
-use discv5::TalkRequest;
 use network::StateNetwork;
 use tokio::{
-    sync::{mpsc, RwLock},
+    sync::{broadcast, mpsc, RwLock},
     task::JoinHandle,
 };
 use tracing::info;
@@ -17,6 +16,7 @@ use ethportal_api::types::jsonrpc::request::StateJsonRpcRequest;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
+    events::{EventEnvelope, OverlayRequest},
     storage::PortalStorageConfig,
 };
 use trin_validation::oracle::HeaderOracle;
@@ -30,8 +30,9 @@ pub mod validation;
 
 type StateHandler = Option<StateRequestHandler>;
 type StateNetworkTask = Option<JoinHandle<()>>;
-type StateEventTx = Option<mpsc::UnboundedSender<TalkRequest>>;
+type StateEventTx = Option<mpsc::UnboundedSender<OverlayRequest>>;
 type StateJsonRpcTx = Option<mpsc::UnboundedSender<StateJsonRpcRequest>>;
+type StateEventStream = Option<broadcast::Receiver<EventEnvelope>>;
 
 pub async fn initialize_state_network(
     discovery: &Arc<Discovery>,
@@ -39,9 +40,15 @@ pub async fn initialize_state_network(
     portalnet_config: PortalnetConfig,
     storage_config: PortalStorageConfig,
     header_oracle: Arc<RwLock<HeaderOracle>>,
-) -> anyhow::Result<(StateHandler, StateNetworkTask, StateEventTx, StateJsonRpcTx)> {
+) -> anyhow::Result<(
+    StateHandler,
+    StateNetworkTask,
+    StateEventTx,
+    StateJsonRpcTx,
+    StateEventStream,
+)> {
     let (state_jsonrpc_tx, state_jsonrpc_rx) = mpsc::unbounded_channel::<StateJsonRpcRequest>();
-    let (state_event_tx, state_event_rx) = mpsc::unbounded_channel::<TalkRequest>();
+    let (state_event_tx, state_event_rx) = mpsc::unbounded_channel::<OverlayRequest>();
     let state_network = StateNetwork::new(
         Arc::clone(discovery),
         utp_socket,
@@ -51,6 +58,7 @@ pub async fn initialize_state_network(
     )
     .await?;
     let state_network = Arc::new(state_network);
+    let state_event_stream = state_network.overlay.event_stream().await?;
     let state_handler = StateRequestHandler {
         network: Arc::clone(&state_network),
         state_rx: state_jsonrpc_rx,
@@ -62,13 +70,14 @@ pub async fn initialize_state_network(
         Some(state_network_task),
         Some(state_event_tx),
         Some(state_jsonrpc_tx),
+        Some(state_event_stream),
     ))
 }
 
 pub fn spawn_state_network(
     network: Arc<StateNetwork>,
     portalnet_config: PortalnetConfig,
-    state_event_rx: mpsc::UnboundedReceiver<TalkRequest>,
+    state_message_rx: mpsc::UnboundedReceiver<OverlayRequest>,
 ) -> JoinHandle<()> {
     let bootnode_enrs: Vec<Enr> = portalnet_config.bootnodes.into();
     info!(
@@ -79,7 +88,7 @@ pub fn spawn_state_network(
     tokio::spawn(async move {
         let state_events = StateEvents {
             network: Arc::clone(&network),
-            event_rx: state_event_rx,
+            message_rx: state_message_rx,
         };
 
         // Spawn state event handler


### PR DESCRIPTION
This pull enables the portalnets handler to subscribe to the event stream of each of the overlays it handles, and redistribute events to all overlays except the one that emits it. This allows an event discovered on one layer to be useful across multiple others.

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
