### PR TITLE
feat: support eth_getBlockByHash over json-rpc (only with header fields, for now)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5254,6 +5254,7 @@ dependencies = [
  "hyper",
  "portalnet",
  "reth-ipc",
+ "reth-rpc-types",
  "serde",
  "serde_json",
  "strum 0.24.1",

--- a/ethportal-api/src/eth.rs
+++ b/ethportal-api/src/eth.rs
@@ -1,9 +1,17 @@
-use ethereum_types::U256;
+use ethereum_types::{H256, U256};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use reth_rpc_types::Block;
 
 /// Web3 JSON-RPC endpoints
 #[rpc(client, server, namespace = "eth")]
 pub trait EthApi {
     #[method(name = "chainId")]
     async fn chain_id(&self) -> RpcResult<U256>;
+
+    #[method(name = "getBlockByHash")]
+    async fn get_block_by_hash(
+        &self,
+        block_hash: H256,
+        hydrated_transactions: bool,
+    ) -> RpcResult<Block>;
 }

--- a/ethportal-api/src/types/content_key/history.rs
+++ b/ethportal-api/src/types/content_key/history.rs
@@ -67,10 +67,17 @@ pub struct BlockHeaderKey {
     pub block_hash: [u8; 32],
 }
 
+impl From<H256> for BlockHeaderKey {
+    fn from(block_hash: H256) -> Self {
+        Self {
+            block_hash: block_hash.to_fixed_bytes(),
+        }
+    }
+}
+
 /// A key for a block body.
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
 pub struct BlockBodyKey {
-    /// Chain identifier.
     /// Hash of the block.
     pub block_hash: [u8; 32],
 }
@@ -78,7 +85,6 @@ pub struct BlockBodyKey {
 /// A key for the transaction receipts for a block.
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
 pub struct BlockReceiptsKey {
-    /// Chain identifier.
     /// Hash of the block.
     pub block_hash: [u8; 32],
 }

--- a/ethportal-api/src/types/execution/header.rs
+++ b/ethportal-api/src/types/execution/header.rs
@@ -219,7 +219,7 @@ impl From<Header> for RpcHeader {
             timestamp,
             extra_data,
             mix_hash,
-            nonce: _,
+            nonce,
             base_fee_per_gas,
             withdrawals_root,
         } = header;
@@ -241,7 +241,13 @@ impl From<Header> for RpcHeader {
             mix_hash: mix_hash
                 .map(|mh| mh.to_fixed_bytes().into())
                 .unwrap_or_default(),
-            nonce: None,
+            // A note on nonce:
+            // ethportal-api and reth both use ethereum-types::H64 for nonce. Unfortunately, we use
+            // v0.12.1 of ethereum-types, which is different from reth, so the value can't be
+            // transparently reused.
+            // Further, if we upgrade to 0.14.1, then we lose SSZ encoding, so we are stuck leaving
+            // the versions different and converting here:
+            nonce: nonce.map(|h64| h64.as_fixed_bytes().into()),
             base_fee_per_gas: base_fee_per_gas.map(u256_to_uint256),
             withdrawals_root: withdrawals_root.map(|root| root.to_fixed_bytes().into()),
             blob_gas_used: None,

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -21,6 +21,7 @@ trin-utils = { path = "../trin-utils"}
 tokio = { version = "1.14.0", features = ["full"] }
 hyper = "0.14"
 reth-ipc = { version = "0.1.0-alpha.6", git = "https://github.com/paradigmxyz/reth.git"}
+reth-rpc-types = { version = "0.1.0-alpha.6", git = "https://github.com/paradigmxyz/reth.git"}
 url = "2.3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.95"

--- a/rpc/src/builder.rs
+++ b/rpc/src/builder.rs
@@ -402,7 +402,13 @@ impl RpcModuleBuilder {
                         PortalRpcModule::Discv5 => {
                             Discv5Api::new(self.discv5.clone()).into_rpc().into()
                         }
-                        PortalRpcModule::Eth => EthApi.into_rpc().into(),
+                        PortalRpcModule::Eth => {
+                            let history_tx = self
+                                .history_tx
+                                .clone()
+                                .expect("History protocol not initialized");
+                            EthApi::new(history_tx).into_rpc().into()
+                        }
                         PortalRpcModule::History => {
                             let history_tx = self
                                 .history_tx

--- a/rpc/src/eth_rpc.rs
+++ b/rpc/src/eth_rpc.rs
@@ -1,19 +1,22 @@
-use crate::jsonrpsee::core::{async_trait, RpcResult};
-use ethereum_types::U256;
+use ethereum_types::{H256, U256};
+use reth_rpc_types::{Block, BlockTransactions};
+use tokio::sync::mpsc;
+
+use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
 use ethportal_api::EthApiServer;
 use trin_validation::constants::CHAIN_ID;
 
-pub struct EthApi;
+use crate::errors::RpcServeError;
+use crate::fetch::find_header_by_hash;
+use crate::jsonrpsee::core::{async_trait, RpcResult};
 
-impl EthApi {
-    pub fn new() -> Self {
-        Self
-    }
+pub struct EthApi {
+    network: mpsc::UnboundedSender<HistoryJsonRpcRequest>,
 }
 
-impl Default for EthApi {
-    fn default() -> Self {
-        Self::new()
+impl EthApi {
+    pub fn new(network: mpsc::UnboundedSender<HistoryJsonRpcRequest>) -> Self {
+        Self { network }
     }
 }
 
@@ -21,6 +24,32 @@ impl Default for EthApi {
 impl EthApiServer for EthApi {
     async fn chain_id(&self) -> RpcResult<U256> {
         Ok(U256::from(CHAIN_ID))
+    }
+
+    async fn get_block_by_hash(
+        &self,
+        block_hash: H256,
+        hydrated_transactions: bool,
+    ) -> RpcResult<Block> {
+        if hydrated_transactions {
+            return Err(RpcServeError::Message(
+                "replying with all transaction bodies is not supported yet".into(),
+            )
+            .into());
+        }
+
+        let header = find_header_by_hash(&self.network, block_hash).await?;
+
+        // Combine header and block body into the single json representation of the block.
+        let block = Block {
+            header: header.into(),
+            transactions: BlockTransactions::Uncle,
+            uncles: vec![],
+            size: None,
+            total_difficulty: None,
+            withdrawals: None,
+        };
+        Ok(block)
     }
 }
 

--- a/rpc/src/fetch.rs
+++ b/rpc/src/fetch.rs
@@ -1,9 +1,14 @@
 /// Fetch data from related Portal networks
+use ethereum_types::H256;
 use serde_json::Value;
 use tokio::sync::mpsc;
 
+use ethportal_api::types::constants::CONTENT_ABSENT;
+use ethportal_api::types::execution::header::Header;
 use ethportal_api::types::jsonrpc::endpoints::HistoryEndpoint;
 use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
+use ethportal_api::utils::bytes::hex_decode;
+use ethportal_api::{ContentValue, HistoryContentKey, HistoryContentValue};
 
 use crate::errors::RpcServeError;
 
@@ -26,5 +31,44 @@ pub async fn proxy_query_to_history_subnet(
         None => Err(RpcServeError::Message(
             "Internal error: No response from chain history subnetwork".to_string(),
         )),
+    }
+}
+
+pub async fn find_header_by_hash(
+    network: &mpsc::UnboundedSender<HistoryJsonRpcRequest>,
+    block_hash: H256,
+) -> Result<Header, RpcServeError> {
+    // Request the block header from the history subnet.
+    let content_key: HistoryContentKey = HistoryContentKey::BlockHeaderWithProof(block_hash.into());
+    let endpoint = HistoryEndpoint::RecursiveFindContent(content_key);
+    let mut result = proxy_query_to_history_subnet(network, endpoint).await?;
+    let content = match result["content"].take() {
+        serde_json::Value::String(s) => s,
+        wrong_type => {
+            let message =
+                format!("Invalid internal representation of block header; json: {wrong_type:?}");
+            return Err(RpcServeError::Message(message));
+        }
+    };
+    if content == CONTENT_ABSENT {
+        return Err(RpcServeError::Message("Block not found".into()));
+    };
+    let content: Vec<u8> =
+        hex_decode(&content).expect("decoding the trin hex-encoded data failed, odd");
+    let header = match HistoryContentValue::decode(&content) {
+        Ok(header) => header,
+        Err(err) => {
+            let message =
+                format!("Invalid internal representation of block header; could not decode: {err}");
+            return Err(RpcServeError::Message(message));
+        }
+    };
+
+    match header {
+        HistoryContentValue::BlockHeaderWithProof(h) => Ok(h.header),
+        wrong_val => Err(RpcServeError::Message(format!(
+            "Internal trin error: got back a non-header from a key that must only point to headers; got {:?}",
+            wrong_val
+        ))),
     }
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,3 +1,5 @@
+use ethereum_types::U256;
+
 // sets the global tracing subscriber, to be used by all other tests
 pub fn init_tracing() {
     let subscriber = tracing_subscriber::fmt()
@@ -6,4 +8,23 @@ pub fn init_tracing() {
         .finish();
     // returns err if already set, which is fine and we just ignore the err
     let _ = tracing::subscriber::set_global_default(subscriber);
+}
+
+// Convert an ethereum-types U256 to an ethers-rs U256
+// Because the test files are compiled individually, this gets detected as dead code in
+// self_peertest.rs, even though it is used in rpc_server.rs. So we disable the warning.
+#[allow(dead_code)]
+pub fn u256_to_ethers_u256(u256: U256) -> ethers_core::types::U256 {
+    let mut bytes = [0u8; 32];
+    u256.to_big_endian(&mut bytes);
+    ethers_core::types::U256::from_big_endian(&bytes)
+}
+
+// Convert a primitive u64 to an ethers-rs U256
+// Because the test files are compiled individually, this gets detected as dead code in
+// self_peertest.rs, even though it is used in rpc_server.rs. So we disable the warning.
+#[allow(dead_code)]
+pub fn u64_to_ethers_u256(u64: u64) -> ethers_core::types::U256 {
+    let bytes = u64.to_be_bytes();
+    ethers_core::types::U256::from_big_endian(&bytes)
 }


### PR DESCRIPTION
Will fix #885 

There are a few little tweaks I have left to do, but nothing standing in the way of a review, IMO. Everything planned is unchecked below. I may just skip the 944 rebase, since it is relatively small, and can probably be reviewed together in this PR. (and I don't want to add unnecessary delay, so I can move on to transactions & uncles)

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history
- [x] What's up with? `2023-09-29T21:58:10.267211Z ERROR jsonrpsee_core::client::async_client: [backend]: Failed to read message: Networking or low-level protocol error: bytes remaining on stream` -- Wow, google is stumped. I guess I'll punt this for now...
- [x] uint conversion utilities, to test timestamp, gas_used, etc
- [x] Rebase on #942 
- [x] Rebase on #943
- [x] ~Rebase on #944~
- [x] Enumerate [full list of header fields](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblockbyhash) (any that don't require further requests, like transactions, uncles, or total difficulty), and test presence:
  - [x] bloom
  - [x] ~size~ - I couldn't find a reliable definition for size, so I am punting it for now
- [x] create issues for TODOs, and remove them
  - [x] https://github.com/ethereum/trin/issues/960
  - [x]  https://github.com/ethereum/trin/issues/279
  - [x]  #961