### PR TITLE
fix: improve the utp connection success rate, by using a default config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4011,6 +4011,7 @@ dependencies = [
  "ethportal-api",
  "fnv",
  "futures 0.3.28",
+ "lazy_static",
  "leb128",
  "lru",
  "parking_lot 0.11.2",

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -25,6 +25,7 @@ ethereum-types = "0.12.1"
 ethportal-api = { path="../ethportal-api" }
 fnv = "1.0.7"
 futures = "0.3.21"
+lazy_static = "1.4.0"
 leb128 = "0.2.1"
 lru = "0.7.8"
 parking_lot = "0.11.2"

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -496,7 +496,7 @@ where
         };
         let mut stream = self
             .utp_socket
-            .connect_with_cid(cid, UTP_CONN_CFG)
+            .connect_with_cid(cid, *UTP_CONN_CFG)
             .await
             .map_err(|err| OverlayRequestError::UtpError(format!("{err:?}")))?;
         let mut data = vec![];


### PR DESCRIPTION
We were seeing failed connection attempts fairly regularly on the testnet. This is one step of resolving that issue.

utp-rs is mostly tested using the default configurations, which have changed a few times to improve results. As far as I can tell, the configuration choices here are just an old copy of the config.

So instead of copying in new values, I switched the config to use defaults whenever possible. (which requires using lazy_static) The only custom configuration that seems to matter is that discv5 enforces a custom maximum packet size.

Some reasons I think this will help:
- Number of connection attempts doubles from 3 -> 6
- Idle connection timeout ~doubles from 32->60
- Maximum packet timeout is cut in a quarter from 60->15, for more retries before triggering an idle timeout. (This will affect mid-stream timeouts, but won't affect the connection timeouts we're seeing)

### To-Do

- [ ] Clean up commit history
