### PR TITLE
Make Trin compilable/(not crash) on Windows + Add check CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ commands:
           command: sudo apt install clang
 orbs:
   rust: circleci/rust@1.6.0
+  win: circleci/windows@2.2.0
 executors:
   docker-publisher:
     environment:
@@ -159,6 +160,31 @@ jobs:
           name: Build Trin workspace
           command: cargo build --workspace
       - save-sccache-cache
+  check-windows:
+    description: |
+      Check the crate on Windows (Check will tell us if we can build on Windows without the need to codegen (which is the time consuming part)).
+    executor:
+      name: win/default
+      size: xlarge
+    environment:
+      RUSTFLAGS: '-D warnings'
+      RUST_LOG: 'debug'
+    steps:
+      - checkout
+      - run:
+          name: Install rustup and clang
+          # We are installing them at the same time because it is faster
+          # todo: Remove --ignore-checksums flag
+          command: choco install rustup.install llvm -y --ignore-checksums
+      - run:
+          name: Add target
+          command: rustup target add x86_64-pc-windows-msvc
+      - run:
+          name: Install target toolchain
+          command: rustup toolchain install stable-x86_64-pc-windows-msvc
+      - run:
+          name: Check Trin workspace
+          command: cargo check --workspace
   test:
     description: |
       Run tests.
@@ -259,4 +285,5 @@ workflows:
       - lint
       - build
       - test
+      - check-windows
       - utp-test

--- a/ethportal-peertest/src/lib.rs
+++ b/ethportal-peertest/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 pub mod constants;
 pub mod scenarios;
 pub mod utils;

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -1520,7 +1520,7 @@ where
                 Request::PopulatedOffer(offer) => Ok(response_clone
                     .content_keys
                     .iter()
-                    .zip(offer.content_items.into_iter())
+                    .zip(offer.content_items)
                     .filter(|(is_accepted, _item)| *is_accepted)
                     .map(|(_is_accepted, (_key, val))| val)
                     .collect()),

--- a/portalnet/src/storage.rs
+++ b/portalnet/src/storage.rs
@@ -1140,6 +1140,8 @@ pub mod test {
         // The restarted store should have the same radius as the original
         assert_eq!(radius, new_storage.radius);
 
+        drop(storage);
+        drop(new_storage);
         temp_dir.close()?;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub async fn run_trin(
     // Make sure not to panic on non-windows configurations.
     #[cfg(windows)]
     if let Web3TransportType::IPC = trin_config.web3_transport {
-        panic!("Windows doesn't support Unix Domain Sockets IPC, use --web3-transport http");
+        panic!("Tokio doesn't support Windows Unix Domain Sockets IPC, use --web3-transport http");
     }
 
     let trin_version = get_trin_version();

--- a/tests/rpc_server.rs
+++ b/tests/rpc_server.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 /// Test that a 3rd-party web3 client can understand our JSON-RPC API
 use std::net::{IpAddr, Ipv4Addr};
 

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 use rpc::RpcServerHandle;
 use std::env;
 use std::net::{IpAddr, Ipv4Addr};


### PR DESCRIPTION
### What was wrong?
Certain parts of Trin either won't compile on Windows or crash because rust doesn't support windows Unix IPC
### How was it fixed?
By adding ``#![cfg(unix)]`` in files that should only be compile on windows and by adding an error if someone tries to use IPC on Windows.

Reth added ``#[cfg(unix)]`` a few months back so the reth-ipc library will compile it will just crash when we try to use ipc functions.

I also added a CI using ``check`` instead of ``build``
https://doc.rust-lang.org/cargo/commands/cargo-check.html

TL:DR it has all the CI benefits of building but without the codegen part. So it is a lot quicker for the result we want.