### PR TITLE
Bump discv5 dependency rev hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,7 +1336,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "discv5"
 version = "0.3.1"
-source = "git+https://github.com/njgheorghita/discv5.git?rev=09262ead2882e062de1a6a45df9ea61917eb8465#09262ead2882e062de1a6a45df9ea61917eb8465"
+source = "git+https://github.com/njgheorghita/discv5.git?rev=700bdb97afd87016222e902f844bb95eb0d78d99#700bdb97afd87016222e902f844bb95eb0d78d99"
 dependencies = [
  "aes 0.7.5",
  "aes-gcm 0.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ description = "A Rust implementation of the Ethereum Portal Network"
 [dependencies]
 anyhow = "1.0.68"
 clap = { version = "4.2.1", features = ["derive"] }
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
 eth2_ssz = "0.4.0"
 ethereum-types = "0.12.1"
 ethportal-api = { path = "ethportal-api" }

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.68"
 base64 = "0.13.0"
 bytes = "1.3.0"
 clap = { version = "4.2.1", features = ["derive"] }
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
 eth_trie = "0.3.0"
 eth2_ssz = "0.4.0"
 eth2_ssz_derive = "0.3.0"

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
 eth2_ssz = "0.4.0"
 ethereum-types = "0.12.1"
 ethportal-api = { path="../ethportal-api"}

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0.68"
 async-trait = "0.1.68"
 chrono = "0.4.26"
 clap = { version = "4.2.1", features = ["derive"] }
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
 ethportal-api = { path = "../ethportal-api" }
 ethereum-types = "0.12.1"
 eth2_ssz = "0.4.0"

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -17,7 +17,7 @@ base64 = "0.13.0"
 bytes = "1.3.0"
 delay_map = "0.1.1"
 directories = "3.0"
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
 eth2_ssz = "0.4.0"
 eth2_ssz_derive = "0.3.0"
 eth2_ssz_types = "0.2.1"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
-discv5 = { git = "https://github.com/njgheorghita/discv5.git",  rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
+discv5 = { git = "https://github.com/njgheorghita/discv5.git",  rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
 ethportal-api = { path = "../ethportal-api"}
 ethereum-types = "0.12.1"
 portalnet = { path = "../portalnet"}

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 async-trait = "0.1.53"
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
 ethportal-api = {path = "../ethportal-api"}
 eth2_ssz = "0.4.0"
 parking_lot = "0.11.2"

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 async-trait = "0.1.53"
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
 eth2_ssz = "0.4.0"
 ethereum-types = "0.12.1"
 ethportal-api = {path = "../ethportal-api"}

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 async-trait = "0.1.53"
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
 ethereum-types = "0.12.1"
 ethportal-api = { path = "../ethportal-api" }
 eth_trie = "0.3.0"

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 clap = { version = "4.2.1", features = ["derive"] }
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465", features = ["serde"] }
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
 ethportal-api = { path="../ethportal-api"}
 jsonrpsee = {version = "0.20.0", features = ["full"]}
 portalnet = { path = "../portalnet" }


### PR DESCRIPTION
### What was wrong?
New bugfix was submitted in https://github.com/njgheorghita/discv5/pull/5, so we need to bump the `discv5` rev hash to include this change.

### How was it fixed?
- bump rev hash

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
