### PR TITLE
Speed up Windows CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ commands:
           command: sudo apt install clang
 orbs:
   rust: circleci/rust@1.6.0
-  win: circleci/windows@2.2.0
 executors:
   docker-publisher:
     environment:
@@ -163,28 +162,26 @@ jobs:
   check-windows:
     description: |
       Check the crate on Windows (Check will tell us if we can build on Windows without the need to codegen (which is the time consuming part)).
+    resource_class: xlarge
     executor:
-      name: win/default
-      size: xlarge
+      name: rust/default
+      tag: 1.71.1
     environment:
       RUSTFLAGS: '-D warnings'
       RUST_LOG: 'debug'
     steps:
       - checkout
       - run:
-          name: Install rustup and clang
-          # We are installing them at the same time because it is faster
-          # todo: Remove --ignore-checksums flag
-          command: choco install rustup.install llvm -y --ignore-checksums
+          name: Prepare for apt updates
+          command: sudo apt update
       - run:
-          name: Add target
-          command: rustup target add x86_64-pc-windows-msvc
-      - run:
-          name: Install target toolchain
-          command: rustup toolchain install stable-x86_64-pc-windows-msvc
+          name: Install g++-mingw-w64-x86-64-posix Windows gnu toolchain for linux
+          command: sudo apt install g++-mingw-w64-x86-64-posix
+      - setup-and-restore-sccache-cache
       - run:
           name: Check Trin workspace
-          command: cargo check --workspace
+          command: cargo check --workspace --target x86_64-pc-windows-gnu
+      - save-sccache-cache
   test:
     description: |
       Run tests.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,9 @@ jobs:
           name: Prepare for apt updates
           command: sudo apt update
       - run:
+          name: Install libclang for rocksdb
+          command: sudo apt install clang
+      - run:
           name: Install g++-mingw-w64-x86-64-posix Windows gnu toolchain for linux
           command: sudo apt install g++-mingw-w64-x86-64-posix
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,12 @@ jobs:
       - run:
           name: Install g++-mingw-w64-x86-64-posix Windows gnu toolchain for linux
           command: sudo apt install g++-mingw-w64-x86-64-posix
+      - run:
+          name: Add target
+          command: rustup target add x86_64-pc-windows-gnu
+      - run:
+          name: Install target toolchain
+          command: rustup toolchain install stable-x86_64-pc-windows-gnu
       - setup-and-restore-sccache-cache
       - run:
           name: Check Trin workspace


### PR DESCRIPTION
### What was wrong?
Windows Circle CI has a long prepare time for Windows, and Windows is slow at installing libraries
### How was it fixed?
Instead of running check on Windows just cross platform run check for windows.

Why do we use check? Well it does everything build does expect code gen so it is just faster and does what we expect build to confirm
https://doc.rust-lang.org/cargo/commands/cargo-check.html

This has the speed of using a linux excuter on CircleCi which is just faster, plus using our CI caching mechanism we already use on our Linux CI for extra speed
