### PR TITLE
fix(overlay-service): Check for peer `NodeId` in discovery ENR cache

### DIFF
--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -264,6 +264,14 @@ impl Discovery {
         self.node_addr_cache.write().get(node_id).cloned()
     }
 
+    /// Put a `NodeAddress` into cache. If the key already exists in the cache, then it updates the key's value and
+    /// returns the old value. Otherwise, `None` is returned.
+    pub fn put_cached_node_addr(&self, node_addr: NodeAddress) -> Option<NodeAddress> {
+        self.node_addr_cache
+            .write()
+            .put(node_addr.enr.node_id(), node_addr)
+    }
+
     /// Sends a TALKREQ message to `enr`.
     pub async fn send_talk_req(
         &self,


### PR DESCRIPTION
### What was wrong?
Many `FindContent` queries fail when the result is an uTP stream.  This is because we cannot find the `ENR `of the source `NodeID` and reject the incoming uTP content.

This fix is expected to also improve `FindNode` queries.

### How was it fixed?
Check in the discovery ENR cache when trying to find an `ENR` for a known `NodeId` when processing `FIndContent` and `FindNode` queries.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
