### PR TITLE
feat: add increasing Enr sequence on updated Enr

### DIFF
--- a/portalnet/src/types/messages.rs
+++ b/portalnet/src/types/messages.rs
@@ -169,7 +169,7 @@ pub struct PortalnetConfig {
     pub internal_ip: bool,
     pub no_stun: bool,
     pub node_addr_cache_capacity: usize,
-    pub node_data_dir: Option<PathBuf>,
+    pub enr_file_location: Option<PathBuf>,
 }
 
 impl Default for PortalnetConfig {
@@ -182,7 +182,7 @@ impl Default for PortalnetConfig {
             data_radius: Distance::MAX,
             internal_ip: false,
             no_stun: false,
-            node_data_dir: None,
+            enr_file_location: None,
             node_addr_cache_capacity: NODE_ADDR_CACHE_CAPACITY,
         }
     }

--- a/portalnet/src/types/messages.rs
+++ b/portalnet/src/types/messages.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::{
     convert::{TryFrom, TryInto},
     fmt,
@@ -168,6 +169,7 @@ pub struct PortalnetConfig {
     pub internal_ip: bool,
     pub no_stun: bool,
     pub node_addr_cache_capacity: usize,
+    pub node_data_dir: Option<PathBuf>,
 }
 
 impl Default for PortalnetConfig {
@@ -180,6 +182,7 @@ impl Default for PortalnetConfig {
             data_radius: Distance::MAX,
             internal_ip: false,
             no_stun: false,
+            node_data_dir: None,
             node_addr_cache_capacity: NODE_ADDR_CACHE_CAPACITY,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub async fn run_trin(
         listen_port: trin_config.discovery_port,
         no_stun: trin_config.no_stun,
         bootnodes: trin_config.bootnodes.clone(),
+        node_data_dir: Some(node_data_dir.clone()),
         ..Default::default()
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub async fn run_trin(
         listen_port: trin_config.discovery_port,
         no_stun: trin_config.no_stun,
         bootnodes: trin_config.bootnodes.clone(),
-        node_data_dir: Some(node_data_dir.clone()),
+        enr_file_location: Some(node_data_dir.clone()),
         ..Default::default()
     };
 


### PR DESCRIPTION
### What was wrong?
We didn't update the sequence number when we updated fields in our Enr.
### How was it fixed?
If in our ``folderpath/nodeid/trin.enr`` did exist we either update or set the enr sequence according to if we updated a field or not relative to the Enr saved to disk. If a file doesn't exist that means the Enr is new and we set it to 1.