### PR TITLE
refactor: reuse logic to fetch history content

### DIFF
--- a/rpc/src/fetch.rs
+++ b/rpc/src/fetch.rs
@@ -1,0 +1,30 @@
+/// Fetch data from related Portal networks
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use ethportal_api::types::jsonrpc::endpoints::HistoryEndpoint;
+use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
+
+use crate::errors::RpcServeError;
+
+pub async fn proxy_query_to_history_subnet(
+    network: &mpsc::UnboundedSender<HistoryJsonRpcRequest>,
+    endpoint: HistoryEndpoint,
+) -> Result<Value, RpcServeError> {
+    let (resp_tx, mut resp_rx) = mpsc::unbounded_channel::<Result<Value, String>>();
+    let message = HistoryJsonRpcRequest {
+        endpoint,
+        resp: resp_tx,
+    };
+    let _ = network.send(message);
+
+    match resp_rx.recv().await {
+        Some(val) => match val {
+            Ok(result) => Ok(result),
+            Err(msg) => Err(RpcServeError::Message(msg)),
+        },
+        None => Err(RpcServeError::Message(
+            "Internal error: No response from chain history subnetwork".to_string(),
+        )),
+    }
+}

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -6,6 +6,7 @@ mod cors;
 mod discv5_rpc;
 mod errors;
 mod eth_rpc;
+mod fetch;
 mod history_rpc;
 mod rpc_server;
 mod serde;


### PR DESCRIPTION
Want to reuse the logic to make requests to the history network, in #908 

### To-Do

- [x] Clean up commit history
