### PR TITLE
chore: add channel from EthApi to history network

### DIFF
--- a/rpc/src/builder.rs
+++ b/rpc/src/builder.rs
@@ -402,7 +402,13 @@ impl RpcModuleBuilder {
                         PortalRpcModule::Discv5 => {
                             Discv5Api::new(self.discv5.clone()).into_rpc().into()
                         }
-                        PortalRpcModule::Eth => EthApi.into_rpc().into(),
+                        PortalRpcModule::Eth => {
+                            let history_tx = self
+                                .history_tx
+                                .clone()
+                                .expect("History protocol not initialized");
+                            EthApi::new(history_tx).into_rpc().into()
+                        }
                         PortalRpcModule::History => {
                             let history_tx = self
                                 .history_tx

--- a/rpc/src/eth_rpc.rs
+++ b/rpc/src/eth_rpc.rs
@@ -1,19 +1,19 @@
-use crate::jsonrpsee::core::{async_trait, RpcResult};
 use ethereum_types::U256;
+use tokio::sync::mpsc;
+
+use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
 use ethportal_api::EthApiServer;
 use trin_validation::constants::CHAIN_ID;
 
-pub struct EthApi;
+use crate::jsonrpsee::core::{async_trait, RpcResult};
 
-impl EthApi {
-    pub fn new() -> Self {
-        Self
-    }
+pub struct EthApi {
+    _network: mpsc::UnboundedSender<HistoryJsonRpcRequest>,
 }
 
-impl Default for EthApi {
-    fn default() -> Self {
-        Self::new()
+impl EthApi {
+    pub fn new(network: mpsc::UnboundedSender<HistoryJsonRpcRequest>) -> Self {
+        Self { _network: network }
     }
 }
 


### PR DESCRIPTION
Need access to the history network to respond to `eth_` rpc requests


### To-Do

- [ ] Clean up commit history
