### PR TITLE
ethportal-peertest: Add gossip test

### DIFF
--- a/ethportal-peertest/src/scenarios/gossip.rs
+++ b/ethportal-peertest/src/scenarios/gossip.rs
@@ -1,0 +1,29 @@
+use tracing::info;
+
+use crate::{constants::fixture_header_with_proof, utils::wait_for_history_content, Peertest};
+use ethportal_api::{HistoryNetworkApiClient, PossibleHistoryContentValue};
+
+pub async fn test_gossip(peertest: &Peertest) {
+    info!("Testing gossip flow");
+
+    let (content_key, content_value) = fixture_header_with_proof();
+    let result = peertest
+        .bootnode
+        .ipc_client
+        .gossip(content_key.clone(), content_value.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(result, 1);
+
+    // Check if the stored content value in another node's DB matches the gossiped
+    let response = wait_for_history_content(&peertest.nodes[0].ipc_client, content_key).await;
+    let received_content_value = match response {
+        PossibleHistoryContentValue::ContentPresent(c) => c,
+        PossibleHistoryContentValue::ContentAbsent => panic!("Expected content to be found"),
+    };
+    assert_eq!(
+        content_value, received_content_value,
+        "The received content {received_content_value:?}, must match the expected {content_value:?}",
+    );
+}

--- a/ethportal-peertest/src/scenarios/mod.rs
+++ b/ethportal-peertest/src/scenarios/mod.rs
@@ -2,6 +2,7 @@ pub mod basic;
 pub mod bridge;
 pub mod eth_rpc;
 pub mod find;
+pub mod gossip;
 pub mod offer_accept;
 pub mod paginate;
 pub mod utp;

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -156,6 +156,15 @@ async fn peertest_trace_recursive_utp() {
     handle.stop().unwrap();
 }
 
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_gossip() {
+    let (peertest, _target, handle) = setup_peertest().await;
+    peertest::scenarios::gossip::test_gossip(&peertest).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
+
 async fn setup_peertest() -> (peertest::Peertest, Client, RpcServerHandle) {
     utils::init_tracing();
     // Run a client, as a buddy peer for ping tests, etc.


### PR DESCRIPTION
Add portal_histroyGossip test that is missing in peertest

- [] Clean up commit history
