### PR TITLE
fix: enr signature changes on restart even if enr content is the same

### DIFF
--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -486,10 +486,7 @@ mod tests {
         // test if Enr changes the Enr sequence is increased and if it is written to disk
         portalnet_config.listen_port = 2424;
         let discovery = Discovery::new(portalnet_config.clone()).unwrap();
-        assert_ne!(
-            get_enr_rlp_content(&discovery.local_enr()),
-            get_enr_rlp_content(&old_enr)
-        );
+        assert_ne!(discovery.local_enr(), old_enr);
         let data = fs::read_to_string(trin_enr_file_location.clone()).unwrap();
         let old_enr = Enr::from_str(&data).unwrap();
         assert_eq!(discovery.local_enr().seq(), 2);
@@ -498,10 +495,7 @@ mod tests {
 
         // test if the enr isn't changed that it's sequence stays the same
         let discovery = Discovery::new(portalnet_config).unwrap();
-        assert_eq!(
-            get_enr_rlp_content(&discovery.local_enr()),
-            get_enr_rlp_content(&old_enr)
-        );
+        assert_eq!(discovery.local_enr(), old_enr);
         let data = fs::read_to_string(trin_enr_file_location).unwrap();
         let old_enr = Enr::from_str(&data).unwrap();
         assert_eq!(discovery.local_enr().seq(), 2);

--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -116,7 +116,7 @@ impl Discovery {
         if trin_enr_path.is_file() {
             let data = fs::read_to_string(trin_enr_path.clone())
                 .expect("Unable to read Trin Enr from file");
-            let old_enr = Enr::from_str(&data).expect("Expected read trin.enr to be valid");
+            let old_enr = Enr::from_str(&data).expect("Expected to read valid Trin Enr from file");
             enr.set_seq(old_enr.seq(), &enr_key)
                 .expect("Unable to set Enr sequence number");
 

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -2695,17 +2695,17 @@ mod tests {
         types::messages::PortalnetConfig,
     };
 
+    use crate::utils::db::setup_temp_dir;
+    use discv5::kbucket::Entry;
+    use ethereum_types::U256;
     use ethportal_api::types::content_key::overlay::IdentityContentKey;
     use ethportal_api::types::distance::XorMetric;
     use ethportal_api::types::enr::generate_random_remote_enr;
-    use trin_validation::validator::MockValidator;
-
-    use discv5::kbucket::Entry;
-    use ethereum_types::U256;
     use serial_test::serial;
     use std::net::SocketAddr;
     use tokio::sync::mpsc::unbounded_channel;
     use tokio_test::{assert_pending, assert_ready, task};
+    use trin_validation::validator::MockValidator;
 
     macro_rules! poll_command_rx {
         ($service:ident) => {
@@ -2719,7 +2719,8 @@ mod tests {
             no_stun: true,
             ..Default::default()
         };
-        let discovery = Arc::new(Discovery::new(portal_config).unwrap());
+        let temp_dir = setup_temp_dir().unwrap().into_path();
+        let discovery = Arc::new(Discovery::new(portal_config, temp_dir).unwrap());
 
         let (_utp_talk_req_tx, utp_talk_req_rx) = unbounded_channel();
         let discv5_utp =

--- a/portalnet/src/types/messages.rs
+++ b/portalnet/src/types/messages.rs
@@ -169,7 +169,7 @@ pub struct PortalnetConfig {
     pub internal_ip: bool,
     pub no_stun: bool,
     pub node_addr_cache_capacity: usize,
-    pub enr_file_location: Option<PathBuf>,
+    pub trin_data_dir: PathBuf,
 }
 
 impl Default for PortalnetConfig {
@@ -182,7 +182,7 @@ impl Default for PortalnetConfig {
             data_radius: Distance::MAX,
             internal_ip: false,
             no_stun: false,
-            enr_file_location: None,
+            trin_data_dir: PathBuf::default(),
             node_addr_cache_capacity: NODE_ADDR_CACHE_CAPACITY,
         }
     }

--- a/portalnet/src/types/messages.rs
+++ b/portalnet/src/types/messages.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::{
     convert::{TryFrom, TryInto},
     fmt,
@@ -169,7 +168,6 @@ pub struct PortalnetConfig {
     pub internal_ip: bool,
     pub no_stun: bool,
     pub node_addr_cache_capacity: usize,
-    pub trin_data_dir: PathBuf,
 }
 
 impl Default for PortalnetConfig {
@@ -182,7 +180,6 @@ impl Default for PortalnetConfig {
             data_radius: Distance::MAX,
             internal_ip: false,
             no_stun: false,
-            trin_data_dir: PathBuf::default(),
             node_addr_cache_capacity: NODE_ADDR_CACHE_CAPACITY,
         }
     }

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -21,6 +21,7 @@ use tokio::{
 use utp_rs::socket::UtpSocket;
 
 use ethportal_api::utils::bytes::hex_encode_upper;
+use portalnet::utils::db::setup_temp_dir;
 
 async fn init_overlay(
     discovery: Arc<Discovery>,
@@ -102,7 +103,8 @@ async fn overlay() {
         external_addr: Some(SocketAddr::new(ip_addr, 8001)),
         ..PortalnetConfig::default()
     };
-    let mut discovery_one = Discovery::new(portal_config_one).unwrap();
+    let temp_dir_one = setup_temp_dir().unwrap().into_path();
+    let mut discovery_one = Discovery::new(portal_config_one, temp_dir_one).unwrap();
     let talk_req_rx_one = discovery_one.start().await.unwrap();
     let discovery_one = Arc::new(discovery_one);
     let overlay_one = Arc::new(init_overlay(Arc::clone(&discovery_one), protocol.clone()).await);
@@ -115,7 +117,8 @@ async fn overlay() {
         external_addr: Some(SocketAddr::new(ip_addr, 8002)),
         ..PortalnetConfig::default()
     };
-    let mut discovery_two = Discovery::new(portal_config_two).unwrap();
+    let temp_dir_two = setup_temp_dir().unwrap().into_path();
+    let mut discovery_two = Discovery::new(portal_config_two, temp_dir_two).unwrap();
     let talk_req_rx_two = discovery_two.start().await.unwrap();
     let discovery_two = Arc::new(discovery_two);
     let overlay_two = Arc::new(init_overlay(Arc::clone(&discovery_two), protocol.clone()).await);
@@ -128,7 +131,8 @@ async fn overlay() {
         external_addr: Some(SocketAddr::new(ip_addr, 8003)),
         ..PortalnetConfig::default()
     };
-    let mut discovery_three = Discovery::new(portal_config_three).unwrap();
+    let temp_dir_three = setup_temp_dir().unwrap().into_path();
+    let mut discovery_three = Discovery::new(portal_config_three, temp_dir_three).unwrap();
     let talk_req_rx_three = discovery_three.start().await.unwrap();
     let discovery_three = Arc::new(discovery_three);
     let overlay_three =
@@ -247,7 +251,8 @@ async fn overlay_event_stream() {
         no_stun: true,
         ..Default::default()
     };
-    let discovery = Arc::new(Discovery::new(portal_config).unwrap());
+    let temp_dir = setup_temp_dir().unwrap().into_path();
+    let discovery = Arc::new(Discovery::new(portal_config, temp_dir).unwrap());
     let overlay = init_overlay(discovery, ProtocolId::Beacon).await;
 
     overlay.event_stream().await.unwrap();

--- a/rpc/src/rpc_server.rs
+++ b/rpc/src/rpc_server.rs
@@ -612,6 +612,7 @@ mod tests {
     use crate::builder::RpcModuleSelection;
     use crate::{PortalRpcModule, RpcModuleBuilder};
     use portalnet::discovery::Discovery;
+    use portalnet::utils::db::setup_temp_dir;
     use std::io;
     use std::sync::Arc;
 
@@ -633,7 +634,8 @@ mod tests {
     pub fn test_rpc_builder() -> RpcModuleBuilder {
         let (history_tx, _) = tokio::sync::mpsc::unbounded_channel();
         let (beacon_tx, _) = tokio::sync::mpsc::unbounded_channel();
-        let discv5 = Arc::new(Discovery::new(Default::default()).unwrap());
+        let temp_dir = setup_temp_dir().unwrap().into_path();
+        let discv5 = Arc::new(Discovery::new(Default::default(), temp_dir).unwrap());
         RpcModuleBuilder::new(discv5)
             .with_history(history_tx)
             .with_beacon(beacon_tx)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,12 +51,11 @@ pub async fn run_trin(
         listen_port: trin_config.discovery_port,
         no_stun: trin_config.no_stun,
         bootnodes: trin_config.bootnodes.clone(),
-        trin_data_dir: node_data_dir.clone(),
         ..Default::default()
     };
 
     // Initialize base discovery protocol
-    let mut discovery = Discovery::new(portalnet_config.clone())?;
+    let mut discovery = Discovery::new(portalnet_config.clone(), node_data_dir.clone())?;
     let talk_req_rx = discovery.start().await?;
     let discovery = Arc::new(discovery);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub async fn run_trin(
         listen_port: trin_config.discovery_port,
         no_stun: trin_config.no_stun,
         bootnodes: trin_config.bootnodes.clone(),
-        enr_file_location: Some(node_data_dir.clone()),
+        trin_data_dir: node_data_dir.clone(),
         ..Default::default()
     };
 

--- a/utp-testing/src/lib.rs
+++ b/utp-testing/src/lib.rs
@@ -12,6 +12,7 @@ use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::{Server, ServerHandle};
 use portalnet::discovery::{Discovery, UtpEnr};
 use portalnet::types::messages::{PortalnetConfig, ProtocolId};
+use portalnet::utils::db::setup_temp_dir;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -148,7 +149,8 @@ pub async fn run_test_app(
         ..Default::default()
     };
 
-    let mut discovery = Discovery::new(config).unwrap();
+    let temp_dir = setup_temp_dir().unwrap().into_path();
+    let mut discovery = Discovery::new(config, temp_dir).unwrap();
     let talk_req_rx = discovery.start().await.unwrap();
     let enr = discovery.local_enr();
     let discovery = Arc::new(discovery);


### PR DESCRIPTION
### What was wrong?
I made a PR https://github.com/sigp/enr/pull/53 and Age Manning gave me the insight that the signature should always be the same in the client if the content is the same.

We had an issue before my increase seq pr and after that even though our enr could be the same, the signature would change which isn't good.
### How was it fixed?

It was fixed by restructuring a bit of my code. I also cleaned it up a bit for how to compare them from suggestions from Age and Nick.

I also resolved a param name nitpik nick had in my last PR.
