### PR TITLE
chore: upgrade utp-rs to v0.1.0-alpha.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7298,9 +7298,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utp-rs"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ff9b8e8ddf52786b4dc8a6860255f4d9ab47a65d50e4a844a29261b6bc7994"
+checksum = "c4ec35d0178f4ccdf5f734af742c264d2c811435ca6e85803b373c6ec077ed33"
 dependencies = [
  "async-trait",
  "delay_map 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ trin-history = { path = "trin-history" }
 trin-state = { path = "trin-state" }
 trin-utils = { path = "trin-utils" }
 trin-validation = { path = "trin-validation" }
-utp-rs = "0.1.0-alpha.7"
+utp-rs = "0.1.0-alpha.8"
 
 [dev-dependencies]
 ethers-core = { version = "2.0", default-features = false}

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -48,7 +48,7 @@ trin-utils = { path="../trin-utils" }
 trin-validation = { path="../trin-validation" }
 validator = { version = "0.13.0", features = ["derive"] }
 url = "2.3.1"
-utp-rs = "0.1.0-alpha.7"
+utp-rs = "0.1.0-alpha.8"
 
 [target.'cfg(windows)'.dependencies]
 uds_windows = "1.0.1"

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -24,4 +24,4 @@ tokio = {version = "1.14.0", features = ["full"]}
 tracing = "0.1.36"
 trin-validation = { path = "../trin-validation" }
 trin-utils = { path = "../trin-utils" }
-utp-rs = "0.1.0-alpha.7"
+utp-rs = "0.1.0-alpha.8"

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -25,7 +25,7 @@ tracing = "0.1.36"
 tree_hash = "0.4.0"
 trin-utils = { path = "../trin-utils" }
 trin-validation = { path = "../trin-validation" }
-utp-rs = "0.1.0-alpha.7"
+utp-rs = "0.1.0-alpha.8"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -23,7 +23,7 @@ rocksdb = "0.21.0"
 tracing = "0.1.36"
 tokio = {version = "1.14.0", features = ["full"]}
 trin-validation = { path = "../trin-validation" }
-utp-rs = "0.1.0-alpha.7"
+utp-rs = "0.1.0-alpha.8"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -22,7 +22,7 @@ tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 trin-utils = { path = "../trin-utils" }
 tokio = {version = "1.14.0", features = ["full"]}
-utp-rs = "0.1.0-alpha.7"
+utp-rs = "0.1.0-alpha.8"
 
 [[bin]]
 name = "utp-test-app"


### PR DESCRIPTION
### What was wrong?

We want the fix pushed out by the latest utp release: https://github.com/ethereum/utp/releases/tag/v0.1.0-alpha.8

### How was it fixed?

Upgrade to it

### To-Do

- [ ] Clean up commit history
