### PR TITLE
Update stale issues bot to 6 months

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,12 +12,12 @@ jobs:
       - uses: actions/stale@v5
         with:
           close-issue-reason: "not_planned"
-          days-before-issue-stale: 42
+          days-before-issue-stale: 180
           days-before-issue-close: 14
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 42 days with no activity."
+          stale-issue-message: "This issue is stale because it has been open for 180 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          exempt-issue-labels: "shelf-stable,good-first-issue,flamingo"
+          exempt-issue-labels: "shelf-stable,good-first-issue,flamingo,good-community-issue"
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What was wrong?
- Update stale issue bot period to 6 months
- Add `good-community-issue` to exempt labels list

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
