### PR TITLE
Order imports by std, external, and internal

### DIFF
--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -1,3 +1,6 @@
+use discv5::enr::NodeId;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
 use crate::types::content_key::beacon::BeaconContentKey;
 use crate::types::enr::Enr;
 use crate::types::portal::FindNodesInfo;
@@ -6,8 +9,6 @@ use crate::types::portal::{
 };
 use crate::RoutingTableInfo;
 use crate::{BeaconContentValue, PossibleBeaconContentValue};
-use discv5::enr::NodeId;
-use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Portal Beacon JSON-RPC endpoints
 #[rpc(client, server, namespace = "portal")]

--- a/ethportal-api/src/dashboard/grafana.rs
+++ b/ethportal-api/src/dashboard/grafana.rs
@@ -1,7 +1,8 @@
+use std::fs;
+
 use base64;
 use nanotemplate::template;
 use serde::Deserialize;
-use std::fs;
 use ureq;
 
 pub const DASHBOARD_TEMPLATES: &[&str] =

--- a/ethportal-api/src/discv5.rs
+++ b/ethportal-api/src/discv5.rs
@@ -1,7 +1,8 @@
-use crate::types::discv5::{NodeInfo, RoutingTableInfo};
-use crate::types::enr::Enr;
 use discv5::enr::NodeId;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
+use crate::types::discv5::{NodeInfo, RoutingTableInfo};
+use crate::types::enr::Enr;
 
 /// Discv5 JSON-RPC endpoints
 #[rpc(client, server, namespace = "discv5")]

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -1,3 +1,6 @@
+use discv5::enr::NodeId;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
 use crate::types::content_key::history::HistoryContentKey;
 use crate::types::enr::Enr;
 use crate::types::portal::FindNodesInfo;
@@ -6,8 +9,6 @@ use crate::types::portal::{
 };
 use crate::RoutingTableInfo;
 use crate::{HistoryContentValue, PossibleHistoryContentValue};
-use discv5::enr::NodeId;
-use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Portal History JSON-RPC endpoints
 #[rpc(client, server, namespace = "portal")]

--- a/ethportal-api/src/lib.rs
+++ b/ethportal-api/src/lib.rs
@@ -15,12 +15,13 @@ pub mod types;
 pub mod utils;
 mod web3;
 
-pub use crate::discv5::{Discv5ApiClient, Discv5ApiServer};
 pub use beacon::{BeaconNetworkApiClient, BeaconNetworkApiServer};
 pub use eth::{EthApiClient, EthApiServer};
 pub use history::{HistoryNetworkApiClient, HistoryNetworkApiServer};
-pub use web3::{Web3ApiClient, Web3ApiServer};
-
+// Re-exports jsonrpsee crate
+pub use jsonrpsee;
+pub use types::consensus;
+pub use types::consensus::light_client;
 pub use types::content_key::{
     beacon::{BeaconContentKey, LightClientBootstrapKey, LightClientUpdatesByRangeKey},
     error::ContentKeyError,
@@ -31,22 +32,18 @@ pub use types::content_key::{
     overlay::{IdentityContentKey, OverlayContentKey},
     state::StateContentKey,
 };
-
-pub use types::consensus;
-pub use types::consensus::light_client;
+pub use types::content_value::ContentValue;
 pub use types::content_value::{
     beacon::{BeaconContentValue, PossibleBeaconContentValue},
     error::ContentValueError,
     history::{HistoryContentValue, PossibleHistoryContentValue},
 };
+pub use types::discv5::*;
+pub use types::enr::*;
 pub use types::execution::block_body::*;
 pub use types::execution::header::*;
 pub use types::execution::receipts::*;
-
-// Re-exports jsonrpsee crate
-pub use jsonrpsee;
-pub use types::content_value::ContentValue;
-
-pub use types::discv5::*;
-pub use types::enr::*;
 pub use types::node_id::*;
+pub use web3::{Web3ApiClient, Web3ApiServer};
+
+pub use crate::discv5::{Discv5ApiClient, Discv5ApiServer};

--- a/ethportal-api/src/types/bootnodes.rs
+++ b/ethportal-api/src/types/bootnodes.rs
@@ -129,9 +129,10 @@ impl FromStr for Bootnodes {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
+    use rstest::rstest;
+
     use super::*;
     use crate::types::cli::TrinConfig;
-    use rstest::rstest;
 
     #[test_log::test]
     fn test_bootnodes_default_with_testnet_bootnodes() {

--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -1,7 +1,8 @@
+use std::{env, ffi::OsString, fmt, net::SocketAddr, path::PathBuf, str::FromStr};
+
 use clap::error::{Error, ErrorKind};
 use clap::{arg, Args, Parser, Subcommand};
 use ethereum_types::H256;
-use std::{env, ffi::OsString, fmt, net::SocketAddr, path::PathBuf, str::FromStr};
 use url::Url;
 
 use crate::types::bootnodes::Bootnodes;
@@ -290,9 +291,11 @@ pub fn create_dashboard(
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use std::net::{IpAddr, Ipv4Addr};
+
     use test_log::test;
+
+    use super::*;
 
     #[test]
     fn test_default_args() {

--- a/ethportal-api/src/types/consensus/body.rs
+++ b/ethportal-api/src/types/consensus/body.rs
@@ -1,10 +1,10 @@
-use crate::types::consensus::execution_payload::ExecutionPayload;
 use ethereum_types::H256;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum, BitList, BitVector, VariableList};
 
 use super::{header::BeaconBlockHeader, proof::Proof, pubkey::PubKey, signature::BlsSignature};
+use crate::types::consensus::execution_payload::ExecutionPayload;
 
 /// Types based off specs @
 /// https://github.com/ethereum/consensus-specs/blob/5970ae56a1cd50ea06049d8aad6bed74093d49d3/specs/bellatrix/beacon-chain.md
@@ -114,10 +114,11 @@ pub struct Eth1Data {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ::ssz::{Decode, Encode};
     use rstest::rstest;
     use serde_json::Value;
+
+    use super::*;
 
     /// Test vectors sourced from:
     /// https://github.com/ethereum/consensus-spec-tests/commit/c6e69469a75392b35169bc6234d4d3e6c4e288da

--- a/ethportal-api/src/types/consensus/execution_payload.rs
+++ b/ethportal-api/src/types/consensus/execution_payload.rs
@@ -1,8 +1,3 @@
-use super::serde::{de_hex_to_txs, de_number_to_u256, se_hex_to_number, se_txs_to_hex};
-use crate::types::consensus::body::Transactions;
-use crate::types::consensus::fork::ForkName;
-use crate::types::wrapped::h160::H160;
-use crate::utils::serde::{hex_fixed_vec, hex_var_list};
 use ethereum_types::{H256, U256};
 use serde::{Deserialize, Serialize};
 use serde_this_or_that::as_u64;
@@ -11,6 +6,12 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum, FixedVector, VariableList};
 use superstruct::superstruct;
 use tree_hash_derive::TreeHash;
+
+use super::serde::{de_hex_to_txs, de_number_to_u256, se_hex_to_number, se_txs_to_hex};
+use crate::types::consensus::body::Transactions;
+use crate::types::consensus::fork::ForkName;
+use crate::types::wrapped::h160::H160;
+use crate::utils::serde::{hex_fixed_vec, hex_var_list};
 
 pub type Bloom = FixedVector<u8, typenum::U256>;
 pub type ExtraData = VariableList<u8, typenum::U32>;
@@ -116,10 +117,11 @@ impl ExecutionPayloadHeader {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ::ssz::{Decode, Encode};
     use rstest::rstest;
     use serde_json::Value;
+
+    use super::*;
 
     #[rstest]
     #[case("case_0")]

--- a/ethportal-api/src/types/consensus/fork.rs
+++ b/ethportal-api/src/types/consensus/fork.rs
@@ -1,8 +1,10 @@
-use crate::utils::bytes::hex_encode;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
+
 use thiserror::Error;
+
+use crate::utils::bytes::hex_encode;
 
 /// Error thrown when failed to parse a valid [`ForkName`].
 #[derive(Debug, Clone, PartialEq, Eq, Error)]

--- a/ethportal-api/src/types/consensus/header.rs
+++ b/ethportal-api/src/types/consensus/header.rs
@@ -22,10 +22,11 @@ pub struct BeaconBlockHeader {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
+
+    use super::*;
 
     /// Test vectors sourced from:
     /// https://github.com/ethereum/consensus-spec-tests/commit/c6e69469a75392b35169bc6234d4d3e6c4e288da

--- a/ethportal-api/src/types/consensus/light_client/bootstrap.rs
+++ b/ethportal-api/src/types/consensus/light_client/bootstrap.rs
@@ -1,8 +1,3 @@
-use crate::types::consensus::fork::ForkName;
-use crate::types::consensus::light_client::header::{
-    LightClientHeaderBellatrix, LightClientHeaderCapella,
-};
-use crate::types::consensus::sync_committee::SyncCommittee;
 use ethereum_types::H256;
 use serde::{Deserialize, Serialize};
 use ssz::Decode;
@@ -10,6 +5,12 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::typenum::U5;
 use ssz_types::FixedVector;
 use superstruct::superstruct;
+
+use crate::types::consensus::fork::ForkName;
+use crate::types::consensus::light_client::header::{
+    LightClientHeaderBellatrix, LightClientHeaderCapella,
+};
+use crate::types::consensus::sync_committee::SyncCommittee;
 
 pub type CurrentSyncCommitteeProofLen = U5;
 
@@ -52,10 +53,11 @@ impl LightClientBootstrap {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
+
+    use super::*;
 
     #[rstest]
     #[case("case_0")]

--- a/ethportal-api/src/types/consensus/light_client/finality_update.rs
+++ b/ethportal-api/src/types/consensus/light_client/finality_update.rs
@@ -1,9 +1,3 @@
-use crate::types::consensus::body::SyncAggregate;
-use crate::types::consensus::fork::ForkName;
-use crate::types::consensus::light_client::header::{
-    LightClientHeaderBellatrix, LightClientHeaderCapella,
-};
-use crate::types::consensus::light_client::update::FinalizedRootProofLen;
 use ethereum_types::H256;
 use serde::{Deserialize, Serialize};
 use serde_this_or_that::as_u64;
@@ -11,6 +5,13 @@ use ssz::Decode;
 use ssz_derive::{Decode, Encode};
 use ssz_types::FixedVector;
 use superstruct::superstruct;
+
+use crate::types::consensus::body::SyncAggregate;
+use crate::types::consensus::fork::ForkName;
+use crate::types::consensus::light_client::header::{
+    LightClientHeaderBellatrix, LightClientHeaderCapella,
+};
+use crate::types::consensus::light_client::update::FinalizedRootProofLen;
 
 /// A LightClientFinalityUpdate is the update that
 /// signal a new finalized beacon block header for the light client sync protocol.
@@ -59,10 +60,11 @@ impl LightClientFinalityUpdate {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
+
+    use super::*;
 
     #[rstest]
     #[case("case_0")]

--- a/ethportal-api/src/types/consensus/light_client/header.rs
+++ b/ethportal-api/src/types/consensus/light_client/header.rs
@@ -1,6 +1,3 @@
-use crate::types::consensus::execution_payload::ExecutionPayloadHeaderCapella;
-use crate::types::consensus::fork::ForkName;
-use crate::types::consensus::header::BeaconBlockHeader;
 use ethereum_types::H256;
 use serde::{Deserialize, Serialize};
 use ssz::Decode;
@@ -9,6 +6,10 @@ use ssz_types::typenum::U4;
 use ssz_types::FixedVector;
 use superstruct::superstruct;
 use tree_hash_derive::TreeHash;
+
+use crate::types::consensus::execution_payload::ExecutionPayloadHeaderCapella;
+use crate::types::consensus::fork::ForkName;
+use crate::types::consensus::header::BeaconBlockHeader;
 
 pub type ExecutionBranchLen = U4;
 
@@ -60,10 +61,11 @@ impl LightClientHeader {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
+
+    use super::*;
 
     #[rstest]
     #[case("case_0")]

--- a/ethportal-api/src/types/consensus/light_client/optimistic_update.rs
+++ b/ethportal-api/src/types/consensus/light_client/optimistic_update.rs
@@ -1,13 +1,14 @@
-use crate::types::consensus::body::SyncAggregate;
-use crate::types::consensus::fork::ForkName;
-use crate::types::consensus::light_client::header::{
-    LightClientHeaderBellatrix, LightClientHeaderCapella,
-};
 use serde::{Deserialize, Serialize};
 use serde_this_or_that::as_u64;
 use ssz::Decode;
 use ssz_derive::{Decode, Encode};
 use superstruct::superstruct;
+
+use crate::types::consensus::body::SyncAggregate;
+use crate::types::consensus::fork::ForkName;
+use crate::types::consensus::light_client::header::{
+    LightClientHeaderBellatrix, LightClientHeaderCapella,
+};
 
 /// A LightClientOptimisticUpdate is the update we receive on each slot,
 /// it is based off the current unfinalized epoch and it is verified only against BLS signature.
@@ -49,10 +50,11 @@ impl LightClientOptimisticUpdate {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
+
+    use super::*;
 
     #[rstest]
     #[case("case_0")]

--- a/ethportal-api/src/types/consensus/light_client/update.rs
+++ b/ethportal-api/src/types/consensus/light_client/update.rs
@@ -1,9 +1,3 @@
-use crate::types::consensus::body::SyncAggregate;
-use crate::types::consensus::fork::ForkName;
-use crate::types::consensus::light_client::header::{
-    LightClientHeaderBellatrix, LightClientHeaderCapella,
-};
-use crate::types::consensus::sync_committee::SyncCommittee;
 use ethereum_types::H256;
 use serde::{Deserialize, Serialize};
 use serde_this_or_that::as_u64;
@@ -12,6 +6,13 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::typenum::{U5, U6};
 use ssz_types::FixedVector;
 use superstruct::superstruct;
+
+use crate::types::consensus::body::SyncAggregate;
+use crate::types::consensus::fork::ForkName;
+use crate::types::consensus::light_client::header::{
+    LightClientHeaderBellatrix, LightClientHeaderCapella,
+};
+use crate::types::consensus::sync_committee::SyncCommittee;
 
 type NextSyncCommitteeProofLen = U5;
 pub type FinalizedRootProofLen = U6;
@@ -63,10 +64,11 @@ impl LightClientUpdate {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
+
+    use super::*;
 
     #[rstest]
     #[case("case_0")]

--- a/ethportal-api/src/types/consensus/pubkey.rs
+++ b/ethportal-api/src/types/consensus/pubkey.rs
@@ -1,7 +1,8 @@
+use std::ops::Deref;
+
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ssz::{Decode, Encode};
 use ssz_types::{typenum, FixedVector};
-use std::ops::Deref;
 use tree_hash_derive::TreeHash;
 
 use crate::utils::bytes::{hex_decode, hex_encode};

--- a/ethportal-api/src/types/consensus/sync_committee.rs
+++ b/ethportal-api/src/types/consensus/sync_committee.rs
@@ -1,9 +1,10 @@
-use crate::types::consensus::pubkey::PubKey;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::typenum::U512;
 use ssz_types::FixedVector;
 use tree_hash_derive::TreeHash;
+
+use crate::types::consensus::pubkey::PubKey;
 
 type SyncCommitteeSize = U512;
 

--- a/ethportal-api/src/types/content_key/beacon.rs
+++ b/ethportal-api/src/types/content_key/beacon.rs
@@ -1,11 +1,13 @@
-use crate::types::content_key::error::ContentKeyError;
-use crate::types::content_key::overlay::OverlayContentKey;
-use crate::utils::bytes::{hex_decode, hex_encode, hex_encode_compact};
+use std::fmt;
+
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
-use std::fmt;
+
+use crate::types::content_key::error::ContentKeyError;
+use crate::types::content_key::overlay::OverlayContentKey;
+use crate::utils::bytes::{hex_decode, hex_encode, hex_encode_compact};
 
 /// A content key in the beacon chain network.
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]

--- a/ethportal-api/src/types/content_key/history.rs
+++ b/ethportal-api/src/types/content_key/history.rs
@@ -1,9 +1,10 @@
+use std::fmt;
+
 use ethereum_types::H256;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest as Sha2Digest, Sha256};
 use ssz::{self, Decode, Encode};
 use ssz_derive::{Decode, Encode};
-use std::fmt;
 
 use crate::types::content_key::error::ContentKeyError;
 use crate::types::content_key::overlay::OverlayContentKey;

--- a/ethportal-api/src/types/content_key/overlay.rs
+++ b/ethportal-api/src/types/content_key/overlay.rs
@@ -1,7 +1,9 @@
+use std::fmt;
+
+use quickcheck::{Arbitrary, Gen};
+
 use crate::types::content_key::error::ContentKeyError;
 use crate::utils::bytes::{hex_encode, hex_encode_compact};
-use quickcheck::{Arbitrary, Gen};
-use std::fmt;
 
 /// Types whose values represent keys to lookup content items in an overlay network.
 /// Keys are serializable.

--- a/ethportal-api/src/types/content_key/state.rs
+++ b/ethportal-api/src/types/content_key/state.rs
@@ -1,12 +1,14 @@
-use crate::types::content_key::overlay::OverlayContentKey;
-use crate::utils::bytes::hex_encode_compact;
+use std::fmt;
+
 use ethereum_types::{U256, U512};
 use sha2::{Digest as Sha2Digest, Sha256};
 use sha3::{Digest, Keccak256};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum, FixedVector, VariableList};
-use std::fmt;
+
+use crate::types::content_key::overlay::OverlayContentKey;
+use crate::utils::bytes::hex_encode_compact;
 
 /// A content key in the state overlay network.
 #[derive(Clone, Debug, Decode, Encode)]

--- a/ethportal-api/src/types/content_value/beacon.rs
+++ b/ethportal-api/src/types/content_value/beacon.rs
@@ -1,3 +1,10 @@
+use std::ops::Deref;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use ssz::{Decode, DecodeError, Encode};
+use ssz_types::typenum::U128;
+use ssz_types::VariableList;
+
 use crate::types::consensus::fork::{ForkDigest, ForkName};
 use crate::types::consensus::header_proof::HistoricalSummariesWithProof;
 use crate::types::consensus::light_client::bootstrap::{
@@ -17,11 +24,6 @@ use crate::types::constants::CONTENT_ABSENT;
 use crate::types::content_value::ContentValue;
 use crate::utils::bytes::{hex_decode, hex_encode};
 use crate::ContentValueError;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use ssz::{Decode, DecodeError, Encode};
-use ssz_types::typenum::U128;
-use ssz_types::VariableList;
-use std::ops::Deref;
 
 #[derive(Clone, Debug, PartialEq)]
 #[allow(clippy::large_enum_variant)]
@@ -539,10 +541,12 @@ impl<'de> Deserialize<'de> for BeaconContentValue {
 
 #[cfg(test)]
 mod test {
+    use std::fs;
+
+    use serde_json::Value;
+
     use crate::utils::bytes::hex_decode;
     use crate::{BeaconContentValue, ContentValue, PossibleBeaconContentValue};
-    use serde_json::Value;
-    use std::fs;
 
     #[test]
     fn light_client_bootstrap_encode_decode() {

--- a/ethportal-api/src/types/content_value/history.rs
+++ b/ethportal-api/src/types/content_value/history.rs
@@ -1,10 +1,11 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use ssz::{Decode, Encode};
+
 use crate::types::constants::CONTENT_ABSENT;
 use crate::types::content_value::ContentValue;
 use crate::types::execution::accumulator::EpochAccumulator;
 use crate::utils::bytes::{hex_decode, hex_encode};
 use crate::{BlockBody, ContentValueError, HeaderWithProof, Receipts};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use ssz::{Decode, Encode};
 
 /// A Portal History content value.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -168,12 +169,12 @@ impl<'de> Deserialize<'de> for HistoryContentValue {
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use std::fs;
 
     use serde_json::Value;
 
+    use super::*;
     use crate::HistoryContentValue;
-    use std::fs;
 
     /// Max number of blocks / epoch = 2 ** 13
     pub const EPOCH_SIZE: usize = 8192;

--- a/ethportal-api/src/types/discv5.rs
+++ b/ethportal-api/src/types/discv5.rs
@@ -1,8 +1,8 @@
-use super::enr::Enr;
+use discv5::enr::NodeId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use discv5::enr::NodeId;
+use super::enr::Enr;
 
 /// Discv5 bucket
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/ethportal-api/src/types/distance.rs
+++ b/ethportal-api/src/types/distance.rs
@@ -77,10 +77,10 @@ impl Metric for XorMetric {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-
     use quickcheck::{quickcheck, Arbitrary, Gen, TestResult};
     use test_log::test;
+
+    use super::*;
 
     /// Wrapper type around a 256-bit identifier in the DHT key space.
     ///

--- a/ethportal-api/src/types/enr.rs
+++ b/ethportal-api/src/types/enr.rs
@@ -1,3 +1,7 @@
+use std::net::Ipv4Addr;
+use std::ops::{Deref, DerefMut};
+use std::str::FromStr;
+
 use discv5::enr::CombinedKey;
 use discv5::enr::EnrBuilder;
 use rand::Rng;
@@ -5,9 +9,6 @@ use rlp::Encodable;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use ssz::DecodeError;
-use std::net::Ipv4Addr;
-use std::ops::{Deref, DerefMut};
-use std::str::FromStr;
 use validator::ValidationError;
 
 pub type Enr = discv5::enr::Enr<CombinedKey>;
@@ -99,10 +100,11 @@ pub fn generate_random_remote_enr() -> (CombinedKey, Enr) {
 
 #[cfg(test)]
 mod test {
-    use crate::generate_random_node_id;
-    use crate::types::distance::{Metric, XorMetric};
     use discv5::enr::NodeId;
     use test_log::test;
+
+    use crate::generate_random_node_id;
+    use crate::types::distance::{Metric, XorMetric};
 
     #[test]
     fn test_generate_random_node_id_1() {

--- a/ethportal-api/src/types/execution/block_body.rs
+++ b/ethportal-api/src/types/execution/block_body.rs
@@ -359,11 +359,11 @@ impl ssz::Decode for BlockBodyShanghai {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
     use ethereum_types::U256;
     use rstest::rstest;
     use ssz::{Decode, Encode};
 
+    use super::*;
     use crate::utils::bytes::{hex_decode, hex_encode};
 
     // tx data from: https://etherscan.io/txs?block=14764013

--- a/ethportal-api/src/types/execution/header.rs
+++ b/ethportal-api/src/types/execution/header.rs
@@ -435,12 +435,13 @@ impl ssz::Encode for SszNone {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
     use std::fs;
 
     use serde_json::{json, Value};
     use ssz::Decode;
     use test_log::test;
+
+    use super::*;
 
     #[test]
     fn decode_and_encode_header() {

--- a/ethportal-api/src/types/execution/receipts.rs
+++ b/ethportal-api/src/types/execution/receipts.rs
@@ -461,7 +461,6 @@ impl DerefMut for Receipt {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
     use std::str::FromStr;
 
     use ethereum_types::H160;
@@ -469,6 +468,7 @@ mod tests {
     use ssz::{Decode, Encode};
     use test_log::test;
 
+    use super::*;
     use crate::utils::bytes::hex_encode;
 
     //

--- a/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -1,7 +1,8 @@
+use discv5::enr::NodeId;
+
 use crate::types::enr::Enr;
 use crate::{BeaconContentKey, HistoryContentKey};
 use crate::{BeaconContentValue, HistoryContentValue};
-use discv5::enr::NodeId;
 
 /// Discv5 JSON-RPC endpoints. Start with "discv5_" prefix
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/ethportal-api/src/types/jsonrpc/params.rs
+++ b/ethportal-api/src/types/jsonrpc/params.rs
@@ -26,8 +26,9 @@ impl From<Params> for Value {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use rstest::rstest;
+
+    use super::*;
 
     fn expected_map() -> Map<String, Value> {
         let mut expected_map = serde_json::Map::new();

--- a/ethportal-api/src/types/jsonrpc/request.rs
+++ b/ethportal-api/src/types/jsonrpc/request.rs
@@ -75,8 +75,9 @@ fn validate_jsonrpc_version(jsonrpc: &str) -> Result<(), ValidationError> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use validator::ValidationErrors;
+
+    use super::*;
 
     #[test_log::test]
     fn test_json_validator_accepts_valid_json() {

--- a/ethportal-api/src/types/node_id.rs
+++ b/ethportal-api/src/types/node_id.rs
@@ -1,10 +1,9 @@
-use super::enr::Enr;
+use discv5::enr::NodeId as EnrNodeId;
 use serde::{Deserialize, Serialize};
 use stremio_serde_hex::{SerHex, StrictPfx};
 
-use discv5::enr::NodeId as EnrNodeId;
-
 use super::distance::{Metric, XorMetric};
+use super::enr::Enr;
 
 type RawNodeId = [u8; 32];
 

--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -1,10 +1,10 @@
-use crate::types::enr::Enr;
-use crate::HistoryContentKey;
-use crate::PossibleHistoryContentValue;
 use serde::{Deserialize, Serialize};
 use ssz_types::{typenum, BitList};
 
 use super::query_trace::QueryTrace;
+use crate::types::enr::Enr;
+use crate::HistoryContentKey;
+use crate::PossibleHistoryContentValue;
 
 pub type DataRadius = ethereum_types::U256;
 pub type Distance = ethereum_types::U256;

--- a/ethportal-api/src/types/query_trace.rs
+++ b/ethportal-api/src/types/query_trace.rs
@@ -1,11 +1,11 @@
-use super::enr::Enr;
-use super::node_id::NodeId;
 use std::collections::HashMap;
 use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 
 use super::distance::{Metric, XorMetric};
+use super::enr::Enr;
+use super::node_id::NodeId;
 
 type ContentId = NodeId;
 
@@ -152,7 +152,6 @@ pub struct NodeInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::types::enr::generate_random_remote_enr;
 
     #[test]

--- a/ethportal-api/src/utils/serde/hex_fixed_vec.rs
+++ b/ethportal-api/src/utils/serde/hex_fixed_vec.rs
@@ -1,8 +1,9 @@
-use crate::utils::bytes::hex_encode;
 use serde::{Deserializer, Serializer};
 use serde_utils::hex::PrefixedHexVisitor;
 use ssz_types::typenum::Unsigned;
 use ssz_types::FixedVector;
+
+use crate::utils::bytes::hex_encode;
 
 pub fn serialize<S, U>(bytes: &FixedVector<u8, U>, serializer: S) -> Result<S::Ok, S::Error>
 where

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -1,5 +1,3 @@
-use crate::constants::fixture_header_with_proof;
-use crate::Peertest;
 use ethereum_types::{H256, U256};
 use ethportal_api::types::distance::Distance;
 use ethportal_api::{
@@ -10,6 +8,9 @@ use jsonrpsee::async_client::Client;
 use ssz::Encode;
 use tracing::info;
 use trin_utils::version::get_trin_version;
+
+use crate::constants::fixture_header_with_proof;
+use crate::Peertest;
 
 pub async fn test_web3_client_version(target: &Client) {
     info!("Testing web3_clientVersion");

--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -1,6 +1,5 @@
-use crate::constants::fixture_header_with_proof_1000010;
-use crate::utils::{wait_for_beacon_content, wait_for_history_content};
-use crate::Peertest;
+use std::sync::Arc;
+
 use ethportal_api::jsonrpsee::http_client::HttpClient;
 use ethportal_api::{
     BeaconContentKey, BeaconContentValue, PossibleBeaconContentValue, PossibleHistoryContentValue,
@@ -12,10 +11,13 @@ use portal_bridge::execution_api::ExecutionApi;
 use portal_bridge::mode::BridgeMode;
 use portal_bridge::pandaops::PandaOpsMiddleware;
 use serde_json::Value;
-use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 use trin_validation::accumulator::MasterAccumulator;
 use trin_validation::oracle::HeaderOracle;
+
+use crate::constants::fixture_header_with_proof_1000010;
+use crate::utils::{wait_for_beacon_content, wait_for_history_content};
+use crate::Peertest;
 
 pub async fn test_history_bridge(peertest: &Peertest, target: &HttpClient) {
     let master_acc = MasterAccumulator::default();

--- a/ethportal-peertest/src/scenarios/eth_rpc.rs
+++ b/ethportal-peertest/src/scenarios/eth_rpc.rs
@@ -1,7 +1,6 @@
 use ethereum_types::U256;
-use tracing::info;
-
 use ethportal_api::EthApiClient;
+use tracing::info;
 use trin_validation::constants::CHAIN_ID;
 
 use crate::Peertest;

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -1,11 +1,12 @@
-use crate::constants::fixture_header_with_proof;
-use crate::Peertest;
 use discv5::enr::NodeId;
 use ethportal_api::types::portal::{ContentInfo, TraceContentInfo};
 use ethportal_api::utils::bytes::hex_decode;
 use ethportal_api::{HistoryNetworkApiClient, PossibleHistoryContentValue};
 use jsonrpsee::async_client::Client;
 use tracing::info;
+
+use crate::constants::fixture_header_with_proof;
+use crate::Peertest;
 
 pub async fn test_find_content_return_enr(target: &Client, peertest: &Peertest) {
     info!("Testing find content returns enrs properly");

--- a/ethportal-peertest/src/scenarios/offer_accept.rs
+++ b/ethportal-peertest/src/scenarios/offer_accept.rs
@@ -1,12 +1,12 @@
 use std::str::FromStr;
 
-use tracing::info;
-
-use crate::{constants::fixture_header_with_proof, utils::wait_for_history_content, Peertest};
 use ethportal_api::{
     jsonrpsee::async_client::Client, types::enr::Enr, utils::bytes::hex_encode,
     HistoryNetworkApiClient, PossibleHistoryContentValue,
 };
+use tracing::info;
+
+use crate::{constants::fixture_header_with_proof, utils::wait_for_history_content, Peertest};
 
 pub async fn test_unpopulated_offer(peertest: &Peertest, target: &Client) {
     info!("Testing Unpopulated OFFER/ACCEPT flow");

--- a/ethportal-peertest/src/scenarios/utp.rs
+++ b/ethportal-peertest/src/scenarios/utp.rs
@@ -1,11 +1,12 @@
-use crate::{
-    constants::{fixture_block_body, fixture_header_with_proof},
-    Peertest,
-};
 use discv5::enr::NodeId;
 use ethportal_api::types::portal::{ContentInfo, TraceContentInfo};
 use ethportal_api::{HistoryNetworkApiClient, PossibleHistoryContentValue};
 use tracing::info;
+
+use crate::{
+    constants::{fixture_block_body, fixture_header_with_proof},
+    Peertest,
+};
 
 pub async fn test_recursive_utp(peertest: &Peertest) {
     info!("Test recursive utp");

--- a/ethportal-peertest/src/scenarios/validation.rs
+++ b/ethportal-peertest/src/scenarios/validation.rs
@@ -1,7 +1,5 @@
-use crate::{
-    constants::{fixture_block_body, fixture_header_with_proof, fixture_receipts},
-    Peertest,
-};
+use std::str::FromStr;
+
 use ethereum_types::H256;
 use ethportal_api::types::content_key::history::BlockHeaderKey;
 use ethportal_api::types::enr::Enr;
@@ -10,8 +8,12 @@ use ethportal_api::{
     jsonrpsee::async_client::Client, HistoryContentKey, HistoryNetworkApiClient,
     PossibleHistoryContentValue,
 };
-use std::str::FromStr;
 use tracing::info;
+
+use crate::{
+    constants::{fixture_block_body, fixture_header_with_proof, fixture_receipts},
+    Peertest,
+};
 
 pub async fn test_validate_pre_merge_header_with_proof(peertest: &Peertest, target: &Client) {
     info!("Test validating a pre-merge header-with-proof");

--- a/ethportal-peertest/src/utils.rs
+++ b/ethportal-peertest/src/utils.rs
@@ -1,9 +1,8 @@
-use tracing::error;
-
 use ethportal_api::{
     BeaconContentKey, BeaconNetworkApiClient, HistoryContentKey, HistoryNetworkApiClient,
     PossibleBeaconContentValue, PossibleHistoryContentValue,
 };
+use tracing::error;
 
 /// Wait for the history content to be transferred
 pub async fn wait_for_history_content<P: HistoryNetworkApiClient + std::marker::Sync>(

--- a/light-client/src/client.rs
+++ b/light-client/src/client.rs
@@ -1,24 +1,20 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
-use eyre::{eyre, Result};
-
-use crate::consensus::ConsensusLightClient;
-use log::{error, info, warn};
-use tokio::sync::RwLock;
-
 use ethportal_api::consensus::header::BeaconBlockHeader;
-use std::path::PathBuf;
+use eyre::{eyre, Result};
+use log::{error, info, warn};
 use tokio::spawn;
+use tokio::sync::RwLock;
 use tokio::time::sleep;
 
 use crate::config::client_config::Config;
 use crate::config::{CheckpointFallback, Network};
 use crate::consensus::errors::ConsensusError;
-
+use crate::consensus::ConsensusLightClient;
 use crate::database::Database;
 use crate::errors::NodeError;
 use crate::node::Node;
-
 use crate::rpc::Rpc;
 
 #[derive(Default)]

--- a/light-client/src/config/client_config.rs
+++ b/light-client/src/config/client_config.rs
@@ -1,9 +1,10 @@
+use std::{path::PathBuf, process::exit};
+
 use figment::{
     providers::{Format, Serialized, Toml},
     Figment,
 };
 use serde::Deserialize;
-use std::{path::PathBuf, process::exit};
 
 use crate::config::utils::{bytes_deserialize, bytes_opt_deserialize};
 use crate::config::{networks, BaseConfig, ChainConfig, CliConfig, Forks};

--- a/light-client/src/consensus/consensus_client.rs
+++ b/light-client/src/consensus/consensus_client.rs
@@ -1,33 +1,32 @@
 use std::cmp;
 use std::sync::Arc;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use chrono::Duration;
-use eyre::eyre;
-use eyre::Result;
-use log::warn;
-use log::{debug, info};
-use milagro_bls::PublicKey;
-use ssz_rs::prelude::*;
-
-use super::rpc::ConsensusRpc;
-use super::types::*;
-use super::utils::*;
-
-use super::constants::MAX_REQUEST_LIGHT_CLIENT_UPDATES;
-use super::errors::ConsensusError;
-use crate::config::client_config::Config;
-use crate::types::Bytes32;
-use crate::utils::bytes_to_bytes32;
 use ethereum_types::H256;
 use ethportal_api::consensus::header::BeaconBlockHeader;
 use ethportal_api::consensus::signature::BlsSignature;
 use ethportal_api::light_client::bootstrap::CurrentSyncCommitteeProofLen;
 use ethportal_api::light_client::update::FinalizedRootProofLen;
 use ethportal_api::utils::bytes::hex_encode;
+use eyre::eyre;
+use eyre::Result;
+use log::warn;
+use log::{debug, info};
+use milagro_bls::PublicKey;
+use ssz_rs::prelude::*;
 use ssz_types::{typenum, BitVector, FixedVector};
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
 use tree_hash::TreeHash;
+
+use super::constants::MAX_REQUEST_LIGHT_CLIENT_UPDATES;
+use super::errors::ConsensusError;
+use super::rpc::ConsensusRpc;
+use super::types::*;
+use super::utils::*;
+use crate::config::client_config::Config;
+use crate::types::Bytes32;
+use crate::utils::bytes_to_bytes32;
 
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/sync-protocol.md
 // does not implement force updates

--- a/light-client/src/consensus/rpc/mock_rpc.rs
+++ b/light-client/src/consensus/rpc/mock_rpc.rs
@@ -1,12 +1,13 @@
 use std::{fs::read_to_string, path::PathBuf};
 
+use async_trait::async_trait;
+use eyre::Result;
+
 use super::ConsensusRpc;
 use crate::consensus::types::{
     LightClientBootstrapCapella, LightClientFinalityUpdateCapella,
     LightClientOptimisticUpdateCapella, LightClientUpdateCapella,
 };
-use async_trait::async_trait;
-use eyre::Result;
 
 pub struct MockRpc {
     testdata: PathBuf,

--- a/light-client/src/consensus/rpc/mod.rs
+++ b/light-client/src/consensus/rpc/mod.rs
@@ -1,12 +1,13 @@
 pub mod mock_rpc;
 pub mod nimbus_rpc;
 
+use async_trait::async_trait;
+use eyre::Result;
+
 use super::types::{
     LightClientBootstrapCapella, LightClientFinalityUpdateCapella,
     LightClientOptimisticUpdateCapella, LightClientUpdateCapella,
 };
-use async_trait::async_trait;
-use eyre::Result;
 
 // implements https://github.com/ethereum/beacon-APIs/tree/master/apis/beacon/light_client
 #[async_trait]

--- a/light-client/src/consensus/rpc/nimbus_rpc.rs
+++ b/light-client/src/consensus/rpc/nimbus_rpc.rs
@@ -1,10 +1,11 @@
-use crate::consensus::types::u64_deserialize;
+use std::cmp;
+
 use async_trait::async_trait;
 use eyre::Result;
-use std::cmp;
 
 use super::ConsensusRpc;
 use crate::consensus::constants::MAX_REQUEST_LIGHT_CLIENT_UPDATES;
+use crate::consensus::types::u64_deserialize;
 use crate::consensus::types::{
     LightClientBootstrapCapella, LightClientFinalityUpdateCapella,
     LightClientOptimisticUpdateCapella, LightClientUpdateCapella,

--- a/light-client/src/consensus/utils.rs
+++ b/light-client/src/consensus/utils.rs
@@ -1,11 +1,12 @@
-use crate::types::Bytes32;
-use crate::utils::bytes32_to_node;
 use ethportal_api::consensus::header::BeaconBlockHeader;
 use ethportal_api::consensus::signature::BlsSignature;
 use eyre::Result;
 use milagro_bls::{AggregateSignature, PublicKey};
 use ssz_rs::prelude::*;
 use tree_hash::TreeHash;
+
+use crate::types::Bytes32;
+use crate::utils::bytes32_to_node;
 
 pub fn calc_sync_period(slot: u64) -> u64 {
     let epoch = slot / 32; // 32 slots per epoch

--- a/light-client/src/database.rs
+++ b/light-client/src/database.rs
@@ -4,8 +4,9 @@ use std::{
     path::PathBuf,
 };
 
-use crate::config::client_config::Config;
 use eyre::Result;
+
+use crate::config::client_config::Config;
 
 pub trait Database {
     fn new(config: &Config) -> Result<Self>

--- a/light-client/src/main.rs
+++ b/light-client/src/main.rs
@@ -1,8 +1,9 @@
+use std::path::PathBuf;
+
 use eyre::Result;
 use light_client::config::networks;
 use light_client::database::FileDB;
 use light_client::{Client, ClientBuilder};
-use std::path::PathBuf;
 use tracing::info;
 
 #[tokio::main]

--- a/light-client/src/node.rs
+++ b/light-client/src/node.rs
@@ -7,7 +7,6 @@ use eyre::Result;
 use crate::config::client_config::Config;
 use crate::consensus::rpc::nimbus_rpc::NimbusRpc;
 use crate::consensus::ConsensusLightClient;
-
 use crate::errors::NodeError;
 
 pub struct Node {

--- a/light-client/src/rpc.rs
+++ b/light-client/src/rpc.rs
@@ -1,17 +1,16 @@
-use eyre::Result;
-use log::info;
 use std::{net::SocketAddr, sync::Arc};
-use tokio::sync::RwLock;
 
+use eyre::Result;
 use jsonrpsee::{
     core::{async_trait, RpcResult},
     proc_macros::rpc,
     server::{Server, ServerHandle},
     Methods,
 };
+use log::info;
+use tokio::sync::RwLock;
 
 use crate::node::Node;
-
 use crate::utils::u64_to_hex_string;
 
 pub struct Rpc {

--- a/light-client/src/utils.rs
+++ b/light-client/src/utils.rs
@@ -1,6 +1,7 @@
-use crate::types::Bytes32;
 use eyre::Result;
 use ssz_rs::{Node, Vector};
+
+use crate::types::Bytes32;
 
 pub fn bytes_to_bytes32(bytes: &[u8]) -> Bytes32 {
     Vector::from_iter(bytes.to_vec())

--- a/portal-bridge/src/beacon_bridge.rs
+++ b/portal-bridge/src/beacon_bridge.rs
@@ -1,9 +1,8 @@
-use crate::consensus_api::ConsensusApi;
-use crate::constants::BEACON_GENESIS_TIME;
-use crate::mode::BridgeMode;
-use crate::utils::{
-    duration_until_next_update, expected_current_slot, read_test_assets_from_file, TestAssets,
-};
+use std::cmp::Ordering;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::SystemTime;
+
 use anyhow::bail;
 use ethportal_api::types::consensus::fork::ForkName;
 use ethportal_api::types::consensus::light_client::bootstrap::LightClientBootstrapCapella;
@@ -11,6 +10,9 @@ use ethportal_api::types::consensus::light_client::finality_update::LightClientF
 use ethportal_api::types::consensus::light_client::optimistic_update::LightClientOptimisticUpdateCapella;
 use ethportal_api::types::consensus::light_client::update::{
     LightClientUpdate, LightClientUpdateCapella,
+};
+use ethportal_api::types::content_key::beacon::{
+    LightClientFinalityUpdateKey, LightClientOptimisticUpdateKey,
 };
 use ethportal_api::types::content_value::beacon::{
     ForkVersionedLightClientUpdate, LightClientUpdatesByRange,
@@ -23,16 +25,15 @@ use ethportal_api::{
 use jsonrpsee::http_client::HttpClient;
 use serde_json::Value;
 use ssz_types::VariableList;
-use std::cmp::Ordering;
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::time::SystemTime;
+use tokio::time::{interval, sleep, Duration, MissedTickBehavior};
 use tracing::{info, warn};
 
-use ethportal_api::types::content_key::beacon::{
-    LightClientFinalityUpdateKey, LightClientOptimisticUpdateKey,
+use crate::consensus_api::ConsensusApi;
+use crate::constants::BEACON_GENESIS_TIME;
+use crate::mode::BridgeMode;
+use crate::utils::{
+    duration_until_next_update, expected_current_slot, read_test_assets_from_file, TestAssets,
 };
-use tokio::time::{interval, sleep, Duration, MissedTickBehavior};
 
 pub struct BeaconBridge {
     pub api: ConsensusApi,

--- a/portal-bridge/src/bridge.rs
+++ b/portal-bridge/src/bridge.rs
@@ -1,7 +1,9 @@
-use crate::execution_api::ExecutionApi;
-use crate::full_header::FullHeader;
-use crate::mode::{BridgeMode, ModeType};
-use crate::utils::{read_test_assets_from_file, TestAssets};
+use std::fs;
+use std::ops::Range;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time;
+
 use anyhow::{anyhow, bail};
 use ethportal_api::jsonrpsee::http_client::HttpClient;
 use ethportal_api::types::execution::accumulator::EpochAccumulator;
@@ -21,11 +23,6 @@ use ethportal_api::{
 };
 use futures::stream::StreamExt;
 use ssz::Decode;
-use std::fs;
-use std::ops::Range;
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-use std::time;
 use surf::{
     middleware::{Middleware, Next},
     Body, Client, Request, Response,
@@ -35,6 +32,11 @@ use tracing::{debug, info, warn};
 use trin_validation::accumulator::MasterAccumulator;
 use trin_validation::constants::{EPOCH_SIZE as EPOCH_SIZE_USIZE, MERGE_BLOCK_NUMBER};
 use trin_validation::oracle::HeaderOracle;
+
+use crate::execution_api::ExecutionApi;
+use crate::full_header::FullHeader;
+use crate::mode::{BridgeMode, ModeType};
+use crate::utils::{read_test_assets_from_file, TestAssets};
 
 // todo: calculate / test optimal saturation delay
 const HEADER_SATURATION_DELAY: u64 = 10; // seconds

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -1,11 +1,13 @@
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use clap::{Parser, Subcommand};
+use tokio::process::Child;
+use url::Url;
+
 use crate::client_handles::{fluffy_handle, trin_handle};
 use crate::mode::BridgeMode;
 use crate::types::NetworkKind;
-use clap::{Parser, Subcommand};
-use std::path::PathBuf;
-use std::str::FromStr;
-use tokio::process::Child;
-use url::Url;
 
 // max value of 16 b/c...
 // - reliably calculate spaced private keys in a reasonable time

--- a/portal-bridge/src/client_handles.rs
+++ b/portal-bridge/src/client_handles.rs
@@ -1,8 +1,10 @@
-use crate::cli::BridgeConfig;
+use std::net::SocketAddr;
+
 use anyhow::bail;
 use portalnet::socket::stun_for_external;
-use std::net::SocketAddr;
 use tokio::process::{Child, Command};
+
+use crate::cli::BridgeConfig;
 
 pub fn fluffy_handle(
     private_key: String,

--- a/portal-bridge/src/consensus_api.rs
+++ b/portal-bridge/src/consensus_api.rs
@@ -1,5 +1,6 @@
-use crate::pandaops::PandaOpsMiddleware;
 use std::fmt::Display;
+
+use crate::pandaops::PandaOpsMiddleware;
 
 /// Implements endpoints from the Beacon API to access data from the consensus layer.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/portal-bridge/src/execution_api.rs
+++ b/portal-bridge/src/execution_api.rs
@@ -1,5 +1,3 @@
-use crate::full_header::{FullHeader, FullHeaderBatch};
-use crate::pandaops::PandaOpsMiddleware;
 use anyhow::{anyhow, bail};
 use ethereum_types::H256;
 use ethportal_api::types::jsonrpc::params::Params;
@@ -7,6 +5,9 @@ use ethportal_api::types::jsonrpc::request::JsonRequest;
 use ethportal_api::utils::bytes::hex_encode;
 use ethportal_api::{Header, Receipts};
 use serde_json::{json, Value};
+
+use crate::full_header::{FullHeader, FullHeaderBatch};
+use crate::pandaops::PandaOpsMiddleware;
 
 /// Implements endpoints from the Execution API to access data from the execution layer.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/portal-bridge/src/full_header.rs
+++ b/portal-bridge/src/full_header.rs
@@ -1,13 +1,12 @@
 use std::sync::Arc;
 
 use ethereum_types::H256;
-use serde::{Deserialize, Deserializer};
-use serde_json::Value;
-
 use ethportal_api::types::consensus::withdrawal::Withdrawal;
 use ethportal_api::types::execution::accumulator::EpochAccumulator;
 use ethportal_api::types::execution::header::{Header, TxHashes};
 use ethportal_api::types::execution::transaction::Transaction;
+use serde::{Deserialize, Deserializer};
+use serde_json::Value;
 
 /// Helper type to deserialize a response from a batched Header request.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -75,11 +74,12 @@ impl TryFrom<Value> for FullHeader {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use ethportal_api::types::execution::block_body::{
         BlockBody, BlockBodyLegacy, BlockBodyShanghai,
     };
     use serde_json::Value;
+
+    use super::*;
 
     #[test]
     fn full_header_from_get_block_response() {

--- a/portal-bridge/src/lib.rs
+++ b/portal-bridge/src/lib.rs
@@ -13,8 +13,9 @@ pub mod pandaops;
 pub mod types;
 pub mod utils;
 
-use lazy_static::lazy_static;
 use std::env;
+
+use lazy_static::lazy_static;
 
 lazy_static! {
     static ref PANDAOPS_CLIENT_ID: String =

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use clap::Parser;
 use ethportal_api::jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use portal_bridge::beacon_bridge::BeaconBridge;
@@ -8,7 +10,6 @@ use portal_bridge::execution_api::ExecutionApi;
 use portal_bridge::pandaops::PandaOpsMiddleware;
 use portal_bridge::types::NetworkKind;
 use portal_bridge::utils::generate_spaced_private_keys;
-use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 use trin_utils::log::init_tracing_logger;
 use trin_validation::accumulator::MasterAccumulator;

--- a/portal-bridge/src/mode.rs
+++ b/portal-bridge/src/mode.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::str::FromStr;
+
 use trin_validation::constants::EPOCH_SIZE;
 
 /// Used to help decode cli args identifying the desired bridge mode.
@@ -89,10 +90,11 @@ impl FromStr for ModeType {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::cli::BridgeConfig;
     use clap::Parser;
     use rstest::rstest;
+
+    use super::*;
+    use crate::cli::BridgeConfig;
 
     #[rstest]
     #[case("latest", BridgeMode::Latest)]

--- a/portal-bridge/src/pandaops.rs
+++ b/portal-bridge/src/pandaops.rs
@@ -1,11 +1,12 @@
-use crate::bridge::Retry;
-use crate::constants::{BASE_CL_ENDPOINT, BASE_EL_ENDPOINT};
-use crate::{PANDAOPS_CLIENT_ID, PANDAOPS_CLIENT_SECRET};
 use anyhow::anyhow;
 use ethportal_api::types::jsonrpc::request::JsonRequest;
 use futures::future::join_all;
 use serde_json::{json, Value};
 use tracing::warn;
+
+use crate::bridge::Retry;
+use crate::constants::{BASE_CL_ENDPOINT, BASE_EL_ENDPOINT};
+use crate::{PANDAOPS_CLIENT_ID, PANDAOPS_CLIENT_SECRET};
 
 /// Limit the number of requests in a single batch to avoid exceeding the
 /// provider's batch size limit configuration of 100.

--- a/portal-bridge/src/utils.rs
+++ b/portal-bridge/src/utils.rs
@@ -1,3 +1,7 @@
+use std::ops::Deref;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use anyhow::bail;
 use chrono::Duration;
 use discv5::enr::{CombinedKey, EnrBuilder, NodeId};
@@ -5,9 +9,6 @@ use ethportal_api::utils::bytes::hex_encode;
 use ethportal_api::HistoryContentKey;
 use ethportal_api::{BeaconContentKey, BeaconContentValue, HistoryContentValue};
 use serde::{Deserialize, Serialize};
-use std::ops::Deref;
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Generates a set of N private keys, with node ids that are equally spaced
 /// around the 256-bit keys space.
@@ -153,16 +154,17 @@ fn slot_timestamp(slot: u64, genesis_time: u64) -> u64 {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
-    use crate::constants::{
-        BEACON_GENESIS_TIME, HEADER_WITH_PROOF_CONTENT_KEY, HEADER_WITH_PROOF_CONTENT_VALUE,
-    };
     use chrono::{DateTime, TimeZone, Utc};
     use ethereum_types::U256;
     use ethportal_api::types::distance::{Metric, XorMetric};
     use ethportal_api::utils::bytes::hex_decode;
     use rstest::rstest;
     use serde_json::json;
+
+    use super::*;
+    use crate::constants::{
+        BEACON_GENESIS_TIME, HEADER_WITH_PROOF_CONTENT_KEY, HEADER_WITH_PROOF_CONTENT_VALUE,
+    };
 
     #[rstest]
     #[case(2)]

--- a/portalnet/src/config.rs
+++ b/portalnet/src/config.rs
@@ -1,7 +1,6 @@
 use std::net::SocketAddr;
 
 use ethereum_types::H256;
-
 use ethportal_api::types::bootnodes::Bootnodes;
 use ethportal_api::types::cli::TrinConfig;
 use ethportal_api::types::distance::Distance;

--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -11,21 +11,21 @@ use discv5::{
     enr::{CombinedKey, EnrBuilder, NodeId},
     ConfigBuilder, Discv5, Event, ListenConfig, RequestError, TalkRequest,
 };
+use ethportal_api::types::enr::Enr;
+use ethportal_api::utils::bytes::hex_encode;
+use ethportal_api::NodeInfo;
 use lru::LruCache;
 use parking_lot::RwLock;
 use rlp::RlpStream;
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
+use trin_utils::version::get_trin_version;
 use utp_rs::{cid::ConnectionPeer, udp::AsyncUdpSocket};
 
 use super::config::PortalnetConfig;
 use super::types::messages::ProtocolId;
 use crate::socket;
-use ethportal_api::types::enr::Enr;
-use ethportal_api::utils::bytes::hex_encode;
-use ethportal_api::NodeInfo;
-use trin_utils::version::get_trin_version;
 
 /// Size of the buffer of the Discv5 TALKREQ channel.
 const TALKREQ_CHANNEL_BUFFER: usize = 100;
@@ -452,9 +452,10 @@ fn get_enr_rlp_content(enr: &Enr) -> BytesMut {
 
 #[cfg(test)]
 mod tests {
+    use ethportal_api::types::bootnodes::Bootnodes;
+
     use super::*;
     use crate::utils::db::{configure_node_data_dir, configure_trin_data_dir};
-    use ethportal_api::types::bootnodes::Bootnodes;
 
     #[test]
     fn test_enr_file() {

--- a/portalnet/src/events.rs
+++ b/portalnet/src/events.rs
@@ -2,11 +2,11 @@ use std::str::FromStr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use discv5::TalkRequest;
+use ethportal_api::utils::bytes::{hex_encode, hex_encode_upper};
 use tokio::sync::mpsc;
 use tracing::{error, warn};
 
 use super::types::messages::ProtocolId;
-use ethportal_api::utils::bytes::{hex_encode, hex_encode_upper};
 
 /// Main handler for portal network events
 pub struct PortalnetEvents {
@@ -171,8 +171,9 @@ pub fn millis_to_epoch(time: SystemTime) -> i64 {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use std::time::SystemTime;
+
+    use super::*;
 
     #[test]
     fn test_timestamp_creation() {

--- a/portalnet/src/find/iterators/findcontent.rs
+++ b/portalnet/src/find/iterators/findcontent.rs
@@ -432,12 +432,14 @@ where
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
+    use std::time::Duration;
+
     use discv5::enr::NodeId;
     use quickcheck::*;
     use rand::{thread_rng, Rng};
-    use std::time::Duration;
     use test_log::test;
+
+    use super::*;
 
     type TestQuery = FindContentQuery<NodeId>;
 

--- a/portalnet/src/find/iterators/findnodes.rs
+++ b/portalnet/src/find/iterators/findnodes.rs
@@ -21,14 +21,15 @@
 // This basis of this file has been taken from the rust-libp2p codebase:
 // https://github.com/libp2p/rust-libp2p
 
-use super::super::query_pool::QueryState;
-use super::query::{Query, QueryConfig, QueryPeer, QueryPeerState, QueryProgress};
-
-use discv5::kbucket::{Distance, Key};
 use std::{
     collections::btree_map::{BTreeMap, Entry},
     time::Instant,
 };
+
+use discv5::kbucket::{Distance, Key};
+
+use super::super::query_pool::QueryState;
+use super::query::{Query, QueryConfig, QueryPeer, QueryPeerState, QueryProgress};
 
 #[derive(Debug, Clone)]
 pub struct FindNodeQuery<TNodeId> {
@@ -320,12 +321,14 @@ where
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
+    use std::time::Duration;
+
     use discv5::enr::NodeId;
     use quickcheck::*;
     use rand::{thread_rng, Rng};
-    use std::time::Duration;
     use test_log::test;
+
+    use super::*;
 
     type TestQuery = FindNodeQuery<NodeId>;
 

--- a/portalnet/src/find/iterators/query.rs
+++ b/portalnet/src/find/iterators/query.rs
@@ -21,11 +21,11 @@
 // This basis of this file has been taken from the rust-libp2p codebase:
 // https://github.com/libp2p/rust-libp2p
 
-use super::super::query_pool::QueryState;
-
 use std::time::{Duration, Instant};
 
 use discv5::kbucket::Key;
+
+use super::super::query_pool::QueryState;
 
 // Configuration for a `Query`.
 #[derive(Debug, Clone)]

--- a/portalnet/src/find/query_info.rs
+++ b/portalnet/src/find/query_info.rs
@@ -1,4 +1,6 @@
 use discv5::{enr::NodeId, kbucket::Key, Enr};
+use ethportal_api::types::query_trace::QueryTrace;
+use ethportal_api::OverlayContentKey;
 use futures::channel::oneshot;
 use smallvec::SmallVec;
 
@@ -6,8 +8,6 @@ use crate::{
     find::query_pool::TargetKey,
     types::messages::{Content, FindContent, FindNodes, Request},
 };
-use ethportal_api::types::query_trace::QueryTrace;
-use ethportal_api::OverlayContentKey;
 
 /// Information about a query.
 #[derive(Debug)]
@@ -126,8 +126,9 @@ fn findnode_log2distance(target: NodeId, peer: NodeId, size: usize) -> Option<Ve
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
     use test_log::test;
+
+    use super::*;
 
     #[test]
     fn test_log2distance() {

--- a/portalnet/src/find/query_pool.rs
+++ b/portalnet/src/find/query_pool.rs
@@ -21,15 +21,16 @@
 // This basis of this file has been taken from the rust-libp2p codebase:
 // https://github.com/libp2p/rust-libp2p
 
-use super::{iterators::query::Query, query_info::QueryInfo};
-use ethportal_api::OverlayContentKey;
-
-use discv5::kbucket::Key;
-use fnv::FnvHashMap;
 use std::{
     marker::PhantomData,
     time::{Duration, Instant},
 };
+
+use discv5::kbucket::Key;
+use ethportal_api::OverlayContentKey;
+use fnv::FnvHashMap;
+
+use super::{iterators::query::Query, query_info::QueryInfo};
 
 pub trait TargetKey<TNodeId> {
     fn key(&self) -> Key<TNodeId>;

--- a/portalnet/src/metrics/portalnet.rs
+++ b/portalnet/src/metrics/portalnet.rs
@@ -1,7 +1,8 @@
-use crate::metrics::overlay::OverlayMetrics;
-use crate::metrics::storage::StorageMetrics;
 use lazy_static::lazy_static;
 use prometheus_exporter::prometheus::default_registry;
+
+use crate::metrics::overlay::OverlayMetrics;
+use crate::metrics::storage::StorageMetrics;
 
 // We use lazy_static to ensure that the metrics registry is initialized only once, for each
 // runtime. This is important because the registry is a global singleton, and if it is

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -1,3 +1,12 @@
+use std::future::Future;
+use std::{
+    collections::{BTreeMap, HashSet},
+    fmt::{Debug, Display},
+    marker::{PhantomData, Sync},
+    sync::Arc,
+    time::Duration,
+};
+
 use anyhow::anyhow;
 use discv5::{
     enr::NodeId,
@@ -7,22 +16,22 @@ use discv5::{
     },
     ConnectionDirection, ConnectionState, TalkRequest,
 };
+use ethportal_api::types::bootnodes::Bootnode;
+use ethportal_api::types::distance::{Distance, Metric};
+use ethportal_api::types::enr::Enr;
+use ethportal_api::utils::bytes::hex_encode;
+use ethportal_api::OverlayContentKey;
+use ethportal_api::RawContentKey;
 use futures::channel::oneshot;
 use parking_lot::RwLock;
 use ssz::Encode;
-use std::future::Future;
-use std::{
-    collections::{BTreeMap, HashSet},
-    fmt::{Debug, Display},
-    marker::{PhantomData, Sync},
-    sync::Arc,
-    time::Duration,
-};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, error, info, warn};
+use trin_validation::validator::Validator;
 use utp_rs::socket::UtpSocket;
 
+use crate::events::EventEnvelope;
 use crate::{
     discovery::{Discovery, UtpEnr},
     find::query_info::{FindContentResult, RecursiveFindContentResult},
@@ -41,15 +50,6 @@ use crate::{
         node::Node,
     },
 };
-use ethportal_api::types::bootnodes::Bootnode;
-use ethportal_api::types::distance::{Distance, Metric};
-use ethportal_api::types::enr::Enr;
-use ethportal_api::utils::bytes::hex_encode;
-use ethportal_api::OverlayContentKey;
-use ethportal_api::RawContentKey;
-use trin_validation::validator::Validator;
-
-use crate::events::EventEnvelope;
 
 /// Configuration parameters for the overlay network.
 #[derive(Clone)]
@@ -784,8 +784,9 @@ fn validate_find_nodes_distances(distances: &Vec<u16>) -> Result<(), OverlayRequ
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case(vec![0u16])]

--- a/portalnet/src/socket.rs
+++ b/portalnet/src/socket.rs
@@ -1,4 +1,5 @@
 use std::net::{SocketAddr, UdpSocket};
+
 use tracing::{debug, info, warn};
 
 // This stun server is part of the testnet infrastructure.

--- a/portalnet/src/storage.rs
+++ b/portalnet/src/storage.rs
@@ -7,7 +7,10 @@ use std::{
 
 use anyhow::anyhow;
 use discv5::enr::NodeId;
+use ethportal_api::types::distance::{Distance, Metric, XorMetric};
 use ethportal_api::types::portal::PaginateLocalContentInfo;
+use ethportal_api::utils::bytes::{hex_decode, hex_encode, ByteUtilsError};
+use ethportal_api::{ContentKeyError, HistoryContentKey, OverlayContentKey};
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 use rocksdb::{Options, DB};
@@ -18,9 +21,6 @@ use tracing::{debug, error, info};
 use crate::metrics::portalnet::PORTALNET_METRICS;
 use crate::metrics::storage::StorageMetricsReporter;
 use crate::types::messages::ProtocolId;
-use ethportal_api::types::distance::{Distance, Metric, XorMetric};
-use ethportal_api::utils::bytes::{hex_decode, hex_encode, ByteUtilsError};
-use ethportal_api::{ContentKeyError, HistoryContentKey, OverlayContentKey};
 
 const BYTES_IN_MB_U64: u64 = 1000 * 1000;
 
@@ -803,15 +803,14 @@ struct EntryCount(u64);
 #[allow(clippy::unwrap_used)]
 pub mod test {
 
-    use super::*;
-
     use discv5::enr::{CombinedKey, EnrBuilder};
+    use ethportal_api::types::content_key::overlay::IdentityContentKey;
     use quickcheck::{quickcheck, QuickCheck, TestResult};
     use rand::RngCore;
     use serial_test::serial;
 
+    use super::*;
     use crate::utils::db::{configure_node_data_dir, setup_temp_dir};
-    use ethportal_api::types::content_key::overlay::IdentityContentKey;
 
     const CAPACITY_MB: u64 = 2;
 

--- a/portalnet/src/types/messages.rs
+++ b/portalnet/src/types/messages.rs
@@ -6,6 +6,11 @@ use std::{
 };
 
 use ethereum_types::U256;
+use ethportal_api::types::bytes::ByteList;
+use ethportal_api::types::distance::Distance;
+use ethportal_api::types::enr::{Enr, SszEnr};
+use ethportal_api::utils::bytes::{hex_decode, hex_encode, ByteUtilsError};
+use ethportal_api::RawContentKey;
 use rlp::Encodable;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -14,12 +19,6 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum, BitList};
 use thiserror::Error;
 use validator::ValidationError;
-
-use ethportal_api::types::bytes::ByteList;
-use ethportal_api::types::distance::Distance;
-use ethportal_api::types::enr::{Enr, SszEnr};
-use ethportal_api::utils::bytes::{hex_decode, hex_encode, ByteUtilsError};
-use ethportal_api::RawContentKey;
 
 /// The maximum size of a Discv5 packet.
 pub(crate) const MAX_DISCV5_PACKET_SIZE: usize = 1280;
@@ -553,9 +552,10 @@ impl From<Accept> for Value {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ethportal_api::utils::bytes::hex_encode_upper;
     use test_log::test;
+
+    use super::*;
 
     #[test]
     #[should_panic]

--- a/portalnet/src/utils/db.rs
+++ b/portalnet/src/utils/db.rs
@@ -5,10 +5,9 @@ use anyhow::anyhow;
 use directories::ProjectDirs;
 use discv5::enr::{CombinedKey, EnrBuilder, NodeId};
 use ethereum_types::H256;
+use ethportal_api::utils::bytes::{hex_decode, hex_encode};
 use tempfile::TempDir;
 use tracing::debug;
-
-use ethportal_api::utils::bytes::{hex_decode, hex_encode};
 
 const TRIN_DATA_ENV_VAR: &str = "TRIN_DATA_PATH";
 const TRIN_DATA_DIR: &str = "trin";
@@ -100,9 +99,9 @@ fn get_application_private_key(trin_data_dir: &Path) -> anyhow::Result<CombinedK
 
 #[cfg(test)]
 pub mod test {
-    use super::*;
-
     use serial_test::serial;
+
+    use super::*;
 
     #[test]
     #[serial]

--- a/portalnet/src/utils/portal_wire.rs
+++ b/portalnet/src/utils/portal_wire.rs
@@ -1,6 +1,7 @@
+use std::io::{Read, Write};
+
 use anyhow::anyhow;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use std::io::{Read, Write};
 
 /// Decode content values from uTP payload. All content values are encoded with a LEB128 varint prefix
 /// which indicates the length in bytes of the consecutive content item.
@@ -71,9 +72,10 @@ pub fn read_varint(buf: &[u8]) -> anyhow::Result<(usize, u32)> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ethportal_api::utils::bytes::hex_decode;
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case(u8::MIN as u32)]

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -2,17 +2,11 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::{net::SocketAddr, str::FromStr, sync::Arc};
 
 use discv5::TalkRequest;
-use parking_lot::RwLock;
-use tokio::{
-    sync::{mpsc, mpsc::unbounded_channel},
-    time::{self, Duration},
-};
-use utp_rs::socket::UtpSocket;
-
 use ethportal_api::types::content_key::overlay::IdentityContentKey;
 use ethportal_api::types::distance::XorMetric;
 use ethportal_api::types::enr::{Enr, SszEnr};
 use ethportal_api::utils::bytes::hex_encode_upper;
+use parking_lot::RwLock;
 use portalnet::utils::db::setup_temp_dir;
 use portalnet::{
     config::PortalnetConfig,
@@ -21,7 +15,12 @@ use portalnet::{
     storage::{ContentStore, DistanceFunction, MemoryContentStore},
     types::messages::{Content, Message, ProtocolId},
 };
+use tokio::{
+    sync::{mpsc, mpsc::unbounded_channel},
+    time::{self, Duration},
+};
 use trin_validation::validator::MockValidator;
+use utp_rs::socket::UtpSocket;
 
 async fn init_overlay(
     discovery: Arc<Discovery>,

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -1,7 +1,3 @@
-use crate::errors::RpcServeError;
-use crate::serde::from_value;
-
-use crate::jsonrpsee::core::{async_trait, RpcResult};
 use discv5::enr::NodeId;
 use ethportal_api::types::constants::CONTENT_ABSENT;
 use ethportal_api::types::enr::Enr;
@@ -18,6 +14,10 @@ use ethportal_api::PossibleBeaconContentValue;
 use ethportal_api::RoutingTableInfo;
 use serde_json::Value;
 use tokio::sync::mpsc;
+
+use crate::errors::RpcServeError;
+use crate::jsonrpsee::core::{async_trait, RpcResult};
+use crate::serde::from_value;
 
 pub struct BeaconNetworkApi {
     network: mpsc::UnboundedSender<BeaconJsonRpcRequest>,

--- a/rpc/src/builder.rs
+++ b/rpc/src/builder.rs
@@ -1,7 +1,7 @@
-use crate::errors::{RpcError, WsHttpSamePortError};
-use crate::jsonrpsee::{Methods, RpcModule};
-use crate::rpc_server::{RpcServerConfig, RpcServerHandle};
-use crate::{BeaconNetworkApi, Discv5Api, EthApi, HistoryNetworkApi, Web3Api};
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::sync::Arc;
+
 use ethportal_api::types::jsonrpc::request::{
     BeaconJsonRpcRequest, HistoryJsonRpcRequest, StateJsonRpcRequest,
 };
@@ -10,11 +10,13 @@ use ethportal_api::{
 };
 use portalnet::discovery::Discovery;
 use serde::Deserialize;
-use std::collections::{HashMap, HashSet};
-use std::fmt;
-use std::sync::Arc;
 use strum::{AsRefStr, EnumString, EnumVariantNames, VariantNames};
 use tokio::sync::mpsc;
+
+use crate::errors::{RpcError, WsHttpSamePortError};
+use crate::jsonrpsee::{Methods, RpcModule};
+use crate::rpc_server::{RpcServerConfig, RpcServerHandle};
+use crate::{BeaconNetworkApi, Discv5Api, EthApi, HistoryNetworkApi, Web3Api};
 
 /// Represents RPC modules that are supported by Trin
 #[derive(

--- a/rpc/src/discv5_rpc.rs
+++ b/rpc/src/discv5_rpc.rs
@@ -1,12 +1,13 @@
-use crate::errors::RpcServeError;
+use std::sync::Arc;
 
-use crate::jsonrpsee::core::{async_trait, RpcResult};
 use discv5::enr::NodeId;
 use ethportal_api::types::enr::Enr;
 use ethportal_api::Discv5ApiServer;
 use ethportal_api::{NodeInfo, RoutingTableInfo};
 use portalnet::discovery::Discovery;
-use std::sync::Arc;
+
+use crate::errors::RpcServeError;
+use crate::jsonrpsee::core::{async_trait, RpcResult};
 
 pub struct Discv5Api {
     discv5: Arc<Discovery>,

--- a/rpc/src/errors.rs
+++ b/rpc/src/errors.rs
@@ -1,8 +1,9 @@
+use std::io;
+
 use crate::jsonrpsee::core::Error as JsonRpseeError;
 use crate::jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
 use crate::rpc_server::ServerKind;
 use crate::PortalRpcModule;
-use std::io;
 
 /// Rpc Errors.
 #[derive(Debug, thiserror::Error)]

--- a/rpc/src/eth_rpc.rs
+++ b/rpc/src/eth_rpc.rs
@@ -1,7 +1,8 @@
-use crate::jsonrpsee::core::{async_trait, RpcResult};
 use ethereum_types::U256;
 use ethportal_api::EthApiServer;
 use trin_validation::constants::CHAIN_ID;
+
+use crate::jsonrpsee::core::{async_trait, RpcResult};
 
 pub struct EthApi;
 

--- a/rpc/src/fetch.rs
+++ b/rpc/src/fetch.rs
@@ -1,9 +1,8 @@
+use ethportal_api::types::jsonrpc::endpoints::HistoryEndpoint;
+use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
 /// Fetch data from related Portal networks
 use serde_json::Value;
 use tokio::sync::mpsc;
-
-use ethportal_api::types::jsonrpc::endpoints::HistoryEndpoint;
-use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
 
 use crate::errors::RpcServeError;
 

--- a/rpc/src/history_rpc.rs
+++ b/rpc/src/history_rpc.rs
@@ -1,7 +1,3 @@
-use crate::fetch::proxy_query_to_history_subnet;
-use crate::serde::from_value;
-
-use crate::jsonrpsee::core::{async_trait, RpcResult};
 use discv5::enr::NodeId;
 use ethportal_api::types::constants::CONTENT_ABSENT;
 use ethportal_api::types::enr::Enr;
@@ -17,6 +13,10 @@ use ethportal_api::HistoryNetworkApiServer;
 use ethportal_api::PossibleHistoryContentValue;
 use ethportal_api::RoutingTableInfo;
 use tokio::sync::mpsc;
+
+use crate::fetch::proxy_query_to_history_subnet;
+use crate::jsonrpsee::core::{async_trait, RpcResult};
+use crate::serde::from_value;
 
 pub struct HistoryNetworkApi {
     network: mpsc::UnboundedSender<HistoryJsonRpcRequest>,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -12,8 +12,8 @@ mod rpc_server;
 mod serde;
 mod web3_rpc;
 
-use crate::jsonrpsee::server::ServerBuilder;
-pub use crate::rpc_server::RpcServerHandle;
+use std::sync::Arc;
+
 use beacon_rpc::BeaconNetworkApi;
 pub use builder::{PortalRpcModule, RpcModuleBuilder, TransportRpcModuleConfig};
 use discv5_rpc::Discv5Api;
@@ -27,13 +27,14 @@ use ethportal_api::types::jsonrpc::request::{
     BeaconJsonRpcRequest, HistoryJsonRpcRequest, StateJsonRpcRequest,
 };
 use history_rpc::HistoryNetworkApi;
-use web3_rpc::Web3Api;
-
-use crate::rpc_server::RpcServerConfig;
 use portalnet::discovery::Discovery;
 use reth_ipc::server::Builder as IpcServerBuilder;
-use std::sync::Arc;
 use tokio::sync::mpsc;
+use web3_rpc::Web3Api;
+
+use crate::jsonrpsee::server::ServerBuilder;
+use crate::rpc_server::RpcServerConfig;
+pub use crate::rpc_server::RpcServerHandle;
 
 pub async fn launch_jsonrpc_server(
     trin_config: TrinConfig,

--- a/rpc/src/rpc_server.rs
+++ b/rpc/src/rpc_server.rs
@@ -1,3 +1,15 @@
+use std::fmt;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+use ethportal_api::types::cli::{
+    DEFAULT_WEB3_HTTP_PORT, DEFAULT_WEB3_IPC_PATH, DEFAULT_WEB3_WS_PORT,
+};
+use reth_ipc::server::Builder as IpcServerBuilder;
+use reth_ipc::server::{Endpoint, IpcServer};
+use tower::layer::util::{Identity, Stack};
+use tower_http::cors::CorsLayer;
+use tracing::instrument;
+
 use crate::builder::TransportRpcModules;
 use crate::cors;
 use crate::errors::WsHttpSamePortError;
@@ -6,16 +18,6 @@ use crate::jsonrpsee::server::{IdProvider, Server, ServerBuilder, ServerHandle};
 use crate::jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 use crate::jsonrpsee::RpcModule;
 use crate::{RpcError, TransportRpcModuleConfig};
-use ethportal_api::types::cli::{
-    DEFAULT_WEB3_HTTP_PORT, DEFAULT_WEB3_IPC_PATH, DEFAULT_WEB3_WS_PORT,
-};
-use reth_ipc::server::Builder as IpcServerBuilder;
-use reth_ipc::server::{Endpoint, IpcServer};
-use std::fmt;
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-use tower::layer::util::{Identity, Stack};
-use tower_http::cors::CorsLayer;
-use tracing::instrument;
 
 /// Container type for each transport ie. http, ws, and ipc server
 pub struct RpcServer {
@@ -608,13 +610,15 @@ impl WsHttpServerKind {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    use std::io;
+    use std::sync::Arc;
+
+    use portalnet::discovery::Discovery;
+    use portalnet::utils::db::setup_temp_dir;
+
     use super::*;
     use crate::builder::RpcModuleSelection;
     use crate::{PortalRpcModule, RpcModuleBuilder};
-    use portalnet::discovery::Discovery;
-    use portalnet::utils::db::setup_temp_dir;
-    use std::io;
-    use std::sync::Arc;
 
     /// Localhost with port 0 so a free port is used.
     pub fn test_address() -> SocketAddr {

--- a/rpc/src/serde.rs
+++ b/rpc/src/serde.rs
@@ -1,5 +1,6 @@
-use crate::errors::RpcServeError;
 use serde_json::{from_value as serde_json_from_value, Value};
+
+use crate::errors::RpcServeError;
 
 pub fn from_value<T: serde::de::DeserializeOwned>(value: Value) -> Result<T, RpcServeError> {
     serde_json_from_value(value).map_err(|e| RpcServeError::Message(e.to_string()))

--- a/rpc/src/web3_rpc.rs
+++ b/rpc/src/web3_rpc.rs
@@ -1,6 +1,7 @@
-use crate::jsonrpsee::core::{async_trait, RpcResult};
 use ethportal_api::Web3ApiServer;
 use trin_utils::version::get_trin_version;
+
+use crate::jsonrpsee::core::{async_trait, RpcResult};
 
 pub struct Web3Api;
 

--- a/src/bin/purge_db.rs
+++ b/src/bin/purge_db.rs
@@ -2,10 +2,6 @@ use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use discv5::enr::{CombinedKey, EnrBuilder};
 use ethereum_types::H256;
-use rocksdb::IteratorMode;
-use ssz::Decode;
-use tracing::{info, warn};
-
 use ethportal_api::types::execution::accumulator::EpochAccumulator;
 use ethportal_api::types::execution::block_body::BlockBody;
 use ethportal_api::types::execution::header::HeaderWithProof;
@@ -15,6 +11,9 @@ use ethportal_api::HistoryContentKey;
 use portalnet::storage::{PortalStorage, PortalStorageConfig};
 use portalnet::types::messages::ProtocolId;
 use portalnet::utils::db::{configure_node_data_dir, configure_trin_data_dir};
+use rocksdb::IteratorMode;
+use ssz::Decode;
+use tracing::{info, warn};
 use trin_utils::log::init_tracing_logger;
 
 ///
@@ -146,8 +145,9 @@ pub enum PurgeMode {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use std::str::FromStr;
+
+    use super::*;
 
     #[test]
     fn test_default_purge_config() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,6 @@
 
 use std::sync::Arc;
 
-use rpc::{launch_jsonrpc_server, RpcServerHandle};
-use tokio::sync::mpsc;
-use tokio::sync::RwLock;
-use tracing::info;
-use utp_rs::socket::UtpSocket;
-
 #[cfg(windows)]
 use ethportal_api::types::cli::Web3TransportType;
 use ethportal_api::types::cli::{TrinConfig, BEACON_NETWORK, HISTORY_NETWORK, STATE_NETWORK};
@@ -18,11 +12,16 @@ use portalnet::{
     storage::PortalStorageConfig,
     utils::db::{configure_node_data_dir, configure_trin_data_dir},
 };
+use rpc::{launch_jsonrpc_server, RpcServerHandle};
+use tokio::sync::mpsc;
+use tokio::sync::RwLock;
+use tracing::info;
 use trin_beacon::initialize_beacon_network;
 use trin_history::initialize_history_network;
 use trin_state::initialize_state_network;
 use trin_utils::version::get_trin_version;
 use trin_validation::{accumulator::MasterAccumulator, oracle::HeaderOracle};
+use utp_rs::socket::UtpSocket;
 
 pub async fn run_trin(
     trin_config: TrinConfig,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,8 @@
 
 use ethportal_api::types::cli::TrinConfig;
 use tracing::error;
-use trin_utils::log::init_tracing_logger;
-
 use trin::run_trin;
+use trin_utils::log::init_tracing_logger;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/rpc_server.rs
+++ b/tests/rpc_server.rs
@@ -4,10 +4,9 @@ use std::net::{IpAddr, Ipv4Addr};
 
 use ethers_core::types::U256;
 use ethers_providers::*;
-use serial_test::serial;
-
 use ethportal_api::types::cli::{TrinConfig, DEFAULT_WEB3_IPC_PATH};
 use rpc::RpcServerHandle;
+use serial_test::serial;
 
 mod utils;
 

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -1,5 +1,4 @@
 #![cfg(unix)]
-use rpc::RpcServerHandle;
 use std::env;
 use std::net::{IpAddr, Ipv4Addr};
 
@@ -8,6 +7,7 @@ use ethportal_peertest as peertest;
 use ethportal_peertest::Peertest;
 use jsonrpsee::async_client::Client;
 use jsonrpsee::http_client::HttpClient;
+use rpc::RpcServerHandle;
 use serial_test::serial;
 use tokio::time::{sleep, Duration};
 

--- a/trin-beacon/src/events.rs
+++ b/trin-beacon/src/events.rs
@@ -1,9 +1,11 @@
-use crate::network::BeaconNetwork;
+use std::sync::Arc;
+
 use discv5::TalkRequest;
 use portalnet::types::messages::Message;
-use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{error, warn, Instrument};
+
+use crate::network::BeaconNetwork;
 
 pub struct BeaconEvents {
     pub network: Arc<BeaconNetwork>,

--- a/trin-beacon/src/lib.rs
+++ b/trin-beacon/src/lib.rs
@@ -8,16 +8,6 @@ pub mod validation;
 use std::sync::Arc;
 
 use discv5::TalkRequest;
-use tokio::{
-    sync::{mpsc, Mutex, RwLock},
-    task::JoinHandle,
-    time::{interval, Duration},
-};
-use tracing::info;
-use utp_rs::socket::UtpSocket;
-
-use crate::network::BeaconNetwork;
-use crate::{events::BeaconEvents, jsonrpc::BeaconRequestHandler};
 use ethportal_api::types::enr::Enr;
 use ethportal_api::types::jsonrpc::request::BeaconJsonRpcRequest;
 use portalnet::{
@@ -25,7 +15,17 @@ use portalnet::{
     discovery::{Discovery, UtpEnr},
     storage::PortalStorageConfig,
 };
+use tokio::{
+    sync::{mpsc, Mutex, RwLock},
+    task::JoinHandle,
+    time::{interval, Duration},
+};
+use tracing::info;
 use trin_validation::oracle::HeaderOracle;
+use utp_rs::socket::UtpSocket;
+
+use crate::network::BeaconNetwork;
+use crate::{events::BeaconEvents, jsonrpc::BeaconRequestHandler};
 
 type BeaconHandler = Option<BeaconRequestHandler>;
 type BeaconNetworkTask = Option<JoinHandle<()>>;

--- a/trin-beacon/src/network.rs
+++ b/trin-beacon/src/network.rs
@@ -1,13 +1,9 @@
 use std::sync::Arc;
 
-use parking_lot::RwLock as PLRwLock;
-use tokio::sync::RwLock;
-use utp_rs::socket::UtpSocket;
-
-use crate::validation::BeaconValidator;
 use ethportal_api::types::distance::XorMetric;
 use ethportal_api::types::enr::Enr;
 use ethportal_api::BeaconContentKey;
+use parking_lot::RwLock as PLRwLock;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
@@ -15,7 +11,11 @@ use portalnet::{
     storage::{PortalStorage, PortalStorageConfig},
     types::messages::ProtocolId,
 };
+use tokio::sync::RwLock;
 use trin_validation::oracle::HeaderOracle;
+use utp_rs::socket::UtpSocket;
+
+use crate::validation::BeaconValidator;
 
 /// Beacon network layer on top of the overlay protocol. Encapsulates beacon network specific data and logic.
 #[derive(Clone)]

--- a/trin-beacon/src/validation.rs
+++ b/trin-beacon/src/validation.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use ethportal_api::BeaconContentKey;
 use tokio::sync::RwLock;
-
 use trin_validation::{oracle::HeaderOracle, validator::Validator};
 
 pub struct BeaconValidator {

--- a/trin-history/src/events.rs
+++ b/trin-history/src/events.rs
@@ -1,9 +1,11 @@
-use crate::network::HistoryNetwork;
+use std::sync::Arc;
+
 use discv5::TalkRequest;
 use portalnet::types::messages::Message;
-use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{error, warn, Instrument};
+
+use crate::network::HistoryNetwork;
 
 pub struct HistoryEvents {
     pub network: Arc<HistoryNetwork>,

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -9,24 +9,24 @@ pub mod validation;
 use std::sync::Arc;
 
 use discv5::TalkRequest;
+use ethportal_api::types::enr::Enr;
+use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
 use network::HistoryNetwork;
+use portalnet::{
+    config::PortalnetConfig,
+    discovery::{Discovery, UtpEnr},
+    storage::PortalStorageConfig,
+};
 use tokio::{
     sync::{mpsc, Mutex, RwLock},
     task::JoinHandle,
     time::{interval, Duration},
 };
 use tracing::info;
+use trin_validation::oracle::HeaderOracle;
 use utp_rs::socket::UtpSocket;
 
 use crate::{events::HistoryEvents, jsonrpc::HistoryRequestHandler};
-use ethportal_api::types::enr::Enr;
-use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
-use portalnet::{
-    config::PortalnetConfig,
-    discovery::{Discovery, UtpEnr},
-    storage::PortalStorageConfig,
-};
-use trin_validation::oracle::HeaderOracle;
 
 type HistoryHandler = Option<HistoryRequestHandler>;
 type HistoryNetworkTask = Option<JoinHandle<()>>;

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -1,12 +1,9 @@
 use std::sync::Arc;
 
-use parking_lot::RwLock as PLRwLock;
-use tokio::sync::RwLock;
-use utp_rs::socket::UtpSocket;
-
 use ethportal_api::types::distance::XorMetric;
 use ethportal_api::types::enr::Enr;
 use ethportal_api::HistoryContentKey;
+use parking_lot::RwLock as PLRwLock;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
@@ -14,7 +11,9 @@ use portalnet::{
     storage::{PortalStorage, PortalStorageConfig},
     types::messages::ProtocolId,
 };
+use tokio::sync::RwLock;
 use trin_validation::oracle::HeaderOracle;
+use utp_rs::socket::UtpSocket;
 
 use crate::validation::ChainHistoryValidator;
 

--- a/trin-history/src/utils.rs
+++ b/trin-history/src/utils.rs
@@ -1,13 +1,13 @@
+use std::collections::BTreeMap;
+
 use discv5::{
     enr::NodeId,
     kbucket::{ConnectionState, NodeStatus},
 };
-use serde_json::{json, Value};
-use std::collections::BTreeMap;
-
 use ethportal_api::types::distance::Distance;
 use ethportal_api::types::enr::Enr;
 use ethportal_api::utils::bytes::hex_encode;
+use serde_json::{json, Value};
 
 type NodeMap = BTreeMap<String, String>;
 type NodeTuple = (NodeId, Enr, NodeStatus, Distance, Option<String>);
@@ -107,8 +107,9 @@ fn expand_client_name(client_shorthand: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
 
-    use super::*;
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case("f 3", Some("fluffy 3".to_owned()))]

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -3,10 +3,6 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use ethereum_types::H256;
-use ssz::Decode;
-use tokio::sync::RwLock;
-use tree_hash::TreeHash;
-
 use ethportal_api::types::execution::{
     accumulator::EpochAccumulator,
     block_body::BlockBody,
@@ -14,6 +10,9 @@ use ethportal_api::types::execution::{
     receipts::Receipts,
 };
 use ethportal_api::{utils::bytes::hex_encode, HistoryContentKey};
+use ssz::Decode;
+use tokio::sync::RwLock;
+use tree_hash::TreeHash;
 use trin_validation::{oracle::HeaderOracle, validator::Validator};
 
 pub struct ChainHistoryValidator {
@@ -127,19 +126,19 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
     use std::fs;
     use std::path::PathBuf;
 
     use ethereum_types::U256;
-    use serde_json::Value;
-    use ssz::Encode;
-
     use ethportal_api::types::cli::DEFAULT_MASTER_ACC_PATH;
     use ethportal_api::types::execution::accumulator::HeaderRecord;
     use ethportal_api::utils::bytes::hex_decode;
     use ethportal_api::{BlockHeaderKey, EpochAccumulatorKey};
+    use serde_json::Value;
+    use ssz::Encode;
     use trin_validation::accumulator::MasterAccumulator;
+
+    use super::*;
 
     fn get_hwp_ssz() -> Vec<u8> {
         let file =

--- a/trin-state/src/events.rs
+++ b/trin-state/src/events.rs
@@ -1,9 +1,11 @@
-use crate::network::StateNetwork;
+use std::sync::Arc;
+
 use discv5::TalkRequest;
 use portalnet::types::messages::Message;
-use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{error, warn, Instrument};
+
+use crate::network::StateNetwork;
 
 pub struct StateEvents {
     pub network: Arc<StateNetwork>,

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
+use ethportal_api::types::jsonrpc::request::StateJsonRpcRequest;
 use tokio::sync::mpsc;
 use tracing::error;
 
 use crate::network::StateNetwork;
-use ethportal_api::types::jsonrpc::request::StateJsonRpcRequest;
 
 /// Handles State network JSON-RPC requests
 pub struct StateRequestHandler {

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -3,23 +3,23 @@
 use std::sync::Arc;
 
 use discv5::TalkRequest;
-use network::StateNetwork;
-use tokio::{
-    sync::{mpsc, RwLock},
-    task::JoinHandle,
-};
-use tracing::info;
-use utp_rs::socket::UtpSocket;
-
-use crate::{events::StateEvents, jsonrpc::StateRequestHandler};
 use ethportal_api::types::enr::Enr;
 use ethportal_api::types::jsonrpc::request::StateJsonRpcRequest;
+use network::StateNetwork;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
     storage::PortalStorageConfig,
 };
+use tokio::{
+    sync::{mpsc, RwLock},
+    task::JoinHandle,
+};
+use tracing::info;
 use trin_validation::oracle::HeaderOracle;
+use utp_rs::socket::UtpSocket;
+
+use crate::{events::StateEvents, jsonrpc::StateRequestHandler};
 
 pub mod events;
 mod jsonrpc;

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -1,13 +1,10 @@
 use std::sync::Arc;
 
 use eth_trie::EthTrie;
-use parking_lot::RwLock as PLRwLock;
-use tokio::sync::RwLock;
-use utp_rs::socket::UtpSocket;
-
 use ethportal_api::types::distance::XorMetric;
 use ethportal_api::types::enr::Enr;
 use ethportal_api::StateContentKey;
+use parking_lot::RwLock as PLRwLock;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
@@ -15,7 +12,9 @@ use portalnet::{
     storage::{PortalStorage, PortalStorageConfig},
     types::messages::ProtocolId,
 };
+use tokio::sync::RwLock;
 use trin_validation::oracle::HeaderOracle;
+use utp_rs::socket::UtpSocket;
 
 use crate::{trie::TrieDB, validation::StateValidator};
 

--- a/trin-state/src/utils.rs
+++ b/trin-state/src/utils.rs
@@ -22,8 +22,9 @@ pub fn distance(node_id: U256, content_id: U256) -> U256 {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use test_log::test;
+
+    use super::*;
 
     // all 7 of these test cases are from
     // https://github.com/ethereum/portal-network-specs/blob/master/state-network.md

--- a/trin-state/src/validation.rs
+++ b/trin-state/src/validation.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tokio::sync::RwLock;
-
 use ethportal_api::StateContentKey;
+use tokio::sync::RwLock;
 use trin_validation::{oracle::HeaderOracle, validator::Validator};
 
 pub struct StateValidator {

--- a/trin-validation/src/accumulator.rs
+++ b/trin-validation/src/accumulator.rs
@@ -1,8 +1,14 @@
-use rust_embed::RustEmbed;
 use std::path::PathBuf;
 
 use anyhow::anyhow;
 use ethereum_types::H256;
+use ethportal_api::types::execution::accumulator::EpochAccumulator;
+use ethportal_api::types::execution::header::{BlockHeaderProof, Header, HeaderWithProof};
+use ethportal_api::types::jsonrpc::endpoints::HistoryEndpoint;
+use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
+use ethportal_api::utils::bytes::hex_decode;
+use ethportal_api::{EpochAccumulatorKey, HistoryContentKey};
+use rust_embed::RustEmbed;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use ssz::Decode;
@@ -16,12 +22,6 @@ use crate::{
     constants::{EPOCH_SIZE, MERGE_BLOCK_NUMBER},
     merkle::proof::{verify_merkle_proof, MerkleTree},
 };
-use ethportal_api::types::execution::accumulator::EpochAccumulator;
-use ethportal_api::types::execution::header::{BlockHeaderProof, Header, HeaderWithProof};
-use ethportal_api::types::jsonrpc::endpoints::HistoryEndpoint;
-use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
-use ethportal_api::utils::bytes::hex_decode;
-use ethportal_api::{EpochAccumulatorKey, HistoryContentKey};
 
 /// SSZ List[Hash256, max_length = MAX_HISTORICAL_EPOCHS]
 /// List of historical epoch accumulator merkle roots preceding current epoch.
@@ -238,20 +238,20 @@ fn calculate_generalized_index(header: &Header) -> usize {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use std::fs;
     use std::str::FromStr;
 
     use ethereum_types::{Bloom, H160, U256};
-    use rstest::*;
-    use serde_json::json;
-    use ssz::Decode;
-
-    use crate::constants::DEFAULT_MASTER_ACC_HASH;
     use ethportal_api::types::execution::header::{
         AccumulatorProof, BlockHeaderProof, HeaderWithProof, SszNone,
     };
     use ethportal_api::utils::bytes::hex_encode;
+    use rstest::*;
+    use serde_json::json;
+    use ssz::Decode;
+
+    use super::*;
+    use crate::constants::DEFAULT_MASTER_ACC_HASH;
 
     #[rstest]
     #[case(1_000_001)]

--- a/trin-validation/src/merkle/proof.rs
+++ b/trin-validation/src/merkle/proof.rs
@@ -1,11 +1,12 @@
+use eth2_hashing::{hash, hash32_concat, ZERO_HASHES};
+use ethereum_types::H256;
+use lazy_static::lazy_static;
+
 ///
 /// Code sourced from:
 /// https://github.com/sigp/lighthouse/blob/bf533c8e42/consensus/merkle_proof/src/lib.rs
 ///
 use crate::merkle::safe_arith::ArithError;
-use eth2_hashing::{hash, hash32_concat, ZERO_HASHES};
-use ethereum_types::H256;
-use lazy_static::lazy_static;
 
 const MAX_TREE_DEPTH: usize = 32;
 const EMPTY_SLICE: &[H256] = &[];
@@ -407,9 +408,10 @@ impl From<InvalidSnapshot> for MerkleTreeError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use quickcheck::TestResult;
     use quickcheck_macros::quickcheck;
+
+    use super::*;
 
     /// Check that we can:
     /// 1. Build a MerkleTree from arbitrary leaves and an arbitrary depth.

--- a/trin-validation/src/oracle.rs
+++ b/trin-validation/src/oracle.rs
@@ -1,9 +1,5 @@
 use anyhow::anyhow;
 use ethereum_types::H256;
-use serde_json::Value;
-use tokio::sync::mpsc;
-
-use crate::accumulator::MasterAccumulator;
 use ethportal_api::types::execution::header::HeaderWithProof;
 use ethportal_api::types::jsonrpc::endpoints::HistoryEndpoint;
 use ethportal_api::types::jsonrpc::request::{BeaconJsonRpcRequest, HistoryJsonRpcRequest};
@@ -11,6 +7,10 @@ use ethportal_api::types::portal::ContentInfo;
 use ethportal_api::{
     BlockHeaderKey, HistoryContentKey, HistoryContentValue, PossibleHistoryContentValue,
 };
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use crate::accumulator::MasterAccumulator;
 
 /// Responsible for dispatching cross-overlay-network requests
 /// for data to perform validation.
@@ -103,13 +103,13 @@ impl HeaderOracle {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use std::str::FromStr;
 
+    use ethportal_api::types::cli::TrinConfig;
     use tree_hash::TreeHash;
 
+    use super::*;
     use crate::constants::DEFAULT_MASTER_ACC_HASH;
-    use ethportal_api::types::cli::TrinConfig;
 
     #[tokio::test]
     async fn header_oracle_bootstraps_with_default_merge_master_acc() {

--- a/trin-validation/src/validator.rs
+++ b/trin-validation/src/validator.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-
 use ethportal_api::types::content_key::overlay::IdentityContentKey;
 
 /// Used by all overlay-network Validators to validate content in the overlay service.

--- a/utp-testing/src/bin/test_app.rs
+++ b/utp-testing/src/bin/test_app.rs
@@ -1,11 +1,11 @@
-use clap::Parser;
 use std::net::SocketAddr;
 use std::str::FromStr;
+
+use clap::Parser;
 use tracing::info;
 use trin_utils::log::init_tracing_logger;
-use utp_testing::run_test_app;
-
 use utp_testing::cli::TestAppConfig;
+use utp_testing::run_test_app;
 
 /// uTP test app, used for creation of a `test-app` docker image
 #[tokio::main]

--- a/utp-testing/src/bin/test_suite.rs
+++ b/utp-testing/src/bin/test_suite.rs
@@ -1,11 +1,10 @@
+use std::time::Duration;
+
+use ethportal_api::utils::bytes::hex_encode;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::rpc_params;
 use rand::{thread_rng, Rng};
-
-use std::time::Duration;
-
-use ethportal_api::utils::bytes::hex_encode;
 
 const SERVER_ADDR: &str = "193.167.100.100:9041";
 const CLIENT_ADDR: &str = "193.167.0.100:9042";

--- a/utp-testing/src/lib.rs
+++ b/utp-testing/src/lib.rs
@@ -3,7 +3,11 @@ extern crate core;
 pub mod cli;
 pub mod rpc;
 
-use crate::rpc::RpcServer;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
 use discv5::TalkRequest;
 use ethportal_api::types::enr::Enr;
 use ethportal_api::utils::bytes::{hex_encode, hex_encode_upper};
@@ -14,13 +18,11 @@ use portalnet::config::PortalnetConfig;
 use portalnet::discovery::{Discovery, UtpEnr};
 use portalnet::types::messages::ProtocolId;
 use portalnet::utils::db::setup_temp_dir;
-use std::net::SocketAddr;
-use std::str::FromStr;
-use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 use utp_rs::{conn::ConnectionConfig, socket::UtpSocket};
+
+use crate::rpc::RpcServer;
 
 /// uTP test app
 pub struct TestApp {


### PR DESCRIPTION
### What was wrong?
See conversation here, but the import statements throughout our codebase do not have a consistent grouping. It is unlikely that a lint for this will become available on `stable` channel anytime soon, so for the time being I just ran the [group_imports](https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#group_imports) lint using the `StdExternalCrate` level.

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
