### PR TITLE
Add transaction hashes and uncles to the block that json-rpc returns

### DIFF
--- a/ethportal-api/src/types/content_key/history.rs
+++ b/ethportal-api/src/types/content_key/history.rs
@@ -82,6 +82,14 @@ pub struct BlockBodyKey {
     pub block_hash: [u8; 32],
 }
 
+impl From<H256> for BlockBodyKey {
+    fn from(block_hash: H256) -> Self {
+        Self {
+            block_hash: block_hash.to_fixed_bytes(),
+        }
+    }
+}
+
 /// A key for the transaction receipts for a block.
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
 pub struct BlockReceiptsKey {


### PR DESCRIPTION
### What was wrong?

Fix #279 

### How was it fixed?

### To-Do

- [x] Clean up commit history
- [x] Test that txn hashes match expected value
- [x] ~Add uncles~ Hah right, [there are no uncles post-merge](https://ethereum.stackexchange.com/questions/139390/are-uncle-ommer-blocks-still-possible-after-the-merge).
- [x] rebase all the things
