### PR TITLE
chore: pin reth dependencies to a release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ dependencies = [
 [[package]]
 name = "codecs-derive"
 version = "0.1.0-alpha.10"
-source = "git+https://github.com/paradigmxyz/reth.git#4dbd8835e5f06ddfc5c0987046773d592dbff860"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v0.1.0-alpha.10#1b16d804ef01f4ec3c25e7986381c22739c105b9"
 dependencies = [
  "convert_case 0.6.0",
  "parity-scale-codec 3.6.5",
@@ -5049,7 +5049,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.1.0-alpha.10"
-source = "git+https://github.com/paradigmxyz/reth.git#4dbd8835e5f06ddfc5c0987046773d592dbff860"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v0.1.0-alpha.10#1b16d804ef01f4ec3c25e7986381c22739c105b9"
 dependencies = [
  "bytes 1.5.0",
  "codecs-derive",
@@ -5059,7 +5059,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "0.1.0-alpha.10"
-source = "git+https://github.com/paradigmxyz/reth.git#4dbd8835e5f06ddfc5c0987046773d592dbff860"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v0.1.0-alpha.10#1b16d804ef01f4ec3c25e7986381c22739c105b9"
 dependencies = [
  "async-trait",
  "bytes 1.5.0",
@@ -5079,7 +5079,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "0.1.0-alpha.10"
-source = "git+https://github.com/paradigmxyz/reth.git#4dbd8835e5f06ddfc5c0987046773d592dbff860"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v0.1.0-alpha.10#1b16d804ef01f4ec3c25e7986381c22739c105b9"
 dependencies = [
  "bytes 1.5.0",
  "c-kzg 0.1.0 (git+https://github.com/ethereum/c-kzg-4844?rev=f5f6f863d475847876a2bd5ee252058d37c3a15d)",
@@ -5121,7 +5121,7 @@ dependencies = [
 [[package]]
 name = "reth-rlp"
 version = "0.1.0-alpha.10"
-source = "git+https://github.com/paradigmxyz/reth.git#4dbd8835e5f06ddfc5c0987046773d592dbff860"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v0.1.0-alpha.10#1b16d804ef01f4ec3c25e7986381c22739c105b9"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -5135,7 +5135,7 @@ dependencies = [
 [[package]]
 name = "reth-rlp-derive"
 version = "0.1.0-alpha.10"
-source = "git+https://github.com/paradigmxyz/reth.git#4dbd8835e5f06ddfc5c0987046773d592dbff860"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v0.1.0-alpha.10#1b16d804ef01f4ec3c25e7986381c22739c105b9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types"
 version = "0.1.0-alpha.10"
-source = "git+https://github.com/paradigmxyz/reth.git#4dbd8835e5f06ddfc5c0987046773d592dbff860"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v0.1.0-alpha.10#1b16d804ef01f4ec3c25e7986381c22739c105b9"
 dependencies = [
  "itertools 0.11.0",
  "jsonrpsee-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ parking_lot = "0.11.2"
 portalnet = { path = "portalnet" }
 prometheus_exporter = "0.8.4"
 rand = "0.8.4"
-reth-ipc = { version = "0.1.0-alpha.6", git = "https://github.com/paradigmxyz/reth.git"}
+reth-ipc = { tag = "v0.1.0-alpha.10", git = "https://github.com/paradigmxyz/reth.git"}
 rlp = "0.5.0"
 rocksdb = "0.21.0"
 rpc = { path = "rpc"}

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -30,7 +30,7 @@ lazy_static = "1.4.0"
 nanotemplate = "0.3.0"
 quickcheck = "1.0.3"
 rand = "0.8.5"
-reth-rpc-types = { version = "0.1.0-alpha.6", git = "https://github.com/paradigmxyz/reth.git"}
+reth-rpc-types = { tag = "v0.1.0-alpha.10", git = "https://github.com/paradigmxyz/reth.git"}
 rlp = "0.5.0"
 rlp-derive = "0.1.0"
 ruint = { version = "1.9.0", features = ["primitive-types"] }

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -22,7 +22,7 @@ hex = "0.4.3"
 hyper = { version = "0.14", features = ["full"] }
 jsonrpsee = {version="0.20.0", features = ["async-client", "client", "macros", "server"]}
 rand = "0.8.4"
-reth-ipc = { version = "0.1.0-alpha.6", git = "https://github.com/paradigmxyz/reth.git"}
+reth-ipc = { tag = "v0.1.0-alpha.10", git = "https://github.com/paradigmxyz/reth.git"}
 rocksdb = "0.21.0"
 rpc = { path = "../rpc" }
 serde_json = "1.0.89"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -20,8 +20,8 @@ tracing = "0.1.27"
 trin-utils = { path = "../trin-utils"}
 tokio = { version = "1.14.0", features = ["full"] }
 hyper = "0.14"
-reth-ipc = { version = "0.1.0-alpha.6", git = "https://github.com/paradigmxyz/reth.git"}
-reth-rpc-types = { version = "0.1.0-alpha.6", git = "https://github.com/paradigmxyz/reth.git"}
+reth-ipc = { tag = "v0.1.0-alpha.10", git = "https://github.com/paradigmxyz/reth.git"}
+reth-rpc-types = { tag = "v0.1.0-alpha.10", git = "https://github.com/paradigmxyz/reth.git"}
 url = "2.3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.95"


### PR DESCRIPTION
Building against a moving target is hard. It's just good practice to have everyone working against a consistent version of the dependency anyway. The "version" attribute was basically ignored by cargo.

So those are the theoretical reasons. Here is a practical one: Basic things are changing about the RPC structs, like the type of the transaction hashes, even in just the last few weeks.

Split from #963 

- [ ] Clean up commit history
