### PR TITLE
docs: remove outdated towncrier line from template todo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,4 @@
 ### To-Do
 
 [//]: # (Stay ahead of things, add list items here!)
-- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
 - [ ] Clean up commit history


### PR DESCRIPTION
### What was wrong?
We no longer use towncrier, so we should remove the line from the pr template

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trin/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
