### PR TITLE
chore: change bool to enum for is_key_within_radius_and_unavailable for better errors

### DIFF
--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -35,6 +35,7 @@ use tracing::{debug, error, info, trace, warn};
 use utp_rs::{conn::ConnectionConfig, socket::UtpSocket, stream::UtpStream};
 
 use crate::events::EventEnvelope;
+use crate::storage::ShouldWeStoreContent;
 use crate::{
     discovery::Discovery,
     events::OverlayEvent,
@@ -1203,6 +1204,7 @@ where
                 .store
                 .read()
                 .is_key_within_radius_and_unavailable(key)
+                .map(|value| matches!(value, ShouldWeStoreContent::Store))
                 .map_err(|err| {
                     OverlayRequestError::AcceptError(format!(
                         "Unable to check content availability {err}"
@@ -1633,7 +1635,7 @@ where
                     // Check if data should be stored, and store if true.
                     let key_desired = store.read().is_key_within_radius_and_unavailable(&key);
                     match key_desired {
-                        Ok(true) => {
+                        Ok(ShouldWeStoreContent::Store) => {
                             if let Err(err) = store.write().put(key.clone(), &content_value) {
                                 warn!(
                                     error = %err,
@@ -1642,10 +1644,16 @@ where
                                 );
                             }
                         }
-                        Ok(false) => {
+                        Ok(ShouldWeStoreContent::NotWithinRadius) => {
                             warn!(
                                 content.key = %key.to_hex(),
-                                "Accepted content outside radius or already stored"
+                                "Accepted content outside radius"
+                            );
+                        }
+                        Ok(ShouldWeStoreContent::AlreadyStored) => {
+                            warn!(
+                                content.key = %key.to_hex(),
+                                "Accepted content already stored"
                             );
                         }
                         Err(err) => {
@@ -1856,7 +1864,7 @@ where
                 .read()
                 .is_key_within_radius_and_unavailable(&content_key)
             {
-                Ok(val) => val,
+                Ok(val) => matches!(val, ShouldWeStoreContent::Store),
                 Err(msg) => {
                     error!("Unable to read store: {}", msg);
                     false

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -1632,7 +1632,7 @@ where
                     }
                     metrics.report_validation(true);
 
-                    // Check if data should be stored, and store if true.
+                    // Check if data should be stored, and store if it is within our radius and not already stored.
                     let key_desired = store.read().is_key_within_radius_and_unavailable(&key);
                     match key_desired {
                         Ok(ShouldWeStoreContent::Store) => {

--- a/portalnet/src/storage.rs
+++ b/portalnet/src/storage.rs
@@ -67,6 +67,7 @@ pub enum ContentStoreError {
     ContentKey(#[from] ContentKeyError),
 }
 
+/// An enum which tells us if we should store or not store content, and if not why for better errors.
 #[derive(Debug, PartialEq)]
 pub enum ShouldWeStoreContent {
     Store,


### PR DESCRIPTION
### What was wrong?
I was debugging gossip and then getting

```nim
2023-10-10T00:02:24.255068Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x00389863ef224a3d170b0d396387c31a39eb0cda2b59aee881cd8aaa3a2e73c5e4
2023-10-10T00:02:33.252706Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x029031e54f5b379e53a959fb3ac11b52c7943c1f06d4f5bb061da60a8573f2301f
2023-10-10T00:02:56.485819Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x035688720000000000
2023-10-10T00:02:56.569614Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x035b88720000000000
2023-10-10T00:02:56.690561Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02b7ae9353c706ba6ed2af6695db4c5366b9cdc433254ff3d35041377804403046
2023-10-10T00:02:59.370235Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x035688720000000000
2023-10-10T00:03:02.502284Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x0081aa845bdb2b8175efe9cd5a2eb84e10c1bfcaf507b3784584931e732d244543
2023-10-10T00:03:02.702406Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x0081aa845bdb2b8175efe9cd5a2eb84e10c1bfcaf507b3784584931e732d244543
2023-10-10T00:03:03.501519Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x0070de357519e6c13dc8bd802ebec2dbb90026e73e4e3fd2cc9d466081c3953aa8
2023-10-10T00:03:06.577001Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x025d88720000000000
2023-10-10T00:03:06.862692Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x035d88720000000000
2023-10-10T00:03:06.870258Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x025d88720000000000
2023-10-10T00:03:25.392371Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x0281aa845bdb2b8175efe9cd5a2eb84e10c1bfcaf507b3784584931e732d244543
2023-10-10T00:03:25.395235Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x0170de357519e6c13dc8bd802ebec2dbb90026e73e4e3fd2cc9d466081c3953aa8
2023-10-10T00:03:25.766420Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x0170de357519e6c13dc8bd802ebec2dbb90026e73e4e3fd2cc9d466081c3953aa8
2023-10-10T00:03:25.777803Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x0170de357519e6c13dc8bd802ebec2dbb90026e73e4e3fd2cc9d466081c3953aa8
2023-10-10T00:03:25.819712Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x0170de357519e6c13dc8bd802ebec2dbb90026e73e4e3fd2cc9d466081c3953aa8
2023-10-10T00:03:30.665624Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x025f88720000000000
2023-10-10T00:03:31.829169Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x025e88720000000000
2023-10-10T00:03:47.621830Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x01817f216a7d52ce926aaf66b212a4df54c18e6562729437e909140db770fd9a46
2023-10-10T00:03:47.692627Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02c9bdf87bc15a4e5fbc33a99554b7568c66c73ed1ffc3eecd1c7208d10a68aaac
2023-10-10T00:03:48.385482Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02c9bdf87bc15a4e5fbc33a99554b7568c66c73ed1ffc3eecd1c7208d10a68aaac
2023-10-10T00:03:48.797153Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02c9bdf87bc15a4e5fbc33a99554b7568c66c73ed1ffc3eecd1c7208d10a68aaac
2023-10-10T00:03:56.635546Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02c9bdf87bc15a4e5fbc33a99554b7568c66c73ed1ffc3eecd1c7208d10a68aaac
2023-10-10T00:03:56.973116Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x01817f216a7d52ce926aaf66b212a4df54c18e6562729437e909140db770fd9a46
2023-10-10T00:03:58.088142Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:03:58.330381Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:03:58.982694Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:04:00.031900Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:04:00.413834Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:04:00.838684Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:04:00.893539Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:04:00.988972Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:04:01.135871Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:04:01.168392Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:04:01.215831Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:04:01.279974Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:04:01.508719Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:04:01.765883Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:04:02.403408Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:04:02.865727Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:04:02.872610Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x02bcaec14408355e96c2ee4d93ebcb219c7a8cf04e6046a487b55c94c989fe1e58
2023-10-10T00:04:04.124284Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x0065e7244c44d522780627c6e17a9ad945a35363e89829c889383eae7bad617848
2023-10-10T00:04:06.588619Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x01817f216a7d52ce926aaf66b212a4df54c18e6562729437e909140db770fd9a46
2023-10-10T00:04:09.554527Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x018bbcb94aedf20f334de50df3b17623c9b9e72bfacc1882623351755cb178b04f
2023-10-10T00:04:11.407619Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x018bbcb94aedf20f334de50df3b17623c9b9e72bfacc1882623351755cb178b04f
2023-10-10T00:04:19.752912Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x0085d7117de9df645a7e0396528a8a1dc63f817274a0730acf8e05528b38f33932
2023-10-10T00:05:04.750450Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x0285d7117de9df645a7e0396528a8a1dc63f817274a0730acf8e05528b38f33932
2023-10-10T00:05:09.076492Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x026788720000000000
2023-10-10T00:05:13.355423Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x023ea03eb2778b2bbd9decb351a7d2261271a5a70c03ae5d91f1052332b55b8794
2023-10-10T00:05:13.375733Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x01d86387af1c4038e9a7581acf48989a890da607e922f3a9faef5d976db923ffc9
2023-10-10T00:05:33.532006Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x01a30169098a44f02845764727f9873b64ddad7ba9813dbf41c05741fec499d31d
2023-10-10T00:05:53.337305Z  WARN portalnet::overlay_service: Accepted content outside radius or already stored content.key=0x0050400fcad1e0da329bd402b5fb0cb86c9ecf69c7e4734618d4b01f1ba2776867
```

Which is very unhelpful because then I need to manually check both the content in relation to the radius and if it is already stored.
### How was it fixed?
By changing the bool to a enum, this allows us to better define warnings decreasing the guessing games when debugging. Checking if the content is outside of the radius requires quite a bit of setup to calculate if you aren't already prepared for it.

Checking if the content is stored is also work.

So I just made it so the error can be clear and direct in what the problem is. This decreases the work understanding the logs a lot which is a life saver when you are stairing at logs all day.