### PR TITLE
fix: bug ping rpc returns our radius instead of target's

### DIFF
--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use discv5::enr::NodeId;
 use ethportal_api::types::content_value::ContentValue;
+use ethportal_api::types::distance::Distance;
 use ethportal_api::types::jsonrpc::endpoints::BeaconEndpoint;
 use ethportal_api::types::jsonrpc::request::BeaconJsonRpcRequest;
 use ethportal_api::types::portal::{
@@ -322,7 +323,7 @@ async fn ping(
     match overlay.send_ping(enr).await {
         Ok(pong) => Ok(json!(PongInfo {
             enr_seq: pong.enr_seq as u32,
-            data_radius: *overlay.data_radius(),
+            data_radius: *Distance::from(pong.custom_payload),
         })),
         Err(msg) => Err(format!("Ping request timeout: {msg:?}")),
     }

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use discv5::enr::NodeId;
 use ethportal_api::types::{
-    constants::CONTENT_ABSENT, jsonrpc::endpoints::HistoryEndpoint,
+    constants::CONTENT_ABSENT, distance::Distance, jsonrpc::endpoints::HistoryEndpoint,
     jsonrpc::request::HistoryJsonRpcRequest, query_trace::QueryTrace,
 };
 use ethportal_api::utils::bytes::hex_encode;
@@ -333,7 +333,7 @@ async fn ping(
     match overlay.send_ping(enr).await {
         Ok(pong) => Ok(json!(PongInfo {
             enr_seq: pong.enr_seq as u32,
-            data_radius: *overlay.data_radius(),
+            data_radius: *Distance::from(pong.custom_payload),
         })),
         Err(msg) => Err(format!("Ping request timeout: {msg:?}")),
     }


### PR DESCRIPTION
### What was wrong?
When I would ping nodes I would recieve the wrong data_radius, turns out ping was giving me our data radius back
### How was it fixed?
By decoding the data radius from the pong instead of returning our nodes data_radius
