### PR TITLE
DON"T MERGE: instructions/debug gossip content won't stick

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7221,9 +7221,8 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utp-rs"
-version = "0.1.0-alpha.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ec35d0178f4ccdf5f734af742c264d2c811435ca6e85803b373c6ec077ed33"
+version = "0.1.0-alpha.7"
+source = "git+https://github.com/KolbyML/utp?rev=d5c7a66#d5c7a6677e0e6a03241b820f8acb132361e14bd9"
 dependencies = [
  "async-trait",
  "delay_map 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ trin-history = { path = "trin-history" }
 trin-state = { path = "trin-state" }
 trin-utils = { path = "trin-utils" }
 trin-validation = { path = "trin-validation" }
-utp-rs = "0.1.0-alpha.8"
+utp-rs = { git = "https://github.com/KolbyML/utp", rev="d5c7a66" }
 
 [dev-dependencies]
 ethers-core = { version = "2.0", default-features = false}

--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -1,5 +1,6 @@
 use crate::types::content_key::beacon::BeaconContentKey;
 use crate::types::enr::Enr;
+use crate::types::enr::GossipTrace;
 use crate::types::portal::FindNodesInfo;
 use crate::types::portal::{
     AcceptInfo, ContentInfo, DataRadius, PaginateLocalContentInfo, PongInfo, TraceContentInfo,
@@ -83,7 +84,7 @@ pub trait BeaconNetworkApi {
         &self,
         content_key: BeaconContentKey,
         content_value: BeaconContentValue,
-    ) -> RpcResult<u32>;
+    ) -> RpcResult<GossipTrace>;
 
     /// Send an OFFER request with given ContentKey, to the designated peer and wait for a response.
     /// Returns the content keys bitlist upon successful content transmission or empty bitlist receive.

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -1,5 +1,6 @@
 use crate::types::content_key::history::HistoryContentKey;
 use crate::types::enr::Enr;
+use crate::types::enr::GossipTrace;
 use crate::types::portal::FindNodesInfo;
 use crate::types::portal::{
     AcceptInfo, ContentInfo, DataRadius, PaginateLocalContentInfo, PongInfo, TraceContentInfo,
@@ -86,7 +87,7 @@ pub trait HistoryNetworkApi {
         &self,
         content_key: HistoryContentKey,
         content_value: HistoryContentValue,
-    ) -> RpcResult<u32>;
+    ) -> RpcResult<GossipTrace>;
 
     /// Send an OFFER request with given ContentKey, to the designated peer and wait for a response.
     /// Returns the content keys bitlist upon successful content transmission or empty bitlist receive.

--- a/ethportal-api/src/types/enr.rs
+++ b/ethportal-api/src/types/enr.rs
@@ -10,6 +10,12 @@ use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use validator::ValidationError;
 
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct GossipTrace {
+    pub ss: usize,
+    pub enr_list: Vec<String>,
+}
+
 pub type Enr = discv5::enr::Enr<CombinedKey>;
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/portal-bridge/src/bridge.rs
+++ b/portal-bridge/src/bridge.rs
@@ -320,6 +320,17 @@ impl Bridge {
             "Gossip: Block #{:?} HeaderWithProof",
             full_header.header.number
         );
+
+        let content_key2 =
+            format!("- content_key: {}\n", content_key.to_hex()).to_string();
+        let content_value2 = format!(
+            "  content_value: {}\n",
+            hex_encode(content_value.encode())
+        )
+            .to_string();
+
+        // Write asset to file
+        warn!("{}", format!("hihihih{content_key2}{content_value2}"));
         warn!("yo123321 1");
         let result = Bridge::gossip_content(portal_clients, content_key, content_value).await;
         warn!("yo123321 2 {:?}", result);

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -48,7 +48,7 @@ trin-utils = { path="../trin-utils" }
 trin-validation = { path="../trin-validation" }
 validator = { version = "0.13.0", features = ["derive"] }
 url = "2.3.1"
-utp-rs = "0.1.0-alpha.8"
+utp-rs = { git = "https://github.com/KolbyML/utp", rev="d5c7a66" }
 
 [target.'cfg(windows)'.dependencies]
 uds_windows = "1.0.1"

--- a/portalnet/src/metrics/storage.rs
+++ b/portalnet/src/metrics/storage.rs
@@ -75,6 +75,7 @@ pub struct StorageMetricsReporter {
 }
 use ethportal_api::types::distance::Metric;
 use ethportal_api::OverlayContentKey;
+use ethportal_api::types::distance::XorMetric;
 #[test]
 fn hi () {
     let bob = "0x978e003e087fb7f21833fd43136d126ba97e0fffb90b6c04ebea9ba55c877fee";
@@ -101,9 +102,9 @@ fn hi () {
 
     let content_key: ethportal_api::HistoryContentKey =
         serde_json::from_value(serde_json::json!("0x01823def5821988f866db5d2e9400ec9c9df613f299677aa577a0ff9c0ee631c35")).unwrap();
-    let a = Distance::from(ethereum_types::U256::from("0x381cb22dde95c4282adeb5abe2afd87a50400ca92e78c78f4acf348223095c6"));
-    let b = Distance::from(ethereum_types::U256::from("0x3f1c1dce64a7e5d40a1e0c561500f1dc5cf08918fcb531af69afdd375cc6b976"));
-    if b > a {
+    let radius = Distance::from(ethereum_types::U256::from("0xcb878505d1ab04003cfcc57c142da04c66d71f8a52401722a870fdf07f181772"));
+    let node_id = Distance::from(ethereum_types::U256::from("0x8c51e87021ff95f7af423a09d002a2b5448dca2fb5423929881db1cef7419c64"));
+    if XorMetric::distance(&content_key.content_id(), &node_id.big_endian()) > radius {
         panic!("hi");
     }
     panic!("{}", ethportal_api::utils::bytes::hex_encode(content_key.content_id()));

--- a/portalnet/src/metrics/storage.rs
+++ b/portalnet/src/metrics/storage.rs
@@ -73,6 +73,52 @@ pub struct StorageMetricsReporter {
     pub protocol: String,
     pub storage_metrics: StorageMetrics,
 }
+use ethportal_api::types::distance::Metric;
+use ethportal_api::OverlayContentKey;
+#[test]
+fn hi () {
+    let bob = "0x978e003e087fb7f21833fd43136d126ba97e0fffb90b6c04ebea9ba55c877fee";
+    let bob = ethereum_types::U256::from(bob);
+    let ff = Distance::from(ethereum_types::U256::from("0xa8921df06cd85226122df115066de3b7f58e86e745be5dab824546920041c698"));
+    let bob = Distance::from(bob);
+    let radius_high_bytes = [
+        bob.byte(31),
+        bob.byte(30),
+        bob.byte(29),
+        bob.byte(28),
+    ];
+    let radius_int = u32::from_be_bytes(radius_high_bytes);
+    let coverage_ratio = radius_int as f64 / u32::MAX as f64;
+    let distance = ethportal_api::types::distance::XorMetric::distance(&bob.big_endian(), &ff.big_endian());
+    let radius_high_bytes = [
+        distance.byte(31),
+        distance.byte(30),
+        distance.byte(29),
+        distance.byte(28),
+    ];
+    let radius_int = u32::from_be_bytes(radius_high_bytes);
+    let coverage_ratio = radius_int as f64 / u32::MAX as f64;
+
+    let content_key: ethportal_api::HistoryContentKey =
+        serde_json::from_value(serde_json::json!("0x01823def5821988f866db5d2e9400ec9c9df613f299677aa577a0ff9c0ee631c35")).unwrap();
+    let a = Distance::from(ethereum_types::U256::from("0x381cb22dde95c4282adeb5abe2afd87a50400ca92e78c78f4acf348223095c6"));
+    let b = Distance::from(ethereum_types::U256::from("0x3f1c1dce64a7e5d40a1e0c561500f1dc5cf08918fcb531af69afdd375cc6b976"));
+    if b > a {
+        panic!("hi");
+    }
+    panic!("{}", ethportal_api::utils::bytes::hex_encode(content_key.content_id()));
+    // panic!("{}", ethportal_api::utils::bytes::hex_encode(content_key.big_endian()));
+}
+
+use ssz_types::{typenum, BitList};
+
+#[test]
+fn hi2 () {
+    let hi: BitList<typenum::U8> = BitList::with_capacity(5).unwrap();
+    panic!("{}", hi.is_zero());
+    // panic!("{}", ethportal_api::utils::bytes::hex_encode(content_key.big_endian()));
+}
+
 
 impl StorageMetricsReporter {
     pub fn report_content_data_storage_bytes(&self, bytes: f64) {

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -44,6 +44,7 @@ use crate::{
 use ethportal_api::types::bootnodes::Bootnode;
 use ethportal_api::types::distance::{Distance, Metric};
 use ethportal_api::types::enr::Enr;
+use ethportal_api::types::enr::GossipTrace;
 use ethportal_api::utils::bytes::hex_encode;
 use ethportal_api::OverlayContentKey;
 use ethportal_api::RawContentKey;
@@ -215,13 +216,13 @@ where
     }
 
     /// Propagate gossip accepted content via OFFER/ACCEPT, return number of peers propagated
-    pub fn propagate_gossip(&self, content: Vec<(TContentKey, Vec<u8>)>) -> usize {
+    pub async fn propagate_gossip(&self, content: Vec<(TContentKey, Vec<u8>)>) -> GossipTrace {
         let kbuckets = Arc::clone(&self.kbuckets);
         crate::overlay_service::propagate_gossip_cross_thread(
             content,
             kbuckets,
             self.command_tx.clone(),
-        )
+        ).await
     }
 
     /// Returns a vector of all ENR node IDs of nodes currently contained in the routing table.

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -5,6 +5,7 @@ use crate::jsonrpsee::core::{async_trait, RpcResult};
 use discv5::enr::NodeId;
 use ethportal_api::types::constants::CONTENT_ABSENT;
 use ethportal_api::types::enr::Enr;
+use ethportal_api::types::enr::GossipTrace;
 use ethportal_api::types::jsonrpc::endpoints::BeaconEndpoint;
 use ethportal_api::types::jsonrpc::request::BeaconJsonRpcRequest;
 use ethportal_api::types::portal::{
@@ -182,10 +183,10 @@ impl BeaconNetworkApiServer for BeaconNetworkApi {
         &self,
         content_key: BeaconContentKey,
         content_value: BeaconContentValue,
-    ) -> RpcResult<u32> {
+    ) -> RpcResult<GossipTrace> {
         let endpoint = BeaconEndpoint::Gossip(content_key, content_value);
         let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
-        let result: u32 = from_value(result)?;
+        let result: GossipTrace = from_value(result)?;
         Ok(result)
     }
 

--- a/rpc/src/history_rpc.rs
+++ b/rpc/src/history_rpc.rs
@@ -5,6 +5,7 @@ use crate::jsonrpsee::core::{async_trait, RpcResult};
 use discv5::enr::NodeId;
 use ethportal_api::types::constants::CONTENT_ABSENT;
 use ethportal_api::types::enr::Enr;
+use ethportal_api::types::enr::GossipTrace;
 use ethportal_api::types::jsonrpc::endpoints::HistoryEndpoint;
 use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
 use ethportal_api::types::portal::{
@@ -161,10 +162,10 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
         &self,
         content_key: HistoryContentKey,
         content_value: HistoryContentValue,
-    ) -> RpcResult<u32> {
+    ) -> RpcResult<GossipTrace> {
         let endpoint = HistoryEndpoint::Gossip(content_key, content_value);
         let result = proxy_query_to_history_subnet(&self.network, endpoint).await?;
-        let result: u32 = from_value(result)?;
+        let result: GossipTrace = from_value(result)?;
         Ok(result)
     }
 

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -23,4 +23,4 @@ tokio = {version = "1.14.0", features = ["full"]}
 tracing = "0.1.36"
 trin-validation = { path = "../trin-validation" }
 trin-utils = { path = "../trin-utils" }
-utp-rs = "0.1.0-alpha.8"
+utp-rs = { git = "https://github.com/KolbyML/utp", rev="d5c7a66" }

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -280,8 +280,8 @@ async fn gossip(
     let data = content_value.encode();
     let content_values = vec![(content_key, data)];
     let overlay = network.read().await.overlay.clone();
-    let num_peers = overlay.propagate_gossip(content_values);
-    Ok(num_peers.into())
+    let num_peers = overlay.propagate_gossip(content_values).await;
+    Ok(json!(num_peers))
 }
 
 /// Constructs a JSON call for the Offer method.

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -25,7 +25,7 @@ tracing = "0.1.36"
 tree_hash = "0.5.2"
 trin-utils = { path = "../trin-utils" }
 trin-validation = { path = "../trin-validation" }
-utp-rs = "0.1.0-alpha.8"
+utp-rs = { git = "https://github.com/KolbyML/utp", rev="d5c7a66" }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -290,8 +290,8 @@ async fn gossip(
     let data = content_value.encode();
     let content_values = vec![(content_key, data)];
     let overlay = network.read().await.overlay.clone();
-    let num_peers = overlay.propagate_gossip(content_values);
-    Ok(num_peers.into())
+    let num_peers = overlay.propagate_gossip(content_values).await;
+    Ok(json!(num_peers))
 }
 
 /// Constructs a JSON call for the Offer method.

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -23,7 +23,7 @@ rocksdb = "0.21.0"
 tracing = "0.1.36"
 tokio = {version = "1.14.0", features = ["full"]}
 trin-validation = { path = "../trin-validation" }
-utp-rs = "0.1.0-alpha.8"
+utp-rs = { git = "https://github.com/KolbyML/utp", rev="d5c7a66" }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -22,7 +22,7 @@ tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 trin-utils = { path = "../trin-utils" }
 tokio = {version = "1.14.0", features = ["full"]}
-utp-rs = "0.1.0-alpha.8"
+utp-rs = { git = "https://github.com/KolbyML/utp", rev="d5c7a66" }
 
 [[bin]]
 name = "utp-test-app"


### PR DESCRIPTION
### What was wrong?
Content being bridged isn't getting on the network

### Replication instructions
#### Prelude
![image](https://github.com/ethereum/trin/assets/31669092/b555e0d4-bc9a-4e5d-a5b7-9d140d022f08)
We have a bunch of failed Random requests if you RFC this content you can't find it.
#### step 1
pick a random failed audit
![image](https://github.com/ethereum/trin/assets/31669092/6d13ac7b-b1a9-4d32-a771-8a8169c3ec65)
#### step 2
RFC the content key to double check it isn't on the network
```python
from web3 import Web3
w3 = Web3(Web3.HTTPProvider('http://127.0.0.1:8545', request_kwargs={'timeout': 61}))
print(w3.provider.make_request("portal_historyTraceRecursiveFindContent", ["content_key"]))
```

#### step 3
Run bridge in single block mode (in this PR I have gossip receipt commited out because I am not debugging for that so you will have to uncomment it)
``RUST_LOG=trace cargo run -p portal-bridge -- --node-count 1 --executable-path ./target/debug/trin --mode single:b(enter block number here) --epoch-accumulator-path ./portal-accumulators trin > bridge.log``
#### step 4
run ``grep -i "wasn't accepted by any peers" bridge.log
if (X content type) is ss: 0, enr: [] **do step 3 again**
run ``grep -i "conn starting" bridge.log
the uTP connections will be listed in the order of the 3 expective enr:[] lists so if ``Header enr [eners]`` and ``Block body enr [1, 2]`` If you want the 2nd block body stream it will be the third ``conn starting`` log.

the ``send x, recv y`` are the uTP connection ID's so you can grep recv_cid for your local logs uTP transfer or send_cid if you ssh into the peers node.
#### step 6
Grep the CID on both your node and the clusters node to see if they closed successfully.

On the cluster node you can do that by
``sudo docker logs trin | grep -i "cid number put here"``

If the last uTP log for that cid is close and you don't see an error you should be able to assume the transfer worked
#### step 6
RFC the content key again
```python
from web3 import Web3
w3 = Web3(Web3.HTTPProvider('http://127.0.0.1:8545', request_kwargs={'timeout': 61}))
print(w3.provider.make_request("portal_historyTraceRecursiveFindContent", ["content_key"]))
```

If: it returns '0x' go to step 7
else: goto step 1
#### step 7
At this point you can try briging the content more times to see if it will stick, but I have found piece's of content I have tried to gossip 20-30 times without it succeding for example

http://glados.ethportal.net/content/key/0x01823def5821988f866db5d2e9400ec9c9df613f299677aa577a0ff9c0ee631c35/
#### conclusion

This is a rough outline of what I am doing to find these odd situations on the network