### PR TITLE
feat: make info log default level in most cases

### DIFF
--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -401,7 +401,7 @@ impl AsyncUdpSocket<UtpEnr> for Discv5UdpSocket {
                         let enr = match self.discv5.cached_node_addr(src_node_id) {
                             Some(node_addr) => Ok(node_addr.enr),
                             None => {
-                                warn!(node_id = %src_node_id, "uTP packet from unknown source");
+                                debug!(node_id = %src_node_id, "uTP packet from unknown source");
                                 Err(io::Error::new(
                                     io::ErrorKind::Other,
                                     "ENR not found for talk req destination",

--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -171,11 +171,8 @@ impl Discovery {
     }
 
     pub async fn start(&mut self) -> Result<mpsc::Receiver<TalkRequest>, String> {
-        info!(
-            enr.encoded = ?self.local_enr(),
-            enr.decoded = %self.local_enr(),
-            "Starting discv5",
-        );
+        info!(enr = %self.local_enr(), "Starting discv5 with");
+        debug!(enr = ?self.local_enr(), "Discv5 enr details");
 
         self.discv5
             .start()

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -815,7 +815,7 @@ where
                         let source = match self.find_enr(&peer) {
                             Some(enr) => enr,
                             _ => {
-                                warn!("Received uTP payload from unknown {peer}");
+                                debug!("Received uTP payload from unknown {peer}");
                                 if let Some(responder) = callback {
                                     let _ = responder.send((None, true, query_info.trace));
                                 };
@@ -843,7 +843,7 @@ where
                                         UtpDirectionLabel::Inbound,
                                         UtpOutcomeLabel::FailedConnection,
                                     );
-                                    warn!(
+                                    debug!(
                                         %err,
                                         cid.send,
                                         cid.recv,
@@ -863,7 +863,7 @@ where
                                     UtpDirectionLabel::Inbound,
                                     UtpOutcomeLabel::FailedDataTx,
                                 );
-                                error!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), "error reading data from uTP stream, while handling a FindContent request.");
+                                debug!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), "error reading data from uTP stream, while handling a FindContent request.");
                                 if let Some(responder) = callback {
                                     let _ = responder.send((None, true, query_info.trace));
                                 };
@@ -1123,7 +1123,7 @@ where
                                     UtpDirectionLabel::Outbound,
                                     UtpOutcomeLabel::FailedConnection,
                                 );
-                                error!(
+                                debug!(
                                     %err,
                                     %cid.send,
                                     %cid.recv,
@@ -1134,7 +1134,7 @@ where
                             }
                         };
                         if let Err(err) = Self::send_utp_content(stream, &content, metrics).await {
-                            warn!(
+                            debug!(
                                 %err,
                                 %cid.send,
                                 %cid.recv,
@@ -1270,7 +1270,7 @@ where
                         UtpDirectionLabel::Inbound,
                         UtpOutcomeLabel::FailedConnection,
                     );
-                    error!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), content_keys = ?content_keys_string, "unable to accept uTP stream");
+                    debug!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), content_keys = ?content_keys_string, "unable to accept uTP stream");
                     return;
                 }
             };
@@ -1279,7 +1279,7 @@ where
             if let Err(err) = stream.read_to_eof(&mut data).await {
                 metrics
                     .report_utp_outcome(UtpDirectionLabel::Inbound, UtpOutcomeLabel::FailedDataTx);
-                error!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), content_keys = ?content_keys_string, "error reading data from uTP stream, while handling an Offer request.");
+                debug!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), content_keys = ?content_keys_string, "error reading data from uTP stream, while handling an Offer request.");
                 return;
             }
 
@@ -1297,7 +1297,7 @@ where
             )
             .await
             {
-                error!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), content_keys = ?content_keys_string, "unable to process uTP payload");
+                debug!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), content_keys = ?content_keys_string, "unable to process uTP payload");
             }
         });
 
@@ -1534,7 +1534,7 @@ where
                         UtpDirectionLabel::Outbound,
                         UtpOutcomeLabel::FailedConnection,
                     );
-                    warn!(
+                    debug!(
                         %err,
                         cid.send,
                         cid.recv,
@@ -1587,7 +1587,7 @@ where
 
             // send the content to the acceptor over a uTP stream
             if let Err(err) = Self::send_utp_content(stream, &content_payload, metrics).await {
-                warn!(
+                debug!(
                     %err,
                     %cid.send,
                     %cid.recv,
@@ -1712,7 +1712,7 @@ where
                 } else {
                     format!("{:?}", err)
                 };
-                error!(err, content_key = ?content_keys_string[index], "Process uTP payload tokio task failed:");
+                debug!(err, content_key = ?content_keys_string[index], "Process uTP payload tokio task failed:");
                 None
             }))
             .collect();

--- a/trin-utils/src/log.rs
+++ b/trin-utils/src/log.rs
@@ -1,8 +1,15 @@
+use std::env;
 use tracing_subscriber::EnvFilter;
 
 pub fn init_tracing_logger() {
+    let rust_log = env::var(EnvFilter::DEFAULT_ENV).unwrap_or_default();
+    let env_filter = match rust_log.is_empty() {
+        true => EnvFilter::builder().parse_lossy("info,discv5=error,utp_rs=error"),
+        false => EnvFilter::builder().parse_lossy(rust_log),
+    };
+
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
+        .with_env_filter(env_filter)
         .with_ansi(detect_ansi_support())
         .init();
 }


### PR DESCRIPTION
### What was wrong?
fixes https://github.com/ethereum/trin/issues/940
### How was it fixed?
by adding info as the default log level. Then setting discv5 to Error cause it is super noisy.

https://stackoverflow.com/a/67310139 < apparently log level hierarchy is in order of ``error`` > ``warn`` > ``info`` > ``debug`` > ``trace``. So by enabling info we are also enabling warn.

```nim
/home/kolby/.cargo/bin/cargo run --color=always --package trin --bin trin
    Finished dev [unoptimized + debuginfo] target(s) in 0.68s
     Running `target/debug/trin`
2023-10-18T01:00:53.405856Z  INFO trin: Launching Trin: v0.1.1-alpha.1-de638d
2023-10-18T01:00:53.405942Z  INFO trin: With: config=TrinConfig { networks: ["history"], capacity_mb: 100, ephemeral: false, json_rpc_url: /tmp/trin-jsonrpc.ipc, metrics_enabled: false }
2023-10-18T01:00:53.413046Z  INFO portalnet::socket: Connecting to STUN server to find public network endpoint
2023-10-18T01:00:53.639299Z  INFO portalnet::discovery: Starting discv5 enr.encoded=Enr { id: Some("v4"), seq: 6, NodeId: 0x3cad3f55f919d98b19d18585715423de28223470be2915cf88178b9a08b0d2f9, signature: "6d8bcd7d073db0024207c1542763e9eb40db1bf085a55c55cfdb3799091d9cca7da772cd286a5828dbdc047b8bbfb9cd27b6a9218c69205f0e885c60c1fb0027", IpV4 UDP Socket: Some(162.157.246.69:9000), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "967420302e312e312d616c7068612e312d646536333864"), ("secp256k1", "a10277004232d5c704729c216cd91a9c861dd1d72fa5e9beb6ddcd02506c980a34d5")] } enr.decoded=enr:-Jy4QG2LzX0HPbACQgfBVCdj6etA2xvwhaVcVc_bN5kJHZzKfadyzShqWCjb3AR7i7-5zSe2qSGMaSBfDohcYMH7ACcGY5Z0IDAuMS4xLWFscGhhLjEtZGU2MzhkgmlkgnY0gmlwhKKd9kWJc2VjcDI1NmsxoQJ3AEIy1ccEcpwhbNkanIYd0dcvpem-tt3NAlBsmAo01YN1ZHCCIyg
2023-10-18T01:00:53.640704Z  INFO portalnet::storage: Setting up RocksDB path=/home/kolby/.local/share/trin/trin_0x3cad3f/rocksdb
2023-10-18T01:00:53.709884Z  INFO portalnet::storage: Setting up SqliteDB path=/home/kolby/.local/share/trin/trin_0x3cad3f/trin.sqlite
2023-10-18T01:00:53.713269Z  INFO trin: Loaded master accumulator from: "validation_assets/merge_macc.bin"
2023-10-18T01:00:53.717797Z  INFO trin_history: About to spawn History Network with 11 boot nodes
2023-10-18T01:00:53.717835Z  INFO portalnet::overlay_service: Starting overlay service protocol=History
2023-10-18T01:00:53.719158Z  INFO trin_history: reports~ data: radius=1.6% content=100.2/100mb #=1500 disk=51.3mb; msgs: offers=0/0, accepts=0/0, validations=0/0
2023-10-18T01:00:53.719200Z  INFO trin_history: reports~ utp: (in/out): active=0 (0/0), success=0 (0/0), failed=0 (0/0) failed_connection=0 (0/0), failed_data_tx=0 (0/0), failed_shutdown=0 (0/0)
2023-10-18T01:00:54.212034Z  INFO portalnet::overlay: Bonded with bootnode alias=fluffy-4 protocol=History
2023-10-18T01:00:54.373834Z  INFO portalnet::overlay: Bonded with bootnode alias=trin-ams3-1 protocol=History
2023-10-18T01:00:54.456552Z  INFO portalnet::overlay: Bonded with bootnode alias=trin-nyc1-1 protocol=History
2023-10-18T01:00:55.011572Z  INFO portalnet::overlay: Bonded with bootnode alias=trin-sgp1-1 protocol=History
2023-10-18T01:00:55.472659Z  INFO portalnet::overlay: Bonded with bootnode alias=fluffy-1 protocol=History
2023-10-18T01:00:55.880641Z  INFO portalnet::overlay: Bonded with bootnode alias=fluffy-2 protocol=History
2023-10-18T01:00:56.310806Z  INFO portalnet::overlay: Bonded with bootnode alias=fluffy-3 protocol=History
2023-10-18T01:00:57.314254Z ERROR portalnet::overlay: Error bonding with bootnode alias=ultralight-1 protocol=History error=The request timed out
2023-10-18T01:00:58.317525Z ERROR portalnet::overlay: Error bonding with bootnode alias=ultralight-2 protocol=History error=The request timed out
2023-10-18T01:00:59.320746Z ERROR portalnet::overlay: Error bonding with bootnode alias=ultralight-3 protocol=History error=The request timed out
2023-10-18T01:01:00.324565Z ERROR portalnet::overlay: Error bonding with bootnode alias=ultralight-4 protocol=History error=The request timed out
2023-10-18T01:01:03.064548Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0xfda8..714d }
2023-10-18T01:01:03.527396Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0x9c70..5ce6 }
2023-10-18T01:01:05.979406Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0xe8a1..c082 }
2023-10-18T01:01:09.650795Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0xed7b..f86e }
2023-10-18T01:01:09.696368Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0xc78c..9538 }
2023-10-18T01:01:12.042423Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0xa445..1ddd }
2023-10-18T01:01:14.571173Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0x78c4..5be8 }
2023-10-18T01:01:15.831416Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0xbabb..19f9 }
2023-10-18T01:01:16.299992Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0x8ffd..b148 }
2023-10-18T01:01:18.094395Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0x8ffd..b148 }
2023-10-18T01:01:18.384973Z  WARN portalnet::overlay_service: Accepted content already stored content.key=0x028ffd59def0d765d909310da48b44d261e80491e98c24e1866febf1827bebb148
2023-10-18T01:01:21.842171Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0xbabb..19f9 }
2023-10-18T01:01:22.159721Z  WARN portalnet::overlay_service: Accepted content already stored content.key=0x01babbd90fce526379a44d471d4c4c87b00e6fb4aae6d3ca4a456aa7e08e1919f9
2023-10-18T01:01:23.719611Z  INFO trin_history: reports~ data: radius=1.6% content=100.0/100mb #=1493 disk=50.0mb; msgs: offers=99/105, accepts=23/23, validations=24/24
2023-10-18T01:01:23.719658Z  INFO trin_history: reports~ utp: (in/out): active=3 (2/1), success=16 (13/3), failed=0 (0/0) failed_connection=0 (0/0), failed_data_tx=0 (0/0), failed_shutdown=0 (0/0)
2023-10-18T01:01:27.325276Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0x6d4c..5d9c }
2023-10-18T01:01:46.879971Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0xf9ae..ad2f }
2023-10-18T01:01:53.719499Z  INFO trin_history: reports~ data: radius=1.6% content=100.2/100mb #=1494 disk=50.4mb; msgs: offers=145/153, accepts=76/76, validations=32/32
2023-10-18T01:01:53.719553Z  INFO trin_history: reports~ utp: (in/out): active=1 (1/0), success=25 (19/6), failed=0 (0/0) failed_connection=0 (0/0), failed_data_tx=0 (0/0), failed_shutdown=0 (0/0)
2023-10-18T01:02:12.060103Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0xfd04..c27a }
2023-10-18T01:02:23.718853Z  INFO trin_history: reports~ data: radius=1.6% content=100.0/100mb #=1485 disk=50.9mb; msgs: offers=160/169, accepts=89/89, validations=35/35
2023-10-18T01:02:23.718910Z  INFO trin_history: reports~ utp: (in/out): active=1 (1/0), success=27 (21/6), failed=0 (0/0) failed_connection=0 (0/0), failed_data_tx=0 (0/0), failed_shutdown=0 (0/0)
2023-10-18T01:02:50.110787Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0x1142..a1c6 }
2023-10-18T01:02:53.719521Z  INFO trin_history: reports~ data: radius=1.6% content=100.1/100mb #=1490 disk=51.0mb; msgs: offers=197/209, accepts=152/152, validations=41/41
2023-10-18T01:02:53.719577Z  INFO trin_history: reports~ utp: (in/out): active=2 (2/0), success=33 (26/7), failed=0 (0/0) failed_connection=0 (0/0), failed_data_tx=0 (0/0), failed_shutdown=0 (0/0)
2023-10-18T01:02:53.907369Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0x9733..e5a2 }
2023-10-18T01:03:08.371165Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0xb008..6dd4 }
2023-10-18T01:03:10.575076Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0x94c6..ea1b }
2023-10-18T01:03:18.548284Z  INFO portalnet::overlay_service: Starting query for content key: BlockHeaderWithProof { block_hash: 0x90ae..ce87 }
2023-10-18T01:03:23.718954Z  INFO trin_history: reports~ data: radius=1.6% content=100.0/100mb #=1490 disk=51.4mb; msgs: offers=229/241, accepts=417/417, validations=49/49
2023-10-18T01:03:23.718992Z  INFO trin_history: reports~ utp: (in/out): active=1 (1/0), success=38 (30/8), failed=0 (0/0) failed_connection=0 (0/0), failed_data_tx=0 (0/0), failed_shutdown=0 (0/0)
```

^ This is an example of what it looks like