### PR TITLE
Update trace-recursive-find-content response to match spec changes

### DIFF
--- a/ethportal-peertest/src/scenarios/utp.rs
+++ b/ethportal-peertest/src/scenarios/utp.rs
@@ -97,7 +97,7 @@ pub async fn test_trace_recursive_utp(peertest: &Peertest) {
     assert_eq!(origin, ethportal_api::NodeId::from(query_origin_node));
 
     // Test that `received_content_from_node` is set correctly
-    let received_content_from_node = trace.received_content_from_node.unwrap();
+    let received_content_from_node = trace.received_from.unwrap();
     assert_eq!(
         ethportal_api::NodeId::from(node_with_content),
         received_content_from_node

--- a/portalnet/src/find/iterators/findcontent.rs
+++ b/portalnet/src/find/iterators/findcontent.rs
@@ -427,6 +427,22 @@ where
             .take(self.config.num_results)
             .collect()
     }
+
+    /// Return a list of peers with whom we have unresolved queries, for use in trace result.
+    /// Do not include the source who returned the content.
+    pub fn pending_peers(&self, source: TNodeId) -> Vec<TNodeId> {
+        self.closest_peers
+            .iter()
+            .filter(|(_, peer)| peer.key().clone().into_preimage() != source)
+            .filter_map(|(_, peer)| {
+                if let QueryPeerState::Waiting(..) = peer.state() {
+                    Some(peer.key().clone().into_preimage())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/portalnet/src/find/query_info.rs
+++ b/portalnet/src/find/query_info.rs
@@ -25,6 +25,7 @@ pub struct QueryInfo<TContentKey> {
 // Content is Option<Vec<u8>> because it can be None if the content is not found
 // in a recursive find content query.
 pub type RecursiveFindContentResult = (Option<Vec<u8>>, bool, Option<QueryTrace>);
+
 // Content, utp_transfer
 // Content is Content type because the response to a simple find content query
 // cannot be None and must be a valid Content response, to account for the

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -2059,6 +2059,11 @@ where
             }
             if let Some(trace) = &mut query_info.trace {
                 trace.node_responded_with(&source, new_enrs);
+                trace.cancelled = query
+                    .pending_peers(source.node_id())
+                    .into_iter()
+                    .map(|peer| peer.into())
+                    .collect();
             }
             let closest_nodes: Vec<NodeId> = enrs
                 .iter()
@@ -2084,6 +2089,11 @@ where
         if let Some((query_info, query)) = self.find_content_query_pool.write().get_mut(*query_id) {
             if let Some(trace) = &mut query_info.trace {
                 trace.node_responded_with_content(&source);
+                trace.cancelled = query
+                    .pending_peers(source.node_id())
+                    .into_iter()
+                    .map(|peer| peer.into())
+                    .collect();
             }
             // Mark the query successful for the source of the response with the connection id.
             query.on_success(
@@ -2104,6 +2114,11 @@ where
         if let Some((query_info, query)) = pool.get_mut(*query_id) {
             if let Some(trace) = &mut query_info.trace {
                 trace.node_responded_with_content(&source);
+                trace.cancelled = query
+                    .pending_peers(source.node_id())
+                    .into_iter()
+                    .map(|peer| peer.into())
+                    .collect();
             }
             // Mark the query successful for the source of the response with the content.
             query.on_success(
@@ -2447,7 +2462,7 @@ where
 
         let trace: Option<QueryTrace> = {
             if is_trace {
-                let mut trace = QueryTrace::new(&self.local_enr(), target_node_id.into());
+                let mut trace = QueryTrace::new(&self.local_enr(), target_node_id.raw());
                 let local_enr = self.local_enr();
                 trace.node_responded_with(&local_enr, closest_enrs.iter().collect());
                 Some(trace)

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -101,10 +101,7 @@ async fn recursive_find_content(
     let (possible_content_bytes, utp_transfer, trace) = match local_content {
         Some(val) => {
             let local_enr = overlay.local_enr();
-            let mut trace = QueryTrace::new(
-                &overlay.local_enr(),
-                NodeId::new(&content_key.content_id()).into(),
-            );
+            let mut trace = QueryTrace::new(&overlay.local_enr(), content_key.content_id());
             trace.node_responded_with_content(&local_enr);
             (Some(val), false, if is_trace { Some(trace) } else { None })
         }

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -105,10 +105,7 @@ async fn recursive_find_content(
     let (possible_content_bytes, utp_transfer, trace) = match local_content {
         Some(val) => {
             let local_enr = overlay.local_enr();
-            let mut trace = QueryTrace::new(
-                &overlay.local_enr(),
-                NodeId::new(&content_key.content_id()).into(),
-            );
+            let mut trace = QueryTrace::new(&overlay.local_enr(), content_key.content_id());
             trace.node_responded_with_content(&local_enr);
             (Some(val), false, if is_trace { Some(trace) } else { None })
         }


### PR DESCRIPTION
### What was wrong?
Changes to the `portal_*TraceRecursiveFindContent` endpoint in the [specs](https://github.com/ethereum/portal-network-specs/pull/236) needed implementation.

Fixes #987 

### How was it fixed?
- Implemented changes to endpoint
- Changed `ContentId` type from `NodeId` -> `[u8; 32]`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
