### PR TITLE
Adds disable poke CLI flag to trin

### DIFF
--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -148,6 +148,12 @@ pub struct TrinConfig {
     )]
     pub master_acc_path: PathBuf,
 
+    #[arg(
+        long = "disable-poke",
+        help = "Disables the poke mechanism, which propogates content at the end of a successful content query. Disabling is useful for network analysis purposes."
+    )]
+    pub disable_poke: bool,
+
     #[command(subcommand)]
     pub command: Option<TrinConfigCommands>,
 }
@@ -177,6 +183,7 @@ impl Default for TrinConfig {
             enable_metrics_with_url: None,
             ephemeral: false,
             master_acc_path: PathBuf::from(DEFAULT_MASTER_ACC_PATH.to_string()),
+            disable_poke: false,
             command: None,
         }
     }

--- a/portalnet/src/config.rs
+++ b/portalnet/src/config.rs
@@ -21,6 +21,7 @@ pub struct PortalnetConfig {
     pub internal_ip: bool,
     pub no_stun: bool,
     pub node_addr_cache_capacity: usize,
+    pub disable_poke: bool,
 }
 
 impl Default for PortalnetConfig {
@@ -34,6 +35,7 @@ impl Default for PortalnetConfig {
             internal_ip: false,
             no_stun: false,
             node_addr_cache_capacity: NODE_ADDR_CACHE_CAPACITY,
+            disable_poke: false,
         }
     }
 }
@@ -46,6 +48,7 @@ impl PortalnetConfig {
             listen_port: trin_config.discovery_port,
             no_stun: trin_config.no_stun,
             bootnodes: trin_config.bootnodes.clone(),
+            disable_poke: trin_config.disable_poke,
             ..Default::default()
         }
     }

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -65,6 +65,7 @@ pub struct OverlayConfig {
     pub query_peer_timeout: Duration,
     pub query_num_results: usize,
     pub findnodes_query_distances_per_peer: usize,
+    pub disable_poke: bool,
 }
 
 impl Default for OverlayConfig {
@@ -81,6 +82,7 @@ impl Default for OverlayConfig {
             query_timeout: Duration::from_secs(60),
             query_num_results: MAX_NODES_PER_BUCKET,
             findnodes_query_distances_per_peer: 3,
+            disable_poke: false,
         }
     }
 }
@@ -161,6 +163,7 @@ where
             config.query_parallelism,
             config.query_num_results,
             config.findnodes_query_distances_per_peer,
+            config.disable_poke,
         )
         .await;
 

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -36,6 +36,7 @@ impl HistoryNetwork {
         let bootnode_enrs: Vec<Enr> = portal_config.bootnodes.into();
         let config = OverlayConfig {
             bootnode_enrs,
+            disable_poke: portal_config.disable_poke,
             ..Default::default()
         };
         let storage = Arc::new(PLRwLock::new(PortalStorage::new(


### PR DESCRIPTION
### What was wrong?

#766 

Disabling the poke mechanism is useful for keeping a clear, unaffected view of the network while doing network analysis eg in glados. 

Kind of like how when you're fishing, throwing a fish back in will disturb the water. 🐟 

### How was it fixed?

Adds `--disable-poke` flag to Trin, and passes it into the `OverlayService` where poking is handled.

Tested manually.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
