### PR TITLE
Use `finalized slot` in `LightClientFinalityUpdate` content key and update beacon bridge to serve the data.

### DIFF
--- a/ethportal-api/src/types/content_key/beacon.rs
+++ b/ethportal-api/src/types/content_key/beacon.rs
@@ -37,19 +37,19 @@ pub struct LightClientUpdatesByRangeKey {
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
 pub struct LightClientFinalityUpdateKey {
     /// Finalized slot number
-    pub signature_slot: u64,
+    pub finalized_slot: u64,
 }
 
 impl LightClientFinalityUpdateKey {
-    pub fn new(signature_slot: u64) -> Self {
-        Self { signature_slot }
+    pub fn new(finalized_slot: u64) -> Self {
+        Self { finalized_slot }
     }
 }
 
 /// Key used to identify a light client optimistic update.
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
 pub struct LightClientOptimisticUpdateKey {
-    /// Optimistic slot number
+    /// Signature slot number
     pub signature_slot: u64,
 }
 
@@ -94,8 +94,8 @@ impl fmt::Display for BeaconContentKey {
                 key.start_period, key.count
             ),
             Self::LightClientFinalityUpdate(key) => format!(
-                "LightClientFinalityUpdate {{ signature_slot: {} }}",
-                key.signature_slot
+                "LightClientFinalityUpdate {{ finalized_slot: {} }}",
+                key.finalized_slot
             ),
             Self::LightClientOptimisticUpdate(key) => format!(
                 "LightClientOptimisticUpdate {{ signature_slot: {} }}",
@@ -129,7 +129,7 @@ impl OverlayContentKey for BeaconContentKey {
             }
             BeaconContentKey::LightClientFinalityUpdate(key) => {
                 bytes.push(0x02);
-                bytes.extend_from_slice(&key.signature_slot.as_ssz_bytes())
+                bytes.extend_from_slice(&key.finalized_slot.as_ssz_bytes())
             }
             BeaconContentKey::LightClientOptimisticUpdate(key) => {
                 bytes.push(0x03);
@@ -237,7 +237,7 @@ mod test {
         assert_eq!(content_key.to_bytes(), expected_content_key);
         assert_eq!(
             content_key.to_string(),
-            "LightClientFinalityUpdate { signature_slot: 7271362 }"
+            "LightClientFinalityUpdate { finalized_slot: 7271362 }"
         );
         assert_eq!(content_key.to_hex(), KEY_STR);
     }


### PR DESCRIPTION
### What was wrong?
Beacon network [specs](https://github.com/ethereum/portal-network-specs/blob/master/beacon-chain/beacon-network.md#lightclientfinalityupdate) require a finalized slot to be included in `LightClientFinalityUpdate`'s content key.

### How was it fixed?
- Use the finalized instead of the signature slot in the `LightClientFinalityUpdate` content key.
- Update beacon bridge to serve `LightClientFinalityUpdate` content only if the finalized slot changes.
- Improve some beacon bridge logs. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Record a screencast for Devconnect with the current beacon sync prototype before merging/deploying this PR.
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
