### PR TITLE
chore: add bootnodes,external-ip cli to bridge to support hive test

### DIFF
--- a/portal-bridge/src/bridge.rs
+++ b/portal-bridge/src/bridge.rs
@@ -76,6 +76,10 @@ impl Bridge {
             BridgeMode::Latest => self.launch_latest().await,
             _ => self.launch_backfill().await,
         }
+        // let test finish uTP transfer before shutting down gossip nodes
+        if let BridgeMode::Test(_) = self.mode.clone() {
+            sleep(Duration::from_secs(2)).await;
+        }
         info!("Bridge mode: {:?} complete.", self.mode);
     }
 

--- a/portal-bridge/src/bridge.rs
+++ b/portal-bridge/src/bridge.rs
@@ -76,10 +76,6 @@ impl Bridge {
             BridgeMode::Latest => self.launch_latest().await,
             _ => self.launch_backfill().await,
         }
-        // let test finish uTP transfer before shutting down gossip nodes
-        if let BridgeMode::Test(_) = self.mode.clone() {
-            sleep(Duration::from_secs(2)).await;
-        }
         info!("Bridge mode: {:?} complete.", self.mode);
     }
 

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -53,6 +53,20 @@ pub struct BridgeConfig {
     #[arg(long, help = "Url for metrics reporting")]
     pub metrics_url: Option<Url>,
 
+    #[arg(
+        default_value = "default",
+        long = "bootnodes",
+        help = "One or more comma-delimited base64-encoded ENR's or multiaddr strings of peers to initially add to the local routing table"
+    )]
+    pub bootnodes: String,
+
+    #[arg(
+        default_value = "none",
+        long = "external-ip",
+        help = "(Only use this if you are behind a NAT) The address which will be advertised to peers (in an ENR). Changing it does not change which address trin binds to, ex: 127.0.0.1"
+    )]
+    pub external_ip: String,
+
     #[command(subcommand)]
     pub client_type: ClientType,
 }

--- a/portal-bridge/src/client_handles.rs
+++ b/portal-bridge/src/client_handles.rs
@@ -38,6 +38,14 @@ pub fn fluffy_handle(
             .arg(format!("--metrics-address:{address}"))
             .arg(format!("--metrics-port:{port}"));
     }
+    if bridge_config.bootnodes != "default" {
+        for enr in bridge_config.bootnodes.split(',') {
+            command.args(["--bootstrap-node", enr]);
+        }
+    }
+    if !bridge_config.external_ip.is_empty() {
+        command.arg(format!("--nat:extip:{}", bridge_config.external_ip));
+    }
     Ok(command.spawn()?)
 }
 
@@ -67,7 +75,13 @@ pub fn trin_handle(
             &format!("http://127.0.0.1:{rpc_port}"),
         ])
         .args(["--discovery-port", &format!("{udp_port}")])
-        .args(["--bootnodes", "default"]);
+        .args(["--bootnodes", &bridge_config.bootnodes]);
+    if !bridge_config.external_ip.is_empty() {
+        command.args([
+            "--external-address",
+            &format!("{}:{}", bridge_config.external_ip, udp_port),
+        ]);
+    }
     if let Some(metrics_url) = bridge_config.metrics_url {
         let url: String = metrics_url.into();
         command.args(["--enable-metrics-with-url", &url]);


### PR DESCRIPTION
### What was wrong?
this is required for the rewrite of the hive bridge test I am writing

Without the timeout bridge closes without the finishing uTP transfers.
Without being able to set bootnodes I can't test this as it wouldn't be valid
Without being able to set external ip the trin node can't be connected to from the other docker containers

below is the chat history of the problem we are trying to solve.
https://github.com/ethereum/portal-hive/pull/110#discussion_r1372181073
https://github.com/ethereum/portal-hive/pull/110#discussion_r1372183148
https://github.com/ethereum/portal-hive/pull/110#discussion_r1372187887

this PR is required to make the sister pr on portal hive https://github.com/ethereum/portal-hive/pull/115
### How was it fixed?
By adding 2 params required to write the test
