### PR TITLE
Only run commitlint on pull_request action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   commitlint:


### PR DESCRIPTION
### What was wrong?
Since `trin`'s entire commit history (on master) doesn't follow conventional commit formatting, we don't want to run the commitlint check on pushes to master but only on pull request actions.

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
