### PR TITLE
fix: use option for bridge external ip cli arg

### DIFF
--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -61,11 +61,10 @@ pub struct BridgeConfig {
     pub bootnodes: String,
 
     #[arg(
-        default_value = "none",
         long = "external-ip",
         help = "(Only use this if you are behind a NAT) The address which will be advertised to peers (in an ENR). Changing it does not change which address trin binds to, ex: 127.0.0.1"
     )]
-    pub external_ip: String,
+    pub external_ip: Option<String>,
 
     #[command(subcommand)]
     pub client_type: ClientType,

--- a/portal-bridge/src/client_handles.rs
+++ b/portal-bridge/src/client_handles.rs
@@ -43,8 +43,8 @@ pub fn fluffy_handle(
             command.args(["--bootstrap-node", enr]);
         }
     }
-    if !bridge_config.external_ip.is_empty() {
-        command.arg(format!("--nat:extip:{}", bridge_config.external_ip));
+    if let Some(ip) = bridge_config.external_ip {
+        command.arg(format!("--nat:extip:{ip}"));
     }
     Ok(command.spawn()?)
 }
@@ -76,11 +76,8 @@ pub fn trin_handle(
         ])
         .args(["--discovery-port", &format!("{udp_port}")])
         .args(["--bootnodes", &bridge_config.bootnodes]);
-    if !bridge_config.external_ip.is_empty() {
-        command.args([
-            "--external-address",
-            &format!("{}:{}", bridge_config.external_ip, udp_port),
-        ]);
+    if let Some(ip) = bridge_config.external_ip {
+        command.args(["--external-address", &format!("{ip}:{udp_port}")]);
     }
     if let Some(metrics_url) = bridge_config.metrics_url {
         let url: String = metrics_url.into();


### PR DESCRIPTION
### What was wrong?
Bridge cli default value for `external_ip` was `"none"` when it should have been an `Option`

### How was it fixed?
Updated default value. Tested locally and bridge does successfully gossip content

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
