### PR TITLE
chore: increase discv5 request_timeout from 1 to 3 seconds

### DIFF
--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -2,6 +2,7 @@ use std::hash::{Hash, Hasher};
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::time::Duration;
 use std::{convert::TryFrom, fmt, fs, io, net::SocketAddr, sync::Arc};
 
 use anyhow::anyhow;
@@ -144,7 +145,9 @@ impl Discovery {
             port: portal_config.listen_port,
         };
 
-        let discv5_config = ConfigBuilder::new(listen_config).build();
+        let discv5_config = ConfigBuilder::new(listen_config)
+            .request_timeout(Duration::from_secs(3))
+            .build();
         let discv5 = Discv5::new(enr, enr_key, discv5_config)
             .map_err(|e| format!("Failed to create discv5 instance: {e}"))?;
 


### PR DESCRIPTION
### What was wrong?
Assume client A and B don't have a session together

A wants to send B a Ping or FindContent request

```mermaid
sequenceDiagram
     participant Node1
     participant Node2
     Note over Node1: Start discv5 server
     Note over Node2: Start discv5 server
 
     Node1 ->> Node2: PING message packet encrypted with unknown key
     Node2 ->> Node1: WHOAREYOU packet including id-nonce, enr-seq
     Node1 ->> Node2: PING handshake message packet, encrypted with new initiator-key
     Node2 ->> Node1: PONG encrypted with new recipient-key
```
diagram of if a new session needs to be formed ^
```mermaid
sequenceDiagram
     participant Node1
     participant Node2
     Note over Node1: Start discv5 server
     Note over Node2: Start discv5 server
 
     Node1 ->> Node2: PING
     Node2 ->> Node1: PONG
```
diagram of if a session already exists ^



Currently there is a request timeout of 1 second for sigp/discv5 so if you need to initate a session
- if network latancy is 250ms network wide, Node1 Will get the pong back within 1 second and not timeout
- if network latancy is 251ms network wide, but the time Node 1 would recieve the Pong it would be 4ms over the time limit and have timed out. 4 packets so 251ms*4=1004ms which is when Node1 would have recieved it if it didn't already timeout

This effectively means that 
- if you are starting a new session if the latency of the 4 overall packets is over 1 second, your request will timeout
- but if you already had a connection your request would only timeout  if the latency of the 2 overall packets is over 1 second, your request will timeout

So a request which already has a session has a metaphorical timeout of 500ms per packet, were if you need to initiate a new session it would have a metaphorical timeout of 250ms per packet.

For testing this I used https://github.com/KolbyML/portal-testground ``ping-one-way`` test case, which just does a ``A pings B`` test
I tested fluffy to fluffy, and ultralight to ultralight, starting new sessions to see what network wide latency would cause them to time out, testing in 10ms increments and found they would fail at.
- fluffy to fluffy 670ms 
- ultralight to ultralight 250ms

I tested trin to trin in 1ms increments and found it would timeout on sending a request which required a new session
- trin to trin 251ms

250ms passed for Trin which made sense in my theory.

**Interesting note** To my knowledge the lowest common denominator will cause it to fail, but I believe if node b of the connection has a low timeout, if node A accounts for this, maybe it will be resilient to other nodes being a LCD but I haven't tested that theory, just an idea.

So whichever clients timeout is effectively lower will cause the request to fail, at least for certain implementations of discv5

### How was it fixed?
In the Trin meeting on 11/6/2023 @carver suggested that we just increase the request_timeout instead of trying to find a final solution right off the bat. I Agree that it is a good idea to do the quick and dirty naive solution as it should tell us a lot. So that we are better informed what is the right way to resolve this issue long term.

So I decided to do 3 seconds instead of 1. As this will give us an effective timeout of 750ms per packet on creating a session, which is aboves fluffy's timeout so it should give us breathing room. This should also more clearly display the impact of the change compared to 2 seconds.
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
