### PR TITLE
feat: add cli option for root private key in bridge

### DIFF
--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -245,9 +245,9 @@ impl TrinConfig {
     }
 }
 
-fn check_private_key_length(private_key: &str) -> Result<H256, String> {
+pub fn check_private_key_length(private_key: &str) -> Result<H256, String> {
     if private_key.len() == 66 {
-        return H256::from_str(private_key).map_err(|err| format!("HexError: {}", err));
+        return H256::from_str(private_key).map_err(|err| format!("HexError: {err}"));
     }
     Err(format!(
         "Invalid private key length: {}, expected 66 (0x-prefixed 32 byte hexstring)",

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -1,11 +1,15 @@
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use clap::{Parser, Subcommand};
+use ethereum_types::H256;
+use tokio::process::Child;
+use url::Url;
+
 use crate::client_handles::{fluffy_handle, trin_handle};
 use crate::mode::BridgeMode;
 use crate::types::NetworkKind;
-use clap::{Parser, Subcommand};
-use std::path::PathBuf;
-use std::str::FromStr;
-use tokio::process::Child;
-use url::Url;
+use ethportal_api::types::cli::check_private_key_length;
 
 // max value of 16 b/c...
 // - reliably calculate spaced private keys in a reasonable time
@@ -68,6 +72,13 @@ pub struct BridgeConfig {
 
     #[command(subcommand)]
     pub client_type: ClientType,
+
+    #[arg(
+        long = "root-private-key",
+        value_parser = check_private_key_length,
+        help = "Hex encoded 32 byte private key (with 0x prefix) (used as the root key for generating spaced private keys, if multiple nodes are selected)"
+    )]
+    pub root_private_key: Option<H256>,
 }
 
 fn check_node_count(val: &str) -> Result<u8, String> {

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -20,7 +20,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_tracing_logger();
 
     let bridge_config = BridgeConfig::parse();
-    let private_keys = generate_spaced_private_keys(bridge_config.node_count);
+    let private_keys =
+        generate_spaced_private_keys(bridge_config.node_count, bridge_config.root_private_key);
     let mut handles = vec![];
     let mut http_addresses = vec![];
     for (i, key) in private_keys.into_iter().enumerate() {


### PR DESCRIPTION
### What was wrong?
In our bridge architecture, we spin up multiple bridge nodes, but their private keys are currently randomly generated. We want the option to provide custom private keys so that we can ensure the bridge nodes are equally distributed around the keyspace.

### How was it fixed?
- Added cli option for providing custom private keys to bridge nodes

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
