### PR TITLE
fix: filter out disconnected nodes on Node/(Content Enr) response

### DIFF
--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -2360,11 +2360,15 @@ where
         }
     }
 
-    /// Returns a vector of all the ENRs of nodes currently contained in the routing table.
+    /// Returns a vector of all the ENRs of nodes currently contained in the routing table which are connected.
     fn table_entries_enr(&self) -> Vec<Enr> {
         self.kbuckets
             .write()
             .iter()
+            .filter(|entry| {
+                // Filter out disconnected nodes.
+                entry.status.is_connected()
+            })
             .map(|entry| entry.node.value.enr())
             .collect()
     }
@@ -2387,6 +2391,10 @@ where
             for node in kbuckets
                 .nodes_by_distances(log2_distances, FIND_NODES_MAX_NODES)
                 .into_iter()
+                .filter(|entry| {
+                    // Filter out disconnected nodes.
+                    entry.status.is_connected()
+                })
                 .map(|entry| entry.node.value.clone())
             {
                 nodes_to_send.push(SszEnr::new(node.enr()));


### PR DESCRIPTION
### What was wrong?
during devconnect Mike brought up glados's cartographer was trying to ping 1800 enrs, because trin nodes were returning disconnect nodes.

I don't think we should remove the last resort of using disconnected nodes to initialize a RFC/RFN. Since the last resort will only be used if there are 0 connected nodes in the whole routing table which should only happen on startup.

in short I believe this is the right solution

This can also be in glados audits

![image](https://github.com/ethereum/trin/assets/31669092/7aa2623c-1ac8-42a3-a97f-987d335f2d5f)

In this picture the Trin node is returning Enr's of disconnected nodes which haven't run for over a month. The trin node returned these because it sorted by distance without filtering out disconnected first. This PR adds the filter so that should no longer happen.
### How was it fixed?
by filtering out disconnected nodes by status

I applied to filter to both the Nodes response and the Content Enr Response