### PR TITLE
docs: add pull latest master deployment scripts to deployment steps

### DIFF
--- a/book/src/developers/contributing/releases/deployment.md
+++ b/book/src/developers/contributing/releases/deployment.md
@@ -50,6 +50,7 @@ This step directs Ansible to use the current master version of trin. Read [about
     - [Glados](http://glados.ethportal.net/content/)
     - [Grafana](https://trin-bench.ethdevops.io/d/e23mBdEVk/trin-metrics?orgId=1)
 - Activate the virtual environment in the cluster repo: `. venv/bin/activate`
+- Make sure you've pulled the latest master branch of the deployment scripts, to include any recent changes: `git pull origin master`
 - Go into Portal section of Ansible: `cd portal-network/trin/ansible/`
 - Run the deployment: `ansible-playbook playbook.yml --tags trin`
 - Wait for completion


### PR DESCRIPTION
### What was wrong?
Add step to remind deployers to pull latest master from cluster repo

### How was it fixed?
---

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
