### PR TITLE
fix: Uses ``rustls-tls`` for ``reqwest`` instead of requiring ``openssl``

### DIFF
--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -23,7 +23,7 @@ tracing-subscriber = "0.3.15"
 hex = "0.4.3"
 parking_lot = "0.11.2"
 portalnet = { path = "../portalnet" }
-reqwest = { version = "0.11.13", features = ["json"] }
+reqwest = { version = "0.11.13", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1.0.85"
 ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "d09f55b4f8554491e3431e01af1c32347a8781cd" }
 ssz_types = "0.5.4"


### PR DESCRIPTION
### What was wrong?

`/usr/bin/trin: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory` when running a docker image built from trin's `docker/Dockerfile`.

I thought it was interesting that @njgheorghita saw this error but his instance kept running normally.

This was caused by this commit on master https://github.com/ethereum/trin/commit/00cbbd8e73ba6c1e92e4df609862e5401a20d543

Which started using openssl through our reqwest library
### How was it fixed?

By changing ``reqwest = { version = "0.11.13", features = ["json"] }``

to

``reqwest = { version = "0.11.13", default-features = false, features = ["json", "rustls-tls"] }``
``default-features = false`` disables openssl from being used
``features = ["rustls-tls"]`` enables using the rust native tls library

Kolby tested the docker build on portal-hive and it works

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
