### PR TITLE
chore: make add_enr rpc insert enr as connected so hive test work

### DIFF
--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -325,7 +325,7 @@ where
                 data_radius: Distance::MAX,
             },
             NodeStatus {
-                state: ConnectionState::Disconnected,
+                state: ConnectionState::Connected,
                 direction: ConnectionDirection::Incoming,
             },
         ) {


### PR DESCRIPTION
### What was wrong?
We are now enforcing strict connection requirements, we didn't write certain parts of code for this.
### How was it fixed?
There was 3 ways we could have resolved this problem

- changed the tests on portal-hive
- make add-enr set the added enr state to connected instead of disconnected
- add the enr then ping before returning the result of add-enr

I decided to do the 2nd option since it resolve the problem and is also the same way fluffy handles this.
Here kim says something about it https://github.com/ethereum/portal-hive/pull/94#issuecomment-1705136258


I don't think we should change the portal-hive test with a trin specific fix which rules out option one.

option 3 is viable but it seems a little overbearing, which is why I choose option 2
