### PR TITLE
fix: add deployment step to confirm that docker images can be run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ jobs:
           no_output_timeout: 30m
           command: docker build -f ./docker/Dockerfile -t $IMAGE_NAME:latest --build-arg GIT_HASH=$CIRCLE_SHA1 .
       - run:
+          name: Check that Docker container has no defects
+          command: docker run $IMAGE_NAME:latest -h
+      - run:
           name: Archive Docker image
           command: docker save -o image.tar $IMAGE_NAME
       - persist_to_workspace:

--- a/book/src/developers/contributing/releases/release_checklist.md
+++ b/book/src/developers/contributing/releases/release_checklist.md
@@ -1,5 +1,10 @@
 # Release checklist
 
+## First
+
+Ensure that the CI for the latest commit to master is passing.
+This ensures that trin itself is working, and that the latest docker image is working and published. 
+
 ## Communicate
 
 Announce in #trin chat the upcoming release. Aim for a day or more notice, but


### PR DESCRIPTION
### What was wrong?
We had an issue where the docker image tagged for testnet couldn't be run, it was missing a library. 

### How was it fixed?
Adds a step to the CI that attempts to run the docker image (with the `-h` flag for immediate but successful exit).

Adds a step to release steps to check that the master CI was successful for what we're about to deploy. This both applies to the docker image, as well as to the testing iteself, which I realized was also failing for the latest commit on master after having deployed a broken docker image.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
