### PR TITLE
fix: remove naked unwraps in `light-client` crate

### DIFF
--- a/light-client/src/config/cli.rs
+++ b/light-client/src/config/cli.rs
@@ -31,7 +31,14 @@ impl CliConfig {
             user_dict.insert("rpc_port", Value::from(port));
         }
 
-        user_dict.insert("data_dir", Value::from(self.data_dir.to_str().unwrap()));
+        user_dict.insert(
+            "data_dir",
+            Value::from(
+                self.data_dir
+                    .to_str()
+                    .expect("data dir path must be a valid UTF-8 str"),
+            ),
+        );
 
         if let Some(fallback) = &self.fallback {
             user_dict.insert("fallback", Value::from(fallback.clone()));

--- a/light-client/src/config/networks.rs
+++ b/light-client/src/config/networks.rs
@@ -37,7 +37,7 @@ pub fn mainnet() -> BaseConfig {
         default_checkpoint: hex_str_to_bytes(
             "0x766647f3c4e1fc91c0db9a9374032ae038778411fbff222974e11f2e3ce7dadf",
         )
-        .unwrap(),
+        .expect("should be a valid hex str"),
         rpc_port: 8545,
         consensus_rpc: Some("https://www.lightclientdata.org".to_string()),
         chain: ChainConfig {
@@ -46,24 +46,24 @@ pub fn mainnet() -> BaseConfig {
             genesis_root: hex_str_to_bytes(
                 "0x4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95",
             )
-            .unwrap(),
+            .expect("should be a valid hex str"),
         },
         forks: Forks {
             genesis: Fork {
                 epoch: 0,
-                fork_version: hex_str_to_bytes("0x00000000").unwrap(),
+                fork_version: hex_str_to_bytes("0x00000000").expect("should be a valid hex str"),
             },
             altair: Fork {
                 epoch: 74240,
-                fork_version: hex_str_to_bytes("0x01000000").unwrap(),
+                fork_version: hex_str_to_bytes("0x01000000").expect("should be a valid hex str"),
             },
             bellatrix: Fork {
                 epoch: 144896,
-                fork_version: hex_str_to_bytes("0x02000000").unwrap(),
+                fork_version: hex_str_to_bytes("0x02000000").expect("should be a valid hex str"),
             },
             capella: Fork {
                 epoch: 194048,
-                fork_version: hex_str_to_bytes("0x03000000").unwrap(),
+                fork_version: hex_str_to_bytes("0x03000000").expect("should be a valid hex str"),
             },
         },
         max_checkpoint_age: 1_209_600, // 14 days
@@ -75,7 +75,7 @@ pub fn goerli() -> BaseConfig {
         default_checkpoint: hex_str_to_bytes(
             "0xd4344682866dbede543395ecf5adf9443a27f423a4b00f270458e7932686ced1",
         )
-        .unwrap(),
+        .expect("should be a valid hex str"),
         rpc_port: 8545,
         consensus_rpc: None,
         chain: ChainConfig {
@@ -84,24 +84,24 @@ pub fn goerli() -> BaseConfig {
             genesis_root: hex_str_to_bytes(
                 "0x043db0d9a83813551ee2f33450d23797757d430911a9320530ad8a0eabc43efb",
             )
-            .unwrap(),
+            .expect("should be a valid hex str"),
         },
         forks: Forks {
             genesis: Fork {
                 epoch: 0,
-                fork_version: hex_str_to_bytes("0x00001020").unwrap(),
+                fork_version: hex_str_to_bytes("0x00001020").expect("should be a valid hex str"),
             },
             altair: Fork {
                 epoch: 36660,
-                fork_version: hex_str_to_bytes("0x01001020").unwrap(),
+                fork_version: hex_str_to_bytes("0x01001020").expect("should be a valid hex str"),
             },
             bellatrix: Fork {
                 epoch: 112260,
-                fork_version: hex_str_to_bytes("0x02001020").unwrap(),
+                fork_version: hex_str_to_bytes("0x02001020").expect("should be a valid hex str"),
             },
             capella: Fork {
                 epoch: 162304,
-                fork_version: hex_str_to_bytes("0x03000000").unwrap(),
+                fork_version: hex_str_to_bytes("0x03000000").expect("should be a valid hex str"),
             },
         },
         max_checkpoint_age: 1_209_600, // 14 days

--- a/light-client/src/consensus/types.rs
+++ b/light-client/src/consensus/types.rs
@@ -68,6 +68,9 @@ pub fn u64_deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
+    use serde::de::{Error, Unexpected};
+
     let val: String = serde::Deserialize::deserialize(deserializer)?;
-    Ok(val.parse().unwrap())
+    val.parse()
+        .map_err(|_| Error::invalid_value(Unexpected::Str(&val), &"valid u64"))
 }

--- a/light-client/src/consensus/utils.rs
+++ b/light-client/src/consensus/utils.rs
@@ -75,7 +75,7 @@ pub fn compute_domain(
     let start = domain_type;
     let end = &fork_data_root.as_bytes()[..28];
     let d = [start, end].concat();
-    Ok(d.to_vec().try_into().unwrap())
+    Ok(d.to_vec().try_into()?)
 }
 
 fn compute_fork_data_root(

--- a/light-client/src/lib.rs
+++ b/light-client/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::uninlined_format_args)]
+#![warn(clippy::unwrap_used)]
 mod client;
 pub use crate::client::*;
 

--- a/light-client/src/node.rs
+++ b/light-client/src/node.rs
@@ -18,7 +18,13 @@ pub struct Node<R: ConsensusRpc> {
 impl<R: ConsensusRpc> Node<R> {
     pub fn new(config: Arc<Config>) -> Result<Self, NodeError> {
         let consensus_rpc = &config.consensus_rpc;
-        let checkpoint_hash = &config.checkpoint.as_ref().unwrap();
+        let checkpoint_hash =
+            &config
+                .checkpoint
+                .as_ref()
+                .ok_or(NodeError::ConsensusClientCreationError(eyre::Report::msg(
+                    "`config.checkpoint` is None",
+                )))?;
 
         let consensus = ConsensusLightClient::new(consensus_rpc, checkpoint_hash, config.clone())
             .map_err(NodeError::ConsensusClientCreationError)?;
@@ -27,7 +33,13 @@ impl<R: ConsensusRpc> Node<R> {
     }
 
     pub fn with_portal(config: Arc<Config>, portal_rpc: R) -> Result<Self, NodeError> {
-        let checkpoint_hash = &config.checkpoint.as_ref().unwrap();
+        let checkpoint_hash =
+            &config
+                .checkpoint
+                .as_ref()
+                .ok_or(NodeError::ConsensusClientCreationError(eyre::Report::msg(
+                    "`config.checkpoint` is None",
+                )))?;
 
         let consensus =
             ConsensusLightClient::with_custom_rpc(portal_rpc, checkpoint_hash, config.clone());
@@ -58,7 +70,7 @@ impl<R: ConsensusRpc> Node<R> {
         self.consensus
             .duration_until_next_update()
             .to_std()
-            .unwrap()
+            .expect("`duration_until_next_update` gives always positive duration")
     }
 
     pub fn chain_id(&self) -> u64 {


### PR DESCRIPTION
### What was wrong?

This PR fıxes #1045.

### How was it fixed?

Mostly done by using `expect` to make clippy happy. On de/serializer functions, I used serde errors and returned them.

I didn't touch any test code.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
