### PR TITLE
fix: remove --no-upnp from "external-ips" group

### DIFF
--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -107,7 +107,6 @@ pub struct TrinConfig {
 
     #[arg(
         long = "no-upnp",
-        group = "external-ips",
         help = "Do not use UPnP to determine an external port."
     )]
     pub no_upnp: bool,


### PR DESCRIPTION
### What was wrong?
I can't disable --no-upnp on glados, I thought since ``--no-upnp`` was in ``external-ips`` group it would disable it, because if ``--no-upnp`` is in the ``external-ips`` group you can only choose to use on of the cli options.
### How was it fixed?
by removing ``--no-upnp`` from the ``external-ips`` group. No we can activate ``--no-upnp`` and (``external-ip`` or ``--no-stun``) at the same time
