### PR TITLE
chore(bridge): use archive pandaops URL

### DIFF
--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -8,7 +8,7 @@ pub const BATCH_SIZE: u64 = 128;
 // If you don't have access to the PANDAOPS nodes, but still want to use the bridge feature, let us
 // know on Discord or Github and we'll prioritize support for any provider.
 /// Execution layer PandaOps endpoint
-pub const BASE_EL_ENDPOINT: &str = "https://geth.mainnet.na1.ethpandaops.io";
+pub const BASE_EL_ENDPOINT: &str = "https://archive.mainnet.ethpandaops.io";
 /// Consensus layer PandaOps endpoint
 /// We use Nimbus as the CL client, because it supports light client data by default.
 pub const BASE_CL_ENDPOINT: &str = "https://nimbus.mainnet.ethpandaops.io";


### PR DESCRIPTION
The dshackle proxy in front of the geth nodes ran out of RAM. We are going to use the archive nodes anyway, so let's switch to that and give more RAM to the proxy there.

@njgheorghita paired with me on it. Bridge is down, so I'm going to take the verbal 👍🏻 