### PR TITLE
refactor: relocate retry logic

### DIFF
--- a/ethportal-api/src/types/content_value/beacon.rs
+++ b/ethportal-api/src/types/content_value/beacon.rs
@@ -86,11 +86,12 @@ impl<'de> Deserialize<'de> for PossibleBeaconContentValue {
             ));
         }
 
-        Err(ContentValueError::UnknownContent {
-            bytes: s,
-            network: "beacon".to_string(),
-        })
-        .map_err(serde::de::Error::custom)
+        Err(serde::de::Error::custom(
+            ContentValueError::UnknownContent {
+                bytes: s,
+                network: "beacon".to_string(),
+            },
+        ))
     }
 }
 
@@ -529,11 +530,12 @@ impl<'de> Deserialize<'de> for BeaconContentValue {
             return Ok(Self::LightClientFinalityUpdate(value));
         }
 
-        Err(ContentValueError::UnknownContent {
-            bytes: s,
-            network: "beacon".to_string(),
-        })
-        .map_err(serde::de::Error::custom)
+        Err(serde::de::Error::custom(
+            ContentValueError::UnknownContent {
+                bytes: s,
+                network: "beacon".to_string(),
+            },
+        ))
     }
 }
 

--- a/ethportal-api/src/types/content_value/history.rs
+++ b/ethportal-api/src/types/content_value/history.rs
@@ -72,11 +72,12 @@ impl<'de> Deserialize<'de> for PossibleHistoryContentValue {
             )));
         }
 
-        Err(ContentValueError::UnknownContent {
-            bytes: s,
-            network: "history".to_string(),
-        })
-        .map_err(serde::de::Error::custom)
+        Err(serde::de::Error::custom(
+            ContentValueError::UnknownContent {
+                bytes: s,
+                network: "history".to_string(),
+            },
+        ))
     }
 }
 
@@ -158,11 +159,12 @@ impl<'de> Deserialize<'de> for HistoryContentValue {
             return Ok(Self::EpochAccumulator(value));
         }
 
-        Err(ContentValueError::UnknownContent {
-            bytes: s,
-            network: "history".to_string(),
-        })
-        .map_err(serde::de::Error::custom)
+        Err(serde::de::Error::custom(
+            ContentValueError::UnknownContent {
+                bytes: s,
+                network: "history".to_string(),
+            },
+        ))
     }
 }
 


### PR DESCRIPTION
### What was wrong?
`Retry` logic is better suited to be located alongside the other pandaops request logic. 

### How was it fixed?
- Relocated `Retry` type
- Fixed a couple of lint errors

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
