### PR TITLE
Bump discv5 version dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,21 +1727,22 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "discv5"
-version = "0.3.1"
-source = "git+https://github.com/njgheorghita/discv5.git?rev=700bdb97afd87016222e902f844bb95eb0d78d99#700bdb97afd87016222e902f844bb95eb0d78d99"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b0b31b65aa1fcbd4e0171f1afed5363ccf25efb988ecd42450036f4c6d8539"
 dependencies = [
  "aes 0.7.5",
  "aes-gcm 0.9.4",
  "arrayvec",
  "delay_map 0.3.0",
- "enr",
+ "enr 0.10.0",
  "fnv",
  "futures 0.3.29",
- "hashlink",
+ "hashlink 0.8.4",
  "hex",
  "hkdf 0.12.3",
  "lazy_static",
- "lru",
+ "lru 0.12.1",
  "more-asserts",
  "parking_lot 0.11.2",
  "rand 0.8.5",
@@ -1842,6 +1843,24 @@ name = "enr"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe81b5c06ecfdbc71dd845216f225f53b62a10cb8a16c946836a3467f701d05b"
+dependencies = [
+ "base64 0.21.5",
+ "bytes 1.5.0",
+ "hex",
+ "k256",
+ "log",
+ "rand 0.8.5",
+ "rlp",
+ "serde",
+ "sha3 0.10.8",
+ "zeroize",
+]
+
+[[package]]
+name = "enr"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
 dependencies = [
  "base64 0.21.5",
  "bytes 1.5.0",
@@ -2075,7 +2094,7 @@ dependencies = [
  "base64 0.21.5",
  "bytes 1.5.0",
  "const-hex",
- "enr",
+ "enr 0.9.1",
  "ethers-core",
  "futures-channel",
  "futures-core",
@@ -2719,6 +2738,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
 dependencies = [
  "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -3725,6 +3753,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2994eeba8ed550fd9b47a0b38f0242bc3344e496483c6180b69139cc2fa5d1d7"
+dependencies = [
+ "hashbrown 0.14.3",
+]
+
+[[package]]
 name = "lz4-sys"
 version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3886,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "more-asserts"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "nanotemplate"
@@ -4480,7 +4517,7 @@ dependencies = [
  "lazy_static",
  "leb128",
  "local-ip-address",
- "lru",
+ "lru 0.7.8",
  "parking_lot 0.11.2",
  "quickcheck",
  "r2d2",
@@ -5398,7 +5435,7 @@ dependencies = [
  "bitflags 1.3.2",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.7.0",
  "libsqlite3-sys",
  "memchr",
  "smallvec 1.11.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ description = "A Rust implementation of the Ethereum Portal Network"
 [dependencies]
 anyhow = "1.0.68"
 clap = { version = "4.2.1", features = ["derive"] }
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
+discv5 = { version = "0.4.0", features = ["serde"] }
 ethereum-types = "0.14.1"
 ethereum_ssz = "0.5.3"
 ethportal-api = { path = "ethportal-api" }

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.68"
 base64 = "0.13.0"
 bytes = "1.3.0"
 clap = { version = "4.2.1", features = ["derive"] }
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
+discv5 = { version = "0.4.0", features = ["serde"] }
 eth_trie = "0.4.0"
 ethereum-types = "0.14.1"
 ethereum_serde_utils = "0.5.1"

--- a/ethportal-api/src/types/enr.rs
+++ b/ethportal-api/src/types/enr.rs
@@ -1,5 +1,5 @@
 use discv5::enr::CombinedKey;
-use discv5::enr::EnrBuilder;
+use discv5::enr::Enr as Discv5Enr;
 use rand::Rng;
 use rlp::Encodable;
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,7 @@ use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use validator::ValidationError;
 
-pub type Enr = discv5::enr::Enr<CombinedKey>;
+pub type Enr = Discv5Enr<CombinedKey>;
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct SszEnr(pub Enr);
@@ -88,7 +88,7 @@ pub fn generate_random_remote_enr() -> (CombinedKey, Enr) {
     let mut rng = rand::thread_rng();
     let ip = Ipv4Addr::from(rng.gen::<u32>());
 
-    let enr = EnrBuilder::new("v4")
+    let enr = Discv5Enr::builder()
         .ip(ip.into())
         .udp4(8000)
         .build(&key)

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
+discv5 = { version = "0.4.0", features = ["serde"] }
 ethereum-types = "0.14.1"
 ethereum_ssz = "0.5.3"
 ethportal-api = { path="../ethportal-api"}

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -16,25 +16,25 @@ ethereum-types = "0.14.1"
 ethportal-api = { path = "../ethportal-api" }
 eyre = "0.6.8"
 figment = { version = "0.10.7", features = ["toml", "env"] }
-jsonrpsee = { version = "0.20.0", features = ["full"] }
-serde = { version = "1.0.143", features = ["derive"] }
-serde_yaml = "0.9.14"
-tracing-subscriber = "0.3.15"
+futures = "0.3.23"
 hex = "0.4.3"
+jsonrpsee = { version = "0.20.0", features = ["full"] }
+log = "0.4.17"
+milagro_bls = { git = "https://github.com/Snowfork/milagro_bls" }
 parking_lot = "0.11.2"
 portalnet = { path = "../portalnet" }
 reqwest = { version = "0.11.13", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.85"
+serde_yaml = "0.9.14"
 ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "d09f55b4f8554491e3431e01af1c32347a8781cd" }
 ssz_types = "0.5.4"
 strum = { version = "0.25.0", features = ["derive"] }
+thiserror = "1.0.37"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.36"
+tracing-subscriber = "0.3.15"
 tree_hash = "0.5.2"
-futures = "0.3.23"
-log = "0.4.17"
-thiserror = "1.0.37"
-milagro_bls = { git = "https://github.com/Snowfork/milagro_bls" }
 
 [lib]
 name = "light_client"

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0.68"
 async-trait = "0.1.68"
 chrono = "0.4.26"
 clap = { version = "4.2.1", features = ["derive"] }
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
+discv5 = { version = "0.4.0", features = ["serde"] }
 ethportal-api = { path = "../ethportal-api" }
 ethereum-types = "0.14.1"
 ethereum_ssz = "0.5.3"

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -17,7 +17,7 @@ base64 = "0.13.0"
 bytes = "1.3.0"
 delay_map = "0.1.1"
 directories = "3.0"
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
+discv5 = { version = "0.4.0", features = ["serde"] }
 ethereum-types = "0.14.1"
 ethereum_ssz = "0.5.3"
 ethereum_ssz_derive = "0.5.3"

--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -9,7 +9,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use bytes::BytesMut;
 use discv5::{
-    enr::{CombinedKey, EnrBuilder, NodeId},
+    enr::{CombinedKey, Enr as Discv5Enr, NodeId},
     ConfigBuilder, Discv5, Event, ListenConfig, RequestError, TalkRequest,
 };
 use lru::LruCache;
@@ -120,7 +120,7 @@ impl Discovery {
                 .map_err(|e| format!("Unable to create enr key: {:?}", e.to_string()))?;
 
         let mut enr = {
-            let mut builder = EnrBuilder::new("v4");
+            let mut builder = Discv5Enr::builder();
             if let Some(ip_address) = enr_address {
                 builder.ip(ip_address);
             }

--- a/portalnet/src/storage.rs
+++ b/portalnet/src/storage.rs
@@ -818,7 +818,7 @@ pub mod test {
 
     use super::*;
 
-    use discv5::enr::{CombinedKey, EnrBuilder};
+    use discv5::enr::{CombinedKey, Enr as Discv5Enr};
     use quickcheck::{quickcheck, QuickCheck, TestResult};
     use rand::RngCore;
     use serial_test::serial;
@@ -1027,7 +1027,7 @@ pub mod test {
         let (node_data_dir, mut private_key) =
             configure_node_data_dir(temp_dir.path().to_path_buf(), None).unwrap();
         let private_key = CombinedKey::secp256k1_from_bytes(private_key.0.as_mut_slice()).unwrap();
-        let node_id = EnrBuilder::new("v4").build(&private_key).unwrap().node_id();
+        let node_id = Discv5Enr::empty(&private_key).unwrap().node_id();
         let storage_config =
             PortalStorageConfig::new(CAPACITY_MB, node_data_dir.clone(), node_id).unwrap();
         let mut storage = PortalStorage::new(storage_config, ProtocolId::History)?;
@@ -1259,6 +1259,6 @@ pub mod test {
     fn get_active_node_id(temp_dir: PathBuf) -> NodeId {
         let (_, mut pk) = configure_node_data_dir(temp_dir, None).unwrap();
         let pk = CombinedKey::secp256k1_from_bytes(pk.0.as_mut_slice()).unwrap();
-        EnrBuilder::new("v4").build(&pk).unwrap().node_id()
+        Discv5Enr::empty(&pk).unwrap().node_id()
     }
 }

--- a/portalnet/src/utils/db.rs
+++ b/portalnet/src/utils/db.rs
@@ -3,7 +3,7 @@ use std::{env, fs};
 
 use anyhow::anyhow;
 use directories::ProjectDirs;
-use discv5::enr::{CombinedKey, EnrBuilder, NodeId};
+use discv5::enr::{CombinedKey, Enr, NodeId};
 use ethereum_types::H256;
 use tempfile::TempDir;
 use tracing::debug;
@@ -54,7 +54,7 @@ pub fn configure_node_data_dir(
             .map_err(|e| anyhow!("When building server key pair: {e:?}"))?,
         None => get_application_private_key(&trin_data_dir)?,
     };
-    let node_id = EnrBuilder::new("v4").build(&pk)?.node_id();
+    let node_id = Enr::empty(&pk)?.node_id();
     let node_data_dir = get_node_data_dir(trin_data_dir, node_id);
     fs::create_dir_all(&node_data_dir)?;
     Ok((node_data_dir, H256::from_slice(&pk.encode())))

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
-discv5 = { git = "https://github.com/njgheorghita/discv5.git",  rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
+discv5 = { version = "0.4.0", features = ["serde"] }
 ethportal-api = { path = "../ethportal-api"}
 ethereum-types = "0.14.1"
 portalnet = { path = "../portalnet"}

--- a/src/bin/purge_db.rs
+++ b/src/bin/purge_db.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
-use discv5::enr::{CombinedKey, EnrBuilder};
+use discv5::enr::{CombinedKey, Enr};
 use ethereum_types::H256;
 use rocksdb::IteratorMode;
 use ssz::Decode;
@@ -31,7 +31,7 @@ pub fn main() -> Result<()> {
     let enr_key =
         CombinedKey::secp256k1_from_bytes(purge_config.private_key.0.clone().as_mut_slice())
             .expect("Failed to create ENR key");
-    let enr = EnrBuilder::new("v4").build(&enr_key).unwrap();
+    let enr = Enr::empty(&enr_key).unwrap();
     let node_id = enr.node_id();
     let trin_data_dir = configure_trin_data_dir(false)?;
     let (node_data_dir, _) =

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 async-trait = "0.1.53"
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
+discv5 = { version = "0.4.0", features = ["serde"] }
 ethereum_ssz = "0.5.3"
 ethportal-api = {path = "../ethportal-api"}
 eyre = "0.6.8"

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 async-trait = "0.1.53"
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
+discv5 = { version = "0.4.0", features = ["serde"] }
 ethereum-types = "0.14.1"
 ethereum_ssz = "0.5.3"
 ethportal-api = {path = "../ethportal-api"}

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 async-trait = "0.1.53"
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
+discv5 = { version = "0.4.0", features = ["serde"] }
 ethereum-types = "0.14.1"
 ethportal-api = { path = "../ethportal-api" }
 eth_trie = "0.4.0"

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 clap = { version = "4.2.1", features = ["derive"] }
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "700bdb97afd87016222e902f844bb95eb0d78d99", features = ["serde"] }
+discv5 = { version = "0.4.0", features = ["serde"] }
 ethportal-api = { path="../ethportal-api"}
 jsonrpsee = {version = "0.20.0", features = ["full"]}
 portalnet = { path = "../portalnet" }


### PR DESCRIPTION
### What was wrong?
Bump `discv5` library to latest `0.4.0` version.
This includes native concurrent discv5 requests, and the latest `enr` library dependency.

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
