### PR TITLE
fix: update base el endpoint for bridge provider

### DIFF
--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -7,8 +7,13 @@ pub const BATCH_SIZE: u64 = 128;
 // These are only intended to be used by core team members who have access to the nodes.
 // If you don't have access to the PANDAOPS nodes, but still want to use the bridge feature, let us
 // know on Discord or Github and we'll prioritize support for any provider.
+//
 /// Execution layer PandaOps endpoint
-pub const BASE_EL_ENDPOINT: &str = "https://archive.mainnet.ethpandaops.io";
+// This endpoint points towards an archive node (erigon) and skips dshackle (by using el-cl url
+// format), shackle is known to be somewhat buggy has caused some invalid responses.
+// Reth's archive node, has also exhibited some problems with the concurrent requests rate we
+// currently use.
+pub const BASE_EL_ENDPOINT: &str = "https://erigon-lighthouse.mainnet.eu1.ethpandaops.io";
 /// Consensus layer PandaOps endpoint
 /// We use Nimbus as the CL client, because it supports light client data by default.
 pub const BASE_CL_ENDPOINT: &str = "https://nimbus.mainnet.ethpandaops.io";


### PR DESCRIPTION
### What was wrong?
Investigating some of the issues with our bridge provider.
1. The assumption that we were simply not able to deserialize the requests from different clients seems to have been "mostly" disproven.
  - I don't even think this is a valid concern, I would be shocked if production execution clients have jsonrpc responses formatted differently from each other. I mean that's the entire point of the spec. Of course... I haven't thoroughly audited all jsonrpc responses from different clients, but I think this concern has been a bit of a red herring.
2. It seems like the cause of most of our issues is dshackle. A new load-balancing service that routes "most" of the requests to the pandaops nodes. All pandaops urls use dshackle (as of today) except for those that have an explicitly defined `el-cl` pair. eg. `https://erigon-lighthouse.mainnet.eu1.ethpandaops.io`
3. Dshackle seemed to be particularly finicky with the reth archive node endpoint. There were many instances where reth failed to return some receipts from a batched `eth_getTransactionReceipt` request, which led to invalid receipts roots. That's why I decided to go with erigon in this pr. 

This is the simplest fix. There are some improvements that I'd like to implement in future prs. 
- [ ] Use different urls for `latest` and `backfill` bridge modes.
- [ ] Implement a fallback url, if there's a problem getting responses from the primary uri.
- [ ] Write failed jsonrpc responses to disk, for easy debugging & improve general error messages / logs for failed jsonrpc requests
- [ ] Explore different concurrent rate limits & batch size limits to see if those have an effect on request failure rates.
- [ ] add support for infura / non-pandaops nodes
- [ ] set provider url via env var?

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
