### PR TITLE
Add Beacon Storage

### DIFF
--- a/ethportal-api/src/types/content_key/beacon.rs
+++ b/ethportal-api/src/types/content_key/beacon.rs
@@ -9,10 +9,10 @@ use std::fmt;
 
 // Prefixes for the different types of beacon content keys:
 // https://github.com/ethereum/portal-network-specs/blob/72327da43c7a199ba2735344ef98f9121aef2f68/beacon-chain/beacon-network.md
-const LIGHT_CLIENT_BOOTSTRAP_KEY_PREFIX: u8 = 0x10;
-const LIGHT_CLIENT_UPDATES_BY_RANGE_KEY_PREFIX: u8 = 0x11;
-const LIGHT_CLIENT_FINALITY_UPDATE_KEY_PREFIX: u8 = 0x12;
-const LIGHT_CLIENT_OPTIMISTIC_UPDATE_KEY_PREFIX: u8 = 0x13;
+pub const LIGHT_CLIENT_BOOTSTRAP_KEY_PREFIX: u8 = 0x10;
+pub const LIGHT_CLIENT_UPDATES_BY_RANGE_KEY_PREFIX: u8 = 0x11;
+pub const LIGHT_CLIENT_FINALITY_UPDATE_KEY_PREFIX: u8 = 0x12;
+pub const LIGHT_CLIENT_OPTIMISTIC_UPDATE_KEY_PREFIX: u8 = 0x13;
 
 /// A content key in the beacon chain network.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/portalnet/src/storage.rs
+++ b/portalnet/src/storage.rs
@@ -1,3 +1,4 @@
+use anyhow::Error;
 use std::{
     convert::TryInto,
     fs,
@@ -6,16 +7,22 @@ use std::{
 
 use discv5::enr::NodeId;
 use ethportal_api::types::portal::PaginateLocalContentInfo;
-use r2d2::Pool;
+use r2d2::{Pool, PooledConnection};
 use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::params;
+use ssz::Decode;
 use thiserror::Error;
 use tracing::{debug, error, info};
 
+use ethportal_api::types::content_key::beacon::{
+    LIGHT_CLIENT_BOOTSTRAP_KEY_PREFIX, LIGHT_CLIENT_FINALITY_UPDATE_KEY_PREFIX,
+    LIGHT_CLIENT_OPTIMISTIC_UPDATE_KEY_PREFIX, LIGHT_CLIENT_UPDATES_BY_RANGE_KEY_PREFIX,
+};
+use ethportal_api::types::content_value::beacon::LightClientUpdatesByRange;
 use ethportal_api::types::distance::{Distance, Metric, XorMetric};
 use ethportal_api::types::portal_wire::ProtocolId;
 use ethportal_api::utils::bytes::{hex_decode, hex_encode, ByteUtilsError};
-use ethportal_api::{ContentKeyError, HistoryContentKey, OverlayContentKey};
+use ethportal_api::{BeaconContentKey, ContentKeyError, HistoryContentKey, OverlayContentKey};
 use trin_metrics::portalnet::PORTALNET_METRICS;
 use trin_metrics::storage::StorageMetricsReporter;
 
@@ -362,7 +369,7 @@ impl PortalStorage {
         let conn = self.sql_connection_pool.get()?;
         let mut query = conn.prepare(TOTAL_ENTRY_COUNT_QUERY)?;
         let result: Result<Vec<EntryCount>, rusqlite::Error> = query
-            .query_map([], |row| Ok(EntryCount(row.get(0)?)))?
+            .query_map([u8::from(self.network)], |row| Ok(EntryCount(row.get(0)?)))?
             .collect();
         match result?.first() {
             Some(val) => Ok(val.0),
@@ -531,20 +538,8 @@ impl PortalStorage {
     /// Public method for looking up a content value by its content id
     pub fn lookup_content_value(&self, id: [u8; 32]) -> anyhow::Result<Option<Vec<u8>>> {
         let conn = self.sql_connection_pool.get()?;
-        let mut query = conn.prepare(CONTENT_VALUE_LOOKUP_QUERY)?;
-        let id = id.to_vec();
-        let result: Result<Vec<Vec<u8>>, ContentStoreError> = query
-            .query_map([id], |row| {
-                let row: String = row.get(0)?;
-                Ok(row)
-            })?
-            .map(|row| hex_decode(row?.as_str()).map_err(ContentStoreError::ByteUtilsError))
-            .collect();
 
-        match result?.first() {
-            Some(val) => Ok(Some(val.to_vec())),
-            None => Ok(None),
-        }
+        lookup_content_value(id, conn)?
     }
 
     /// Public method for retrieving the node's current radius.
@@ -555,7 +550,7 @@ impl PortalStorage {
     /// Public method for determining how much actual disk space is being used to store this node's Portal Network data.
     /// Intended for analysis purposes. PortalStorage's capacity decision-making is not based off of this method.
     pub fn get_total_storage_usage_in_bytes_on_disk(&self) -> Result<u64, ContentStoreError> {
-        let storage_usage = Self::get_total_size_of_directory_in_bytes(&self.node_data_dir)?;
+        let storage_usage = get_total_size_of_directory_in_bytes(&self.node_data_dir)?;
         Ok(storage_usage)
     }
 
@@ -566,27 +561,8 @@ impl PortalStorage {
         content_key: &String,
         value: &Vec<u8>,
     ) -> Result<(), ContentStoreError> {
-        let content_id_as_u32: u32 = Self::byte_vector_to_u32(content_id.to_vec());
-        let value_size = value.len();
-        if content_key.starts_with("0x") {
-            return Err(ContentStoreError::InvalidData {
-                message: "Content key should not start with 0x".to_string(),
-            });
-        }
-        match self.sql_connection_pool.get()?.execute(
-            INSERT_QUERY,
-            params![
-                content_id.to_vec(),
-                content_id_as_u32,
-                content_key,
-                hex_encode(value),
-                u8::from(self.network),
-                value_size
-            ],
-        ) {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err.into()),
-        }
+        let conn = self.sql_connection_pool.get()?;
+        insert_value(conn, content_id, content_key, value, u8::from(self.network))
     }
 
     /// Internal method for removing a given content-id from the db.
@@ -633,7 +609,7 @@ impl PortalStorage {
     fn find_farthest_content_id(&self) -> Result<Option<[u8; 32]>, ContentStoreError> {
         let result = match self.distance_fn {
             DistanceFunction::Xor => {
-                let node_id_u32 = Self::byte_vector_to_u32(self.node_id.raw().to_vec());
+                let node_id_u32 = byte_vector_to_u32(self.node_id.raw().to_vec());
 
                 let conn = self.sql_connection_pool.get()?;
                 let mut query = conn.prepare(XOR_FIND_FARTHEST_QUERY)?;
@@ -670,59 +646,11 @@ impl PortalStorage {
         Ok(Some(result))
     }
 
-    /// Internal method used to measure on-disk storage usage.
-    fn get_total_size_of_directory_in_bytes(
-        path: impl AsRef<Path>,
-    ) -> Result<u64, ContentStoreError> {
-        let metadata = match fs::metadata(&path) {
-            Ok(metadata) => metadata,
-            Err(_) => {
-                return Ok(0);
-            }
-        };
-        let mut size = metadata.len();
-
-        if metadata.is_dir() {
-            for entry in fs::read_dir(&path)? {
-                let dir = entry?;
-                let path_string = match dir.path().into_os_string().into_string() {
-                    Ok(path_string) => path_string,
-                    Err(err) => {
-                        let err = format!(
-                            "Unable to convert path {:?} into string {:?}",
-                            path.as_ref(),
-                            err
-                        );
-                        return Err(ContentStoreError::Database(err));
-                    }
-                };
-                size += Self::get_total_size_of_directory_in_bytes(path_string)?;
-            }
-        }
-
-        Ok(size)
-    }
-
     /// Method that returns the distance between our node ID and a given content ID.
     pub fn distance_to_content_id(&self, content_id: &[u8; 32]) -> Distance {
         match self.distance_fn {
             DistanceFunction::Xor => XorMetric::distance(content_id, &self.node_id.raw()),
         }
-    }
-
-    /// Converts most significant 4 bytes of a vector to a u32.
-    fn byte_vector_to_u32(vec: Vec<u8>) -> u32 {
-        if vec.len() < 4 {
-            debug!("Error: XOR returned less than 4 bytes.");
-            return 0;
-        }
-
-        let mut array: [u8; 4] = [0, 0, 0, 0];
-        for (index, byte) in vec.iter().take(4).enumerate() {
-            array[index] = *byte;
-        }
-
-        u32::from_be_bytes(array)
     }
 
     /// Helper function for opening a SQLite connection.
@@ -735,12 +663,391 @@ impl PortalStorage {
         let manager = SqliteConnectionManager::file(sql_path);
         let pool = Pool::new(manager)?;
         pool.get()?.execute(CREATE_QUERY, params![])?;
+        pool.get()?.execute(CREATE_LC_UPDATE_TABLE, params![])?;
         Ok(pool)
     }
 
     /// Get a summary of the current state of storage
     pub fn get_summary_info(&self) -> String {
         self.metrics.get_summary()
+    }
+}
+
+#[derive(Debug)]
+pub struct BeaconStorage {
+    node_data_dir: PathBuf,
+    sql_connection_pool: Pool<SqliteConnectionManager>,
+    storage_capacity_in_bytes: u64,
+    metrics: StorageMetricsReporter,
+    network: ProtocolId,
+}
+
+impl ContentStore for BeaconStorage {
+    fn get<K: OverlayContentKey>(&self, key: &K) -> Result<Option<Vec<u8>>, ContentStoreError> {
+        let content_key: Vec<u8> = key.clone().into();
+        let beacon_content_key =
+            BeaconContentKey::from_ssz_bytes(content_key.as_slice()).map_err(|err| {
+                ContentStoreError::InvalidData {
+                    message: format!("Error deserializing BeaconContentKey value: {err:?}"),
+                }
+            })?;
+
+        match beacon_content_key {
+            BeaconContentKey::LightClientBootstrap(_) => {
+                let content_id = key.content_id();
+                self.lookup_content_value(content_id).map_err(|err| {
+                    ContentStoreError::Database(format!("Error looking up content value: {err:?}"))
+                })
+            }
+            BeaconContentKey::LightClientUpdatesByRange(_) => {
+                // TODO: Build LightClientUpdatesByRange response from lc_updates table
+                Ok(None)
+            }
+            BeaconContentKey::LightClientFinalityUpdate(_) => {
+                // TODO: Get LightClientFinalityUpdate from cache
+                Ok(None)
+            }
+            BeaconContentKey::LightClientOptimisticUpdate(_) => {
+                // TODO: Get LightClientOptimisticUpdate from cache
+                Ok(None)
+            }
+        }
+    }
+
+    fn put<K: OverlayContentKey, V: AsRef<[u8]>>(
+        &mut self,
+        key: K,
+        value: V,
+    ) -> Result<(), ContentStoreError> {
+        self.store(&key, &value.as_ref().to_vec())
+    }
+
+    fn is_key_within_radius_and_unavailable<K: OverlayContentKey>(
+        &self,
+        key: &K,
+    ) -> Result<ShouldWeStoreContent, ContentStoreError> {
+        let key = key.content_id();
+        let is_key_available = self
+            .lookup_content_key(key)
+            .map_err(|err| {
+                ContentStoreError::Database(format!("Error looking up content key: {err:?}"))
+            })?
+            .is_some();
+        if is_key_available {
+            return Ok(ShouldWeStoreContent::AlreadyStored);
+        }
+        Ok(ShouldWeStoreContent::Store)
+    }
+
+    fn radius(&self) -> Distance {
+        Distance::MAX
+    }
+}
+
+impl BeaconStorage {
+    pub fn new(config: PortalStorageConfig) -> Result<Self, ContentStoreError> {
+        let metrics = StorageMetricsReporter {
+            storage_metrics: PORTALNET_METRICS.storage(),
+            protocol: ProtocolId::Beacon.to_string(),
+        };
+        let storage = Self {
+            node_data_dir: config.node_data_dir,
+            sql_connection_pool: config.sql_connection_pool,
+            storage_capacity_in_bytes: config.storage_capacity_mb * BYTES_IN_MB_U64,
+            metrics,
+            network: ProtocolId::Beacon,
+        };
+
+        // Report current storage capacity.
+        storage
+            .metrics
+            .report_storage_capacity_bytes(storage.storage_capacity_in_bytes as f64);
+
+        // Report current total storage usage.
+        let total_storage_usage = storage.get_total_storage_usage_in_bytes_on_disk()?;
+        storage
+            .metrics
+            .report_total_storage_usage_bytes(total_storage_usage as f64);
+
+        // Report total storage used by network content.
+        let network_content_storage_usage =
+            storage.get_total_storage_usage_in_bytes_from_network()?;
+        storage
+            .metrics
+            .report_content_data_storage_bytes(network_content_storage_usage as f64);
+
+        Ok(storage)
+    }
+
+    fn db_insert(
+        &self,
+        content_id: &[u8; 32],
+        content_key: &String,
+        value: &Vec<u8>,
+    ) -> Result<(), ContentStoreError> {
+        let conn = self.sql_connection_pool.get()?;
+        insert_value(conn, content_id, content_key, value, u8::from(self.network))
+    }
+
+    fn db_insert_lc_update(&self, period: &u64, value: &Vec<u8>) -> Result<(), ContentStoreError> {
+        let conn = self.sql_connection_pool.get()?;
+        let value_size = value.len();
+
+        match conn.execute(
+            INSERT_LC_UPDATE_QUERY,
+            params![period, value, 0, value_size],
+        ) {
+            Ok(_) => Ok(()),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    pub fn store(
+        &mut self,
+        key: &impl OverlayContentKey,
+        value: &Vec<u8>,
+    ) -> Result<(), ContentStoreError> {
+        let content_id = key.content_id();
+        let content_key: Vec<u8> = key.clone().into();
+
+        match content_key.first() {
+            Some(&LIGHT_CLIENT_BOOTSTRAP_KEY_PREFIX) => {
+                // store content key w/o the 0x prefix
+                let content_key = hex_encode(content_key).trim_start_matches("0x").to_string();
+                if let Err(err) = self.db_insert(&content_id, &content_key, value) {
+                    debug!("Error writing light client bootstrap content ID {content_id:?} to beacon network db: {err:?}");
+                    return Err(err);
+                } else {
+                    self.metrics.increase_entry_count();
+                }
+            }
+            Some(&LIGHT_CLIENT_UPDATES_BY_RANGE_KEY_PREFIX) => {
+                if let Ok(update) = BeaconContentKey::from_ssz_bytes(content_key.as_slice()) {
+                    match update {
+                        BeaconContentKey::LightClientUpdatesByRange(update) => {
+                            // Build a range of values starting with update.start_period and len update.count
+                            let periods = update.start_period..(update.start_period + update.count);
+                            let update_values = LightClientUpdatesByRange::from_ssz_bytes(
+                                value.as_slice(),
+                            )
+                            .map_err(|err| {
+                                ContentStoreError::InvalidData {
+                                    message: format!(
+                                        "Error deserializing LightClientUpdatesByRange value: {err:?}"
+                                    ),
+                                }
+                            })?;
+
+                            for (period, value) in periods.zip(update_values.as_ref()) {
+                                if let Err(err) = self.db_insert_lc_update(&period, &value.encode())
+                                {
+                                    debug!("Error writing light client update by range content ID {content_id:?} to beacon network db: {err:?}");
+                                } else {
+                                    self.metrics.increase_entry_count();
+                                }
+                            }
+                        }
+                        _ => {
+                            // Unknown content type
+                            return Err(ContentStoreError::InvalidData {
+                                message: "Unexpected LightClientUpdatesByRange content key"
+                                    .to_string(),
+                            });
+                        }
+                    }
+                }
+            }
+            Some(&LIGHT_CLIENT_FINALITY_UPDATE_KEY_PREFIX) => {
+                // TODO: Store LightClientFinalityUpdate in cache
+            }
+            Some(&LIGHT_CLIENT_OPTIMISTIC_UPDATE_KEY_PREFIX) => {
+                // TODO: Store LightClientOptimisticUpdate in cache
+            }
+            _ => {
+                // Unknown content type
+                return Err(ContentStoreError::InvalidData {
+                    message: "Unknown beacon content key".to_string(),
+                });
+            }
+        }
+
+        let total_bytes_on_disk = self.get_total_storage_usage_in_bytes_on_disk()?;
+        self.metrics
+            .report_total_storage_usage_bytes(total_bytes_on_disk as f64);
+
+        Ok(())
+    }
+
+    pub fn paginate(
+        &self,
+        _offset: &u64,
+        _limit: &u64,
+    ) -> Result<PaginateLocalContentInfo, ContentStoreError> {
+        Err(ContentStoreError::Database(
+            "Paginate not implemented for Beacon storage".to_string(),
+        ))
+    }
+
+    /// Public method for determining how much actual disk space is being used to store this node's Portal Network data.
+    /// Intended for analysis purposes. PortalStorage's capacity decision-making is not based off of this method.
+    pub fn get_total_storage_usage_in_bytes_on_disk(&self) -> Result<u64, ContentStoreError> {
+        let storage_usage = get_total_size_of_directory_in_bytes(&self.node_data_dir)?;
+        Ok(storage_usage)
+    }
+
+    /// Internal method for measuring the total amount of requestable data that the node is storing.
+    fn get_total_storage_usage_in_bytes_from_network(&self) -> Result<u64, ContentStoreError> {
+        let conn = self.sql_connection_pool.get()?;
+        let mut query = conn.prepare(TOTAL_DATA_SIZE_QUERY)?;
+
+        let result = query.query_map([], |row| {
+            Ok(DataSize {
+                num_bytes: row.get(0)?,
+            })
+        });
+
+        let sum = match result?.next() {
+            Some(total) => total,
+            None => {
+                let err = "Unable to compute sum over content item sizes".to_string();
+                return Err(ContentStoreError::Database(err));
+            }
+        }?
+        .num_bytes;
+
+        self.metrics.report_content_data_storage_bytes(sum);
+
+        Ok(sum as u64)
+    }
+
+    pub fn lookup_content_key(&self, id: [u8; 32]) -> anyhow::Result<Option<Vec<u8>>> {
+        let conn = self.sql_connection_pool.get()?;
+        let mut query = conn.prepare(CONTENT_KEY_LOOKUP_QUERY)?;
+        let id = id.to_vec();
+        let result: Result<Vec<BeaconContentKey>, ContentStoreError> = query
+            .query_map([id], |row| {
+                let row: String = row.get(0)?;
+                Ok(row)
+            })?
+            .map(|row| {
+                // value is stored without 0x prefix, so we must add it
+                let bytes: Vec<u8> = hex_decode(&format!("0x{}", row?))?;
+                BeaconContentKey::try_from(bytes).map_err(ContentStoreError::ContentKey)
+            })
+            .collect();
+
+        match result?.first() {
+            Some(val) => Ok(Some(val.into())),
+            None => Ok(None),
+        }
+    }
+
+    /// Public method for looking up a content value by its content id
+    pub fn lookup_content_value(&self, id: [u8; 32]) -> anyhow::Result<Option<Vec<u8>>> {
+        let conn = self.sql_connection_pool.get()?;
+        lookup_content_value(id, conn)?
+    }
+
+    /// Get a summary of the current state of storage
+    pub fn get_summary_info(&self) -> String {
+        self.metrics.get_summary()
+    }
+}
+
+/// Internal method used to measure on-disk storage usage.
+fn get_total_size_of_directory_in_bytes(path: impl AsRef<Path>) -> Result<u64, ContentStoreError> {
+    let metadata = match fs::metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(_) => {
+            return Ok(0);
+        }
+    };
+    let mut size = metadata.len();
+
+    if metadata.is_dir() {
+        for entry in fs::read_dir(&path)? {
+            let dir = entry?;
+            let path_string = match dir.path().into_os_string().into_string() {
+                Ok(path_string) => path_string,
+                Err(err) => {
+                    let err = format!(
+                        "Unable to convert path {:?} into string {:?}",
+                        path.as_ref(),
+                        err
+                    );
+                    return Err(ContentStoreError::Database(err));
+                }
+            };
+            size += get_total_size_of_directory_in_bytes(path_string)?;
+        }
+    }
+
+    Ok(size)
+}
+
+fn lookup_content_value(
+    id: [u8; 32],
+    conn: PooledConnection<SqliteConnectionManager>,
+) -> Result<Result<Option<Vec<u8>>, Error>, Error> {
+    let mut query = conn.prepare(CONTENT_VALUE_LOOKUP_QUERY)?;
+    let id = id.to_vec();
+    let result: Result<Vec<Vec<u8>>, ContentStoreError> = query
+        .query_map([id], |row| {
+            let row: String = row.get(0)?;
+            Ok(row)
+        })?
+        .map(|row| hex_decode(row?.as_str()).map_err(ContentStoreError::ByteUtilsError))
+        .collect();
+
+    Ok(match result?.first() {
+        Some(val) => Ok(Some(val.to_vec())),
+        None => Ok(None),
+    })
+}
+
+/// Converts most significant 4 bytes of a vector to a u32.
+fn byte_vector_to_u32(vec: Vec<u8>) -> u32 {
+    if vec.len() < 4 {
+        debug!("Error: XOR returned less than 4 bytes.");
+        return 0;
+    }
+
+    let mut array: [u8; 4] = [0, 0, 0, 0];
+    for (index, byte) in vec.iter().take(4).enumerate() {
+        array[index] = *byte;
+    }
+
+    u32::from_be_bytes(array)
+}
+
+/// Inserts a content  into the database.
+fn insert_value(
+    conn: PooledConnection<SqliteConnectionManager>,
+    content_id: &[u8; 32],
+    content_key: &String,
+    value: &Vec<u8>,
+    network_id: u8,
+) -> Result<(), ContentStoreError> {
+    let content_id_as_u32: u32 = byte_vector_to_u32(content_id.to_vec());
+    let value_size = value.len();
+    if content_key.starts_with("0x") {
+        return Err(ContentStoreError::InvalidData {
+            message: "Content key should not start with 0x".to_string(),
+        });
+    }
+    match conn.execute(
+        INSERT_QUERY,
+        params![
+            content_id.to_vec(),
+            content_id_as_u32,
+            content_key,
+            hex_encode(value),
+            network_id,
+            value_size
+        ],
+    ) {
+        Ok(_) => Ok(()),
+        Err(err) => Err(err.into()),
     }
 }
 
@@ -762,6 +1069,10 @@ const INSERT_QUERY: &str =
     "INSERT OR IGNORE INTO content_data (content_id_long, content_id_short, content_key, content_value, network, content_size)
                             VALUES (?1, ?2, ?3, ?4, ?5, ?6)";
 
+const INSERT_LC_UPDATE_QUERY: &str =
+    "INSERT OR IGNORE INTO lc_update (period, value, score, update_size)
+                            VALUES (?1, ?2, ?3, ?4)";
+
 const DELETE_QUERY: &str = "DELETE FROM content_data
                             WHERE content_id_long = (?1)";
 
@@ -779,13 +1090,23 @@ const CONTENT_VALUE_LOOKUP_QUERY: &str =
 
 const TOTAL_DATA_SIZE_QUERY: &str = "SELECT TOTAL(content_size) FROM content_data";
 
-const TOTAL_ENTRY_COUNT_QUERY: &str = "SELECT COUNT(content_id_long) FROM content_data";
+const TOTAL_ENTRY_COUNT_QUERY: &str =
+    "SELECT COUNT(content_id_long) FROM content_data WHERE network = (?1)";
 
 const PAGINATE_QUERY: &str =
     "SELECT content_key FROM content_data ORDER BY content_key LIMIT :limit OFFSET :offset";
 
 const CONTENT_SIZE_LOOKUP_QUERY: &str =
     "SELECT content_size FROM content_data WHERE content_id_long = (?1)";
+
+const CREATE_LC_UPDATE_TABLE: &str = "CREATE TABLE IF NOT EXISTS lc_update (
+                                          period INTEGER PRIMARY KEY,
+                                          value BLOB NOT NULL,
+                                          score INTEGER NOT NULL,
+                                          update_size INTEGER
+                                      );
+                                     CREATE INDEX update_size_idx ON lc_update(update_size);
+                                     CREATE INDEX period_idx ON lc_update(period);";
 
 // SQLite Result Containers
 struct ContentId {

--- a/trin-beacon/src/network.rs
+++ b/trin-beacon/src/network.rs
@@ -10,18 +10,19 @@ use ethportal_api::types::distance::XorMetric;
 use ethportal_api::types::enr::Enr;
 use ethportal_api::types::portal_wire::ProtocolId;
 use ethportal_api::BeaconContentKey;
+use portalnet::storage::BeaconStorage;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
     overlay::{OverlayConfig, OverlayProtocol},
-    storage::{PortalStorage, PortalStorageConfig},
+    storage::PortalStorageConfig,
 };
 use trin_validation::oracle::HeaderOracle;
 
 /// Beacon network layer on top of the overlay protocol. Encapsulates beacon network specific data and logic.
 #[derive(Clone)]
 pub struct BeaconNetwork {
-    pub overlay: Arc<OverlayProtocol<BeaconContentKey, XorMetric, BeaconValidator, PortalStorage>>,
+    pub overlay: Arc<OverlayProtocol<BeaconContentKey, XorMetric, BeaconValidator, BeaconStorage>>,
 }
 
 impl BeaconNetwork {
@@ -37,10 +38,7 @@ impl BeaconNetwork {
             bootnode_enrs,
             ..Default::default()
         };
-        let storage = Arc::new(PLRwLock::new(PortalStorage::new(
-            storage_config,
-            ProtocolId::Beacon,
-        )?));
+        let storage = Arc::new(PLRwLock::new(BeaconStorage::new(storage_config)?));
         let validator = Arc::new(BeaconValidator { header_oracle });
         let overlay = OverlayProtocol::new(
             config,


### PR DESCRIPTION
_This PR is open against the upstream `remove-rocksdb`  branch._

### What was wrong?

We need different storage mechanics for the Beacon portal network

### How was it fixed?

- create a `BeaconStorage` struct which implements the `ContentStore` trait used by the overlay service.
- create a new `lc_update` SQL table for storing and querying `LigthClientUpdate` content (see #1006).
- Add beacon specific implementations to all `ContentStore` methods.
- some common utils for `PortalStorage` and `BeaconStorage` were extracted

It may be useful to review this PR commit by commit.

All storage code and SQL queries are in a single `storage.rs` file, which is a mess. We will refactor this at a later stage.

Ideally, we want to rename `PortalStorage` to `HistoryStorage` but I prefer to do this in a separate PR because I don't want to introduce many diffs here.

In a following PR, we will resolve the TODOs and implement a storage cache for storing lc finality and optimistic updates.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
