### PR TITLE
feat: add utp transfer limit for requests not initiated by rpc

### DIFF
--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -184,7 +184,7 @@ pub struct TrinConfig {
 
     #[arg(
         long = "utp-transfer-limit", 
-        help = "The limit of max inbound and max outbound uTP transfers", 
+        help = "The limit of max background uTP transfers for any given channel (inbound or outbound) for each subnetwork", 
         default_value_t = DEFAULT_UTP_TRANSFER_LIMIT,
     )]
     pub utp_transfer_limit: usize,

--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -15,6 +15,7 @@ pub const DEFAULT_WEB3_HTTP_ADDRESS: &str = "http://127.0.0.1:8545/";
 pub const DEFAULT_WEB3_HTTP_PORT: u16 = 8545;
 pub const DEFAULT_WEB3_WS_PORT: u16 = 8546;
 pub const DEFAULT_DISCOVERY_PORT: u16 = 9009;
+pub const DEFAULT_UTP_TRANSFER_LIMIT: usize = 50;
 pub const BEACON_NETWORK: &str = "beacon";
 pub const HISTORY_NETWORK: &str = "history";
 pub const STATE_NETWORK: &str = "state";
@@ -181,6 +182,13 @@ pub struct TrinConfig {
     )]
     pub ws_port: u16,
 
+    #[arg(
+        long = "utp-transfer-limit", 
+        help = "The limit of max inbound and max outbound uTP transfers", 
+        default_value_t = DEFAULT_UTP_TRANSFER_LIMIT,
+    )]
+    pub utp_transfer_limit: usize,
+
     #[command(subcommand)]
     pub command: Option<TrinConfigCommands>,
 }
@@ -214,6 +222,7 @@ impl Default for TrinConfig {
             ws: false,
             ws_port: DEFAULT_WEB3_WS_PORT,
             command: None,
+            utp_transfer_limit: DEFAULT_UTP_TRANSFER_LIMIT,
         }
     }
 }

--- a/portalnet/src/lib.rs
+++ b/portalnet/src/lib.rs
@@ -11,3 +11,4 @@ pub mod overlay_service;
 pub mod socket;
 pub mod types;
 pub mod utils;
+pub mod utp_controller;

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -2777,7 +2777,7 @@ mod tests {
         let discv5_utp =
             crate::discovery::Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx);
         let utp_socket = utp_rs::socket::UtpSocket::with_socket(discv5_utp);
-        let utp_controller = UtpController::new(50, utp_socket);
+        let utp_controller = UtpController::new(50, Arc::new(utp_socket));
         let utp_controller = Arc::new(utp_controller);
 
         let node_id = discovery.local_enr().node_id();

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -30,14 +30,15 @@ use tokio::{
     sync::{
         broadcast,
         mpsc::{self, UnboundedReceiver, UnboundedSender},
+        OwnedSemaphorePermit,
     },
     task::JoinHandle,
 };
 use tracing::{debug, enabled, error, info, trace, warn, Level};
-use utp_rs::{conn::ConnectionConfig, socket::UtpSocket, stream::UtpStream};
+use utp_rs::{cid::ConnectionId, conn::ConnectionConfig, stream::UtpStream};
 
 use crate::{
-    discovery::Discovery,
+    discovery::{Discovery, UtpEnr},
     events::{EventEnvelope, OverlayEvent},
     find::{
         iterators::{
@@ -51,6 +52,7 @@ use crate::{
     gossip::propagate_gossip_cross_thread,
     types::node::Node,
     utils::portal_wire,
+    utp_controller::UtpController,
 };
 use ethportal_api::{
     generate_random_node_id,
@@ -226,6 +228,8 @@ pub struct OverlayRequest {
     /// ID of query that request's response will advance.
     /// Will be None for requests that are not associated with a query.
     pub query_id: Option<QueryId>,
+    /// An optional permit to allow for transfer caps
+    pub request_permit: Option<OwnedSemaphorePermit>,
 }
 
 impl OverlayRequest {
@@ -235,6 +239,7 @@ impl OverlayRequest {
         direction: RequestDirection,
         responder: Option<OverlayResponder>,
         query_id: Option<QueryId>,
+        request_permit: Option<OwnedSemaphorePermit>,
     ) -> Self {
         OverlayRequest {
             id: rand::random(),
@@ -242,6 +247,7 @@ impl OverlayRequest {
             direction,
             responder,
             query_id,
+            request_permit,
         }
     }
 }
@@ -255,6 +261,8 @@ struct ActiveOutgoingRequest {
     pub request: Request,
     /// An optional QueryID for the query that this request is associated with.
     pub query_id: Option<QueryId>,
+    /// An optional permit to allow for transfer caps
+    pub request_permit: Option<OwnedSemaphorePermit>,
 }
 
 /// A response for a particular overlay request.
@@ -304,8 +312,8 @@ pub struct OverlayService<TContentKey, TMetric, TValidator, TStore> {
     response_rx: UnboundedReceiver<OverlayResponse>,
     /// The sender half of a channel for responses to outgoing requests.
     response_tx: UnboundedSender<OverlayResponse>,
-    /// uTP socket.
-    utp_socket: Arc<UtpSocket<crate::discovery::UtpEnr>>,
+    /// uTP controller.
+    utp_controller: Arc<UtpController>,
     /// Phantom content key.
     phantom_content_key: PhantomData<TContentKey>,
     /// Phantom metric (distance function).
@@ -342,7 +350,7 @@ where
         bootnode_enrs: Vec<Enr>,
         ping_queue_interval: Option<Duration>,
         protocol: ProtocolId,
-        utp_socket: Arc<UtpSocket<crate::discovery::UtpEnr>>,
+        utp_controller: Arc<UtpController>,
         metrics: OverlayMetricsReporter,
         validator: Arc<TValidator>,
         query_timeout: Duration,
@@ -385,7 +393,7 @@ where
                 findnodes_query_distances_per_peer,
                 response_rx,
                 response_tx,
-                utp_socket,
+                utp_controller,
                 phantom_content_key: PhantomData,
                 phantom_metric: PhantomData,
                 metrics,
@@ -533,7 +541,7 @@ where
                         match response.response {
                             Ok(response) => {
                                 self.metrics.report_inbound_response(&response);
-                                self.process_response(response, request.destination, request.request, request.query_id)
+                                self.process_response(response, request.destination, request.request, request.query_id, request.request_permit)
                             }
                             Err(error) => self.process_request_failure(response.request_id, request.destination, error),
                         }
@@ -684,6 +692,7 @@ where
                         RequestDirection::Outgoing { destination: enr },
                         None,
                         Some(query_id),
+                        None,
                     );
                     let _ = self.command_tx.send(OverlayCommand::Request(request));
                 } else {
@@ -761,6 +770,7 @@ where
                         RequestDirection::Outgoing { destination: enr },
                         None,
                         Some(query_id),
+                        None,
                     );
                     let _ = self.command_tx.send(OverlayCommand::Request(request));
                 } else {
@@ -805,6 +815,7 @@ where
                         let kbuckets = self.kbuckets.clone();
                         let command_tx = self.command_tx.clone();
                         let metrics = self.metrics.clone();
+                        let utp = self.utp_controller.clone();
                         let disable_poke = self.disable_poke;
                         tokio::spawn(async move {
                             Self::process_received_content(
@@ -820,6 +831,7 @@ where
                                 nodes_to_poke,
                                 metrics,
                                 disable_poke,
+                                utp,
                             )
                             .await;
                         });
@@ -830,7 +842,7 @@ where
                         nodes_to_poke,
                     } => {
                         let metrics = self.metrics.clone();
-                        let utp = self.utp_socket.clone();
+                        let utp = self.utp_controller.clone();
                         let source = match self.find_enr(&peer) {
                             Some(enr) => enr,
                             _ => {
@@ -844,7 +856,7 @@ where
                         let cid = utp_rs::cid::ConnectionId {
                             recv: connection_id,
                             send: connection_id.wrapping_add(1),
-                            peer: crate::discovery::UtpEnr(source),
+                            peer: UtpEnr(source),
                         };
                         let validator = self.validator.clone();
                         let store = self.store.clone();
@@ -912,6 +924,7 @@ where
                                 nodes_to_poke,
                                 metrics,
                                 disable_poke,
+                                utp,
                             )
                             .await;
                         });
@@ -929,6 +942,7 @@ where
         content_key: TContentKey,
         content: Vec<u8>,
         nodes_to_poke: Vec<NodeId>,
+        utp_controller: Arc<UtpController>,
     ) {
         let content_id = content_key.content_id();
 
@@ -950,6 +964,17 @@ where
                 let content_items = vec![(content_key.clone().into(), content.clone())];
                 let offer_request = Request::PopulatedOffer(PopulatedOffer { content_items });
 
+                // if we have met the max outbound utp transfer limit continue the loop as we aren't
+                // allow to generate another utp stream
+                let permit = match utp_controller
+                    .outbound_utp_transfer_semaphore
+                    .clone()
+                    .try_acquire_owned()
+                {
+                    Ok(permit) => permit,
+                    Err(_) => continue,
+                };
+
                 let request = OverlayRequest::new(
                     offer_request,
                     RequestDirection::Outgoing {
@@ -957,6 +982,7 @@ where
                     },
                     None,
                     None,
+                    Some(permit),
                 );
 
                 match command_tx.send(OverlayCommand::Request(request)) {
@@ -1013,6 +1039,7 @@ where
                         responder: request.responder,
                         request: request.request.clone(),
                         query_id: request.query_id,
+                        request_permit: request.request_permit,
                     },
                 );
                 self.metrics.report_outbound_request(&request.request);
@@ -1122,8 +1149,14 @@ where
                 ))
             }
         };
-        match self.store.read().get(&content_key) {
-            Ok(Some(content)) => {
+        match (
+            self.store.read().get(&content_key),
+            self.utp_controller
+                .outbound_utp_transfer_semaphore
+                .clone()
+                .try_acquire_owned(),
+        ) {
+            (Ok(Some(content)), Ok(permit)) => {
                 if content.len() <= MAX_PORTAL_CONTENT_PAYLOAD_SIZE {
                     Ok(Content::Content(content))
                 } else {
@@ -1133,13 +1166,13 @@ where
                             "unable to find ENR for NodeId".to_string(),
                         )
                     })?;
-                    let enr = crate::discovery::UtpEnr(node_addr.enr);
-                    let cid = self.utp_socket.cid(enr, false);
+                    let enr = UtpEnr(node_addr.enr);
+                    let cid = self.utp_controller.cid(enr, false);
                     let cid_send = cid.send;
 
                     // Wait for an incoming connection with the given CID. Then, write the data
                     // over the uTP stream.
-                    let utp = Arc::clone(&self.utp_socket);
+                    let utp = Arc::clone(&self.utp_controller);
                     let metrics = self.metrics.clone();
                     tokio::spawn(async move {
                         metrics.report_utp_active_inc(UtpDirectionLabel::Outbound);
@@ -1170,13 +1203,16 @@ where
                                 "Error sending content over uTP, in response to FindContent"
                             );
                         }
+                        drop(permit);
                     });
 
                     // Connection id is send as BE because uTP header values are stored also as BE
                     Ok(Content::ConnectionId(cid_send.to_be()))
                 }
             }
-            Ok(None) => {
+            // If we don't have data to send back or can't obtain a permit, send the requester a
+            // list of closer ENR
+            (Ok(Some(_)), _) | (Ok(None), _) => {
                 let enrs = self.find_nodes_close_to_content(content_key);
                 match enrs {
                     Ok(mut val) => {
@@ -1187,7 +1223,7 @@ where
                     Err(msg) => Err(OverlayRequestError::InvalidRequest(msg.to_string())),
                 }
             }
-            Err(msg) => Err(OverlayRequestError::Failure(format!(
+            (Err(msg), _) => Err(OverlayRequestError::Failure(format!(
                 "Unable to respond to FindContent: {msg}",
             ))),
         }
@@ -1213,6 +1249,22 @@ where
                     "Unable to initialize bitlist for requested keys.".to_owned(),
                 )
             })?;
+
+        // Attempt to get semaphore permit if fails we return an empty accept
+        let permit = match self
+            .utp_controller
+            .inbound_utp_transfer_semaphore
+            .clone()
+            .try_acquire_owned()
+        {
+            Ok(permit) => permit,
+            Err(_) => {
+                return Ok(Accept {
+                    connection_id: 0,
+                    content_keys: requested_keys,
+                });
+            }
+        };
 
         let content_keys: Vec<TContentKey> = request
             .content_keys
@@ -1258,19 +1310,19 @@ where
         let node_addr = self.discovery.cached_node_addr(source).ok_or_else(|| {
             OverlayRequestError::AcceptError("unable to find ENR for NodeId".to_string())
         })?;
-        let enr = crate::discovery::UtpEnr(node_addr.enr);
+        let enr = UtpEnr(node_addr.enr);
         let enr_str = if enabled!(Level::TRACE) {
             enr.0.to_base64()
         } else {
             String::with_capacity(0)
         };
-        let cid = self.utp_socket.cid(enr, false);
+        let cid: ConnectionId<UtpEnr> = self.utp_controller.cid(enr, false);
         let cid_send = cid.send;
         let validator = Arc::clone(&self.validator);
         let store = Arc::clone(&self.store);
         let kbuckets = Arc::clone(&self.kbuckets);
         let command_tx = self.command_tx.clone();
-        let utp = Arc::clone(&self.utp_socket);
+        let utp = Arc::clone(&self.utp_controller);
         let metrics = self.metrics.clone();
 
         let content_keys_string: Vec<String> = content_keys
@@ -1323,11 +1375,14 @@ where
                 command_tx,
                 content_keys,
                 data,
+                utp.clone(),
             )
             .await
             {
                 debug!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), content_keys = ?content_keys_string, "unable to process uTP payload");
             }
+            // explictically drop semaphore permit in thread so the permit is moved into the thread
+            drop(permit);
         });
 
         let accept = Accept {
@@ -1470,6 +1525,7 @@ where
         source: Enr,
         request: Request,
         query_id: Option<QueryId>,
+        request_permit: Option<OwnedSemaphorePermit>,
     ) {
         // If the node is present in the routing table, but the node is not connected, then
         // use the existing entry's value and direction. Otherwise, build a new entry from
@@ -1517,7 +1573,7 @@ where
             Response::Nodes(nodes) => self.process_nodes(nodes, source, query_id),
             Response::Content(content) => self.process_content(content, source, query_id),
             Response::Accept(accept) => {
-                if let Err(err) = self.process_accept(accept, source, request) {
+                if let Err(err) = self.process_accept(accept, source, request, request_permit) {
                     error!(response.error = %err, "Error processing ACCEPT message")
                 }
             }
@@ -1525,7 +1581,13 @@ where
     }
 
     // Process ACCEPT response
-    fn process_accept(&self, response: Accept, enr: Enr, offer: Request) -> anyhow::Result<Accept> {
+    fn process_accept(
+        &self,
+        response: Accept,
+        enr: Enr,
+        offer: Request,
+        request_permit: Option<OwnedSemaphorePermit>,
+    ) -> anyhow::Result<Accept> {
         // Check that a valid triggering request was sent
         let mut gossip_result_tx = None;
         match &offer {
@@ -1553,13 +1615,13 @@ where
         let cid = utp_rs::cid::ConnectionId {
             recv: conn_id,
             send: conn_id.wrapping_add(1),
-            peer: crate::discovery::UtpEnr(enr),
+            peer: UtpEnr(enr),
         };
 
         let store = Arc::clone(&self.store);
         let response_clone = response.clone();
 
-        let utp = Arc::clone(&self.utp_socket);
+        let utp = Arc::clone(&self.utp_controller);
         let metrics = self.metrics.clone();
 
         tokio::spawn(async move {
@@ -1658,12 +1720,17 @@ where
                     }
                 }
             }
+            // explicitly drop permit in the thread so the permit is included in the thread
+            if let Some(permit) = request_permit {
+                drop(permit);
+            }
         });
 
         Ok(response)
     }
 
     /// Process accepted uTP payload of the OFFER/ACCEPT stream
+    #[allow(clippy::too_many_arguments)]
     async fn process_accept_utp_payload(
         validator: Arc<TValidator>,
         store: Arc<RwLock<TStore>>,
@@ -1672,6 +1739,7 @@ where
         command_tx: UnboundedSender<OverlayCommand<TContentKey>>,
         content_keys: Vec<TContentKey>,
         payload: Vec<u8>,
+        utp_controller: Arc<UtpController>,
     ) -> anyhow::Result<()> {
         let content_keys_string: Vec<String> = content_keys
             .iter()
@@ -1785,13 +1853,18 @@ where
             .map(|(k, _)| hex_encode_compact(k.content_id()))
             .collect();
         debug!(ids = ?validated_ids, "propagating validated content");
-        propagate_gossip_cross_thread(validated_content, kbuckets, command_tx.clone());
+        propagate_gossip_cross_thread(
+            validated_content,
+            kbuckets,
+            command_tx.clone(),
+            Some(utp_controller),
+        );
 
         Ok(())
     }
 
     async fn send_utp_content(
-        mut stream: UtpStream<crate::discovery::UtpEnr>,
+        mut stream: UtpStream<UtpEnr>,
         content: &[u8],
         metrics: OverlayMetricsReporter,
     ) -> anyhow::Result<()> {
@@ -1939,6 +2012,7 @@ where
         nodes_to_poke: Vec<NodeId>,
         metrics: OverlayMetricsReporter,
         disable_poke: bool,
+        utp_controller: Arc<UtpController>,
     ) {
         let mut content = content;
         // Operate under assumption that all content in the store is valid
@@ -1992,7 +2066,14 @@ where
         }
 
         if !disable_poke {
-            Self::poke_content(kbuckets, command_tx, content_key, content, nodes_to_poke);
+            Self::poke_content(
+                kbuckets,
+                command_tx,
+                content_key,
+                content,
+                nodes_to_poke,
+                utp_controller,
+            );
         }
     }
 
@@ -2249,6 +2330,7 @@ where
             },
             None,
             None,
+            None,
         );
         let _ = self.command_tx.send(OverlayCommand::Request(request));
     }
@@ -2261,6 +2343,7 @@ where
             RequestDirection::Outgoing {
                 destination: destination.clone(),
             },
+            None,
             None,
             None,
         );
@@ -2694,7 +2777,8 @@ mod tests {
         let discv5_utp =
             crate::discovery::Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx);
         let utp_socket = utp_rs::socket::UtpSocket::with_socket(discv5_utp);
-        let utp_socket = Arc::new(utp_socket);
+        let utp_controller = UtpController::new(50, utp_socket);
+        let utp_controller = Arc::new(utp_controller);
 
         let node_id = discovery.local_enr().node_id();
         let store = MemoryContentStore::new(node_id, DistanceFunction::Xor);
@@ -2722,7 +2806,7 @@ mod tests {
 
         OverlayService {
             discovery,
-            utp_socket,
+            utp_controller,
             store,
             kbuckets,
             protocol,
@@ -3107,6 +3191,7 @@ mod tests {
             content_key,
             content,
             peer_node_ids,
+            service.utp_controller.clone(),
         );
         let cmd = assert_ready!(poll_command_rx!(service));
         let cmd = cmd.unwrap();
@@ -3144,6 +3229,7 @@ mod tests {
             content_key,
             content,
             peer_node_ids,
+            service.utp_controller.clone(),
         );
         assert_pending!(poll_command_rx!(service));
     }
@@ -3195,6 +3281,7 @@ mod tests {
             content_key,
             content,
             peer_node_ids,
+            service.utp_controller.clone(),
         );
         let cmd = assert_ready!(poll_command_rx!(service));
         let cmd = cmd.unwrap();

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -2751,7 +2751,9 @@ mod tests {
         utils::db::setup_temp_dir,
     };
     use ethportal_api::types::{
-        cli::DEFAULT_DISCOVERY_PORT, content_key::overlay::IdentityContentKey, distance::XorMetric,
+        cli::{DEFAULT_DISCOVERY_PORT, DEFAULT_UTP_TRANSFER_LIMIT},
+        content_key::overlay::IdentityContentKey,
+        distance::XorMetric,
         enr::generate_random_remote_enr,
     };
     use trin_metrics::portalnet::PORTALNET_METRICS;
@@ -2777,7 +2779,7 @@ mod tests {
         let discv5_utp =
             crate::discovery::Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx);
         let utp_socket = utp_rs::socket::UtpSocket::with_socket(discv5_utp);
-        let utp_controller = UtpController::new(50, Arc::new(utp_socket));
+        let utp_controller = UtpController::new(DEFAULT_UTP_TRANSFER_LIMIT, Arc::new(utp_socket));
         let utp_controller = Arc::new(utp_controller);
 
         let node_id = discovery.local_enr().node_id();

--- a/portalnet/src/utp_controller.rs
+++ b/portalnet/src/utp_controller.rs
@@ -16,11 +16,11 @@ pub struct UtpController {
     pub inbound_utp_transfer_semaphore: Arc<Semaphore>,
     pub outbound_utp_transfer_semaphore: Arc<Semaphore>,
     /// uTP socket.
-    utp_socket: UtpSocket<UtpEnr>,
+    utp_socket: Arc<UtpSocket<UtpEnr>>,
 }
 
 impl UtpController {
-    pub fn new(utp_transfer_limit: usize, utp_socket: UtpSocket<UtpEnr>) -> Self {
+    pub fn new(utp_transfer_limit: usize, utp_socket: Arc<UtpSocket<UtpEnr>>) -> Self {
         Self {
             utp_socket,
             inbound_utp_transfer_semaphore: Arc::new(Semaphore::new(utp_transfer_limit)),

--- a/portalnet/src/utp_controller.rs
+++ b/portalnet/src/utp_controller.rs
@@ -1,0 +1,48 @@
+use std::{io, sync::Arc};
+use tokio::sync::Semaphore;
+use utp_rs::{cid::ConnectionId, conn::ConnectionConfig, socket::UtpSocket, stream::UtpStream};
+
+use crate::discovery::UtpEnr;
+
+/// UtpController is meant to be a container which contains all code related to/for managing uTP
+/// streams We are implementing this because we want the utils of controlling uTP connection to be
+/// as contained as it can, instead of extending overlay_service even more.
+/// Currently we are implementing this to control the max utp_transfer_limit
+/// But in the future this will be where we implement
+/// - thundering herd protection
+/// - killing bad uTP connections which won't send us data or is purposefully keeping the connection
+///   open
+pub struct UtpController {
+    pub inbound_utp_transfer_semaphore: Arc<Semaphore>,
+    pub outbound_utp_transfer_semaphore: Arc<Semaphore>,
+    /// uTP socket.
+    utp_socket: UtpSocket<UtpEnr>,
+}
+
+impl UtpController {
+    pub fn new(utp_transfer_limit: usize, utp_socket: UtpSocket<UtpEnr>) -> Self {
+        Self {
+            utp_socket,
+            inbound_utp_transfer_semaphore: Arc::new(Semaphore::new(utp_transfer_limit)),
+            outbound_utp_transfer_semaphore: Arc::new(Semaphore::new(utp_transfer_limit)),
+        }
+    }
+
+    pub async fn connect_with_cid(
+        &self,
+        cid: ConnectionId<UtpEnr>,
+        config: ConnectionConfig,
+    ) -> io::Result<UtpStream<UtpEnr>> {
+        self.utp_socket.connect_with_cid(cid, config).await
+    }
+    pub async fn accept_with_cid(
+        &self,
+        cid: ConnectionId<UtpEnr>,
+        config: ConnectionConfig,
+    ) -> io::Result<UtpStream<UtpEnr>> {
+        self.utp_socket.accept_with_cid(cid, config).await
+    }
+    pub fn cid(&self, peer: UtpEnr, is_initiator: bool) -> ConnectionId<UtpEnr> {
+        self.utp_socket.cid(peer, is_initiator)
+    }
+}

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -6,6 +6,7 @@ use std::{
 
 use discv5::TalkRequest;
 use parking_lot::RwLock;
+use portalnet::utp_controller::UtpController;
 use tokio::{
     sync::{mpsc, mpsc::unbounded_channel},
     time::{self, Duration},
@@ -43,14 +44,15 @@ async fn init_overlay(
     let (_utp_talk_req_tx, utp_talk_req_rx) = unbounded_channel();
     let discv5_utp = Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx);
     let utp_socket = UtpSocket::with_socket(discv5_utp);
-    let utp_socket = Arc::new(utp_socket);
+    let utp_controller = UtpController::new(50, utp_socket);
+    let utp_controller = Arc::new(utp_controller);
 
     let validator = Arc::new(MockValidator {});
 
     OverlayProtocol::new(
         overlay_config,
         discovery,
-        utp_socket,
+        utp_controller,
         store,
         protocol,
         validator,

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -44,7 +44,7 @@ async fn init_overlay(
     let (_utp_talk_req_tx, utp_talk_req_rx) = unbounded_channel();
     let discv5_utp = Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx);
     let utp_socket = UtpSocket::with_socket(discv5_utp);
-    let utp_controller = UtpController::new(50, utp_socket);
+    let utp_controller = UtpController::new(50, Arc::new(utp_socket));
     let utp_controller = Arc::new(utp_controller);
 
     let validator = Arc::new(MockValidator {});

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -15,6 +15,7 @@ use utp_rs::socket::UtpSocket;
 
 use ethportal_api::{
     types::{
+        cli::DEFAULT_UTP_TRANSFER_LIMIT,
         content_key::overlay::IdentityContentKey,
         distance::XorMetric,
         enr::{Enr, SszEnr},
@@ -44,7 +45,7 @@ async fn init_overlay(
     let (_utp_talk_req_tx, utp_talk_req_rx) = unbounded_channel();
     let discv5_utp = Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx);
     let utp_socket = UtpSocket::with_socket(discv5_utp);
-    let utp_controller = UtpController::new(50, Arc::new(utp_socket));
+    let utp_controller = UtpController::new(DEFAULT_UTP_TRANSFER_LIMIT, Arc::new(utp_socket));
     let utp_controller = Arc::new(utp_controller);
 
     let validator = Arc::new(MockValidator {});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use portalnet::utp_controller::UtpController;
 use rpc::{launch_jsonrpc_server, RpcServerHandle};
 use tokio::sync::{mpsc, RwLock};
 use tracing::info;
@@ -61,7 +62,8 @@ pub async fn run_trin(
     let (utp_talk_reqs_tx, utp_talk_reqs_rx) = mpsc::unbounded_channel();
     let discv5_utp_socket = Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_reqs_rx);
     let utp_socket = UtpSocket::with_socket(discv5_utp_socket);
-    let utp_socket = Arc::new(utp_socket);
+    let utp_controller = UtpController::new(trin_config.utp_transfer_limit, utp_socket);
+    let utp_controller = Arc::new(utp_controller);
 
     let storage_config = PortalStorageConfig::new(
         trin_config.mb.into(),
@@ -83,7 +85,7 @@ pub async fn run_trin(
         if trin_config.networks.iter().any(|val| val == STATE_NETWORK) {
             initialize_state_network(
                 &discovery,
-                Arc::clone(&utp_socket),
+                Arc::clone(&utp_controller),
                 portalnet_config.clone(),
                 storage_config.clone(),
                 header_oracle.clone(),
@@ -103,7 +105,7 @@ pub async fn run_trin(
     ) = if trin_config.networks.iter().any(|val| val == BEACON_NETWORK) {
         initialize_beacon_network(
             &discovery,
-            Arc::clone(&utp_socket),
+            Arc::clone(&utp_controller),
             portalnet_config.clone(),
             storage_config.clone(),
             header_oracle.clone(),
@@ -127,7 +129,7 @@ pub async fn run_trin(
     {
         initialize_history_network(
             &discovery,
-            utp_socket,
+            utp_controller,
             portalnet_config.clone(),
             storage_config.clone(),
             header_oracle.clone(),

--- a/trin-beacon/src/lib.rs
+++ b/trin-beacon/src/lib.rs
@@ -16,14 +16,14 @@ use tokio::{
     time::{interval, Duration},
 };
 use tracing::info;
-use utp_rs::socket::UtpSocket;
 
 use crate::{events::BeaconEvents, jsonrpc::BeaconRequestHandler, network::BeaconNetwork};
 use ethportal_api::types::{enr::Enr, jsonrpc::request::BeaconJsonRpcRequest};
 use portalnet::{
     config::PortalnetConfig,
-    discovery::{Discovery, UtpEnr},
+    discovery::Discovery,
     events::{EventEnvelope, OverlayRequest},
+    utp_controller::UtpController,
 };
 use trin_storage::PortalStorageConfig;
 use trin_validation::oracle::HeaderOracle;
@@ -36,8 +36,7 @@ type BeaconEventStream = Option<broadcast::Receiver<EventEnvelope>>;
 
 pub async fn initialize_beacon_network(
     discovery: &Arc<Discovery>,
-    utp_socket: Arc<UtpSocket<UtpEnr>>,
-
+    utp_controller: Arc<UtpController>,
     portalnet_config: PortalnetConfig,
     storage_config: PortalStorageConfig,
     header_oracle: Arc<RwLock<HeaderOracle>>,
@@ -53,7 +52,7 @@ pub async fn initialize_beacon_network(
     let (beacon_message_tx, beacon_message_rx) = mpsc::unbounded_channel::<OverlayRequest>();
     let beacon_network = BeaconNetwork::new(
         Arc::clone(discovery),
-        utp_socket,
+        utp_controller,
         storage_config,
         portalnet_config.clone(),
         header_oracle,

--- a/trin-beacon/src/network.rs
+++ b/trin-beacon/src/network.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use parking_lot::RwLock as PLRwLock;
 use tokio::sync::RwLock;
-use utp_rs::socket::UtpSocket;
 
 use crate::{storage::BeaconStorage, sync::BeaconSync, validation::BeaconValidator};
 use ethportal_api::{
@@ -11,8 +10,9 @@ use ethportal_api::{
 };
 use portalnet::{
     config::PortalnetConfig,
-    discovery::{Discovery, UtpEnr},
+    discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol},
+    utp_controller::UtpController,
 };
 use trin_storage::PortalStorageConfig;
 use trin_validation::oracle::HeaderOracle;
@@ -27,7 +27,7 @@ pub struct BeaconNetwork {
 impl BeaconNetwork {
     pub async fn new(
         discovery: Arc<Discovery>,
-        utp_socket: Arc<UtpSocket<UtpEnr>>,
+        utp_controller: Arc<UtpController>,
         storage_config: PortalStorageConfig,
         portal_config: PortalnetConfig,
         header_oracle: Arc<RwLock<HeaderOracle>>,
@@ -42,7 +42,7 @@ impl BeaconNetwork {
         let overlay = OverlayProtocol::new(
             config,
             discovery,
-            utp_socket,
+            utp_controller,
             storage,
             ProtocolId::Beacon,
             validator,

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -17,14 +17,14 @@ use tokio::{
     time::{interval, Duration},
 };
 use tracing::info;
-use utp_rs::socket::UtpSocket;
 
 use crate::{events::HistoryEvents, jsonrpc::HistoryRequestHandler};
 use ethportal_api::types::{enr::Enr, jsonrpc::request::HistoryJsonRpcRequest};
 use portalnet::{
     config::PortalnetConfig,
-    discovery::{Discovery, UtpEnr},
+    discovery::Discovery,
     events::{EventEnvelope, OverlayRequest},
+    utp_controller::UtpController,
 };
 use trin_storage::PortalStorageConfig;
 use trin_validation::oracle::HeaderOracle;
@@ -37,8 +37,7 @@ type HistoryEventStream = Option<broadcast::Receiver<EventEnvelope>>;
 
 pub async fn initialize_history_network(
     discovery: &Arc<Discovery>,
-    utp_socket: Arc<UtpSocket<UtpEnr>>,
-
+    utp_controller: Arc<UtpController>,
     portalnet_config: PortalnetConfig,
     storage_config: PortalStorageConfig,
     header_oracle: Arc<RwLock<HeaderOracle>>,
@@ -55,7 +54,7 @@ pub async fn initialize_history_network(
     let (history_event_tx, history_event_rx) = mpsc::unbounded_channel::<OverlayRequest>();
     let history_network = HistoryNetwork::new(
         Arc::clone(discovery),
-        utp_socket,
+        utp_controller,
         storage_config,
         portalnet_config.clone(),
         header_oracle,

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use parking_lot::RwLock as PLRwLock;
 use tokio::sync::RwLock;
-use utp_rs::socket::UtpSocket;
 
 use crate::storage::HistoryStorage;
 use ethportal_api::{
@@ -11,8 +10,9 @@ use ethportal_api::{
 };
 use portalnet::{
     config::PortalnetConfig,
-    discovery::{Discovery, UtpEnr},
+    discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol},
+    utp_controller::UtpController,
 };
 use trin_validation::oracle::HeaderOracle;
 
@@ -30,7 +30,7 @@ pub struct HistoryNetwork {
 impl HistoryNetwork {
     pub async fn new(
         discovery: Arc<Discovery>,
-        utp_socket: Arc<UtpSocket<UtpEnr>>,
+        utp_controller: Arc<UtpController>,
         storage_config: PortalStorageConfig,
         portal_config: PortalnetConfig,
         header_oracle: Arc<RwLock<HeaderOracle>>,
@@ -49,7 +49,7 @@ impl HistoryNetwork {
         let overlay = OverlayProtocol::new(
             config,
             discovery,
-            utp_socket,
+            utp_controller,
             storage,
             ProtocolId::History,
             validator,

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -9,14 +9,14 @@ use tokio::{
     task::JoinHandle,
 };
 use tracing::info;
-use utp_rs::socket::UtpSocket;
 
 use crate::{events::StateEvents, jsonrpc::StateRequestHandler};
 use ethportal_api::types::{enr::Enr, jsonrpc::request::StateJsonRpcRequest};
 use portalnet::{
     config::PortalnetConfig,
-    discovery::{Discovery, UtpEnr},
+    discovery::Discovery,
     events::{EventEnvelope, OverlayRequest},
+    utp_controller::UtpController,
 };
 use trin_storage::PortalStorageConfig;
 use trin_validation::oracle::HeaderOracle;
@@ -36,7 +36,7 @@ type StateEventStream = Option<broadcast::Receiver<EventEnvelope>>;
 
 pub async fn initialize_state_network(
     discovery: &Arc<Discovery>,
-    utp_socket: Arc<UtpSocket<UtpEnr>>,
+    utp_controller: Arc<UtpController>,
     portalnet_config: PortalnetConfig,
     storage_config: PortalStorageConfig,
     header_oracle: Arc<RwLock<HeaderOracle>>,
@@ -51,7 +51,7 @@ pub async fn initialize_state_network(
     let (state_event_tx, state_event_rx) = mpsc::unbounded_channel::<OverlayRequest>();
     let state_network = StateNetwork::new(
         Arc::clone(discovery),
-        utp_socket,
+        utp_controller,
         storage_config,
         portalnet_config.clone(),
         header_oracle,

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -1,7 +1,6 @@
 use parking_lot::RwLock as PLRwLock;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use utp_rs::socket::UtpSocket;
 
 use crate::storage::StateStorage;
 use ethportal_api::{
@@ -10,8 +9,9 @@ use ethportal_api::{
 };
 use portalnet::{
     config::PortalnetConfig,
-    discovery::{Discovery, UtpEnr},
+    discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol},
+    utp_controller::UtpController,
 };
 use trin_validation::oracle::HeaderOracle;
 
@@ -28,7 +28,7 @@ pub struct StateNetwork {
 impl StateNetwork {
     pub async fn new(
         discovery: Arc<Discovery>,
-        utp_socket: Arc<UtpSocket<UtpEnr>>,
+        utp_controller: Arc<UtpController>,
         storage_config: PortalStorageConfig,
         portal_config: PortalnetConfig,
         header_oracle: Arc<RwLock<HeaderOracle>>,
@@ -46,7 +46,7 @@ impl StateNetwork {
         let overlay = OverlayProtocol::new(
             config,
             discovery,
-            utp_socket,
+            utp_controller,
             storage,
             ProtocolId::State,
             validator,


### PR DESCRIPTION
#### What was wrong?
Currently Trin can open up limitless uTP streams. 

X = base X amount of memory trin uses
Y = arbatrary statical average each new uTP connection incurs

So currently Trins memory usage is =  X + (Y * (# of connections))
This is unbounded growth, this PR proposes to set a configurable limit of how many inbound and outbound uTP connections can be made to the node.

I am proposing this limit for connections that are incurred from the node running itself, not requestions started from JSON-RPC requests.

#### why seperate inbound/outbound limits
It is very common for ISP's to provide high download speeds but low upload speeds. So being able to set these seperately can help people who face those kinds of constraints.


#### What will this limit not be applied to
Requests initiated by rpc, we can add a seperate limit if we want but this is a user experience kind of thing. If a user is paying for bandwidth they shouldn't be rate limited, what should be rate limited is its autonomous interations with other nodes.
#### What will this limit be applied to
handle_offer
handle_find_content
poke_content
^ calls which are initiated from the overlay service, not by the rpc
### future work
- optimize uTP more however that would look
- ad hoc protection added to utp controller
- protection from bad uTP connections (implement forced connection shutdowns) currently uTP only supports graceforce connection shutdowns.
