### PR TITLE
fix: use beacon types for beacon rpc instead of history types

### DIFF
--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -1,11 +1,9 @@
 use crate::{
     types::{
+        beacon::{ContentInfo, PaginateLocalContentInfo, TraceContentInfo},
         content_key::beacon::BeaconContentKey,
         enr::Enr,
-        portal::{
-            AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
-            TraceContentInfo, TraceGossipInfo,
-        },
+        portal::{AcceptInfo, DataRadius, FindNodesInfo, PongInfo, TraceGossipInfo},
     },
     BeaconContentValue, PossibleBeaconContentValue, RoutingTableInfo,
 };
@@ -59,10 +57,8 @@ pub trait BeaconNetworkApi {
 
     /// Lookup a target content key in the network
     #[method(name = "beaconRecursiveFindContent")]
-    async fn recursive_find_content(
-        &self,
-        content_key: BeaconContentKey,
-    ) -> RpcResult<PossibleBeaconContentValue>;
+    async fn recursive_find_content(&self, content_key: BeaconContentKey)
+        -> RpcResult<ContentInfo>;
 
     /// Lookup a target content key in the network. Return tracing info.
     #[method(name = "beaconTraceRecursiveFindContent")]

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -2,10 +2,8 @@ use crate::{
     types::{
         content_key::history::HistoryContentKey,
         enr::Enr,
-        portal::{
-            AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
-            TraceContentInfo, TraceGossipInfo,
-        },
+        history::{ContentInfo, PaginateLocalContentInfo, TraceContentInfo},
+        portal::{AcceptInfo, DataRadius, FindNodesInfo, PongInfo, TraceGossipInfo},
     },
     HistoryContentValue, PossibleHistoryContentValue, RoutingTableInfo,
 };

--- a/ethportal-api/src/types/beacon.rs
+++ b/ethportal-api/src/types/beacon.rs
@@ -1,0 +1,39 @@
+use super::query_trace::QueryTrace;
+use crate::{types::enr::Enr, BeaconContentKey, PossibleBeaconContentValue};
+use serde::{Deserialize, Serialize};
+
+/// Response for FindContent & RecursiveFindContent endpoints
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
+pub enum ContentInfo {
+    #[serde(rename_all = "camelCase")]
+    ConnectionId { connection_id: u16 },
+    #[serde(rename_all = "camelCase")]
+    Content {
+        content: PossibleBeaconContentValue,
+        utp_transfer: bool,
+    },
+    #[serde(rename_all = "camelCase")]
+    Enrs { enrs: Vec<Enr> },
+}
+
+/// Parsed response for TraceRecursiveFindContent endpoint
+///
+/// The RPC response encodes absent content as "0x". This struct
+/// represents the content info, using None for absent content.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TraceContentInfo {
+    pub content: PossibleBeaconContentValue,
+    pub utp_transfer: bool,
+    pub trace: QueryTrace,
+}
+
+/// Response for PaginateLocalContentKeys endpoint
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PaginateLocalContentInfo {
+    pub content_keys: Vec<BeaconContentKey>,
+    pub total_entries: u64,
+}

--- a/ethportal-api/src/types/history.rs
+++ b/ethportal-api/src/types/history.rs
@@ -1,0 +1,38 @@
+use super::query_trace::QueryTrace;
+use crate::{types::enr::Enr, HistoryContentKey, PossibleHistoryContentValue};
+use serde::{Deserialize, Serialize};
+
+/// Response for FindContent & RecursiveFindContent endpoints
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ContentInfo {
+    #[serde(rename_all = "camelCase")]
+    ConnectionId { connection_id: u16 },
+    #[serde(rename_all = "camelCase")]
+    Content {
+        content: PossibleHistoryContentValue,
+        utp_transfer: bool,
+    },
+    #[serde(rename_all = "camelCase")]
+    Enrs { enrs: Vec<Enr> },
+}
+
+/// Parsed response for TraceRecursiveFindContent endpoint
+///
+/// The RPC response encodes absent content as "0x". This struct
+/// represents the content info, using None for absent content.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TraceContentInfo {
+    pub content: PossibleHistoryContentValue,
+    pub utp_transfer: bool,
+    pub trace: QueryTrace,
+}
+
+/// Response for PaginateLocalContentKeys endpoint
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PaginateLocalContentInfo {
+    pub content_keys: Vec<HistoryContentKey>,
+    pub total_entries: u64,
+}

--- a/ethportal-api/src/types/mod.rs
+++ b/ethportal-api/src/types/mod.rs
@@ -1,3 +1,4 @@
+pub mod beacon;
 pub mod bootnodes;
 pub mod bytes;
 pub mod cli;
@@ -9,6 +10,7 @@ pub mod discv5;
 pub mod distance;
 pub mod enr;
 pub mod execution;
+pub mod history;
 pub mod jsonrpc;
 pub mod node_id;
 pub mod portal;

--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -1,8 +1,7 @@
 use serde::{Deserialize, Serialize};
 use ssz_types::{typenum, BitList};
 
-use super::query_trace::QueryTrace;
-use crate::{types::enr::Enr, HistoryContentKey, PossibleHistoryContentValue};
+use crate::types::enr::Enr;
 
 pub type DataRadius = ethereum_types::U256;
 pub type Distance = ethereum_types::U256;
@@ -25,46 +24,11 @@ pub struct PongInfo {
 
 pub type FindNodesInfo = Vec<Enr>;
 
-/// Response for FindContent & RecursiveFindContent endpoints
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum ContentInfo {
-    #[serde(rename_all = "camelCase")]
-    ConnectionId { connection_id: u16 },
-    #[serde(rename_all = "camelCase")]
-    Content {
-        content: PossibleHistoryContentValue,
-        utp_transfer: bool,
-    },
-    #[serde(rename_all = "camelCase")]
-    Enrs { enrs: Vec<Enr> },
-}
-
 /// Response for Offer endpoint
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AcceptInfo {
     pub content_keys: BitList<typenum::U8>,
-}
-
-/// Parsed response for TraceRecursiveFindContent endpoint
-///
-/// The RPC response encodes absent content as "0x". This struct
-/// represents the content info, using None for absent content.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TraceContentInfo {
-    pub content: PossibleHistoryContentValue,
-    pub utp_transfer: bool,
-    pub trace: QueryTrace,
-}
-
-/// Response for PaginateLocalContentKeys endpoint
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PaginateLocalContentInfo {
-    pub content_keys: Vec<HistoryContentKey>,
-    pub total_entries: u64,
 }
 
 /// Response for TraceGossip endpoint

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -6,7 +6,7 @@ use tracing::info;
 
 use crate::{constants::fixture_header_with_proof, Peertest};
 use ethportal_api::{
-    types::portal::{ContentInfo, TraceContentInfo},
+    types::history::{ContentInfo, TraceContentInfo},
     utils::bytes::hex_decode,
     HistoryNetworkApiClient, OverlayContentKey, PossibleHistoryContentValue,
 };

--- a/ethportal-peertest/src/scenarios/utp.rs
+++ b/ethportal-peertest/src/scenarios/utp.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use discv5::enr::NodeId;
 use ethportal_api::{
-    types::portal::{ContentInfo, TraceContentInfo},
+    types::history::{ContentInfo, TraceContentInfo},
     HistoryNetworkApiClient, PossibleHistoryContentValue,
 };
 use tracing::info;

--- a/ethportal-peertest/src/scenarios/validation.rs
+++ b/ethportal-peertest/src/scenarios/validation.rs
@@ -5,7 +5,7 @@ use crate::{
 use ethereum_types::H256;
 use ethportal_api::{
     jsonrpsee::async_client::Client,
-    types::{content_key::history::BlockHeaderKey, enr::Enr, portal::ContentInfo},
+    types::{content_key::history::BlockHeaderKey, enr::Enr, history::ContentInfo},
     HistoryContentKey, HistoryNetworkApiClient, PossibleHistoryContentValue,
 };
 use std::str::FromStr;

--- a/portal-bridge/src/gossip.rs
+++ b/portal-bridge/src/gossip.rs
@@ -6,11 +6,9 @@ use tracing::{debug, warn, Instrument};
 
 use crate::stats::{BeaconSlotStats, HistoryBlockStats, StatsReporter};
 use ethportal_api::{
-    jsonrpsee::core::Error,
-    types::portal::{ContentInfo, TraceGossipInfo},
-    BeaconContentKey, BeaconContentValue, BeaconNetworkApiClient, HistoryContentKey,
-    HistoryContentValue, HistoryNetworkApiClient, OverlayContentKey, PossibleBeaconContentValue,
-    PossibleHistoryContentValue,
+    jsonrpsee::core::Error, types::portal::TraceGossipInfo, BeaconContentKey, BeaconContentValue,
+    BeaconNetworkApiClient, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
+    OverlayContentKey, PossibleBeaconContentValue, PossibleHistoryContentValue,
 };
 
 const GOSSIP_RETRY_COUNT: u64 = 3;
@@ -65,7 +63,11 @@ async fn beacon_trace_gossip(
         // if not, make rfc request to see if data is available on network
         let result =
             BeaconNetworkApiClient::recursive_find_content(&client, content_key.clone()).await;
-        if let Ok(PossibleBeaconContentValue::ContentPresent(_)) = result {
+        if let Ok(ethportal_api::types::beacon::ContentInfo::Content {
+            content: PossibleBeaconContentValue::ContentPresent(_),
+            ..
+        }) = result
+        {
             debug!("Found content on network, after failing to gossip, aborting gossip. content key={:?}", content_key.to_hex());
             return Ok((traces, retry_count));
         }
@@ -132,7 +134,7 @@ async fn history_trace_gossip(
         // if not, make rfc request to see if data is available on network
         let result =
             HistoryNetworkApiClient::recursive_find_content(&client, content_key.clone()).await;
-        if let Ok(ContentInfo::Content {
+        if let Ok(ethportal_api::types::history::ContentInfo::Content {
             content: PossibleHistoryContentValue::ContentPresent(_),
             ..
         }) = result

--- a/portalnet/src/storage.rs
+++ b/portalnet/src/storage.rs
@@ -7,7 +7,7 @@ use std::{
 
 use anyhow::anyhow;
 use discv5::enr::NodeId;
-use ethportal_api::types::portal::PaginateLocalContentInfo;
+use ethportal_api::types::history::PaginateLocalContentInfo;
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 use rocksdb::{Options, DB};

--- a/rpc/src/history_rpc.rs
+++ b/rpc/src/history_rpc.rs
@@ -6,11 +6,9 @@ use ethportal_api::{
     types::{
         constants::CONTENT_ABSENT,
         enr::Enr,
+        history::{ContentInfo, PaginateLocalContentInfo, TraceContentInfo},
         jsonrpc::{endpoints::HistoryEndpoint, request::HistoryJsonRpcRequest},
-        portal::{
-            AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
-            TraceContentInfo, TraceGossipInfo,
-        },
+        portal::{AcceptInfo, DataRadius, FindNodesInfo, PongInfo, TraceGossipInfo},
     },
     HistoryContentKey, HistoryContentValue, HistoryNetworkApiServer, PossibleHistoryContentValue,
     RoutingTableInfo,

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -3,11 +3,12 @@ use std::sync::Arc;
 use discv5::enr::NodeId;
 use ethportal_api::{
     types::{
+        beacon::{ContentInfo, TraceContentInfo},
         constants::CONTENT_ABSENT,
         content_value::ContentValue,
         distance::Distance,
         jsonrpc::{endpoints::BeaconEndpoint, request::BeaconJsonRpcRequest},
-        portal::{AcceptInfo, ContentInfo, FindNodesInfo, PongInfo, TraceContentInfo},
+        portal::{AcceptInfo, FindNodesInfo, PongInfo},
         portal_wire::Content,
         query_trace::QueryTrace,
     },

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -5,8 +5,9 @@ use ethportal_api::{
     types::{
         constants::CONTENT_ABSENT,
         distance::Distance,
+        history::{ContentInfo, TraceContentInfo},
         jsonrpc::{endpoints::HistoryEndpoint, request::HistoryJsonRpcRequest},
-        portal::{AcceptInfo, ContentInfo, FindNodesInfo, PongInfo, TraceContentInfo},
+        portal::{AcceptInfo, FindNodesInfo, PongInfo},
         portal_wire::Content,
         query_trace::QueryTrace,
     },

--- a/trin-validation/src/oracle.rs
+++ b/trin-validation/src/oracle.rs
@@ -7,11 +7,11 @@ use crate::accumulator::MasterAccumulator;
 use ethportal_api::{
     types::{
         execution::header::HeaderWithProof,
+        history::ContentInfo,
         jsonrpc::{
             endpoints::HistoryEndpoint,
             request::{BeaconJsonRpcRequest, HistoryJsonRpcRequest},
         },
-        portal::ContentInfo,
     },
     BlockHeaderKey, HistoryContentKey, HistoryContentValue, PossibleHistoryContentValue,
 };


### PR DESCRIPTION
### What was wrong?
I was looking into getting a foundation built out so we can have beacon tests on portal hive and I ran into a issue oh no.

Beacon RFC was out of date with the spec, then I found for FC, RFC, TRFC, PLCK we were returning history Key/Value types :scream: 
### How was it fixed?
By making variants of ContentInfo, PaginateLocalContentInfo, TraceContentInfo for beacon and using them