### PR TITLE
feat: implement basic thundering herd protection

### DIFF
--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -12,6 +12,8 @@ pub const DEFAULT_WEB3_HTTP_ADDRESS: &str = "http://127.0.0.1:8545/";
 pub const DEFAULT_WEB3_HTTP_PORT: u16 = 8545;
 pub const DEFAULT_WEB3_WS_PORT: u16 = 8546;
 pub const DEFAULT_DISCOVERY_PORT: u16 = 9009;
+pub const DEFAULT_INBOUND_UTP_TRANSFER_LIMIT: usize = 50;
+pub const DEFAULT_OUTBOUND_UTP_TRANSFER_LIMIT: usize = 50;
 pub const BEACON_NETWORK: &str = "beacon";
 pub const HISTORY_NETWORK: &str = "history";
 pub const STATE_NETWORK: &str = "state";
@@ -178,6 +180,20 @@ pub struct TrinConfig {
     )]
     pub ws_port: u16,
 
+    #[arg(
+        long = "inbound-utp-transfer-limit", 
+        help = "The limit of inbound uTP transfers", 
+        default_value_t = DEFAULT_INBOUND_UTP_TRANSFER_LIMIT,
+    )]
+    pub inbound_utp_transfer_limit: usize,
+
+    #[arg(
+        long = "outbound-utp-transfer-limit", 
+        help = "The limit of outbound uTP transfers", 
+        default_value_t = DEFAULT_OUTBOUND_UTP_TRANSFER_LIMIT,
+    )]
+    pub outbound_utp_transfer_limit: usize,
+
     #[command(subcommand)]
     pub command: Option<TrinConfigCommands>,
 }
@@ -211,6 +227,8 @@ impl Default for TrinConfig {
             ws: false,
             ws_port: DEFAULT_WEB3_WS_PORT,
             command: None,
+            inbound_utp_transfer_limit: DEFAULT_INBOUND_UTP_TRANSFER_LIMIT,
+            outbound_utp_transfer_limit: DEFAULT_OUTBOUND_UTP_TRANSFER_LIMIT,
         }
     }
 }

--- a/portalnet/src/gossip.rs
+++ b/portalnet/src/gossip.rs
@@ -96,6 +96,7 @@ pub fn propagate_gossip_cross_thread<TContentKey: OverlayContentKey>(
             RequestDirection::Outgoing { destination: enr },
             None,
             None,
+            None,
         );
 
         if let Err(err) = command_tx.send(OverlayCommand::Request(overlay_request)) {
@@ -157,6 +158,7 @@ pub async fn trace_propagate_gossip_cross_thread<TContentKey: OverlayContentKey>
                 destination: enr.clone(),
             },
             responder,
+            None,
             None,
         );
         if let Err(err) = command_tx.send(OverlayCommand::Request(overlay_request)) {

--- a/portalnet/src/lib.rs
+++ b/portalnet/src/lib.rs
@@ -12,3 +12,4 @@ pub mod socket;
 pub mod storage;
 pub mod types;
 pub mod utils;
+pub mod utp_controller;

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -21,10 +21,9 @@ use std::{
 use tokio::sync::broadcast;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, error, info, warn};
-use utp_rs::socket::UtpSocket;
 
 use crate::{
-    discovery::{Discovery, UtpEnr},
+    discovery::Discovery,
     find::query_info::{FindContentResult, RecursiveFindContentResult},
     gossip::{propagate_gossip_cross_thread, trace_propagate_gossip_cross_thread, GossipResult},
     overlay_service::{
@@ -33,6 +32,7 @@ use crate::{
     },
     storage::ContentStore,
     types::node::Node,
+    utp_controller::UtpController,
 };
 use ethportal_api::types::bootnodes::Bootnode;
 use ethportal_api::types::discv5::RoutingTableInfo;
@@ -104,8 +104,8 @@ pub struct OverlayProtocol<TContentKey, TMetric, TValidator, TStore> {
     protocol: ProtocolId,
     /// A sender to send commands to the OverlayService.
     pub command_tx: UnboundedSender<OverlayCommand<TContentKey>>,
-    /// uTP socket.
-    utp_socket: Arc<UtpSocket<UtpEnr>>,
+    /// uTP controller.
+    utp_controller: Arc<UtpController>,
     /// Declare the allowed content key types for a given overlay network.
     /// Use a phantom, because we don't store any keys in this struct.
     /// For example, this type is used when decoding a content key received over the network.
@@ -130,7 +130,7 @@ where
     pub async fn new(
         config: OverlayConfig,
         discovery: Arc<Discovery>,
-        utp_socket: Arc<UtpSocket<UtpEnr>>,
+        utp_controller: Arc<UtpController>,
         store: Arc<RwLock<TStore>>,
         protocol: ProtocolId,
         validator: Arc<TValidator>,
@@ -154,7 +154,7 @@ where
             config.bootnode_enrs,
             config.ping_queue_interval,
             protocol,
-            Arc::clone(&utp_socket),
+            Arc::clone(&utp_controller),
             metrics.clone(),
             Arc::clone(&validator),
             config.query_timeout,
@@ -172,7 +172,7 @@ where
             store,
             protocol,
             command_tx,
-            utp_socket,
+            utp_controller,
             phantom_content_key: PhantomData,
             phantom_metric: PhantomData,
             validator,
@@ -541,7 +541,7 @@ where
             peer: crate::discovery::UtpEnr(enr),
         };
         let mut stream = self
-            .utp_socket
+            .utp_controller
             .connect_with_cid(cid, *UTP_CONN_CFG)
             .await
             .map_err(|err| OverlayRequestError::UtpError(format!("{err:?}")))?;
@@ -691,7 +691,7 @@ where
         direction: RequestDirection,
     ) -> Result<Response, OverlayRequestError> {
         let (tx, rx) = oneshot::channel();
-        let overlay_request = OverlayRequest::new(request, direction, Some(tx), None);
+        let overlay_request = OverlayRequest::new(request, direction, Some(tx), None, None);
         if let Err(error) = self
             .command_tx
             .send(OverlayCommand::Request(overlay_request))

--- a/portalnet/src/utp_controller.rs
+++ b/portalnet/src/utp_controller.rs
@@ -5,6 +5,7 @@ use tokio::sync::Semaphore;
 use utp_rs::{cid::ConnectionId, conn::ConnectionConfig, socket::UtpSocket, stream::UtpStream};
 
 pub struct UtpController {
+    pub unique_transferring_content_limit: u8,
     pub inbound_utp_transfer_semaphore: Arc<Semaphore>,
     pub outbound_utp_transfer_semaphore: Arc<Semaphore>,
     /// uTP socket.
@@ -21,6 +22,7 @@ impl UtpController {
             utp_socket,
             inbound_utp_transfer_semaphore: Arc::new(Semaphore::new(inbound_utp_transfer_limit)),
             outbound_utp_transfer_semaphore: Arc::new(Semaphore::new(outbound_utp_transfer_limit)),
+            unique_transferring_content_limit: 3,
         }
     }
 

--- a/portalnet/src/utp_controller.rs
+++ b/portalnet/src/utp_controller.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+
+use std::io;
+use tokio::sync::Semaphore;
+use utp_rs::{cid::ConnectionId, conn::ConnectionConfig, socket::UtpSocket, stream::UtpStream};
+
+pub struct UtpController {
+    pub inbound_utp_transfer_semaphore: Arc<Semaphore>,
+    pub outbound_utp_transfer_semaphore: Arc<Semaphore>,
+    /// uTP socket.
+    utp_socket: UtpSocket<crate::discovery::UtpEnr>,
+}
+
+impl UtpController {
+    pub fn new(
+        inbound_utp_transfer_limit: usize,
+        outbound_utp_transfer_limit: usize,
+        utp_socket: UtpSocket<crate::discovery::UtpEnr>,
+    ) -> Self {
+        Self {
+            utp_socket,
+            inbound_utp_transfer_semaphore: Arc::new(Semaphore::new(inbound_utp_transfer_limit)),
+            outbound_utp_transfer_semaphore: Arc::new(Semaphore::new(outbound_utp_transfer_limit)),
+        }
+    }
+
+    pub async fn connect_with_cid(
+        &self,
+        cid: ConnectionId<crate::discovery::UtpEnr>,
+        config: ConnectionConfig,
+    ) -> io::Result<UtpStream<crate::discovery::UtpEnr>> {
+        self.utp_socket.connect_with_cid(cid, config).await
+    }
+    pub async fn accept_with_cid(
+        &self,
+        cid: ConnectionId<crate::discovery::UtpEnr>,
+        config: ConnectionConfig,
+    ) -> io::Result<UtpStream<crate::discovery::UtpEnr>> {
+        self.utp_socket.accept_with_cid(cid, config).await
+    }
+    pub fn cid(
+        &self,
+        peer: crate::discovery::UtpEnr,
+        is_initiator: bool,
+    ) -> ConnectionId<crate::discovery::UtpEnr> {
+        self.utp_socket.cid(peer, is_initiator)
+    }
+}

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -3,6 +3,7 @@ use std::{net::SocketAddr, str::FromStr, sync::Arc};
 
 use discv5::TalkRequest;
 use parking_lot::RwLock;
+use portalnet::utp_controller::UtpController;
 use tokio::{
     sync::{mpsc, mpsc::unbounded_channel},
     time::{self, Duration},
@@ -36,14 +37,15 @@ async fn init_overlay(
     let (_utp_talk_req_tx, utp_talk_req_rx) = unbounded_channel();
     let discv5_utp = Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx);
     let utp_socket = UtpSocket::with_socket(discv5_utp);
-    let utp_socket = Arc::new(utp_socket);
+    let utp_controller = UtpController::new(100, 100, utp_socket);
+    let utp_controller = Arc::new(utp_controller);
 
     let validator = Arc::new(MockValidator {});
 
     OverlayProtocol::new(
         overlay_config,
         discovery,
-        utp_socket,
+        utp_controller,
         store,
         protocol,
         validator,

--- a/trin-beacon/src/lib.rs
+++ b/trin-beacon/src/lib.rs
@@ -15,7 +15,6 @@ use tokio::{
     time::{interval, Duration},
 };
 use tracing::info;
-use utp_rs::socket::UtpSocket;
 
 use crate::network::BeaconNetwork;
 use crate::{events::BeaconEvents, jsonrpc::BeaconRequestHandler};
@@ -23,9 +22,10 @@ use ethportal_api::types::enr::Enr;
 use ethportal_api::types::jsonrpc::request::BeaconJsonRpcRequest;
 use portalnet::{
     config::PortalnetConfig,
-    discovery::{Discovery, UtpEnr},
+    discovery::Discovery,
     events::{EventEnvelope, OverlayRequest},
     storage::PortalStorageConfig,
+    utp_controller::UtpController,
 };
 use trin_validation::oracle::HeaderOracle;
 
@@ -37,7 +37,7 @@ type BeaconEventStream = Option<broadcast::Receiver<EventEnvelope>>;
 
 pub async fn initialize_beacon_network(
     discovery: &Arc<Discovery>,
-    utp_socket: Arc<UtpSocket<UtpEnr>>,
+    utp_controller: Arc<UtpController>,
 
     portalnet_config: PortalnetConfig,
     storage_config: PortalStorageConfig,
@@ -54,7 +54,7 @@ pub async fn initialize_beacon_network(
     let (beacon_message_tx, beacon_message_rx) = mpsc::unbounded_channel::<OverlayRequest>();
     let beacon_network = BeaconNetwork::new(
         Arc::clone(discovery),
-        utp_socket,
+        utp_controller,
         storage_config,
         portalnet_config.clone(),
         header_oracle,

--- a/trin-beacon/src/network.rs
+++ b/trin-beacon/src/network.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use parking_lot::RwLock as PLRwLock;
 use tokio::sync::RwLock;
-use utp_rs::socket::UtpSocket;
 
 use crate::sync::BeaconSync;
 use crate::validation::BeaconValidator;
@@ -12,9 +11,10 @@ use ethportal_api::types::portal_wire::ProtocolId;
 use ethportal_api::BeaconContentKey;
 use portalnet::{
     config::PortalnetConfig,
-    discovery::{Discovery, UtpEnr},
+    discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol},
     storage::{PortalStorage, PortalStorageConfig},
+    utp_controller::UtpController,
 };
 use trin_validation::oracle::HeaderOracle;
 
@@ -27,7 +27,7 @@ pub struct BeaconNetwork {
 impl BeaconNetwork {
     pub async fn new(
         discovery: Arc<Discovery>,
-        utp_socket: Arc<UtpSocket<UtpEnr>>,
+        utp_controller: Arc<UtpController>,
         storage_config: PortalStorageConfig,
         portal_config: PortalnetConfig,
         header_oracle: Arc<RwLock<HeaderOracle>>,
@@ -45,7 +45,7 @@ impl BeaconNetwork {
         let overlay = OverlayProtocol::new(
             config,
             discovery,
-            utp_socket,
+            utp_controller,
             storage,
             ProtocolId::Beacon,
             validator,

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -16,16 +16,16 @@ use tokio::{
     time::{interval, Duration},
 };
 use tracing::info;
-use utp_rs::socket::UtpSocket;
 
 use crate::{events::HistoryEvents, jsonrpc::HistoryRequestHandler};
 use ethportal_api::types::enr::Enr;
 use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
 use portalnet::{
     config::PortalnetConfig,
-    discovery::{Discovery, UtpEnr},
+    discovery::Discovery,
     events::{EventEnvelope, OverlayRequest},
     storage::PortalStorageConfig,
+    utp_controller::UtpController,
 };
 use trin_validation::oracle::HeaderOracle;
 
@@ -37,8 +37,7 @@ type HistoryEventStream = Option<broadcast::Receiver<EventEnvelope>>;
 
 pub async fn initialize_history_network(
     discovery: &Arc<Discovery>,
-    utp_socket: Arc<UtpSocket<UtpEnr>>,
-
+    utp_controller: Arc<UtpController>,
     portalnet_config: PortalnetConfig,
     storage_config: PortalStorageConfig,
     header_oracle: Arc<RwLock<HeaderOracle>>,
@@ -55,7 +54,7 @@ pub async fn initialize_history_network(
     let (history_event_tx, history_event_rx) = mpsc::unbounded_channel::<OverlayRequest>();
     let history_network = HistoryNetwork::new(
         Arc::clone(discovery),
-        utp_socket,
+        utp_controller,
         storage_config,
         portalnet_config.clone(),
         header_oracle,

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use parking_lot::RwLock as PLRwLock;
 use tokio::sync::RwLock;
-use utp_rs::socket::UtpSocket;
 
 use ethportal_api::types::distance::XorMetric;
 use ethportal_api::types::enr::Enr;
@@ -10,9 +9,10 @@ use ethportal_api::types::portal_wire::ProtocolId;
 use ethportal_api::HistoryContentKey;
 use portalnet::{
     config::PortalnetConfig,
-    discovery::{Discovery, UtpEnr},
+    discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol},
     storage::{PortalStorage, PortalStorageConfig},
+    utp_controller::UtpController,
 };
 use trin_validation::oracle::HeaderOracle;
 
@@ -28,7 +28,7 @@ pub struct HistoryNetwork {
 impl HistoryNetwork {
     pub async fn new(
         discovery: Arc<Discovery>,
-        utp_socket: Arc<UtpSocket<UtpEnr>>,
+        utp_controller: Arc<UtpController>,
         storage_config: PortalStorageConfig,
         portal_config: PortalnetConfig,
         header_oracle: Arc<RwLock<HeaderOracle>>,
@@ -47,7 +47,7 @@ impl HistoryNetwork {
         let overlay = OverlayProtocol::new(
             config,
             discovery,
-            utp_socket,
+            utp_controller,
             storage,
             ProtocolId::History,
             validator,

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -9,16 +9,16 @@ use tokio::{
     task::JoinHandle,
 };
 use tracing::info;
-use utp_rs::socket::UtpSocket;
 
 use crate::{events::StateEvents, jsonrpc::StateRequestHandler};
 use ethportal_api::types::enr::Enr;
 use ethportal_api::types::jsonrpc::request::StateJsonRpcRequest;
 use portalnet::{
     config::PortalnetConfig,
-    discovery::{Discovery, UtpEnr},
+    discovery::Discovery,
     events::{EventEnvelope, OverlayRequest},
     storage::PortalStorageConfig,
+    utp_controller::UtpController,
 };
 use trin_validation::oracle::HeaderOracle;
 
@@ -37,7 +37,7 @@ type StateEventStream = Option<broadcast::Receiver<EventEnvelope>>;
 
 pub async fn initialize_state_network(
     discovery: &Arc<Discovery>,
-    utp_socket: Arc<UtpSocket<UtpEnr>>,
+    utp_controller: Arc<UtpController>,
     portalnet_config: PortalnetConfig,
     storage_config: PortalStorageConfig,
     header_oracle: Arc<RwLock<HeaderOracle>>,
@@ -52,7 +52,7 @@ pub async fn initialize_state_network(
     let (state_event_tx, state_event_rx) = mpsc::unbounded_channel::<OverlayRequest>();
     let state_network = StateNetwork::new(
         Arc::clone(discovery),
-        utp_socket,
+        utp_controller,
         storage_config,
         portalnet_config.clone(),
         header_oracle,

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use eth_trie::EthTrie;
 use parking_lot::RwLock as PLRwLock;
 use tokio::sync::RwLock;
-use utp_rs::socket::UtpSocket;
 
 use ethportal_api::types::distance::XorMetric;
 use ethportal_api::types::enr::Enr;
@@ -11,9 +10,10 @@ use ethportal_api::types::portal_wire::ProtocolId;
 use ethportal_api::StateContentKey;
 use portalnet::{
     config::PortalnetConfig,
-    discovery::{Discovery, UtpEnr},
+    discovery::Discovery,
     overlay::{OverlayConfig, OverlayProtocol},
     storage::{PortalStorage, PortalStorageConfig},
+    utp_controller::UtpController,
 };
 use trin_validation::oracle::HeaderOracle;
 
@@ -29,7 +29,7 @@ pub struct StateNetwork {
 impl StateNetwork {
     pub async fn new(
         discovery: Arc<Discovery>,
-        utp_socket: Arc<UtpSocket<UtpEnr>>,
+        utp_controller: Arc<UtpController>,
         storage_config: PortalStorageConfig,
         portal_config: PortalnetConfig,
         header_oracle: Arc<RwLock<HeaderOracle>>,
@@ -50,7 +50,7 @@ impl StateNetwork {
         let overlay = OverlayProtocol::new(
             config,
             discovery,
-            utp_socket,
+            utp_controller,
             storage,
             ProtocolId::State,
             validator,


### PR DESCRIPTION
### What was wrong?
If we started 100 brand new nodes we end up in a situation where nodes endlessly regossip to each other eating resources and driving the network to a crawl. A big issue was a node would accept multiple streams from multiple peers as well.

A proof of concept recreating this issue https://github.com/ethereum/trin/pull/1056
A deeper write up of this kind of problem https://github.com/ethereum/trin/pull/1056

This PR is meant to be a basic implementation of idea B, but written to allow for C and D to be built upon it. A part of this is the idea of creating a utp_connection controller a struct where we manage utp connections instead of doing it in overlay_service, which should we want to avoid adding more and more logic to. this utp_controller struct will have the soul job of managing uTP connections we have with other nodes, or at least that is the long term idea.
### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
