### PR TITLE
feat: add an instrument to portal-bridge for more clear logs

### DIFF
--- a/portal-bridge/README.md
+++ b/portal-bridge/README.md
@@ -2,7 +2,8 @@
 Process to feed the portal network by gossiping data retrieved from a trusted provider. Currently, this is only compatible with `Trin` & `Fluffy` clients.
 
 ex.
-```
+```sh
+git clone https://github.com/ethereum/portal-accumulators.git
 cargo run -p portal-bridge -- --node-count 1 --executable-path ./target/debug/trin --epoch-accumulator-path ./portal-accumulators trin
 ```
 

--- a/portal-bridge/src/bridge/beacon.rs
+++ b/portal-bridge/src/bridge/beacon.rs
@@ -8,7 +8,7 @@ use jsonrpsee::http_client::HttpClient;
 use serde_json::Value;
 use ssz_types::VariableList;
 use tokio::time::{interval, sleep, Duration, MissedTickBehavior};
-use tracing::{info, warn};
+use tracing::{info, warn, Instrument};
 
 use crate::api::consensus::ConsensusApi;
 use crate::constants::BEACON_GENESIS_TIME;
@@ -153,6 +153,7 @@ impl BeaconBridge {
                 &finalized_block_root,
                 slot_stats_clone,
             )
+            .in_current_span()
             .await
             .or_else(|err| {
                 warn!("Failed to serve light client bootstrap: {err}");
@@ -173,6 +174,7 @@ impl BeaconBridge {
                 current_period,
                 slot_stats_clone,
             )
+            .in_current_span()
             .await
             .or_else(|err| {
                 warn!("Failed to serve light client update: {err}");
@@ -192,6 +194,7 @@ impl BeaconBridge {
                 finalized_slot,
                 slot_stats_clone,
             )
+            .in_current_span()
             .await
             .or_else(|err| {
                 warn!("Failed to serve light client finality update: {err}");
@@ -205,6 +208,7 @@ impl BeaconBridge {
         let optimistic_update = tokio::spawn(async move {
             if let Err(err) =
                 Self::serve_light_client_optimistic_update(api, portal_clients, slot_stats_clone)
+                    .in_current_span()
                     .await
             {
                 warn!("Failed to serve light client optimistic update: {err}");

--- a/portal-bridge/src/gossip.rs
+++ b/portal-bridge/src/gossip.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use jsonrpsee::http_client::HttpClient;
 use tokio::time::{sleep, Duration};
-use tracing::{debug, warn};
+use tracing::{debug, warn, Instrument};
 
 use crate::stats::{BeaconSlotStats, HistoryBlockStats, StatsReporter};
 use ethportal_api::jsonrpsee::core::Error;
@@ -28,7 +28,9 @@ pub async fn gossip_beacon_content(
         let client = client.clone();
         let content_key = content_key.clone();
         let content_value = content_value.clone();
-        let result = tokio::spawn(beacon_trace_gossip(client, content_key, content_value)).await?;
+        let result =
+            tokio::spawn(beacon_trace_gossip(client, content_key, content_value).in_current_span())
+                .await?;
         results.push(result);
     }
     if let Ok(mut data) = slot_stats.lock() {
@@ -91,7 +93,10 @@ pub async fn gossip_history_content(
         let client = client.clone();
         let content_key = content_key.clone();
         let content_value = content_value.clone();
-        let result = tokio::spawn(history_trace_gossip(client, content_key, content_value)).await?;
+        let result = tokio::spawn(
+            history_trace_gossip(client, content_key, content_value).in_current_span(),
+        )
+        .await?;
         results.push(result);
     }
     if let Ok(mut data) = block_stats.lock() {

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use clap::Parser;
 use tokio::time::{sleep, Duration};
+use tracing::Instrument;
 
 use ethportal_api::jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use ethportal_api::types::cli::{DEFAULT_DISCOVERY_PORT, DEFAULT_WEB3_HTTP_PORT};
@@ -64,7 +65,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let beacon_bridge =
                 BeaconBridge::new(consensus_api, bridge_mode, Arc::new(portal_clients));
 
-            beacon_bridge.launch().await;
+            beacon_bridge
+                .launch()
+                .instrument(tracing::info_span!("beacon"))
+                .await;
         });
 
         bridge_tasks.push(bridge_handle);
@@ -86,7 +90,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 bridge_config.epoch_acc_path,
             );
 
-            bridge.launch().await;
+            bridge
+                .launch()
+                .instrument(tracing::info_span!("history"))
+                .await;
         });
 
         bridge_tasks.push(bridge_handle);


### PR DESCRIPTION
### What was wrong?
I was trying to read through bridge logs and I couldn't tell if they were coming from the history or beacon bridge. This makes grepping and debugging hard.
### How was it fixed?

with this change all the logs generated by the history bridge are marked by history and all the logs generated by the beacon bridge are tagged with beacon

```nim
2024-01-06T15:47:10.139336Z  INFO history: surf::middleware::logger::native: request completed    
2024-01-06T15:47:10.143257Z DEBUG history:send_async{method=POST uri=https://erigon-lighthouse.mainnet.eu1.ethpandaops.io/}:handler{id=8}: isahc::handler: Connection #0 to host erigon-lighthouse.mainnet.eu1.ethpandaops.io left intact
2024-01-06T15:47:10.290635Z DEBUG history: portal_bridge::bridge::history: Gossip: Block #18949112 Receipts
2024-01-06T15:47:10.321927Z DEBUG history: hyper::client::connect::http: connecting to 127.0.0.1:8545
2024-01-06T15:47:10.322390Z DEBUG history: hyper::client::connect::http: connecting to 127.0.0.1:8545
2024-01-06T15:47:10.322571Z DEBUG history: portal_bridge::gossip: Unable to locate content on network, after failing to gossip, retrying in 15s seconds. content key="0x028ae09f4a4939679fe55e0481dc24fc4a69ca9a87ba8c22dd8fe52b6597949352"
```

previously it was unclear for example which bridge generated ``DEBUG: portal_bridge::gossip``, but now it is marked ``DEBUG history: portal_bridge::gossip``

This also improves grepibility since you can just grep logs by network which is awesome.