### PR TITLE
style: remove check flag from makefile lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ help:
 		@echo "push-docker-image - push docker image"
 
 lint:
+		cargo +nightly fmt --all
 		cargo clippy --all --all-targets --all-features --no-deps -- --deny warnings
-		cargo +nightly fmt --all -- --check
 
 lint-unstable:
+		cargo +nightly fmt --all
 		cargo clippy --all --all-targets --all-features --no-deps -- -Wclippy::cargo
-		cargo +nightly fmt --all -- --check
 		RUSTFLAGS="-W unused_crate_dependencies" cargo build
 
 create-docker-image:


### PR DESCRIPTION
### What was wrong?
I'd rather remove the `--check` flag from the newly updated makefile `lint` commands. It makes sense to leverage the automatic correction of these lints rather than going through manually and fixing each error.

### How was it fixed?
Removed the flag from the makefile `lint` commands.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
