### PR TITLE
feat: add rate limit for history backfill. Will be opening a new PR with a different approach. Wrote write up here on why.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stdin"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1ff8b5d9b5ec29e0f49583ba71847b8c8888b67a8510133048a380903aa6822"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +647,17 @@ name = "async-task"
 version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+
+[[package]]
+name = "async-throttle"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c99532de164435a0b91279e715bff4fa0d164643b409a67761907ffc210ee8f"
+dependencies = [
+ "backoff",
+ "dashmap",
+ "tokio",
+]
 
 [[package]]
 name = "async-trait"
@@ -724,6 +744,20 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.11",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
 
 [[package]]
 name = "backtrace"
@@ -1371,6 +1405,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils 0.8.18",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1625,19 @@ dependencies = [
  "darling_core 0.20.3",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if 1.0.0",
+ "hashbrown 0.14.3",
+ "lock_api 0.4.11",
+ "once_cell",
+ "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -4478,6 +4534,7 @@ dependencies = [
  "surf",
  "test-log",
  "tokio",
+ "tokio-utils",
  "tracing",
  "tracing-subscriber",
  "trin-utils",
@@ -6010,6 +6067,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
+name = "shutdown-async"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2799e69bde7e68bedd86c6d94bffa783219114f1f31435ddda61f4aeba348ff"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6841,6 +6907,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-utils"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de75f75f464153a50fe48b9675360e3cf2ae1d7d81f9751363bd2ee4888f5ce8"
+dependencies = [
+ "async-stdin",
+ "async-throttle",
+ "shutdown-async",
+ "tub",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7242,6 +7320,16 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tub"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bca43faba247bc76eb1d6c1b8b561e4a1c5bdd427cc3d7a007faabea75c683a"
+dependencies = [
+ "crossbeam-queue",
+ "tokio",
+]
 
 [[package]]
 name = "typenum"

--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -34,6 +34,7 @@ pub async fn test_history_bridge(peertest: &Peertest, target: &HttpClient) {
         portal_clients,
         header_oracle,
         epoch_acc_path,
+        2,
     );
     bridge.launch().await;
     let (content_key, content_value) = fixture_header_with_proof_1000010();

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -36,6 +36,7 @@ serde_yaml = "0.9"
 ssz_types = "0.5.4"
 surf = "2.3.2"
 tokio = { version = "1.14.0", features = ["full"] }
+tokio-utils = "0.1.2"
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 trin-utils = { path = "../trin-utils" }

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -7,6 +7,7 @@ use url::Url;
 
 use crate::{
     client_handles::{fluffy_handle, trin_handle},
+    constants::DEFAULT_HISTORY_BACKFILL_RATE_LIMIT_SECONDS,
     types::{mode::BridgeMode, network::NetworkKind},
 };
 use ethportal_api::types::cli::check_private_key_length;
@@ -78,6 +79,13 @@ pub struct BridgeConfig {
         help = "Hex encoded 32 byte private key (with 0x prefix) (used as the root key for generating spaced private keys, if multiple nodes are selected)"
     )]
     pub root_private_key: Option<H256>,
+
+    #[arg(
+        default_value_t = DEFAULT_HISTORY_BACKFILL_RATE_LIMIT_SECONDS,
+        long,
+        help = "Lets you choose the rate you want to backfill so if you choose 2s 60s/2s=30 you will gossip 30 blocks a minute"
+    )]
+    pub history_backfill_rate_limit_seconds: u64,
 }
 
 fn check_node_count(val: &str) -> Result<u8, String> {

--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -26,3 +26,7 @@ pub const HEADER_WITH_PROOF_CONTENT_VALUE: &str =
 
 // Beacon chain mainnet genesis time: Tue Dec 01 2020 12:00:23 GMT+0000
 pub const BEACON_GENESIS_TIME: u64 = 1606824023;
+
+// This rate limits how long we wait to gossip a new block
+// with this default setting of 2 seconds, we will gossip 30 blocks a minute
+pub const DEFAULT_HISTORY_BACKFILL_RATE_LIMIT_SECONDS: u64 = 2;

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -92,6 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 portal_clients.expect("Failed to create history JSON-RPC clients"),
                 header_oracle,
                 bridge_config.epoch_acc_path,
+                bridge_config.history_backfill_rate_limit_seconds,
             );
 
             bridge


### PR DESCRIPTION
### What was wrong?
Here https://github.com/ethereum/trin/pull/1082#issuecomment-1883285454 Nick expressed concerns about backfill not being ratelimited to prevent pandaops from being overloaded.
### How was it fixed?
By using tokio_utils ratelimiter.  So now we get the combined benefits of the tokio:spawn solution and also a ratelimiter to not overwelm pandaops!