### PR TITLE
feat(bridge): add (semaphore to limit gossips) + (timeout on gossips) for history backfill

### DIFF
--- a/portal-bridge/src/bridge/history.rs
+++ b/portal-bridge/src/bridge/history.rs
@@ -185,7 +185,8 @@ impl HistoryBridge {
             start: start_block,
             end: end_block,
         };
-        // We are using a semaphore to limit the amount of active gossip transfers
+        // We are using a semaphore to limit the amount of active gossip transfers to make sure we
+        // don't overwhelm the trin client
         let gossip_send_semaphore = Arc::new(Semaphore::new(GOSSIP_LIMIT));
         while epoch_index <= current_epoch {
             // Using epoch_size chunks & epoch boundaries ensures that every


### PR DESCRIPTION
### What was wrong?
this is a new solution for https://github.com/ethereum/trin/pull/1087 me and nick jumped on a call and disscussed it and decided for each of us to take stabs at what we think the best solution is and compare them side to side and merge the best one.
### How was it fixed?

- By adding semaphore's to limit the amount of gossiping at a time.
- adding a timeout on serve_full_block() in case a timeout bug happens

