### PR TITLE
fix: remove `0x` prefix from trin node data directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4429,6 +4429,7 @@ dependencies = [
  "ethportal-api",
  "fnv",
  "futures 0.3.30",
+ "hex",
  "igd-next",
  "lazy_static",
  "leb128",

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -24,6 +24,7 @@ ethereum_ssz_derive = "0.5.3"
 ethportal-api = { path = "../ethportal-api" }
 fnv = "1.0.7"
 futures = "0.3.21"
+hex = "0.4.3"
 igd-next = "0.14.2"
 lazy_static = "1.4.0"
 leb128 = "0.2.1"

--- a/portalnet/src/utils/db.rs
+++ b/portalnet/src/utils/db.rs
@@ -66,7 +66,7 @@ pub fn configure_node_data_dir(
 fn get_node_data_dir(trin_data_dir: PathBuf, node_id: NodeId) -> PathBuf {
     // Append first 8 characters of Node ID
     let mut application_string = "trin_".to_owned();
-    let node_id_string = hex_encode(node_id.raw());
+    let node_id_string = hex::encode(node_id.raw());
     let suffix = &node_id_string[..8];
     application_string.push_str(suffix);
     trin_data_dir.join(application_string)


### PR DESCRIPTION
### What was wrong?

Fixes #941 

### How was it fixed?

Used `hex::encode` directly to encode node id.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
