### PR TITLE
feat(history bridge): add backfill by block range

### DIFF
--- a/portal-bridge/README.md
+++ b/portal-bridge/README.md
@@ -29,7 +29,7 @@ Current options include `"trin"` / `"fluffy"`.
 - `"--mode test:/path/to/test_data.json"`: gossip content keys & values found in test file.
 - `"--mode backfill:b100"`: start backfill at block #100
 - `"--mode backfill:e100"`: start backfill at epoch #100
-- `"--mode backfill:r10-12"`: backfill a block range start from #10 and go till #12
+- `"--mode backfill:r10-12"`: backfill a block range from #10 to #12 (inclusive)
 - `"--mode single:b100"`: gossip a single block #100
 - `"--mode single:e100"`: gossip a single epoch #100
 

--- a/portal-bridge/README.md
+++ b/portal-bridge/README.md
@@ -29,6 +29,7 @@ Current options include `"trin"` / `"fluffy"`.
 - `"--mode test:/path/to/test_data.json"`: gossip content keys & values found in test file.
 - `"--mode backfill:b100"`: start backfill at block #100
 - `"--mode backfill:e100"`: start backfill at epoch #100
+- `"--mode backfill:r10-12"`: backfill a block range start from #10 and go till #12
 - `"--mode single:b100"`: gossip a single block #100
 - `"--mode single:e100"`: gossip a single epoch #100
 

--- a/portal-bridge/src/bridge/history.rs
+++ b/portal-bridge/src/bridge/history.rs
@@ -150,8 +150,8 @@ impl HistoryBridge {
             "Error launching bridge in backfill mode. Unable to get latest block from provider.",
         );
         let (is_single_mode, mode_type) = match self.mode.clone() {
-            BridgeMode::Backfill(val) => (true, val),
-            BridgeMode::Single(val) => (false, val),
+            BridgeMode::Backfill(val) => (false, val),
+            BridgeMode::Single(val) => (true, val),
             _ => panic!("Invalid backfill mode"),
         };
         let (start_block, mut end_block) = match mode_type {
@@ -240,7 +240,7 @@ impl HistoryBridge {
             .await)
                 .is_err()
             {
-                error!("serve_full_block() timed out: this is an indication a bug is present")
+                error!("serve_full_block() timed out on height {height}: this is an indication a bug is present")
             };
             if let Some(permit) = permit {
                 drop(permit);

--- a/portal-bridge/src/bridge/history.rs
+++ b/portal-bridge/src/bridge/history.rs
@@ -154,21 +154,22 @@ impl HistoryBridge {
             BridgeMode::Single(val) => (false, val),
             _ => panic!("Invalid backfill mode"),
         };
-        let (mut start_block, mut end_block, mut epoch_index) = match mode_type {
-            // end block will be same for an epoch in single & backfill modes
-            ModeType::Epoch(epoch_number) => (
-                epoch_number * EPOCH_SIZE,
-                ((epoch_number + 1) * EPOCH_SIZE),
-                epoch_number,
-            ),
-            ModeType::Block(block) => {
-                let epoch_index = block / EPOCH_SIZE;
+        let (start_block, mut end_block) = match mode_type {
+            ModeType::Epoch(epoch_number) => {
                 let end_block = match looped {
-                    true => (epoch_index + 1) * EPOCH_SIZE,
+                    true => latest_block,
+                    false => (epoch_number + 1) * EPOCH_SIZE,
+                };
+                (epoch_number * EPOCH_SIZE, end_block)
+            }
+            ModeType::Block(block) => {
+                let end_block = match looped {
+                    true => latest_block,
                     false => block + 1,
                 };
-                (block, end_block, epoch_index)
+                (block, end_block)
             }
+            ModeType::BlockRange(start_block, end_block) => (start_block, end_block),
         };
         // check that the end block is not greater than the latest block
         if end_block > latest_block {
@@ -180,53 +181,46 @@ impl HistoryBridge {
                         Please specify a starting block/epoch that begins before the current block."
             );
         }
-        let current_epoch = latest_block / EPOCH_SIZE;
-        let mut gossip_range = Range {
+        let mut epoch_index_currently_on = start_block / EPOCH_SIZE;
+        let gossip_range = Range {
             start: start_block,
             end: end_block,
         };
+
         // We are using a semaphore to limit the amount of active gossip transfers to make sure we
         // don't overwhelm the trin client
         let gossip_send_semaphore = Arc::new(Semaphore::new(GOSSIP_LIMIT));
-        while epoch_index <= current_epoch {
+
+        info!("fetching headers in range: {gossip_range:?}");
+        let mut epoch_acc = None;
+        for height in gossip_range.clone() {
             // Using epoch_size chunks & epoch boundaries ensures that every
             // "chunk" shares an epoch accumulator avoiding the need to
             // look up the epoch acc on a header by header basis
-            let epoch_acc = if gossip_range.end <= MERGE_BLOCK_NUMBER {
-                match self.get_epoch_acc(epoch_index).await {
+            if gossip_range.end <= MERGE_BLOCK_NUMBER
+                && epoch_index_currently_on != height / EPOCH_SIZE
+            {
+                epoch_index_currently_on = height / EPOCH_SIZE;
+                epoch_acc = match self.get_epoch_acc(epoch_index_currently_on).await {
                     Ok(val) => Some(val),
                     Err(msg) => {
                         warn!("Unable to find epoch acc for gossip range: {gossip_range:?}. Skipping iteration: {msg:?}");
                         continue;
                     }
-                }
-            } else {
-                None
-            };
-            info!("fetching headers in range: {gossip_range:?}");
-            for height in gossip_range.clone() {
-                let permit = gossip_send_semaphore.clone().acquire_owned().await.expect(
-                    "acquire_owned() can only error on semaphore close, this should be impossible",
-                );
-                Self::spawn_serve_full_block(
-                    height,
-                    epoch_acc.clone(),
-                    self.portal_clients.clone(),
-                    self.execution_api.clone(),
-                    Some(permit),
-                );
+                };
+            } else if gossip_range.end > MERGE_BLOCK_NUMBER {
+                epoch_acc = None;
             }
-            if !looped {
-                break;
-            }
-            // update index values if we're looping
-            epoch_index += 1;
-            start_block = epoch_index * EPOCH_SIZE;
-            end_block = start_block + EPOCH_SIZE;
-            gossip_range = Range {
-                start: start_block,
-                end: end_block,
-            };
+            let permit = gossip_send_semaphore.clone().acquire_owned().await.expect(
+                "acquire_owned() can only error on semaphore close, this should be impossible",
+            );
+            Self::spawn_serve_full_block(
+                height,
+                epoch_acc.clone(),
+                self.portal_clients.clone(),
+                self.execution_api.clone(),
+                Some(permit),
+            );
         }
     }
 

--- a/portal-bridge/src/types/mode.rs
+++ b/portal-bridge/src/types/mode.rs
@@ -8,6 +8,8 @@ use trin_validation::constants::EPOCH_SIZE;
 ///   - ex: "e123" starts at epoch 123
 /// - Single: executes a single block
 ///   - ex: "b123" executes block 123
+/// - BlockRange: generates test data from block x to y
+///   - ex: "r10-12" starts from block 10 and goes till 12
 #[derive(Clone, Debug, PartialEq, Default, Eq)]
 pub enum BridgeMode {
     #[default]
@@ -55,6 +57,7 @@ impl FromStr for BridgeMode {
 pub enum ModeType {
     Epoch(u64),
     Block(u64),
+    BlockRange(u64, u64),
 }
 
 impl ModeType {
@@ -62,6 +65,7 @@ impl ModeType {
         match self {
             ModeType::Epoch(epoch) => epoch * EPOCH_SIZE as u64,
             ModeType::Block(block) => *block,
+            ModeType::BlockRange(_, end_block) => *end_block,
         }
     }
 }
@@ -81,6 +85,28 @@ impl FromStr for ModeType {
                     .parse()
                     .map_err(|_| "Invalid bridge mode arg: block number")?;
                 Ok(ModeType::Block(block))
+            }
+            "r" => {
+                let range_vec = s[1..]
+                    .split('-')
+                    .map(|x| {
+                        x.parse()
+                            .expect("Invalid bridge mode arg: range format invalid expected (x:y)")
+                    })
+                    .collect::<Vec<u64>>();
+
+                if range_vec.len() != 2 {
+                    return Err("Invalid bridge mode arg: expected 2 numbers in range");
+                }
+
+                let start_block = range_vec[0].to_owned();
+                let end_block = range_vec[1].to_owned();
+
+                if start_block > end_block {
+                    return Err("Invalid bridge mode arg: end_block is less than start_block");
+                }
+
+                Ok(ModeType::BlockRange(start_block, end_block))
             }
             _ => Err("Invalid bridge mode arg: type prefix"),
         }


### PR DESCRIPTION
### What was wrong?
Nick said he wanted backfill by block range for making his kurtosis tests. I already wrote most of the code for it in a previous PR so  here is the PR with that.

If this PR doesn't suit what you imagined Nick just close it and open a new one no biggy. I am not too picky about this, just thought it could save you some time which is why I mentioned it. If this PR is 90% percent the way there of course I would be happy to get this reviewed and merged.
### How was it fixed?
This includes the block range change + a quick refactor I did to make it so backfill used block ranges as a whole. This simplifes the code a lot and removes a whole while loop which is code. Functionally both of these will perform the same. Without this refactor adding the backfill via block range code felt awkward.