### PR TITLE
refactor: replace native implementation of this_or_that

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4057,6 +4057,7 @@ dependencies = [
  "portalnet",
  "reqwest",
  "serde",
+ "serde-this-or-that",
  "serde_json",
  "serde_yaml",
  "ssz-rs",

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -27,6 +27,7 @@ reqwest = { version = "0.11.13", default-features = false, features = ["json", "
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.85"
 serde_yaml = "0.9.14"
+serde-this-or-that = "0.4.2"
 ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "d09f55b4f8554491e3431e01af1c32347a8781cd" }
 ssz_types = "0.5.4"
 strum = { version = "0.25.0", features = ["derive"] }

--- a/light-client/src/config/checkpoints.rs
+++ b/light-client/src/config/checkpoints.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 
 use anyhow::anyhow;
 use ethereum_types::H256;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
+use serde_this_or_that::as_u64;
 
 use crate::config::networks;
 
@@ -21,29 +22,13 @@ pub struct RawSlotResponseData {
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Slot {
-    #[serde(deserialize_with = "str_or_u64")]
+    #[serde(deserialize_with = "as_u64")]
     pub slot: u64,
     pub block_root: Option<H256>,
     pub state_root: Option<H256>,
+    #[serde(deserialize_with = "as_u64")]
     pub epoch: u64,
     pub time: StartEndTime,
-}
-
-fn str_or_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum StrOrU64<'a> {
-        Str(&'a str),
-        U64(u64),
-    }
-
-    Ok(match StrOrU64::deserialize(deserializer)? {
-        StrOrU64::Str(v) => v.parse().unwrap_or(0), // Ignoring parsing errors
-        StrOrU64::U64(v) => v,
-    })
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
### What was wrong?
Ahhh, I knew I was forgetting an easier way to accomplish #1099 - this is the fix suggested in https://github.com/ethereum/trin/pull/1099#discussion_r1457142840

### How was it fixed?
- Replace native implementation of "this or that" logic for library version.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
