### PR TITLE
fix(bridge): use archive endpoint for backfill

### DIFF
--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -24,7 +24,9 @@ pub async fn test_history_bridge(peertest: &Peertest, target: &HttpClient) {
     let portal_clients = vec![target.clone()];
     let epoch_acc_path = "validation_assets/epoch_acc.bin".into();
     let mode = BridgeMode::Test("./test_assets/portalnet/bridge_data.json".into());
-    let execution_api = ExecutionApi::new(Provider::Test).await.unwrap();
+    let execution_api = ExecutionApi::new(Provider::Test, mode.clone())
+        .await
+        .unwrap();
     // Wait for bootnode to start
     sleep(Duration::from_secs(1)).await;
     let bridge = HistoryBridge::new(

--- a/portal-bridge/src/api/execution.rs
+++ b/portal-bridge/src/api/execution.rs
@@ -12,8 +12,11 @@ use url::Url;
 
 use crate::{
     cli::Provider,
-    constants::BASE_EL_ENDPOINT,
-    types::full_header::{FullHeader, FullHeaderBatch},
+    constants::{BASE_EL_ARCHIVE_ENDPOINT, BASE_EL_ENDPOINT},
+    types::{
+        full_header::{FullHeader, FullHeaderBatch},
+        mode::BridgeMode,
+    },
     PANDAOPS_CLIENT_ID, PANDAOPS_CLIENT_SECRET,
 };
 use ethportal_api::{
@@ -33,11 +36,15 @@ pub struct ExecutionApi {
 }
 
 impl ExecutionApi {
-    pub async fn new(provider: Provider) -> Result<Self, surf::Error> {
+    pub async fn new(provider: Provider, mode: BridgeMode) -> Result<Self, surf::Error> {
         let client = match &provider {
             Provider::PandaOps => {
-                let base_el_endpoint = Url::parse(BASE_EL_ENDPOINT)
-                    .expect("to be able to parse static base el endpoint url");
+                let endpoint = match mode {
+                    BridgeMode::Backfill(_) => BASE_EL_ARCHIVE_ENDPOINT,
+                    _ => BASE_EL_ENDPOINT,
+                };
+                let base_el_endpoint =
+                    Url::parse(endpoint).expect("to be able to parse static base el endpoint url");
                 Config::new()
                     .add_header("Content-Type", "application/json")?
                     .add_header("CF-Access-Client-Id", PANDAOPS_CLIENT_ID.to_string())?

--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -14,6 +14,8 @@ pub const BATCH_SIZE: u64 = 128;
 // Reth's archive node, has also exhibited some problems with the concurrent requests rate we
 // currently use.
 pub const BASE_EL_ENDPOINT: &str = "https://erigon-lighthouse.mainnet.eu1.ethpandaops.io/";
+// The `archive` endpoint appears to perform much better for backfill requests.
+pub const BASE_EL_ARCHIVE_ENDPOINT: &str = "https://archive.mainnet.ethpandaops.io/";
 /// Consensus layer PandaOps endpoint
 /// We use Nimbus as the CL client, because it supports light client data by default.
 pub const BASE_CL_ENDPOINT: &str = "https://nimbus.mainnet.ethpandaops.io/";

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -78,7 +78,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Launch History Network portal bridge
     if bridge_config.network.contains(&NetworkKind::History) {
-        let execution_api = ExecutionApi::new(bridge_config.el_provider).await?;
+        let execution_api =
+            ExecutionApi::new(bridge_config.el_provider, bridge_config.mode.clone()).await?;
         let bridge_handle = tokio::spawn(async move {
             let master_acc = MasterAccumulator::default();
             let header_oracle = HeaderOracle::new(master_acc);


### PR DESCRIPTION
### What was wrong?
After some initial testing, the `archive.mainnet.ethpandaops.io` endpoint is clearly superior to the `geth` / `erigon` endpoints w/ regards to successfully creating receipts (aka it has access to what I assume are receipts being pruned on `geth` / `erigon`).

### How was it fixed?
This is sort of a hotfix. While it will improve the amount of valid receipts making it into the network (which is a good thing), it's still not 100% from my experiments. Imo, we should go ahead and merge this update. But I'm happy to hold off on this change until we figure out why it's not quite hitting 100%.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
