### PR TITLE
fix: change backfill provider to erigon

### DIFF
--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -14,8 +14,8 @@ pub const BATCH_SIZE: u64 = 128;
 // Reth's archive node, has also exhibited some problems with the concurrent requests rate we
 // currently use.
 pub const BASE_EL_ENDPOINT: &str = "https://erigon-lighthouse.mainnet.eu1.ethpandaops.io/";
-// The `archive` endpoint appears to perform much better for backfill requests.
-pub const BASE_EL_ARCHIVE_ENDPOINT: &str = "https://archive.mainnet.ethpandaops.io/";
+// The `erigon` endpoint appears to perform much better for backfill requests.
+pub const BASE_EL_ARCHIVE_ENDPOINT: &str = "https://erigon-lighthouse.mainnet.eu1.ethpandaops.io/";
 /// Consensus layer PandaOps endpoint
 /// We use Nimbus as the CL client, because it supports light client data by default.
 pub const BASE_CL_ENDPOINT: &str = "https://nimbus.mainnet.ethpandaops.io/";


### PR DESCRIPTION
### What was wrong?
Ok, I was wrong in #1104 . After some experiments using #1106 and the error handling in #1108 , it's clear that the `erigon-*` endpoint is better at creating historical receipts. 

However, I do think it's useful to keep the distinction between a "backfill" endpoint and a "latest" endpoint.

It's still not perfect, but at least it appears to be competent in creating historical receipts that don't involve a "state_root". That pre-byzantium issue still needs addressing. 

### How was it fixed?
- Changed the endpoint.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
