### PR TITLE
feat: configure bridge provider via env variable

### DIFF
--- a/portal-bridge/src/api/consensus.rs
+++ b/portal-bridge/src/api/consensus.rs
@@ -4,9 +4,7 @@ use anyhow::anyhow;
 use surf::{Client, Config};
 use url::Url;
 
-use crate::{
-    cli::Provider, constants::BASE_CL_ENDPOINT, PANDAOPS_CLIENT_ID, PANDAOPS_CLIENT_SECRET,
-};
+use crate::{cli::Provider, BASE_CL_ENDPOINT, PANDAOPS_CLIENT_ID, PANDAOPS_CLIENT_SECRET};
 
 /// Implements endpoints from the Beacon API to access data from the consensus layer.
 #[derive(Clone, Debug, Default)]
@@ -18,7 +16,7 @@ impl ConsensusApi {
     pub async fn new(provider: Provider) -> Result<Self, surf::Error> {
         let client = match provider {
             Provider::PandaOps => {
-                let base_cl_endpoint = Url::parse(BASE_CL_ENDPOINT)
+                let base_cl_endpoint = Url::parse(&BASE_CL_ENDPOINT)
                     .expect("to be able to parse static base cl endpoint url");
                 Config::new()
                     .add_header("CF-Access-Client-Id", PANDAOPS_CLIENT_ID.to_string())?

--- a/portal-bridge/src/api/execution.rs
+++ b/portal-bridge/src/api/execution.rs
@@ -14,9 +14,8 @@ use url::Url;
 
 use crate::{
     cli::Provider,
-    constants::{BASE_EL_ARCHIVE_ENDPOINT, BASE_EL_ENDPOINT},
     types::{full_header::FullHeader, mode::BridgeMode},
-    PANDAOPS_CLIENT_ID, PANDAOPS_CLIENT_SECRET,
+    BASE_EL_ARCHIVE_ENDPOINT, BASE_EL_ENDPOINT, PANDAOPS_CLIENT_ID, PANDAOPS_CLIENT_SECRET,
 };
 use ethportal_api::{
     types::{
@@ -53,11 +52,11 @@ impl ExecutionApi {
         let client = match &provider {
             Provider::PandaOps => {
                 let endpoint = match mode {
-                    BridgeMode::Backfill(_) => BASE_EL_ARCHIVE_ENDPOINT,
-                    _ => BASE_EL_ENDPOINT,
+                    BridgeMode::Backfill(_) => BASE_EL_ARCHIVE_ENDPOINT.to_string(),
+                    _ => BASE_EL_ENDPOINT.to_string(),
                 };
                 let base_el_endpoint =
-                    Url::parse(endpoint).expect("to be able to parse static base el endpoint url");
+                    Url::parse(&endpoint).expect("to be able to parse static base el endpoint url");
                 Config::new()
                     .add_header("Content-Type", "application/json")?
                     .add_header("CF-Access-Client-Id", PANDAOPS_CLIENT_ID.to_string())?

--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -3,23 +3,6 @@
 // successful response rate. This number may change in the future.
 pub const BATCH_SIZE: u64 = 128;
 
-// PANDAOPS refers to the group of clients provisioned by the EF devops team.
-// These are only intended to be used by core team members who have access to the nodes.
-// If you don't have access to the PANDAOPS nodes, but still want to use the bridge feature, let us
-// know on Discord or Github and we'll prioritize support for any provider.
-//
-/// Execution layer PandaOps endpoint
-// This endpoint points towards an archive node (erigon) and skips dshackle (by using el-cl url
-// format), shackle is known to be somewhat buggy has caused some invalid responses.
-// Reth's archive node, has also exhibited some problems with the concurrent requests rate we
-// currently use.
-pub const BASE_EL_ENDPOINT: &str = "https://erigon-lighthouse.mainnet.eu1.ethpandaops.io/";
-// The `erigon` endpoint appears to perform much better for backfill requests.
-pub const BASE_EL_ARCHIVE_ENDPOINT: &str = "https://erigon-lighthouse.mainnet.eu1.ethpandaops.io/";
-/// Consensus layer PandaOps endpoint
-/// We use Nimbus as the CL client, because it supports light client data by default.
-pub const BASE_CL_ENDPOINT: &str = "https://nimbus.mainnet.ethpandaops.io/";
-
 /// History * content key & value
 pub const HEADER_WITH_PROOF_CONTENT_KEY: &str =
     "0x006251d65b8a8668efabe2f89c96a5b6332d83b3bbe585089ea6b2ab9b6754f5e9";

--- a/portal-bridge/src/lib.rs
+++ b/portal-bridge/src/lib.rs
@@ -14,9 +14,31 @@ pub mod utils;
 use lazy_static::lazy_static;
 use std::env;
 
+// PANDAOPS refers to the group of clients provisioned by the EF devops team.
+// These are only intended to be used by core team members who have access to the nodes.
+//
+/// Execution layer PandaOps endpoint
+// This endpoint points towards an archive node (erigon) and skips dshackle (by using el-cl url
+// format), shackle is known to be somewhat buggy has caused some invalid responses.
+// Reth's archive node, has also exhibited some problems with the concurrent requests rate we
+// currently use.
+const DEFAULT_BASE_EL_ENDPOINT: &str = "https://erigon-lighthouse.mainnet.eu1.ethpandaops.io/";
+// The `erigon` endpoint appears to perform much better for backfill requests.
+const DEFAULT_BASE_EL_ARCHIVE_ENDPOINT: &str =
+    "https://erigon-lighthouse.mainnet.eu1.ethpandaops.io/";
+/// Consensus layer PandaOps endpoint
+/// We use Nimbus as the CL client, because it supports light client data by default.
+const DEFAULT_BASE_CL_ENDPOINT: &str = "https://nimbus.mainnet.ethpandaops.io/";
+
 lazy_static! {
     pub static ref PANDAOPS_CLIENT_ID: String =
         env::var("PANDAOPS_CLIENT_ID").expect("PANDAOPS_CLIENT_ID env var not set.");
     pub static ref PANDAOPS_CLIENT_SECRET: String =
         env::var("PANDAOPS_CLIENT_SECRET").expect("PANDAOPS_CLIENT_SECRET env var not set.");
+    static ref BASE_EL_ENDPOINT: String =
+        env::var("BASE_EL_ENDPOINT").unwrap_or_else(|_| DEFAULT_BASE_EL_ENDPOINT.to_string());
+    static ref BASE_EL_ARCHIVE_ENDPOINT: String = env::var("BASE_EL_ARCHIVE_ENDPOINT")
+        .unwrap_or_else(|_| DEFAULT_BASE_EL_ARCHIVE_ENDPOINT.to_string());
+    static ref BASE_CL_ENDPOINT: String =
+        env::var("BASE_CL_ENDPOINT").unwrap_or_else(|_| DEFAULT_BASE_CL_ENDPOINT.to_string());
 }


### PR DESCRIPTION
### What was wrong?
We need a better way to switch between pandaops provider endpoints. For example, the `erigon` nodes went down the other day, breaking our bridge. The only way to change this would be to update the hardcoded `BASE_*_ENDPOINT` variables, then cut a new release, and then deploy the new release. With this change, we can simply change the env variable in the deployment scripts and re-run the deployments. 

*Note* - These env variables will override the default values for pandaops endpoints. If the user selects a non-pandaops provider via the cli flag, the env variables will be ignored. 

### How was it fixed?
- Added the feature to select the pandaops provider endpoint via env variable

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
