### PR TITLE
feat: add instructions for glados deployment

### DIFF
--- a/book/src/developers/contributing/releases/deployment.md
+++ b/book/src/developers/contributing/releases/deployment.md
@@ -53,6 +53,9 @@ This step directs Ansible to use the current master version of trin. Read [about
 - Make sure you've pulled the latest master branch of the deployment scripts, to include any recent changes: `git pull origin master`
 - Go into Portal section of Ansible: `cd portal-network/trin/ansible/`
 - Run the deployment: `ansible-playbook playbook.yml --tags trin`
+- Run Glados deployment
+  - `cd ../../glados/ansible`
+  - `ansible-playbook playbook.yml --tags trin`
 - Wait for completion
 - Launch a fresh trin node, check it against the bootnodes
 - ssh into random nodes, one of each kind, to check the logs:
@@ -65,7 +68,6 @@ This step directs Ansible to use the current master version of trin. Read [about
 		- regular nodes: all remaining ips
   - check logs, ignoring DEBUG: `sudo docker logs trin -n 1000 | grep -v DEBUG`
 - Check monitoring tools to see if network health is the same or better as before deployment. Glados might lag for 10-15 minutes, so keep checking back.
-- ?? Also release glados, to use the latest trin ??
 
 ### Communicate
 

--- a/book/src/developers/contributing/releases/deployment.md
+++ b/book/src/developers/contributing/releases/deployment.md
@@ -53,9 +53,9 @@ This step directs Ansible to use the current master version of trin. Read [about
 - Make sure you've pulled the latest master branch of the deployment scripts, to include any recent changes: `git pull origin master`
 - Go into Portal section of Ansible: `cd portal-network/trin/ansible/`
 - Run the deployment: `ansible-playbook playbook.yml --tags trin`
-- Run Glados deployment
+- Run Glados deployment: updates glados + portal client (currently configured as trin, but this could change)
   - `cd ../../glados/ansible`
-  - `ansible-playbook playbook.yml --tags trin`
+  - `ansible-playbook playbook.yml --tags glados`
 - Wait for completion
 - Launch a fresh trin node, check it against the bootnodes
 - ssh into random nodes, one of each kind, to check the logs:


### PR DESCRIPTION
### What was wrong?
supercedes https://github.com/ethereum/trin/pull/1119 We didn't have instructions to do glados's deployment

Also glados's ansible playbook was broken glados Trin instance hasn't been updated in 6 weeks https://github.com/ethereum/cluster/pull/923 here is the fix
![image](https://github.com/ethereum/trin/assets/31669092/cf552c8c-ae4f-4b7a-940a-883342a6c10c)
^ before ansible fix
![image](https://github.com/ethereum/trin/assets/31669092/7b52e8d2-5cdb-4de0-8fa4-2a57caaae13a)
^ after ansible fix
### How was it fixed?
Wrote the instructions and fixed the playbook