### PR TITLE
Feat: --ephemeral should use a non-default port solution

### DIFF
--- a/portalnet/src/config.rs
+++ b/portalnet/src/config.rs
@@ -43,11 +43,11 @@ impl Default for PortalnetConfig {
 }
 
 impl PortalnetConfig {
-    pub fn new(trin_config: &TrinConfig, private_key: H256) -> Self {
+    pub fn new(trin_config: &TrinConfig, private_key: H256, discovery_port: u16) -> Self {
         Self {
             external_addr: trin_config.external_addr,
             private_key,
-            listen_port: trin_config.discovery_port,
+            listen_port: discovery_port,
             no_stun: trin_config.no_stun,
             no_upnp: trin_config.no_upnp,
             bootnodes: trin_config.bootnodes.clone(),


### PR DESCRIPTION
### What was wrong?
Fixes: https://github.com/ethereum/trin/issues/919
If someone was using a default port and used --ephemeral twice in a row, or run ephemeral and then a non-ephemeral run. Because a bunch of former peers are contacting you on that port, expecting a different public key, your logs get flooded with warnings about incoming packets that can't be decoded
### How was it fixed?
This code sets the discovery port. If in ephemeral mode with the default port, it generates a random port between 30000 and 60000 otherwise it uses the specified discovery port to avoid log flooding issues during consecutive ephemeral runs or mode switches.

