### PR TITLE
feat(bridge): add EL api ratelimit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3015,6 +3015,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "821239e5672ff23e2a7060901fa622950bbd80b649cdaadd78d1c1767ed14eb4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dashmap",
+ "futures 0.3.30",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot 0.12.1",
+ "quanta",
+ "rand 0.8.5",
+ "smallvec 1.12.0",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4016,6 +4034,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4230,6 +4257,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4249,6 +4282,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -4822,6 +4861,7 @@ dependencies = [
  "snap",
  "ssz_types",
  "surf",
+ "surf-governor",
  "test-log",
  "tokio",
  "tracing",
@@ -5048,6 +5088,22 @@ dependencies = [
  "rand_xorshift 0.3.0",
  "regex-syntax 0.8.2",
  "unarray",
+]
+
+[[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils 0.8.19",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5292,6 +5348,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -6802,6 +6867,18 @@ dependencies = [
  "serde",
  "serde_json",
  "web-sys",
+]
+
+[[package]]
+name = "surf-governor"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5072d041267e6b28a6a75a8737a03660ccc7fe8d9d70e8176388206a1e356fb8"
+dependencies = [
+ "governor",
+ "http-types",
+ "lazy_static",
+ "surf",
 ]
 
 [[package]]

--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -11,6 +11,7 @@ use portal_bridge::{
     api::{consensus::ConsensusApi, execution::ExecutionApi},
     bridge::{beacon::BeaconBridge, history::HistoryBridge},
     cli::Provider,
+    constants::EL_PROVIDER_REQUEST_LIMIT,
     types::mode::BridgeMode,
 };
 use serde_json::Value;
@@ -24,7 +25,7 @@ pub async fn test_history_bridge(peertest: &Peertest, target: &HttpClient) {
     let portal_clients = vec![target.clone()];
     let epoch_acc_path = "validation_assets/epoch_acc.bin".into();
     let mode = BridgeMode::Test("./test_assets/portalnet/bridge_data.json".into());
-    let execution_api = ExecutionApi::new(Provider::Test, mode.clone())
+    let execution_api = ExecutionApi::new(Provider::Test, mode.clone(), EL_PROVIDER_REQUEST_LIMIT)
         .await
         .unwrap();
     // Wait for bootnode to start

--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -11,7 +11,7 @@ use portal_bridge::{
     api::{consensus::ConsensusApi, execution::ExecutionApi},
     bridge::{beacon::BeaconBridge, history::HistoryBridge},
     cli::Provider,
-    constants::EL_PROVIDER_REQUEST_LIMIT,
+    constants::PROVIDER_DAILY_REQUEST_LIMIT,
     types::mode::BridgeMode,
 };
 use serde_json::Value;
@@ -25,9 +25,10 @@ pub async fn test_history_bridge(peertest: &Peertest, target: &HttpClient) {
     let portal_clients = vec![target.clone()];
     let epoch_acc_path = "validation_assets/epoch_acc.bin".into();
     let mode = BridgeMode::Test("./test_assets/portalnet/bridge_data.json".into());
-    let execution_api = ExecutionApi::new(Provider::Test, mode.clone(), EL_PROVIDER_REQUEST_LIMIT)
-        .await
-        .unwrap();
+    let execution_api =
+        ExecutionApi::new(Provider::Test, mode.clone(), PROVIDER_DAILY_REQUEST_LIMIT)
+            .await
+            .unwrap();
     // Wait for bootnode to start
     sleep(Duration::from_secs(1)).await;
     let bridge = HistoryBridge::new(

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -37,6 +37,7 @@ serde_yaml = "0.9"
 snap = "1.1.1"
 ssz_types = "0.5.4"
 surf = { version = "2.3.2", default-features = false, features = ["h1-client-rustls", "middleware-logger", "encoding"] } # we use rustils because OpenSSL cause issues compiling on aarch64
+surf-governor = "0.2.0"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"

--- a/portal-bridge/src/api/consensus.rs
+++ b/portal-bridge/src/api/consensus.rs
@@ -42,7 +42,7 @@ impl ConsensusApi {
                 )))
             }
         };
-        // Limits requests to no more then daily_request_limit / SECONDS_IN_A_DAY per a second
+        // Limits the number of requests sent to the CL provider in a day
         let period = Duration::from_secs_f64(daily_request_limit / SECONDS_IN_A_DAY);
         let rate_limit = GovernorMiddleware::with_period(period)
             .expect("Expect GovernerMiddleware should have received a valid Duration");

--- a/portal-bridge/src/api/execution.rs
+++ b/portal-bridge/src/api/execution.rs
@@ -15,6 +15,7 @@ use url::Url;
 
 use crate::{
     cli::Provider,
+    constants::SECONDS_IN_A_DAY,
     types::{full_header::FullHeader, mode::BridgeMode},
     BASE_EL_ARCHIVE_ENDPOINT, BASE_EL_ENDPOINT, PANDAOPS_CLIENT_ID, PANDAOPS_CLIENT_SECRET,
 };
@@ -52,13 +53,9 @@ impl ExecutionApi {
     pub async fn new(
         provider: Provider,
         mode: BridgeMode,
-        requests_allowed_per_day: f64,
+        daily_request_limit: f64,
     ) -> Result<Self, surf::Error> {
-        // Limits requests to no more then requests_allowed_per_day / 86400.0 per a second
-        let period = Duration::from_secs_f64(requests_allowed_per_day / 86400.0);
-        let rate_limit = GovernorMiddleware::with_period(period)
-            .expect("Expect GovnernorMiddleware should have received a valid Duration");
-        let client = match &provider {
+        let client: Client = match &provider {
             Provider::PandaOps => {
                 let endpoint = match mode {
                     BridgeMode::Backfill(_) => BASE_EL_ARCHIVE_ENDPOINT.to_string(),
@@ -66,7 +63,7 @@ impl ExecutionApi {
                 };
                 let base_el_endpoint =
                     Url::parse(&endpoint).expect("to be able to parse static base el endpoint url");
-                let client: Client = Config::new()
+                Config::new()
                     .add_header("Content-Type", "application/json")?
                     .add_header("CF-Access-Client-Id", PANDAOPS_CLIENT_ID.to_string())?
                     .add_header(
@@ -74,21 +71,19 @@ impl ExecutionApi {
                         PANDAOPS_CLIENT_SECRET.to_string(),
                     )?
                     .set_base_url(base_el_endpoint)
-                    .try_into()?;
-                client.with(rate_limit).with(Retry::default())
+                    .try_into()?
             }
-            Provider::Url(url) => {
-                let client: Client = Config::new()
-                    .add_header("Content-Type", "application/json")?
-                    .set_base_url(url.clone())
-                    .try_into()?;
-                client.with(rate_limit).with(Retry::default())
-            }
-            Provider::Test => {
-                let client: Client = Config::new().try_into()?;
-                client.with(rate_limit).with(Retry::default())
-            }
+            Provider::Url(url) => Config::new()
+                .add_header("Content-Type", "application/json")?
+                .set_base_url(url.clone())
+                .try_into()?,
+            Provider::Test => Config::new().try_into()?,
         };
+        // Limits requests to no more then daily_request_limit / SECONDS_IN_A_DAY per a second
+        let period = Duration::from_secs_f64(daily_request_limit / SECONDS_IN_A_DAY);
+        let rate_limit = GovernorMiddleware::with_period(period)
+            .expect("Expect GovernerMiddleware should have received a valid Duration");
+        let client = client.with(rate_limit).with(Retry::default());
         // Only check that provider is connected & available if not using a test provider.
         if provider != Provider::Test {
             check_provider(&client).await?;

--- a/portal-bridge/src/api/execution.rs
+++ b/portal-bridge/src/api/execution.rs
@@ -79,7 +79,7 @@ impl ExecutionApi {
                 .try_into()?,
             Provider::Test => Config::new().try_into()?,
         };
-        // Limits requests to no more then daily_request_limit / SECONDS_IN_A_DAY per a second
+        // Limits the number of requests sent to the EL provider in a day
         let period = Duration::from_secs_f64(daily_request_limit / SECONDS_IN_A_DAY);
         let rate_limit = GovernorMiddleware::with_period(period)
             .expect("Expect GovernerMiddleware should have received a valid Duration");
@@ -337,7 +337,7 @@ async fn construct_proof(
 pub struct Retry {
     attempts: u8,
 }
-
+code
 impl Retry {
     pub fn new(attempts: u8) -> Self {
         Retry { attempts }

--- a/portal-bridge/src/api/execution.rs
+++ b/portal-bridge/src/api/execution.rs
@@ -337,7 +337,7 @@ async fn construct_proof(
 pub struct Retry {
     attempts: u8,
 }
-code
+
 impl Retry {
     pub fn new(attempts: u8) -> Self {
         Retry { attempts }

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -7,6 +7,7 @@ use url::Url;
 
 use crate::{
     client_handles::{fluffy_handle, trin_handle},
+    constants::EL_PROVIDER_REQUEST_LIMIT,
     types::{mode::BridgeMode, network::NetworkKind},
 };
 use ethportal_api::types::cli::check_private_key_length;
@@ -92,6 +93,13 @@ pub struct BridgeConfig {
         help = "Data provider for consensus layer data. (\"pandaops\" / local node url)"
     )]
     pub cl_provider: Provider,
+
+    #[arg(
+        long = "el-provider-request-limit",
+        help = "Limits the amount of EL provider requests request day_limit / 86400 seconds. Ex. if set to 86400 we will only send EL 1 request a second",
+        default_value_t = EL_PROVIDER_REQUEST_LIMIT,
+    )]
+    pub el_provider_request_limit: f64,
 }
 
 fn check_node_count(val: &str) -> Result<u8, String> {

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -2,15 +2,15 @@ use std::{path::PathBuf, str::FromStr};
 
 use clap::{Parser, Subcommand};
 use ethereum_types::H256;
+use ethportal_api::types::cli::check_private_key_length;
 use tokio::process::Child;
 use url::Url;
 
 use crate::{
     client_handles::{fluffy_handle, trin_handle},
-    constants::EL_PROVIDER_REQUEST_LIMIT,
+    constants::PROVIDER_DAILY_REQUEST_LIMIT,
     types::{mode::BridgeMode, network::NetworkKind},
 };
-use ethportal_api::types::cli::check_private_key_length;
 
 // max value of 16 b/c...
 // - reliably calculate spaced private keys in a reasonable time
@@ -95,11 +95,11 @@ pub struct BridgeConfig {
     pub cl_provider: Provider,
 
     #[arg(
-        long = "el-provider-request-limit",
-        help = "Limits the amount of EL provider requests request day_limit / 86400 seconds. Ex. if set to 86400 we will only send EL 1 request a second",
-        default_value_t = EL_PROVIDER_REQUEST_LIMIT,
+        long = "provider-daily-request-limit",
+        help = "Maximum number of requests sent to the provider in a day.",
+        default_value_t = PROVIDER_DAILY_REQUEST_LIMIT,
     )]
-    pub el_provider_request_limit: f64,
+    pub provider_daily_request_limit: f64,
 }
 
 fn check_node_count(val: &str) -> Result<u8, String> {

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -95,11 +95,18 @@ pub struct BridgeConfig {
     pub cl_provider: Provider,
 
     #[arg(
-        long = "provider-daily-request-limit",
-        help = "Maximum number of requests sent to the provider in a day.",
+        long = "el-provider-daily-request-limit",
+        help = "Maximum number of requests execution layer sent to the provider in a day.",
         default_value_t = PROVIDER_DAILY_REQUEST_LIMIT,
     )]
-    pub provider_daily_request_limit: f64,
+    pub el_provider_daily_request_limit: f64,
+
+    #[arg(
+        long = "cl-provider-daily-request-limit",
+        help = "Maximum number of requests consensus layer sent to the provider in a day.",
+        default_value_t = PROVIDER_DAILY_REQUEST_LIMIT,
+    )]
+    pub cl_provider_daily_request_limit: f64,
 }
 
 fn check_node_count(val: &str) -> Result<u8, String> {

--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -12,4 +12,5 @@ pub const HEADER_WITH_PROOF_CONTENT_VALUE: &str =
 // Beacon chain mainnet genesis time: Tue Dec 01 2020 12:00:23 GMT+0000
 pub const BEACON_GENESIS_TIME: u64 = 1606824023;
 
-pub const EL_PROVIDER_REQUEST_LIMIT: f64 = 1_000_000.0;
+pub const PROVIDER_DAILY_REQUEST_LIMIT: f64 = 1_000_000.0;
+pub const SECONDS_IN_A_DAY: f64 = 86400.0;

--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -11,3 +11,5 @@ pub const HEADER_WITH_PROOF_CONTENT_VALUE: &str =
 
 // Beacon chain mainnet genesis time: Tue Dec 01 2020 12:00:23 GMT+0000
 pub const BEACON_GENESIS_TIME: u64 = 1606824023;
+
+pub const EL_PROVIDER_REQUEST_LIMIT: f64 = 1_000_000.0;

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -78,8 +78,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Launch History Network portal bridge
     if bridge_config.network.contains(&NetworkKind::History) {
-        let execution_api =
-            ExecutionApi::new(bridge_config.el_provider, bridge_config.mode.clone()).await?;
+        let execution_api = ExecutionApi::new(
+            bridge_config.el_provider,
+            bridge_config.mode.clone(),
+            bridge_config.el_provider_request_limit,
+        )
+        .await?;
         let bridge_handle = tokio::spawn(async move {
             let master_acc = MasterAccumulator::default();
             let header_oracle = HeaderOracle::new(master_acc);

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -62,7 +62,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let portal_clients = portal_clients
             .clone()
             .expect("Failed to create beacon JSON-RPC clients");
-        let consensus_api = ConsensusApi::new(bridge_config.cl_provider).await?;
+        let consensus_api = ConsensusApi::new(
+            bridge_config.cl_provider,
+            bridge_config.provider_daily_request_limit,
+        )
+        .await?;
         let bridge_handle = tokio::spawn(async move {
             let beacon_bridge =
                 BeaconBridge::new(consensus_api, bridge_mode, Arc::new(portal_clients));
@@ -81,7 +85,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let execution_api = ExecutionApi::new(
             bridge_config.el_provider,
             bridge_config.mode.clone(),
-            bridge_config.el_provider_request_limit,
+            bridge_config.provider_daily_request_limit,
         )
         .await?;
         let bridge_handle = tokio::spawn(async move {

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .expect("Failed to create beacon JSON-RPC clients");
         let consensus_api = ConsensusApi::new(
             bridge_config.cl_provider,
-            bridge_config.provider_daily_request_limit,
+            bridge_config.cl_provider_daily_request_limit,
         )
         .await?;
         let bridge_handle = tokio::spawn(async move {
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let execution_api = ExecutionApi::new(
             bridge_config.el_provider,
             bridge_config.mode.clone(),
-            bridge_config.provider_daily_request_limit,
+            bridge_config.el_provider_daily_request_limit,
         )
         .await?;
         let bridge_handle = tokio::spawn(async move {


### PR DESCRIPTION
### What was wrong?
Depending on the EL provider we can overwhelm it with requests. Or some providers have a request limit per a day. This is a problem because we don't want to overwhelm/(go over our api limit on something like infura)
### How was it fixed?
By adding surf_govener api rate limiter