### PR TITLE
refactor: refactor serialization for content key and values

### DIFF
--- a/ethportal-api/src/lib.rs
+++ b/ethportal-api/src/lib.rs
@@ -40,6 +40,7 @@ pub use types::{
         beacon::{BeaconContentValue, PossibleBeaconContentValue},
         error::ContentValueError,
         history::{HistoryContentValue, PossibleHistoryContentValue},
+        state::{PossibleStateContentValue, StateContentValue},
     },
     execution::{block_body::*, header::*, receipts::*},
 };

--- a/ethportal-api/src/types/content_key/overlay.rs
+++ b/ethportal-api/src/types/content_key/overlay.rs
@@ -1,6 +1,6 @@
 use crate::{
     types::content_key::error::ContentKeyError,
-    utils::bytes::{hex_encode, hex_encode_compact},
+    utils::bytes::{hex_decode, hex_encode, hex_encode_compact},
 };
 use quickcheck::{Arbitrary, Gen};
 use std::fmt;
@@ -8,16 +8,22 @@ use std::fmt;
 /// Types whose values represent keys to lookup content items in an overlay network.
 /// Keys are serializable.
 pub trait OverlayContentKey:
-    Into<Vec<u8>> + TryFrom<Vec<u8>> + Clone + fmt::Debug + fmt::Display
+    Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ContentKeyError> + Clone + fmt::Debug + fmt::Display
 {
     /// Returns the identifier for the content referred to by the key.
     /// The identifier locates the content in the overlay.
     fn content_id(&self) -> [u8; 32];
     /// Returns the bytes of the content key.
     fn to_bytes(&self) -> Vec<u8>;
+
     /// Returns the content key as a hex encoded "0x"-prefixed string.
     fn to_hex(&self) -> String {
         hex_encode(self.to_bytes())
+    }
+    /// Returns the content key from a hex encoded "0x"-prefixed string.
+    fn from_hex(data: &str) -> anyhow::Result<Self> {
+        let bytes = hex_decode(&data.to_lowercase())?;
+        Ok(Self::try_from(bytes)?)
     }
 }
 

--- a/ethportal-api/src/types/content_value/mod.rs
+++ b/ethportal-api/src/types/content_value/mod.rs
@@ -1,4 +1,7 @@
-use crate::ContentValueError;
+use crate::{
+    utils::bytes::{hex_decode, hex_encode},
+    ContentValueError,
+};
 
 pub mod beacon;
 pub mod constants;
@@ -12,4 +15,13 @@ pub trait ContentValue: Sized {
     fn encode(&self) -> Vec<u8>;
     /// Decodes `buf` into a content value.
     fn decode(buf: &[u8]) -> Result<Self, ContentValueError>;
+
+    /// Encodes the content as "0x"-prefixed hex string.
+    fn to_hex(&self) -> String {
+        hex_encode(self.encode())
+    }
+    /// Decodes the "0x"-prefixed hex string as a content value.
+    fn from_hex(data: &str) -> anyhow::Result<Self> {
+        Ok(Self::decode(&hex_decode(data)?)?)
+    }
 }

--- a/ethportal-api/src/types/mod.rs
+++ b/ethportal-api/src/types/mod.rs
@@ -16,4 +16,5 @@ pub mod node_id;
 pub mod portal;
 pub mod portal_wire;
 pub mod query_trace;
+pub mod state;
 pub mod state_trie;

--- a/ethportal-api/src/types/state.rs
+++ b/ethportal-api/src/types/state.rs
@@ -1,0 +1,38 @@
+use super::query_trace::QueryTrace;
+use crate::{types::enr::Enr, PossibleStateContentValue, StateContentKey};
+use serde::{Deserialize, Serialize};
+
+/// Response for FindContent & RecursiveFindContent endpoints
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ContentInfo {
+    #[serde(rename_all = "camelCase")]
+    ConnectionId { connection_id: u16 },
+    #[serde(rename_all = "camelCase")]
+    Content {
+        content: PossibleStateContentValue,
+        utp_transfer: bool,
+    },
+    #[serde(rename_all = "camelCase")]
+    Enrs { enrs: Vec<Enr> },
+}
+
+/// Parsed response for TraceRecursiveFindContent endpoint
+///
+/// The RPC response encodes absent content as "0x". This struct
+/// represents the content info, using None for absent content.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TraceContentInfo {
+    pub content: PossibleStateContentValue,
+    pub utp_transfer: bool,
+    pub trace: QueryTrace,
+}
+
+/// Response for PaginateLocalContentKeys endpoint
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PaginateLocalContentInfo {
+    pub content_keys: Vec<StateContentKey>,
+    pub total_entries: u64,
+}

--- a/ethportal-api/src/utils/bytes.rs
+++ b/ethportal-api/src/utils/bytes.rs
@@ -26,7 +26,7 @@ pub fn hex_decode(data: &str) -> Result<Vec<u8>, ByteUtilsError> {
         data: data.to_string(),
     })?;
 
-    if first_two != "0x" {
+    if first_two.to_lowercase() != "0x" {
         return Err(ByteUtilsError::WrongPrefix {
             first_two: first_two.to_string(),
         });

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -16,7 +16,6 @@ use ethportal_api::{
     BeaconContentKey, BeaconContentValue, OverlayContentKey, RawContentKey,
 };
 use serde_json::{json, Value};
-use ssz::Encode;
 use tokio::sync::{mpsc, Mutex, RwLock};
 use tracing::error;
 use trin_storage::ContentStore;
@@ -314,7 +313,7 @@ async fn offer(
             Err(msg) => Err(format!("Populated Offer request timeout: {msg:?}")),
         }
     } else {
-        let content_key: Vec<RawContentKey> = vec![content_key.as_ssz_bytes()];
+        let content_key: Vec<RawContentKey> = vec![content_key.to_bytes()];
         match overlay.send_offer(content_key, enr).await {
             Ok(accept) => Ok(json!(AcceptInfo {
                 content_keys: accept.content_keys,

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -118,12 +118,11 @@ pub struct BeaconStorage {
 impl ContentStore for BeaconStorage {
     fn get<K: OverlayContentKey>(&self, key: &K) -> Result<Option<Vec<u8>>, ContentStoreError> {
         let content_key: Vec<u8> = key.clone().into();
-        let beacon_content_key =
-            BeaconContentKey::from_ssz_bytes(content_key.as_slice()).map_err(|err| {
-                ContentStoreError::InvalidData {
-                    message: format!("Error deserializing BeaconContentKey value: {err:?}"),
-                }
-            })?;
+        let beacon_content_key = BeaconContentKey::try_from(content_key).map_err(|err| {
+            ContentStoreError::InvalidData {
+                message: format!("Error deserializing BeaconContentKey value: {err:?}"),
+            }
+        })?;
 
         match beacon_content_key {
             BeaconContentKey::LightClientBootstrap(_) => {
@@ -198,12 +197,11 @@ impl ContentStore for BeaconStorage {
         key: &K,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
         let content_key: Vec<u8> = key.clone().into();
-        let beacon_content_key =
-            BeaconContentKey::from_ssz_bytes(content_key.as_slice()).map_err(|err| {
-                ContentStoreError::InvalidData {
-                    message: format!("Error deserializing BeaconContentKey value: {err:?}"),
-                }
-            })?;
+        let beacon_content_key = BeaconContentKey::try_from(content_key).map_err(|err| {
+            ContentStoreError::InvalidData {
+                message: format!("Error deserializing BeaconContentKey value: {err:?}"),
+            }
+        })?;
 
         match beacon_content_key {
             BeaconContentKey::LightClientBootstrap(_) => {
@@ -343,7 +341,7 @@ impl BeaconStorage {
                 }
             }
             Some(&LIGHT_CLIENT_UPDATES_BY_RANGE_KEY_PREFIX) => {
-                if let Ok(update) = BeaconContentKey::from_ssz_bytes(content_key.as_slice()) {
+                if let Ok(update) = BeaconContentKey::try_from(content_key) {
                     match update {
                         BeaconContentKey::LightClientUpdatesByRange(update) => {
                             // Build a range of values starting with update.start_period and len

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -15,7 +15,6 @@ use ethportal_api::{
     ContentValue, HistoryContentKey, OverlayContentKey, RawContentKey,
 };
 use serde_json::{json, Value};
-use ssz::Encode;
 use tokio::sync::{mpsc, Mutex, RwLock};
 use tracing::error;
 use trin_storage::ContentStore;
@@ -328,7 +327,7 @@ async fn offer(
             Err(msg) => Err(format!("Populated Offer request timeout: {msg:?}")),
         }
     } else {
-        let content_key: Vec<RawContentKey> = vec![content_key.as_ssz_bytes()];
+        let content_key: Vec<RawContentKey> = vec![content_key.to_bytes()];
         match overlay.send_offer(content_key, enr).await {
             Ok(accept) => Ok(json!(AcceptInfo {
                 content_keys: accept.content_keys,

--- a/trin-validation/src/accumulator.rs
+++ b/trin-validation/src/accumulator.rs
@@ -285,7 +285,7 @@ mod test {
         // Validate content_key decodes
         let raw_ck = obj.get("content_key").unwrap().as_str().unwrap();
         let raw_ck = hex_decode(raw_ck).unwrap();
-        let ck = HistoryContentKey::from_ssz_bytes(&raw_ck).unwrap();
+        let ck = HistoryContentKey::try_from(raw_ck).unwrap();
         match ck {
             HistoryContentKey::BlockHeaderWithProof(_) => (),
             _ => panic!("Invalid test, content key decoded improperly"),


### PR DESCRIPTION
### What was wrong?

There was repetative logic for serializaion and deserialization of the `<T>ContentKey` and `<T>ContentValue` types.
The state types also didn't implement it yet.

### How was it fixed?

- Refactored functions by extracting common functions into `OverlayContentKey` and `ContentValue` types, and reusing them.
- Implementing missing logic in state types

fix: #1114

### To-Do

- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
