### PR TITLE
refactor: replace VariableList<u8, X> with ByteListX types

### DIFF
--- a/ethportal-api/src/types/bytes.rs
+++ b/ethportal-api/src/types/bytes.rs
@@ -1,3 +1,7 @@
 use ssz_types::{typenum, VariableList};
 
-pub type ByteList = VariableList<u8, typenum::U2048>;
+pub type ByteList32 = VariableList<u8, typenum::U32>;
+pub type ByteList1024 = VariableList<u8, typenum::U1024>;
+pub type ByteList2048 = VariableList<u8, typenum::U2048>;
+pub type ByteList32K = VariableList<u8, typenum::U32768>;
+pub type ByteList1G = VariableList<u8, typenum::U1073741824>;

--- a/ethportal-api/src/types/consensus/body.rs
+++ b/ethportal-api/src/types/consensus/body.rs
@@ -1,4 +1,4 @@
-use crate::types::consensus::execution_payload::ExecutionPayload;
+use crate::types::{bytes::ByteList1G, consensus::execution_payload::ExecutionPayload};
 use ethereum_types::H256;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -28,7 +28,7 @@ pub struct SyncAggregate {
     pub sync_committee_signature: BlsSignature,
 }
 
-pub type Transaction = VariableList<u8, typenum::U1073741824>;
+pub type Transaction = ByteList1G;
 pub type Transactions = VariableList<Transaction, typenum::U1048576>;
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Decode, Encode)]

--- a/ethportal-api/src/types/consensus/execution_payload.rs
+++ b/ethportal-api/src/types/consensus/execution_payload.rs
@@ -1,6 +1,9 @@
 use super::serde::{de_hex_to_txs, de_number_to_u256, se_hex_to_number, se_txs_to_hex};
 use crate::{
-    types::consensus::{body::Transactions, fork::ForkName},
+    types::{
+        bytes::ByteList32,
+        consensus::{body::Transactions, fork::ForkName},
+    },
     utils::serde::{hex_fixed_vec, hex_var_list},
 };
 use ethereum_types::{H160, H256, U256};
@@ -8,12 +11,12 @@ use serde::{Deserialize, Serialize};
 use serde_this_or_that::as_u64;
 use ssz::Decode;
 use ssz_derive::{Decode, Encode};
-use ssz_types::{typenum, FixedVector, VariableList};
+use ssz_types::{typenum, FixedVector};
 use superstruct::superstruct;
 use tree_hash_derive::TreeHash;
 
 pub type Bloom = FixedVector<u8, typenum::U256>;
-pub type ExtraData = VariableList<u8, typenum::U32>;
+pub type ExtraData = ByteList32;
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Encode, Decode)]
 pub struct ExecutionPayload {

--- a/ethportal-api/src/types/consensus/serde.rs
+++ b/ethportal-api/src/types/consensus/serde.rs
@@ -45,7 +45,7 @@ where
     let mut txs: Transactions = VariableList::empty();
     for r in result {
         let tx = hex_decode(&r).map_err(serde::de::Error::custom)?;
-        let tx: Transaction = VariableList::from(tx);
+        let tx = Transaction::from(tx);
         if txs.push(tx).is_err() {
             return Err(serde::de::Error::custom("Unable to deserialize txs"));
         }

--- a/ethportal-api/src/types/execution/header.rs
+++ b/ethportal-api/src/types/execution/header.rs
@@ -7,7 +7,7 @@ use ssz::{Encode, SszDecoderBuilder, SszEncoder};
 use ssz_derive::{Decode, Encode};
 
 use crate::{
-    types::bytes::ByteList,
+    types::bytes::ByteList2048,
     utils::bytes::{hex_decode, hex_encode},
 };
 
@@ -314,9 +314,9 @@ impl ssz::Encode for HeaderWithProof {
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
         let header = rlp::encode(&self.header).to_vec();
-        let header: ByteList = ByteList::from(header);
-        let offset =
-            <ByteList as Encode>::ssz_fixed_len() + <AccumulatorProof as Encode>::ssz_fixed_len();
+        let header = ByteList2048::from(header);
+        let offset = <ByteList2048 as Encode>::ssz_fixed_len()
+            + <AccumulatorProof as Encode>::ssz_fixed_len();
         let mut encoder = SszEncoder::container(buf, offset);
         encoder.append(&header);
         encoder.append(&self.proof);
@@ -325,7 +325,7 @@ impl ssz::Encode for HeaderWithProof {
 
     fn ssz_bytes_len(&self) -> usize {
         let header = rlp::encode(&self.header).to_vec();
-        let header: ByteList = ByteList::from(header);
+        let header = ByteList2048::from(header);
         header.len() + self.proof.ssz_bytes_len()
     }
 }
@@ -352,7 +352,7 @@ impl ssz::Decode for HeaderWithProof {
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
         let mut builder = SszDecoderBuilder::new(bytes);
 
-        builder.register_type::<ByteList>()?;
+        builder.register_type::<ByteList2048>()?;
         builder.register_type::<BlockHeaderProof>()?;
 
         let mut decoder = builder.build()?;

--- a/ethportal-api/src/types/portal_wire.rs
+++ b/ethportal-api/src/types/portal_wire.rs
@@ -17,7 +17,7 @@ use validator::ValidationError;
 
 use crate::{
     types::{
-        bytes::ByteList,
+        bytes::ByteList2048,
         distance::Distance,
         enr::{Enr, SszEnr},
     },
@@ -70,7 +70,7 @@ pub const MAX_PORTAL_CONTENT_PAYLOAD_SIZE: usize = MAX_DISCV5_TALK_REQ_PAYLOAD_S
 /// Custom payload element of Ping and Pong overlay messages
 #[derive(Debug, PartialEq, Clone)]
 pub struct CustomPayload {
-    payload: ByteList,
+    payload: ByteList2048,
 }
 
 impl TryFrom<&Value> for CustomPayload {
@@ -87,7 +87,7 @@ impl TryFrom<&Value> for CustomPayload {
             ))?,
         };
         Ok(Self {
-            payload: ByteList::from(payload),
+            payload: ByteList2048::from(payload),
         })
     }
 }
@@ -95,7 +95,7 @@ impl TryFrom<&Value> for CustomPayload {
 impl From<Vec<u8>> for CustomPayload {
     fn from(ssz_bytes: Vec<u8>) -> Self {
         Self {
-            payload: ByteList::from(ssz_bytes),
+            payload: ByteList2048::from(ssz_bytes),
         }
     }
 }
@@ -114,7 +114,7 @@ impl ssz::Decode for CustomPayload {
 
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
         Ok(Self {
-            payload: ByteList::from(bytes.to_vec()),
+            payload: ByteList2048::from(bytes.to_vec()),
         })
     }
 }

--- a/ethportal-api/src/types/state_trie/mod.rs
+++ b/ethportal-api/src/types/state_trie/mod.rs
@@ -2,12 +2,14 @@ pub mod nibbles;
 
 use ssz_types::{typenum, VariableList};
 
+use super::bytes::{ByteList1024, ByteList32K};
+
 /// The RLP encoding of a trie node.
-pub type EncodedTrieNode = VariableList<u8, typenum::U1024>;
+pub type EncodedTrieNode = ByteList1024;
 
 /// The ordered list of trie nodes. Together they make the path in a trie, first node being the
 /// root, last node being the node whose inclusion we are proving.
 pub type TrieProof = VariableList<EncodedTrieNode, typenum::U65>;
 
 /// The bytecode of the contract. Current maximum size is 24KB, but we are using 32KB to be safe.
-pub type ByteCode = VariableList<u8, typenum::U32768>;
+pub type ByteCode = ByteList32K;

--- a/ethportal-api/src/types/state_trie/nibbles.rs
+++ b/ethportal-api/src/types/state_trie/nibbles.rs
@@ -2,7 +2,8 @@ use std::fmt;
 
 use anyhow::{bail, ensure, Result};
 use ssz_derive::{Decode, Encode};
-use ssz_types::{typenum, VariableList};
+
+use crate::types::bytes::ByteList32;
 
 /// Packed representation of a path in a trie.
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
@@ -11,7 +12,7 @@ pub struct Nibbles {
     pub is_odd_length: bool,
     /// List of pairs of nibbles packed together in single byte. If length is odd, then the highest
     /// bits of the first byte are zero.
-    pub packed_nibbles: VariableList<u8, typenum::U32>,
+    pub packed_nibbles: ByteList32,
 }
 
 impl Nibbles {
@@ -25,7 +26,7 @@ impl Nibbles {
             .collect::<Result<Vec<u8>>>()?;
         Ok(Self {
             is_odd_length: nibbles.len() % 2 == 1,
-            packed_nibbles: VariableList::new(packed_nibbles)
+            packed_nibbles: ByteList32::new(packed_nibbles)
                 .map_err(|e| anyhow::anyhow!("Error while packing nibbles: {e:?}"))?,
         })
     }
@@ -81,35 +82,35 @@ mod test {
         &[],
         Nibbles {
             is_odd_length: false,
-            packed_nibbles: VariableList::default(),
+            packed_nibbles: ByteList32::default(),
         }
     )]
     #[case::single_nibble(
         &[10],
         Nibbles {
             is_odd_length: true,
-            packed_nibbles: VariableList::from(vec![0x0a]),
+            packed_nibbles: ByteList32::from(vec![0x0a]),
         }
     )]
     #[case::even_number_of_nibbles(
         &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
         Nibbles {
             is_odd_length: false,
-            packed_nibbles: VariableList::from(vec![0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]),
+            packed_nibbles: ByteList32::from(vec![0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]),
         }
     )]
     #[case::odd_number_of_nibbles(
         &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
         Nibbles {
             is_odd_length: true,
-            packed_nibbles: VariableList::from(vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd]),
+            packed_nibbles: ByteList32::from(vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd]),
         }
     )]
     #[case::max_number_of_nibbles(
         &[10; 64],
         Nibbles {
             is_odd_length: false,
-            packed_nibbles: VariableList::from(vec![0xaa; 32]),
+            packed_nibbles: ByteList32::from(vec![0xaa; 32]),
         }
     )]
     fn packing_unpacking(#[case] unpacked_nibbles: &[u8], #[case] nibbles: Nibbles) -> Result<()> {
@@ -127,35 +128,35 @@ mod test {
         "0x0005000000",
         Nibbles {
             is_odd_length: false,
-            packed_nibbles: VariableList::default(),
+            packed_nibbles: ByteList32::default(),
         }
     )]
     #[case::single_nibble(
         "0x01050000000a",
         Nibbles {
             is_odd_length: true,
-            packed_nibbles: VariableList::from(vec![0x0a]),
+            packed_nibbles: ByteList32::from(vec![0x0a]),
         }
     )]
     #[case::even_number_of_nibbles(
         "0x0005000000123456789abc",
         Nibbles {
             is_odd_length: false,
-            packed_nibbles: VariableList::from(vec![0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]),
+            packed_nibbles: ByteList32::from(vec![0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]),
         }
     )]
     #[case::odd_number_of_nibbles(
         "0x01050000000123456789abcd",
         Nibbles {
             is_odd_length: true,
-            packed_nibbles: VariableList::from(vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd]),
+            packed_nibbles: ByteList32::from(vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd]),
         }
     )]
     #[case::max_number_of_nibbles(
         "0x0005000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         Nibbles {
             is_odd_length: false,
-            packed_nibbles: VariableList::from(vec![0xaa; 32]),
+            packed_nibbles: ByteList32::from(vec![0xaa; 32]),
         }
     )]
     fn ssz_encode_decode(#[case] ssz_bytes: &str, #[case] nibbles: Nibbles) -> Result<()> {


### PR DESCRIPTION
### What was wrong?

I noticed that we have a type called `ByteList`, which was just:
```
type ByteList = VariableList<u8, typenum::U2048>;
```

I liked the idea considering that `VariableList<u8, ...>` is somewhat common, but I didn't like that the length is somehow assumed.

### How was it fixed?

I renamed the type to `ByteList2048` and I introduced similar types (for lengths that appear in the codebase).

### To-Do

- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
