### PR TITLE
chore: fix github release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,6 @@ jobs:
         # https://github.com/openethereum/openethereum/blob/main/.github/workflows/build.yml
         run: |
           body=$(cat <<- "ENDBODY"
-          <Release Name>
 
           ## Testing Checklist (DELETE ME)
 
@@ -211,7 +210,7 @@ jobs:
           )
           assets=()
           for asset in ./trin-*.tar.gz*; do
-              assets+=("-a" "$asset/$asset")
+              assets+=("$asset/$asset")
           done
           tag_name="${{ env.VERSION }}"
           echo "$body" | gh release create --draft -t "Trin $tag_name" -F "-" "$tag_name" "${assets[@]}" 


### PR DESCRIPTION
### What was wrong?
Another fix of github release workflow

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
