### PR TITLE
feat(bridge): add support for gossiping from era1 files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4853,6 +4853,7 @@ dependencies = [
  "jsonrpsee",
  "lazy_static",
  "portalnet",
+ "rand 0.8.5",
  "rlp",
  "rstest 0.18.2",
  "serde",

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -30,6 +30,7 @@ jsonrpsee = { version = "0.20.0", features = [
 ] }
 lazy_static = "1.4.0"
 portalnet = { path = "../portalnet" }
+rand = "0.8.4"
 rlp = "0.5.0"
 serde = { version = "1.0.150", features = ["derive", "rc"] }
 serde_json = "1.0.89"

--- a/portal-bridge/src/api/execution.rs
+++ b/portal-bridge/src/api/execution.rs
@@ -324,7 +324,7 @@ impl ExecutionApi {
 }
 
 /// Create a proof for the given header / epoch acc
-async fn construct_proof(
+pub async fn construct_proof(
     header: Header,
     epoch_acc: &EpochAccumulator,
 ) -> anyhow::Result<HeaderWithProof> {

--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -1,0 +1,297 @@
+use std::{
+    fs,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+
+use anyhow::ensure;
+use futures::future::join_all;
+use rand::{seq::SliceRandom, thread_rng};
+use tokio::{
+    sync::{OwnedSemaphorePermit, Semaphore},
+    task::JoinHandle,
+    time::timeout,
+};
+use tracing::{debug, error, info, warn};
+
+use crate::{
+    api::execution::construct_proof,
+    bridge::{
+        history::{GOSSIP_LIMIT, SERVE_BLOCK_TIMEOUT},
+        utils::lookup_epoch_acc,
+    },
+    gossip::gossip_history_content,
+    stats::{HistoryBlockStats, StatsReporter},
+    types::era1::{BlockTuple, Era1},
+};
+use ethportal_api::{
+    jsonrpsee::http_client::HttpClient, types::execution::accumulator::EpochAccumulator,
+    BlockBodyKey, BlockHeaderKey, BlockReceiptsKey, EpochAccumulatorKey, HistoryContentKey,
+    HistoryContentValue,
+};
+use trin_validation::{
+    accumulator::MasterAccumulator, constants::EPOCH_SIZE, oracle::HeaderOracle,
+};
+
+pub struct Era1Bridge {
+    pub portal_clients: Vec<HttpClient>,
+    pub header_oracle: HeaderOracle,
+    pub epoch_acc_path: PathBuf,
+    pub era1_files: Vec<PathBuf>,
+}
+
+// todo: fetch era1 files from pandaops source
+// todo: validate via checksum, so we don't have to validate content on a per-value basis
+impl Era1Bridge {
+    pub fn new(
+        portal_clients: Vec<HttpClient>,
+        header_oracle: HeaderOracle,
+        epoch_acc_path: PathBuf,
+    ) -> anyhow::Result<Self> {
+        let era1_dir: Result<Vec<std::fs::DirEntry>, std::io::Error> =
+            fs::read_dir(PathBuf::from("./test_assets/era1"))?.collect();
+        let era1_files: Vec<PathBuf> = era1_dir?.into_iter().map(|entry| entry.path()).collect();
+        Ok(Self {
+            portal_clients,
+            header_oracle,
+            epoch_acc_path,
+            era1_files,
+        })
+    }
+
+    pub async fn launch(&self) {
+        info!("Launching era1 bridge");
+        let mut era1_files = self.era1_files.clone();
+        era1_files.shuffle(&mut thread_rng());
+        for era1_path in era1_files.into_iter() {
+            info!("Processing era1 file at path: {:?}", era1_path);
+            // We are using a semaphore to limit the amount of active gossip transfers to make sure
+            // we don't overwhelm the trin client
+            let gossip_send_semaphore = Arc::new(Semaphore::new(GOSSIP_LIMIT));
+
+            let era1 = Era1::read_from_file(
+                era1_path
+                    .clone()
+                    .into_os_string()
+                    .into_string()
+                    .expect("to be able to convert era1 path into string"),
+            )
+            .unwrap_or_else(|_| panic!("to be able to read era1 file from path: {era1_path:?}"));
+            let epoch_index = era1.block_tuples[0].header.header.number / EPOCH_SIZE as u64;
+            info!("Era1 file read successfully, gossiping block tuples for epoch: {epoch_index}");
+            let epoch_acc = match self.get_epoch_acc(epoch_index).await {
+                Ok(epoch_acc) => epoch_acc,
+                Err(e) => {
+                    error!("Failed to get epoch acc for epoch: {epoch_index}, error: {e}");
+                    continue;
+                }
+            };
+            let master_acc = Arc::new(self.header_oracle.master_acc.clone());
+            let mut serve_block_tuple_handles = vec![];
+            for block_tuple in era1.block_tuples {
+                let permit = gossip_send_semaphore
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .expect("to be able to acquire semaphore");
+                let serve_block_tuple_handle = Self::spawn_serve_block_tuple(
+                    self.portal_clients.clone(),
+                    block_tuple,
+                    epoch_acc.clone(),
+                    master_acc.clone(),
+                    permit,
+                );
+                serve_block_tuple_handles.push(serve_block_tuple_handle);
+            }
+            // Wait till all block tuples are done gossiping.
+            // This can't deadlock, because the tokio::spawn has a timeout.
+            join_all(serve_block_tuple_handles).await;
+        }
+    }
+
+    async fn get_epoch_acc(&self, epoch_index: u64) -> anyhow::Result<Arc<EpochAccumulator>> {
+        let (epoch_hash, epoch_acc) = lookup_epoch_acc(
+            epoch_index,
+            &self.header_oracle.master_acc,
+            &self.epoch_acc_path,
+        )
+        .await?;
+        // Gossip epoch acc to network if found locally
+        let content_key = HistoryContentKey::EpochAccumulator(EpochAccumulatorKey { epoch_hash });
+        let content_value = HistoryContentValue::EpochAccumulator(epoch_acc.clone());
+        // create unique stats for epoch accumulator, since it's rarely gossiped
+        let block_stats = Arc::new(Mutex::new(HistoryBlockStats::new(
+            epoch_index * EPOCH_SIZE as u64,
+        )));
+        debug!("Built EpochAccumulator for Epoch #{epoch_index:?}: now gossiping.");
+        // spawn gossip in new thread to avoid blocking
+        let portal_clients = self.portal_clients.clone();
+        tokio::spawn(async move {
+            if let Err(msg) =
+                gossip_history_content(&portal_clients, content_key, content_value, block_stats)
+                    .await
+            {
+                warn!("Failed to gossip epoch accumulator: {msg}");
+            }
+        });
+        Ok(Arc::new(epoch_acc))
+    }
+
+    fn spawn_serve_block_tuple(
+        portal_clients: Vec<HttpClient>,
+        block_tuple: BlockTuple,
+        epoch_acc: Arc<EpochAccumulator>,
+        master_acc: Arc<MasterAccumulator>,
+        permit: OwnedSemaphorePermit,
+    ) -> JoinHandle<()> {
+        let number = block_tuple.header.header.number;
+        info!("Spawning serve_block_tuple for block at height: {number}",);
+        let block_stats = Arc::new(Mutex::new(HistoryBlockStats::new(number)));
+        tokio::spawn(async move {
+            match timeout(
+                SERVE_BLOCK_TIMEOUT,
+                Self::serve_block_tuple(
+                    portal_clients,
+                    block_tuple,
+                    epoch_acc,
+                    master_acc,
+                    block_stats.clone(),
+                )).await
+                {
+                Ok(result) => match result {
+                    Ok(_) => debug!("Successfully served block: {number}"),
+                    Err(msg) => warn!("Error serving block: {number}: {msg:?}"),
+                },
+                Err(_) => error!("serve_full_block() timed out on height {number}: this is an indication a bug is present")
+            };
+            drop(permit);
+        })
+    }
+
+    async fn serve_block_tuple(
+        portal_clients: Vec<HttpClient>,
+        block_tuple: BlockTuple,
+        epoch_acc: Arc<EpochAccumulator>,
+        master_acc: Arc<MasterAccumulator>,
+        block_stats: Arc<Mutex<HistoryBlockStats>>,
+    ) -> anyhow::Result<()> {
+        info!(
+            "Serving block tuple at height: {}",
+            block_tuple.header.header.number
+        );
+        if let Err(msg) = Self::construct_and_gossip_header(
+            portal_clients.clone(),
+            block_tuple.clone(),
+            epoch_acc,
+            master_acc,
+            block_stats.clone(),
+        )
+        .await
+        {
+            warn!(
+                "Error serving block tuple header at height: {:?} - {:?}",
+                block_tuple.header.header.number, msg
+            );
+        }
+
+        if let Err(msg) = Self::construct_and_gossip_block_body(
+            portal_clients.clone(),
+            block_tuple.clone(),
+            block_stats.clone(),
+        )
+        .await
+        {
+            warn!(
+                "Error serving block tuple block body at height: {:?} - {:?}",
+                block_tuple.header.header.number, msg
+            );
+        }
+
+        if let Err(msg) = Self::construct_and_gossip_receipts(
+            portal_clients.clone(),
+            block_tuple.clone(),
+            block_stats.clone(),
+        )
+        .await
+        {
+            warn!(
+                "Error serving block tuple receipts at height: {:?} - {:?}",
+                block_tuple.header.header.number, msg
+            );
+        }
+        Ok(())
+    }
+
+    async fn construct_and_gossip_header(
+        portal_clients: Vec<HttpClient>,
+        block_tuple: BlockTuple,
+        epoch_acc: Arc<EpochAccumulator>,
+        master_acc: Arc<MasterAccumulator>,
+        block_stats: Arc<Mutex<HistoryBlockStats>>,
+    ) -> anyhow::Result<()> {
+        let header = block_tuple.header.header;
+        // Fetch HeaderRecord from EpochAccumulator for validation
+        let header_index = header.number % EPOCH_SIZE as u64;
+        let header_record = &epoch_acc[header_index as usize];
+
+        // Validate Header
+        let actual_header_hash = header.hash();
+
+        ensure!(
+            header_record.block_hash == actual_header_hash,
+            "Header hash doesn't match record in local accumulator: {:?} - {:?}",
+            actual_header_hash,
+            header_record.block_hash
+        );
+
+        // Construct HistoryContentKey
+        let content_key = HistoryContentKey::BlockHeaderWithProof(BlockHeaderKey {
+            block_hash: header.hash().to_fixed_bytes(),
+        });
+        // Construct HeaderWithProof
+        let header_with_proof = construct_proof(header.clone(), &epoch_acc).await?;
+        // Double check that the proof is valid
+        master_acc.validate_header_with_proof(&header_with_proof)?;
+        // Construct HistoryContentValue
+        let content_value = HistoryContentValue::BlockHeaderWithProof(header_with_proof);
+
+        gossip_history_content(
+            // remove borrow
+            &portal_clients,
+            content_key,
+            content_value,
+            block_stats,
+        )
+        .await
+    }
+
+    async fn construct_and_gossip_block_body(
+        portal_clients: Vec<HttpClient>,
+        block_tuple: BlockTuple,
+        block_stats: Arc<Mutex<HistoryBlockStats>>,
+    ) -> anyhow::Result<()> {
+        let header = block_tuple.header.header;
+        // Construct HistoryContentKey
+        let content_key = HistoryContentKey::BlockBody(BlockBodyKey {
+            block_hash: header.hash().to_fixed_bytes(),
+        });
+        // Construct HistoryContentValue
+        let content_value = HistoryContentValue::BlockBody(block_tuple.body.body);
+        gossip_history_content(&portal_clients, content_key, content_value, block_stats).await
+    }
+
+    async fn construct_and_gossip_receipts(
+        portal_clients: Vec<HttpClient>,
+        block_tuple: BlockTuple,
+        block_stats: Arc<Mutex<HistoryBlockStats>>,
+    ) -> anyhow::Result<()> {
+        let header = block_tuple.header.header;
+        // Construct HistoryContentKey
+        let content_key = HistoryContentKey::BlockReceipts(BlockReceiptsKey {
+            block_hash: header.hash().to_fixed_bytes(),
+        });
+        // Construct HistoryContentValue
+        let content_value = HistoryContentValue::Receipts(block_tuple.receipts.receipts);
+        gossip_history_content(&portal_clients, content_key, content_value, block_stats).await
+    }
+}

--- a/portal-bridge/src/bridge/mod.rs
+++ b/portal-bridge/src/bridge/mod.rs
@@ -1,2 +1,4 @@
 pub mod beacon;
+pub mod era1;
 pub mod history;
+pub mod utils;

--- a/portal-bridge/src/bridge/utils.rs
+++ b/portal-bridge/src/bridge/utils.rs
@@ -1,0 +1,30 @@
+use anyhow::anyhow;
+use ethereum_types::H256;
+use ethportal_api::{types::execution::accumulator::EpochAccumulator, utils::bytes::hex_encode};
+use ssz::Decode;
+use std::{fs, path::Path};
+use trin_validation::accumulator::MasterAccumulator;
+
+/// Lookup the epoch accumulator & epoch hash for the given epoch index.
+pub async fn lookup_epoch_acc(
+    epoch_index: u64,
+    master_acc: &MasterAccumulator,
+    epoch_acc_path: &Path,
+) -> anyhow::Result<(H256, EpochAccumulator)> {
+    let epoch_hash = master_acc.historical_epochs[epoch_index as usize];
+    let epoch_hash_pretty = hex_encode(epoch_hash);
+    let epoch_hash_pretty = epoch_hash_pretty.trim_start_matches("0x");
+    let epoch_acc_path = format!(
+        "{}/bridge_content/0x03{epoch_hash_pretty}.portalcontent",
+        epoch_acc_path.display(),
+    );
+    let epoch_acc = match fs::read(&epoch_acc_path) {
+        Ok(val) => EpochAccumulator::from_ssz_bytes(&val).map_err(|err| anyhow!("{err:?}"))?,
+        Err(_) => {
+            return Err(anyhow!(
+                "Unable to find local epoch acc at path: {epoch_acc_path:?}"
+            ))
+        }
+    };
+    Ok((epoch_hash, epoch_acc))
+}

--- a/portal-bridge/src/types/era1.rs
+++ b/portal-bridge/src/types/era1.rs
@@ -26,17 +26,15 @@ use std::{
 
 const ERA1_ENTRY_COUNT: usize = 8192 * 4 + 3;
 
-#[allow(dead_code)]
-struct Era1 {
-    version: VersionEntry,
-    block_tuples: Vec<BlockTuple>,
-    accumulator: AccumulatorEntry,
-    block_index: BlockIndexEntry,
+pub struct Era1 {
+    pub version: VersionEntry,
+    pub block_tuples: Vec<BlockTuple>,
+    pub accumulator: AccumulatorEntry,
+    pub block_index: BlockIndexEntry,
 }
 
-#[allow(dead_code)]
 impl Era1 {
-    fn read_from_file(path: String) -> anyhow::Result<Self> {
+    pub fn read_from_file(path: String) -> anyhow::Result<Self> {
         let buf = fs::read(path)?;
         Self::read(&buf)
     }
@@ -67,6 +65,7 @@ impl Era1 {
         })
     }
 
+    #[allow(dead_code)]
     fn write(&self) -> anyhow::Result<Vec<u8>> {
         let mut entries: Vec<Entry> = vec![];
         let version_entry: Entry = self.version.clone().try_into()?;
@@ -91,13 +90,12 @@ impl Era1 {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Clone, Eq, PartialEq, Debug)]
-struct BlockTuple {
-    header: HeaderEntry,
-    body: BodyEntry,
-    receipts: ReceiptsEntry,
-    total_difficulty: TotalDifficultyEntry,
+pub struct BlockTuple {
+    pub header: HeaderEntry,
+    pub body: BodyEntry,
+    pub receipts: ReceiptsEntry,
+    pub total_difficulty: TotalDifficultyEntry,
 }
 
 impl TryFrom<&[Entry; 4]> for BlockTuple {
@@ -131,7 +129,7 @@ impl TryInto<[Entry; 4]> for BlockTuple {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct VersionEntry {
+pub struct VersionEntry {
     version: Entry,
 }
 
@@ -170,8 +168,8 @@ impl TryInto<Entry> for VersionEntry {
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]
-struct HeaderEntry {
-    header: Header,
+pub struct HeaderEntry {
+    pub header: Header,
 }
 
 impl TryFrom<&Entry> for HeaderEntry {
@@ -208,8 +206,8 @@ impl TryInto<Entry> for HeaderEntry {
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]
-struct BodyEntry {
-    body: BlockBody,
+pub struct BodyEntry {
+    pub body: BlockBody,
 }
 
 impl TryFrom<&Entry> for BodyEntry {
@@ -246,8 +244,8 @@ impl TryInto<Entry> for BodyEntry {
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]
-struct ReceiptsEntry {
-    receipts: Receipts,
+pub struct ReceiptsEntry {
+    pub receipts: Receipts,
 }
 
 impl TryFrom<&Entry> for ReceiptsEntry {
@@ -289,7 +287,7 @@ impl TryInto<Entry> for ReceiptsEntry {
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]
-struct TotalDifficultyEntry {
+pub struct TotalDifficultyEntry {
     total_difficulty: U256,
 }
 
@@ -329,7 +327,7 @@ impl TryInto<Entry> for TotalDifficultyEntry {
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]
-struct AccumulatorEntry {
+pub struct AccumulatorEntry {
     accumulator: H256,
 }
 
@@ -370,7 +368,7 @@ impl TryInto<Entry> for AccumulatorEntry {
 //   block-index := starting-number | index | index | index ... | count
 
 #[derive(Clone, Eq, PartialEq, Debug)]
-struct BlockIndexEntry {
+pub struct BlockIndexEntry {
     block_index: BlockIndex,
 }
 

--- a/portal-bridge/src/types/mode.rs
+++ b/portal-bridge/src/types/mode.rs
@@ -12,10 +12,13 @@ use trin_validation::constants::EPOCH_SIZE;
 ///   - ex: "b123" executes block 123
 /// - BlockRange: generates test data from block x to y
 ///   - ex: "r10-12" backfills a block range from #10 to #12 (inclusive)
+/// - FourFours: gossips randomly sequenced era1 files
+///   - ex: "fourfours"
 #[derive(Clone, Debug, PartialEq, Default, Eq)]
 pub enum BridgeMode {
     #[default]
     Latest,
+    FourFours,
     Backfill(ModeType),
     Single(ModeType),
     Test(PathBuf),
@@ -28,6 +31,11 @@ impl BridgeMode {
         let (is_single_mode, mode_type) = match self {
             BridgeMode::Backfill(val) => (false, val),
             BridgeMode::Single(val) => (true, val),
+            BridgeMode::FourFours => {
+                return Err(anyhow!(
+                    "BridgeMode `fourfours` does not have a block range"
+                ))
+            }
             BridgeMode::Latest => {
                 return Err(anyhow!("BridgeMode `latest` does not have a block range"))
             }
@@ -69,6 +77,7 @@ impl FromStr for BridgeMode {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "latest" => Ok(BridgeMode::Latest),
+            "fourfours" => Ok(BridgeMode::FourFours),
             val => {
                 let index = val
                     .find(':')


### PR DESCRIPTION
### What was wrong?
We want to use era1 files as our data source for gossiping pre-merge content, to relieve some of our dependency on live providers. 

It may be possible to achieve this feature more elegantly, but for some reasons, I decided against trying to integrate the `HistoryBridge` with `era1` file compatibility.
- we still want to support live providers in the `HistoryBridge`
- data sources are different (eg http requests to era1 file sources & live providers)
- validation model is different for data from live providers & era1 files

For these reasons, it seems like the best way forward is to implement a new "kind" of bridge, `Era1Bridge`. 

### How was it fixed?
The `Era1Bridge` takes a directory of `era1` files, processes them all and then gossips out the data.

A few to-dos remain, which will be handled in upcoming prs to avoid bloat in this pr.
- fetch `era1` files from the `era1.ethportal.net` domain. though, this is blocked until the files have been moved onto cloudflare
- validate `era1` files via their checksum,and replace the current validation on a per-content-value basis

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
