### PR TITLE
refactor(e2store): refactor e2store utils

### DIFF
--- a/portal-bridge/src/types/e2s.rs
+++ b/portal-bridge/src/types/e2s.rs
@@ -9,15 +9,24 @@ pub struct E2storeFile {
     pub entries: Vec<Entry>,
 }
 
+impl TryFrom<E2storeFile> for Vec<u8> {
+    type Error = anyhow::Error;
+    fn try_from(e2store_file: E2storeFile) -> Result<Vec<u8>, Self::Error> {
+        e2store_file.serialize()
+    }
+}
+
 #[allow(dead_code)]
 impl E2storeFile {
-    fn encode(&self) -> anyhow::Result<Vec<u8>> {
+    /// Serialize to a byte vector.
+    fn serialize(&self) -> anyhow::Result<Vec<u8>> {
         let length = self.entries.iter().map(|e| e.length() as u32).sum::<u32>() as usize;
         let mut buf = vec![0; length];
         self.write(&mut buf)?;
         Ok(buf)
     }
 
+    /// Write to a byte slice.
     pub fn write(&self, buf: &mut [u8]) -> anyhow::Result<()> {
         let mut offset = 0;
         for entry in &self.entries {
@@ -32,25 +41,26 @@ impl E2storeFile {
         self.entries.iter().map(|e| e.length()).sum()
     }
 
-    pub fn read(buf: &[u8]) -> anyhow::Result<Self> {
+    /// Deserialize from a byte slice.
+    pub fn deserialize(bytes: &[u8]) -> anyhow::Result<Self> {
         let mut entries = Vec::new();
         let mut offset = 0;
-        while offset < buf.len() {
+        while offset < bytes.len() {
             let entry_length = u32::from_le_bytes([
-                buf[offset + 2],
-                buf[offset + 3],
-                buf[offset + 4],
-                buf[offset + 5],
+                bytes[offset + 2],
+                bytes[offset + 3],
+                bytes[offset + 4],
+                bytes[offset + 5],
             ]) + HEADER_SIZE as u32;
             let terminating_entry_index = offset + entry_length as usize;
-            if buf.len() < terminating_entry_index {
+            if bytes.len() < terminating_entry_index {
                 return Err(anyhow!(
                     "invalid buf length: {} - expected {}",
-                    buf.len(),
+                    bytes.len(),
                     terminating_entry_index
                 ));
             }
-            let entry = Entry::read(&buf[offset..terminating_entry_index])?;
+            let entry = Entry::deserialize(&bytes[offset..terminating_entry_index])?;
             offset += entry_length as usize;
             entries.push(entry);
         }
@@ -58,6 +68,7 @@ impl E2storeFile {
     }
 }
 
+/// Represents an e2store `Entry`
 #[derive(Default, Debug, Eq, PartialEq, Clone)]
 pub struct Entry {
     pub header: Header,
@@ -81,13 +92,15 @@ impl Entry {
         HEADER_SIZE as usize + self.header.length as usize
     }
 
-    fn encode(&self) -> anyhow::Result<Vec<u8>> {
+    /// Serialize to a byte vector.
+    fn serialize(&self) -> anyhow::Result<Vec<u8>> {
         let length = self.length();
         let mut buf = vec![0; length];
         self.write(&mut buf)?;
         Ok(buf)
     }
 
+    /// Write to a byte slice.
     fn write(&self, buf: &mut [u8]) -> anyhow::Result<()> {
         if self.length() != buf.len() {
             return Err(anyhow!(
@@ -108,22 +121,24 @@ impl Entry {
         Ok(())
     }
 
-    pub fn read(buf: &[u8]) -> anyhow::Result<Self> {
-        let header = Header::read(&buf[0..8])?;
-        if header.length as usize + HEADER_SIZE as usize != buf.len() {
+    /// Deserialize from a byte slice.
+    pub fn deserialize(bytes: &[u8]) -> anyhow::Result<Self> {
+        let header = Header::deserialize(&bytes[0..8])?;
+        if header.length as usize + HEADER_SIZE as usize != bytes.len() {
             return Err(anyhow!(
                 "found invalid buf length for entry: {} - expected {}",
-                buf.len(),
+                bytes.len(),
                 header.length as usize + HEADER_SIZE as usize
             ));
         }
         Ok(Self {
-            header: Header::read(&buf[0..8])?,
-            value: buf[8..].to_vec(),
+            header: Header::deserialize(&bytes[0..8])?,
+            value: bytes[8..].to_vec(),
         })
     }
 }
 
+/// Represents the header of an e2store `Entry`
 #[derive(Clone, Debug, Decode, Encode, Default, Eq, PartialEq)]
 pub struct Header {
     pub type_: u16,
@@ -132,19 +147,21 @@ pub struct Header {
 }
 
 impl Header {
+    /// Write to a byte slice.
     fn write(&self, buf: &mut [u8]) {
         buf[0..2].copy_from_slice(&self.type_.to_le_bytes());
         buf[2..6].copy_from_slice(&self.length.to_le_bytes());
         buf[6..8].copy_from_slice(&self.reserved.to_le_bytes());
     }
 
-    fn read(buf: &[u8]) -> anyhow::Result<Self> {
-        if buf.len() != HEADER_SIZE as usize {
-            return Err(anyhow!("invalid header size: {}", buf.len()));
+    /// Deserialize from a byte slice.
+    fn deserialize(bytes: &[u8]) -> anyhow::Result<Self> {
+        if bytes.len() != HEADER_SIZE as usize {
+            return Err(anyhow!("invalid header size: {}", bytes.len()));
         }
-        let type_ = u16::from_le_bytes([buf[0], buf[1]]);
-        let length = u32::from_le_bytes([buf[2], buf[3], buf[4], buf[5]]);
-        let reserved = u16::from_le_bytes([buf[6], buf[7]]);
+        let type_ = u16::from_le_bytes([bytes[0], bytes[1]]);
+        let length = u32::from_le_bytes([bytes[2], bytes[3], bytes[4], bytes[5]]);
+        let reserved = u16::from_le_bytes([bytes[6], bytes[7]]);
         if reserved != 0 {
             return Err(anyhow!("invalid reserved value: {} - expected 0", reserved));
         }
@@ -166,31 +183,31 @@ mod test {
     #[test]
     fn test_entry_empty() {
         let expected = "0xffff000000000000";
-        let entry = Entry::read(&hex_decode(expected).unwrap()).unwrap();
+        let entry = Entry::deserialize(&hex_decode(expected).unwrap()).unwrap();
         assert_eq!(entry.header.type_, 0xffff);
         assert_eq!(entry.header.length, 0);
         assert_eq!(entry.header.reserved, 0);
         assert_eq!(entry.value.len(), 0);
-        let actual = entry.encode().unwrap();
+        let actual = entry.serialize().unwrap();
         assert_eq!(hex_encode(actual), expected);
     }
 
     #[test]
     fn test_entry_beef() {
         let expected = "0x2a00020000000000beef";
-        let entry = Entry::read(&hex_decode(expected).unwrap()).unwrap();
+        let entry = Entry::deserialize(&hex_decode(expected).unwrap()).unwrap();
         assert_eq!(entry.header.type_, 0x2a); // 42
         assert_eq!(entry.header.length, 2);
         assert_eq!(entry.header.reserved, 0);
         assert_eq!(entry.value, vec![0xbe, 0xef]);
-        let actual = entry.encode().unwrap();
+        let actual = entry.serialize().unwrap();
         assert_eq!(hex_encode(actual), expected);
     }
 
     #[test]
     fn test_entry_multiple() {
         let expected = "0x2a00020000000000beef0900040000000000abcdabcd";
-        let file = E2storeFile::read(&hex_decode(expected).unwrap()).unwrap();
+        let file = E2storeFile::deserialize(&hex_decode(expected).unwrap()).unwrap();
         assert_eq!(file.entries.len(), 2);
         assert_eq!(file.entries[0].header.type_, 0x2a); // 42
         assert_eq!(file.entries[0].header.length, 2);
@@ -200,7 +217,7 @@ mod test {
         assert_eq!(file.entries[1].header.length, 4);
         assert_eq!(file.entries[1].header.reserved, 0);
         assert_eq!(file.entries[1].value, vec![0xab, 0xcd, 0xab, 0xcd]);
-        let actual = file.encode().unwrap();
+        let actual: Vec<u8> = file.try_into().unwrap();
         assert_eq!(hex_encode(actual), expected);
     }
 
@@ -209,6 +226,6 @@ mod test {
     #[case("0xbeef010000000000")] // length exceeds buffer
     fn test_entry_invalid_decoding(#[case] input: &str) {
         let buf = hex_decode(input).unwrap();
-        assert!(E2storeFile::read(&buf).is_err());
+        assert!(E2storeFile::deserialize(&buf).is_err());
     }
 }

--- a/portal-bridge/src/types/e2s.rs
+++ b/portal-bridge/src/types/e2s.rs
@@ -5,12 +5,12 @@ const _SLOTS_PER_HISTORICAL_ROOT: usize = 8192;
 const HEADER_SIZE: u16 = 8;
 const VALUE_SIZE_LIMIT: usize = 1024 * 1024 * 50; // 50 MB
 
-pub struct File {
+pub struct E2storeFile {
     pub entries: Vec<Entry>,
 }
 
 #[allow(dead_code)]
-impl File {
+impl E2storeFile {
     fn encode(&self) -> anyhow::Result<Vec<u8>> {
         let length = self.entries.iter().map(|e| e.length() as u32).sum::<u32>() as usize;
         let mut buf = vec![0; length];
@@ -190,7 +190,7 @@ mod test {
     #[test]
     fn test_entry_multiple() {
         let expected = "0x2a00020000000000beef0900040000000000abcdabcd";
-        let file = File::read(&hex_decode(expected).unwrap()).unwrap();
+        let file = E2storeFile::read(&hex_decode(expected).unwrap()).unwrap();
         assert_eq!(file.entries.len(), 2);
         assert_eq!(file.entries[0].header.type_, 0x2a); // 42
         assert_eq!(file.entries[0].header.length, 2);
@@ -209,6 +209,6 @@ mod test {
     #[case("0xbeef010000000000")] // length exceeds buffer
     fn test_entry_invalid_decoding(#[case] input: &str) {
         let buf = hex_decode(input).unwrap();
-        assert!(File::read(&buf).is_err());
+        assert!(E2storeFile::read(&buf).is_err());
     }
 }

--- a/portal-bridge/src/types/era1.rs
+++ b/portal-bridge/src/types/era1.rs
@@ -1,4 +1,4 @@
-use crate::types::e2s::{Entry, E2storeFile};
+use crate::types::e2s::{E2storeFile, Entry};
 use anyhow::ensure;
 use ethereum_types::{H256, U256};
 use ethportal_api::types::execution::{
@@ -38,11 +38,11 @@ struct Era1 {
 impl Era1 {
     fn read_from_file(path: String) -> anyhow::Result<Self> {
         let buf = fs::read(path)?;
-        Self::read(&buf)
+        Self::deserialize(&buf)
     }
 
-    fn read(buf: &[u8]) -> anyhow::Result<Self> {
-        let file = E2storeFile::read(buf)?;
+    fn deserialize(buf: &[u8]) -> anyhow::Result<Self> {
+        let file = E2storeFile::deserialize(buf)?;
         ensure!(
             file.entries.len() == ERA1_ENTRY_COUNT,
             "invalid era1 file: incorrect entry count"

--- a/portal-bridge/src/types/era1.rs
+++ b/portal-bridge/src/types/era1.rs
@@ -1,4 +1,4 @@
-use crate::types::e2s::{Entry, File};
+use crate::types::e2s::{Entry, E2storeFile};
 use anyhow::ensure;
 use ethereum_types::{H256, U256};
 use ethportal_api::types::execution::{
@@ -42,7 +42,7 @@ impl Era1 {
     }
 
     fn read(buf: &[u8]) -> anyhow::Result<Self> {
-        let file = File::read(buf)?;
+        let file = E2storeFile::read(buf)?;
         ensure!(
             file.entries.len() == ERA1_ENTRY_COUNT,
             "invalid era1 file: incorrect entry count"
@@ -79,7 +79,7 @@ impl Era1 {
         entries.push(accumulator_entry);
         let block_index_entry: Entry = self.block_index.clone().try_into()?;
         entries.push(block_index_entry);
-        let file = File { entries };
+        let file = E2storeFile { entries };
         ensure!(
             file.entries.len() == ERA1_ENTRY_COUNT,
             "invalid era1 file: incorrect entry count"


### PR DESCRIPTION
### What was wrong?
Converting bytes to rust types and rust types to bytes is common as serializing and deserializing.
Even if we don't use the serde framework for deserializing/serializing Era files (at this stage), I think it is nice if we don't deviate much from the common concepts.

### How was it fixed?
- rename `File` to `E2storeFIle`
- Reading from a byte slice is confusing with reading into a buffer which is typical to [Readers](https://doc.rust-lang.org/std/io/trait.Read.html). To remove this confusion, I renamed `read` to `deserialize` because this is what we are trying to do here: deserialize from a byte slice into a type.
- To keep consistent with the above, I renamed `encode` to `serialize`.

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
