### PR TITLE
feat(bridge): add http request timeout to prevent requests over 6 minutes

### DIFF
--- a/portal-bridge/src/api/consensus.rs
+++ b/portal-bridge/src/api/consensus.rs
@@ -6,8 +6,9 @@ use surf_governor::GovernorMiddleware;
 use url::Url;
 
 use crate::{
-    cli::Provider, constants::SECONDS_IN_A_DAY, BASE_CL_ENDPOINT, PANDAOPS_CLIENT_ID,
-    PANDAOPS_CLIENT_SECRET,
+    cli::Provider,
+    constants::{HTTP_REQUEST_TIMEOUT, SECONDS_IN_A_DAY},
+    BASE_CL_ENDPOINT, PANDAOPS_CLIENT_ID, PANDAOPS_CLIENT_SECRET,
 };
 
 /// Implements endpoints from the Beacon API to access data from the consensus layer.
@@ -30,11 +31,13 @@ impl ConsensusApi {
                     )?
                     .add_header("Content-Type", "application/json")?
                     .set_base_url(base_cl_endpoint)
+                    .set_timeout(Some(HTTP_REQUEST_TIMEOUT))
                     .try_into()?
             }
             Provider::Url(url) => Config::new()
                 .add_header("Content-Type", "application/json")?
                 .set_base_url(url)
+                .set_timeout(Some(HTTP_REQUEST_TIMEOUT))
                 .try_into()?,
             Provider::Test => {
                 return Err(surf::Error::from(anyhow!(

--- a/portal-bridge/src/api/execution.rs
+++ b/portal-bridge/src/api/execution.rs
@@ -15,7 +15,7 @@ use url::Url;
 
 use crate::{
     cli::Provider,
-    constants::SECONDS_IN_A_DAY,
+    constants::{HTTP_REQUEST_TIMEOUT, SECONDS_IN_A_DAY},
     types::{full_header::FullHeader, mode::BridgeMode},
     BASE_EL_ARCHIVE_ENDPOINT, BASE_EL_ENDPOINT, PANDAOPS_CLIENT_ID, PANDAOPS_CLIENT_SECRET,
 };
@@ -71,11 +71,13 @@ impl ExecutionApi {
                         PANDAOPS_CLIENT_SECRET.to_string(),
                     )?
                     .set_base_url(base_el_endpoint)
+                    .set_timeout(Some(HTTP_REQUEST_TIMEOUT))
                     .try_into()?
             }
             Provider::Url(url) => Config::new()
                 .add_header("Content-Type", "application/json")?
                 .set_base_url(url.clone())
+                .set_timeout(Some(HTTP_REQUEST_TIMEOUT))
                 .try_into()?,
             Provider::Test => Config::new().try_into()?,
         };

--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -1,3 +1,5 @@
+use tokio::time::Duration;
+
 // This number was chosen after some experimentation with different batch sizes.
 // It was found that a batch size of 128 was the best compromise between speed and
 // successful response rate. This number may change in the future.
@@ -14,3 +16,7 @@ pub const BEACON_GENESIS_TIME: u64 = 1606824023;
 
 pub const PROVIDER_DAILY_REQUEST_LIMIT: f64 = 1_000_000.0;
 pub const SECONDS_IN_A_DAY: f64 = 86400.0;
+
+// This is a very conservative timeout if a provider takes longer then even 1 second it is probably
+// overloaded and not performing well
+pub const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);

--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -17,6 +17,6 @@ pub const BEACON_GENESIS_TIME: u64 = 1606824023;
 pub const PROVIDER_DAILY_REQUEST_LIMIT: f64 = 1_000_000.0;
 pub const SECONDS_IN_A_DAY: f64 = 86400.0;
 
-// This is a very conservative timeout if a provider takes longer then even 1 second it is probably
+// This is a very conservative timeout if a provider takes longer than even 1 second it is probably
 // overloaded and not performing well
 pub const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);


### PR DESCRIPTION
### What was wrong?
![image](https://github.com/ethereum/trin/assets/31669092/ff98a106-b898-4372-a355-ebc0a5bda9be)
Yesterday when testing the bridge we found that a surf http  request took 6 minutes to respond. We assume this is becase the provider took forever to respond. Either way we don't want to wait 6 minutes + to timeout if a provider can't respond in a responsible about of time we should give up and log it, so we aren't confused why we aren't seeing logs.
### How was it fixed?
by setting a 20 second timeout in surf.

I choose 20 seconds to be conservative. I don't believe any provider request should take over 1s and if that does happens the provider is overloaded.
