### PR TITLE
feat(bridge): history latest log error if provider isn't giving new blocks

### DIFF
--- a/portal-bridge/src/bridge/history.rs
+++ b/portal-bridge/src/bridge/history.rs
@@ -102,6 +102,10 @@ impl HistoryBridge {
         let mut block_index = self.execution_api.get_latest_block_number().await.expect(
             "Error launching bridge in latest mode. Unable to get latest block from provider.",
         );
+        // If a provider returns the same block number and doesn't time out over and over.
+        // this indictates the provider is no longer in sync with the chain so we want to long an
+        // error
+        let mut seen_old_latest_block_index = 0;
         loop {
             sleep(Duration::from_secs(LATEST_BLOCK_POLL_RATE)).await;
             let latest_block = match self.execution_api.get_latest_block_number().await {
@@ -111,7 +115,9 @@ impl HistoryBridge {
                     continue;
                 }
             };
+            seen_old_latest_block_index += 1;
             if latest_block > block_index {
+                seen_old_latest_block_index = 0;
                 let gossip_range = Range {
                     start: block_index,
                     end: latest_block + 1,
@@ -127,6 +133,12 @@ impl HistoryBridge {
                     );
                 }
                 block_index = gossip_range.end;
+            }
+            // Ethereum mainnet creates a new block every 15 seconds, if we don't get 1 new block in
+            // the time period 4 new blocks should exist report an error something is
+            // wrong with the EL provider
+            if seen_old_latest_block_index > 60 / LATEST_BLOCK_POLL_RATE {
+                tracing::error!("History Latest: Haven't receieved a new block in over 60 seconds EL provider could be out of sync");
             }
         }
     }


### PR DESCRIPTION
### What was wrong?
Currently if a provider is working, but falls out of sync with the chain we report 0 logs that the history bridge is alive or something is wrong or not. If this case happens it is a clear case the EL provider is out of sync so we should inform the user regardless.
### How was it fixed?
Add a counter which prints an error if the provider doesn't give us a new block for over a minute.
This error could go off if the provider down as well either way we want to ring some bells something is wrong with the provider.