### PR TITLE
feat(bridge): use ethportal.net as source for era1 files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4855,6 +4855,7 @@ dependencies = [
  "portalnet",
  "rand 0.8.5",
  "rlp",
+ "roxmltree",
  "rstest 0.18.2",
  "serde",
  "serde_json",
@@ -5729,6 +5730,12 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
+
+[[package]]
+name = "roxmltree"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
 
 [[package]]
 name = "rpc"

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -32,6 +32,7 @@ lazy_static = "1.4.0"
 portalnet = { path = "../portalnet" }
 rand = "0.8.4"
 rlp = "0.5.0"
+roxmltree = "0.19.0"
 serde = { version = "1.0.150", features = ["derive", "rc"] }
 serde_json = "1.0.89"
 serde_yaml = "0.9"

--- a/portal-bridge/README.md
+++ b/portal-bridge/README.md
@@ -32,6 +32,7 @@ Current options include `"trin"` / `"fluffy"`.
 - `"--mode backfill:r10-12"`: backfill a block range from #10 to #12 (inclusive)
 - `"--mode single:b100"`: gossip a single block #100
 - `"--mode single:e100"`: gossip a single epoch #100
+- `"--mode fourfours`: will randomly select era1 files from `era1.ethportal.net` and gossip them
 
 ### Network
 You can specify the `--network` flag for which network to run the bridge for

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -91,6 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     header_oracle,
                     bridge_config.epoch_acc_path,
                 )
+                .await
                 .unwrap();
                 let bridge_handle = tokio::spawn(async move {
                     era1_bridge

--- a/portal-bridge/src/types/era1.rs
+++ b/portal-bridge/src/types/era1.rs
@@ -39,7 +39,7 @@ impl Era1 {
         Self::deserialize(&buf)
     }
 
-    fn deserialize(buf: &[u8]) -> anyhow::Result<Self> {
+    pub fn deserialize(buf: &[u8]) -> anyhow::Result<Self> {
         let file = E2storeFile::deserialize(buf)?;
         ensure!(
             file.entries.len() == ERA1_ENTRY_COUNT,


### PR DESCRIPTION
### What was wrong?
Source `era1` files from `https://era1.ethportal.net` instead of the local test folder. Randomly shuffle the `era1` files and then gossip out their content.

### How was it fixed?
- added support for fetching `era1` files & randomly shuffling them

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
