### PR TITLE
feat(bridge): make provider rate limit opt in

### DIFF
--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -10,7 +10,6 @@ use portal_bridge::{
     api::{consensus::ConsensusApi, execution::ExecutionApi},
     bridge::{beacon::BeaconBridge, history::HistoryBridge},
     cli::Provider,
-    constants::PROVIDER_DAILY_REQUEST_LIMIT,
     types::mode::BridgeMode,
 };
 use serde_json::Value;
@@ -24,10 +23,9 @@ pub async fn test_history_bridge(peertest: &Peertest, target: &HttpClient) {
     let portal_clients = vec![target.clone()];
     let epoch_acc_path = "validation_assets/epoch_acc.bin".into();
     let mode = BridgeMode::Test("./test_assets/portalnet/bridge_data.json".into());
-    let execution_api =
-        ExecutionApi::new(Provider::Test, mode.clone(), PROVIDER_DAILY_REQUEST_LIMIT)
-            .await
-            .unwrap();
+    let execution_api = ExecutionApi::new(Provider::Test, mode.clone(), None)
+        .await
+        .unwrap();
     // Wait for bootnode to start
     sleep(Duration::from_secs(1)).await;
     let bridge = HistoryBridge::new(

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -8,7 +8,6 @@ use url::Url;
 
 use crate::{
     client_handles::{fluffy_handle, trin_handle},
-    constants::PROVIDER_DAILY_REQUEST_LIMIT,
     types::{mode::BridgeMode, network::NetworkKind},
 };
 
@@ -97,16 +96,16 @@ pub struct BridgeConfig {
     #[arg(
         long = "el-provider-daily-request-limit",
         help = "Maximum number of requests execution layer sent to the provider in a day.",
-        default_value_t = PROVIDER_DAILY_REQUEST_LIMIT,
+        default_value = None,
     )]
-    pub el_provider_daily_request_limit: f64,
+    pub el_provider_daily_request_limit: Option<f64>,
 
     #[arg(
         long = "cl-provider-daily-request-limit",
         help = "Maximum number of requests consensus layer sent to the provider in a day.",
-        default_value_t = PROVIDER_DAILY_REQUEST_LIMIT,
+        default_value = None,
     )]
-    pub cl_provider_daily_request_limit: f64,
+    pub cl_provider_daily_request_limit: Option<f64>,
 }
 
 fn check_node_count(val: &str) -> Result<u8, String> {

--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -12,5 +12,4 @@ pub const HEADER_WITH_PROOF_CONTENT_VALUE: &str =
 // Beacon chain mainnet genesis time: Tue Dec 01 2020 12:00:23 GMT+0000
 pub const BEACON_GENESIS_TIME: u64 = 1606824023;
 
-pub const PROVIDER_DAILY_REQUEST_LIMIT: f64 = 1_000_000.0;
 pub const SECONDS_IN_A_DAY: f64 = 86400.0;


### PR DESCRIPTION
### What was wrong?
I did some thinking and I don't like the idea of a rate limit by default. I think it should be an intentional action.
### How was it fixed?
By only setting a rate limit if it was manually asked for. This may change in the future if we have some smart rate limit mechanism, but currently that doesn't exist.