### PR TITLE
fix(bridge): change rate limiter period calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3015,24 +3015,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "governor"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821239e5672ff23e2a7060901fa622950bbd80b649cdaadd78d1c1767ed14eb4"
-dependencies = [
- "cfg-if 1.0.0",
- "dashmap",
- "futures 0.3.30",
- "futures-timer",
- "no-std-compat",
- "nonzero_ext",
- "parking_lot 0.12.1",
- "quanta",
- "rand 0.8.5",
- "smallvec 1.12.0",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,15 +4016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach2"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4257,12 +4230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
-
-[[package]]
 name = "nom"
 version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4282,12 +4249,6 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
-
-[[package]]
-name = "nonzero_ext"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -4862,7 +4823,6 @@ dependencies = [
  "snap",
  "ssz_types",
  "surf",
- "surf-governor",
  "test-log",
  "tokio",
  "tracing",
@@ -5089,22 +5049,6 @@ dependencies = [
  "rand_xorshift 0.3.0",
  "regex-syntax 0.8.2",
  "unarray",
-]
-
-[[package]]
-name = "quanta"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
-dependencies = [
- "crossbeam-utils 0.8.19",
- "libc",
- "mach2",
- "once_cell",
- "raw-cpuid",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "web-sys",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5349,15 +5293,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "10.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -6868,18 +6803,6 @@ dependencies = [
  "serde",
  "serde_json",
  "web-sys",
-]
-
-[[package]]
-name = "surf-governor"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5072d041267e6b28a6a75a8737a03660ccc7fe8d9d70e8176388206a1e356fb8"
-dependencies = [
- "governor",
- "http-types",
- "lazy_static",
- "surf",
 ]
 
 [[package]]

--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -10,7 +10,6 @@ use portal_bridge::{
     api::{consensus::ConsensusApi, execution::ExecutionApi},
     bridge::{beacon::BeaconBridge, history::HistoryBridge},
     cli::Provider,
-    constants::PROVIDER_DAILY_REQUEST_LIMIT,
     types::mode::BridgeMode,
 };
 use serde_json::Value;
@@ -24,10 +23,9 @@ pub async fn test_history_bridge(peertest: &Peertest, target: &HttpClient) {
     let portal_clients = vec![target.clone()];
     let epoch_acc_path = "validation_assets/epoch_acc.bin".into();
     let mode = BridgeMode::Test("./test_assets/portalnet/bridge_data.json".into());
-    let execution_api =
-        ExecutionApi::new(Provider::Test, mode.clone(), PROVIDER_DAILY_REQUEST_LIMIT)
-            .await
-            .unwrap();
+    let execution_api = ExecutionApi::new(Provider::Test, mode.clone())
+        .await
+        .unwrap();
     // Wait for bootnode to start
     sleep(Duration::from_secs(1)).await;
     let bridge = HistoryBridge::new(

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -38,7 +38,6 @@ serde_yaml = "0.9"
 snap = "1.1.1"
 ssz_types = "0.5.4"
 surf = { version = "2.3.2", default-features = false, features = ["h1-client-rustls", "middleware-logger", "encoding"] } # we use rustils because OpenSSL cause issues compiling on aarch64
-surf-governor = "0.2.0"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -99,14 +99,14 @@ pub struct BridgeConfig {
         help = "Maximum number of requests execution layer sent to the provider in a day.",
         default_value_t = PROVIDER_DAILY_REQUEST_LIMIT,
     )]
-    pub el_provider_daily_request_limit: f64,
+    pub el_provider_daily_request_limit: u64,
 
     #[arg(
         long = "cl-provider-daily-request-limit",
         help = "Maximum number of requests consensus layer sent to the provider in a day.",
         default_value_t = PROVIDER_DAILY_REQUEST_LIMIT,
     )]
-    pub cl_provider_daily_request_limit: f64,
+    pub cl_provider_daily_request_limit: u64,
 }
 
 fn check_node_count(val: &str) -> Result<u8, String> {

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -8,7 +8,6 @@ use url::Url;
 
 use crate::{
     client_handles::{fluffy_handle, trin_handle},
-    constants::PROVIDER_DAILY_REQUEST_LIMIT,
     types::{mode::BridgeMode, network::NetworkKind},
 };
 
@@ -93,20 +92,6 @@ pub struct BridgeConfig {
         help = "Data provider for consensus layer data. (\"pandaops\" / local node url)"
     )]
     pub cl_provider: Provider,
-
-    #[arg(
-        long = "el-provider-daily-request-limit",
-        help = "Maximum number of requests execution layer sent to the provider in a day.",
-        default_value_t = PROVIDER_DAILY_REQUEST_LIMIT,
-    )]
-    pub el_provider_daily_request_limit: u64,
-
-    #[arg(
-        long = "cl-provider-daily-request-limit",
-        help = "Maximum number of requests consensus layer sent to the provider in a day.",
-        default_value_t = PROVIDER_DAILY_REQUEST_LIMIT,
-    )]
-    pub cl_provider_daily_request_limit: u64,
 }
 
 fn check_node_count(val: &str) -> Result<u8, String> {

--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -14,9 +14,7 @@ pub const HEADER_WITH_PROOF_CONTENT_VALUE: &str =
 // Beacon chain mainnet genesis time: Tue Dec 01 2020 12:00:23 GMT+0000
 pub const BEACON_GENESIS_TIME: u64 = 1606824023;
 
-pub const PROVIDER_DAILY_REQUEST_LIMIT: f64 = 1_000_000.0;
-pub const SECONDS_IN_A_DAY: f64 = 86400.0;
-
 // This is a very conservative timeout if a provider takes longer than even 1 second it is probably
 // overloaded and not performing well
 pub const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+pub const PROVIDER_DAILY_REQUEST_LIMIT: u64 = 1_000_000;

--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -17,4 +17,3 @@ pub const BEACON_GENESIS_TIME: u64 = 1606824023;
 // This is a very conservative timeout if a provider takes longer than even 1 second it is probably
 // overloaded and not performing well
 pub const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
-pub const PROVIDER_DAILY_REQUEST_LIMIT: u64 = 1_000_000;

--- a/portal-bridge/src/lib.rs
+++ b/portal-bridge/src/lib.rs
@@ -22,7 +22,7 @@ use std::env;
 // format), shackle is known to be somewhat buggy has caused some invalid responses.
 // Reth's archive node, has also exhibited some problems with the concurrent requests rate we
 // currently use.
-const DEFAULT_BASE_EL_ENDPOINT: &str = "https://erigon-lighthouse.mainnet.eu1.ethpandaops.io/";
+const DEFAULT_BASE_EL_ENDPOINT: &str = "https://geth-lighthouse.mainnet.eu1.ethpandaops.io/";
 // The `erigon` endpoint appears to perform much better for backfill requests.
 const DEFAULT_BASE_EL_ARCHIVE_ENDPOINT: &str =
     "https://erigon-lighthouse.mainnet.eu1.ethpandaops.io/";

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -62,11 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let portal_clients = portal_clients
             .clone()
             .expect("Failed to create beacon JSON-RPC clients");
-        let consensus_api = ConsensusApi::new(
-            bridge_config.cl_provider,
-            bridge_config.cl_provider_daily_request_limit,
-        )
-        .await?;
+        let consensus_api = ConsensusApi::new(bridge_config.cl_provider).await?;
         let bridge_handle = tokio::spawn(async move {
             let beacon_bridge =
                 BeaconBridge::new(consensus_api, bridge_mode, Arc::new(portal_clients));
@@ -101,12 +97,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 bridge_tasks.push(bridge_handle);
             }
             _ => {
-                let execution_api = ExecutionApi::new(
-                    bridge_config.el_provider,
-                    bridge_config.mode.clone(),
-                    bridge_config.el_provider_daily_request_limit,
-                )
-                .await?;
+                let execution_api =
+                    ExecutionApi::new(bridge_config.el_provider, bridge_config.mode.clone())
+                        .await?;
                 let bridge_handle = tokio::spawn(async move {
                     let master_acc = MasterAccumulator::default();
                     let header_oracle = HeaderOracle::new(master_acc);

--- a/src/bin/test_providers.rs
+++ b/src/bin/test_providers.rs
@@ -43,7 +43,7 @@ use trin_validation::{
 pub async fn main() -> Result<()> {
     init_tracing_logger();
     let config = ProviderConfig::parse();
-    let api = ExecutionApi::new(Provider::PandaOps, BridgeMode::Latest, 100000)
+    let api = ExecutionApi::new(Provider::PandaOps, BridgeMode::Latest)
         .await
         .unwrap();
     let latest_block = api.get_latest_block_number().await?;


### PR DESCRIPTION
### What was wrong?
When the rate limiter was added, it seems to me like this broke our bridge. Locally (running just trin & inside kurtosis), I'm consistently unable to request any data from any provider, latest / backfill mode. 

The culprit appears to be `GovernorMiddleware::with_period(period)`.. it just doesn't appear to be performing as expected. I've updated it to use the `GovernerMiddleware::per_hour()` limit api, which solves the problem locally. 

### How was it fixed?
- changed default el provider to `geth`, since `erigon` is down
- added some debug logs
- removed the rate limiter (aka governer) and the concept of a daily rate limit

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
