### PR TITLE
fix(bridge): handle too many requests error in retry middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4863,6 +4863,7 @@ dependencies = [
  "ssz_types",
  "surf",
  "surf-governor",
+ "surf-retry",
  "test-log",
  "tokio",
  "tracing",
@@ -5628,6 +5629,17 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17dd00bff1d737c40dbcd47d4375281bf4c17933f9eef0a185fc7bacca23ecbd"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -6879,6 +6891,20 @@ dependencies = [
  "governor",
  "http-types",
  "lazy_static",
+ "surf",
+]
+
+[[package]]
+name = "surf-retry"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e3978e963c08fdff9eb3f074227b47bedbf7be064dffa7ec356fce25298081"
+dependencies = [
+ "async-std",
+ "chrono",
+ "http-types",
+ "httpdate",
+ "retry-policies",
  "surf",
 ]
 

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -39,6 +39,7 @@ snap = "1.1.1"
 ssz_types = "0.5.4"
 surf = { version = "2.3.2", default-features = false, features = ["h1-client-rustls", "middleware-logger", "encoding"] } # we use rustils because OpenSSL cause issues compiling on aarch64
 surf-governor = "0.2.0"
+surf-retry = "0.3.2"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"

--- a/portal-bridge/src/api/consensus.rs
+++ b/portal-bridge/src/api/consensus.rs
@@ -3,6 +3,7 @@ use std::{fmt::Display, time::Duration};
 use anyhow::anyhow;
 use surf::{Client, Config};
 use surf_governor::GovernorMiddleware;
+use surf_retry::RetryMiddleware;
 use url::Url;
 
 use crate::{
@@ -49,7 +50,7 @@ impl ConsensusApi {
         let period = Duration::from_secs_f64(daily_request_limit / SECONDS_IN_A_DAY);
         let rate_limit = GovernorMiddleware::with_period(period)
             .expect("Expect GovernerMiddleware should have received a valid Duration");
-        let client = client.with(rate_limit);
+        let client = client.with(rate_limit).with(RetryMiddleware::default());
         check_provider(&client).await?;
         Ok(Self { client })
     }

--- a/portal-bridge/src/api/consensus.rs
+++ b/portal-bridge/src/api/consensus.rs
@@ -50,7 +50,7 @@ impl ConsensusApi {
         let period = Duration::from_secs_f64(daily_request_limit / SECONDS_IN_A_DAY);
         let rate_limit = GovernorMiddleware::with_period(period)
             .expect("Expect GovernerMiddleware should have received a valid Duration");
-        let client = client.with(rate_limit).with(RetryMiddleware::default());
+        let client = client.with(RetryMiddleware::default()).with(rate_limit);
         check_provider(&client).await?;
         Ok(Self { client })
     }

--- a/portal-bridge/src/api/execution.rs
+++ b/portal-bridge/src/api/execution.rs
@@ -83,7 +83,7 @@ impl ExecutionApi {
         let period = Duration::from_secs_f64(daily_request_limit / SECONDS_IN_A_DAY);
         let rate_limit = GovernorMiddleware::with_period(period)
             .expect("Expect GovernerMiddleware should have received a valid Duration");
-        let client = client.with(rate_limit).with(RetryMiddleware::default());
+        let client = client.with(RetryMiddleware::default()).with(rate_limit);
         // Only check that provider is connected & available if not using a test provider.
         if provider != Provider::Test {
             check_provider(&client).await?;


### PR DESCRIPTION
### What was wrong?
https://github.com/ethereum/trin/pull/1152
### How was it fixed?

When api rate limit was added we weren't handling the errors it sent in our retry middleware
