### PR TITLE
feat(bridge): add support for gossiping a single era1 file

### DIFF
--- a/portal-bridge/README.md
+++ b/portal-bridge/README.md
@@ -33,6 +33,7 @@ Current options include `"trin"` / `"fluffy"`.
 - `"--mode single:b100"`: gossip a single block #100
 - `"--mode single:e100"`: gossip a single epoch #100
 - `"--mode fourfours`: will randomly select era1 files from `era1.ethportal.net` and gossip them
+- `"--mode fourfours:path`: will gossip a single era1 file
 
 ### Network
 You can specify the `--network` flag for which network to run the bridge for

--- a/portal-bridge/src/bridge/history.rs
+++ b/portal-bridge/src/bridge/history.rs
@@ -68,7 +68,7 @@ impl HistoryBridge {
         match self.mode.clone() {
             BridgeMode::Test(path) => self.launch_test(path).await,
             BridgeMode::Latest => self.launch_latest().await,
-            BridgeMode::FourFours => panic!("4444s mode not supported in HistoryBridge."),
+            BridgeMode::FourFours(_) => panic!("4444s mode not supported in HistoryBridge."),
             _ => self.launch_backfill().await,
         }
         info!("Bridge mode: {:?} complete.", self.mode);

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -36,7 +36,7 @@ pub struct BridgeConfig {
     #[arg(
         long,
         default_value = "latest",
-        help = "['latest', 'backfill', <u64> to provide the starting epoch]"
+        help = "['latest', 'backfill', 'fourfours']"
     )]
     pub mode: BridgeMode,
 

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -83,13 +83,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Launch History Network portal bridge
     if bridge_config.network.contains(&NetworkKind::History) {
         match bridge_config.mode {
-            BridgeMode::FourFours => {
+            BridgeMode::FourFours(path) => {
                 let master_acc = MasterAccumulator::default();
                 let header_oracle = HeaderOracle::new(master_acc);
                 let era1_bridge = Era1Bridge::new(
                     portal_clients.expect("Failed to create history JSON-RPC clients"),
                     header_oracle,
                     bridge_config.epoch_acc_path,
+                    path,
                 )
                 .await
                 .unwrap();


### PR DESCRIPTION
### What was wrong?
It's useful in kurtosis to be able to gossip a single epoch. Need this ability w/ era1 files

### How was it fixed?
- added an option to gossip a single era1 file

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
