### PR TITLE
feat(era1 bridge): add gossip epoch mode for reliable testing

### DIFF
--- a/portal-bridge/README.md
+++ b/portal-bridge/README.md
@@ -33,6 +33,7 @@ Current options include `"trin"` / `"fluffy"`.
 - `"--mode single:b100"`: gossip a single block #100
 - `"--mode single:e100"`: gossip a single epoch #100
 - `"--mode fourfours`: will randomly select era1 files from `era1.ethportal.net` and gossip them
+- `"--mode fourfours:e600`: will select era1 file 600 from `era1.ethportal.net` and gossip it
 
 ### Network
 You can specify the `--network` flag for which network to run the bridge for

--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -101,12 +101,11 @@ impl Era1Bridge {
     }
 
     pub async fn launch_single(&self, epoch: u64) {
-        let epoch_string = format!("{epoch}-");
-        let era1_path = self
-            .era1_files
-            .clone()
-            .into_iter()
-            .find(|file| file.contains(&epoch_string));
+        let era1_path = self.era1_files.clone().into_iter().find(|file| {
+            file.contains("mainnet-")
+                && file.contains(&format!("{epoch}-"))
+                && file.contains(".era1")
+        });
         match era1_path {
             Some(path) => self.gossip_era1(path).await,
             None => panic!("4444s bridge couldn't find request epoch on era1 file server"),

--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -101,11 +101,10 @@ impl Era1Bridge {
     }
 
     pub async fn launch_single(&self, epoch: u64) {
-        let era1_path = self.era1_files.clone().into_iter().find(|file| {
-            file.contains("mainnet-")
-                && file.contains(&format!("{epoch}-"))
-                && file.contains(".era1")
-        });
+        let era1_path =
+            self.era1_files.clone().into_iter().find(|file| {
+                file.contains(&format!("mainnet-{epoch:05}-")) && file.contains(".era1")
+            });
         match era1_path {
             Some(path) => self.gossip_era1(path).await,
             None => panic!("4444s bridge couldn't find request epoch on era1 file server"),

--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -22,7 +22,10 @@ use crate::{
     },
     gossip::gossip_history_content,
     stats::{HistoryBlockStats, StatsReporter},
-    types::era1::{BlockTuple, Era1},
+    types::{
+        era1::{BlockTuple, Era1},
+        mode::{BridgeMode, FourFoursModeType},
+    },
 };
 use ethportal_api::{
     jsonrpsee::http_client::HttpClient, types::execution::accumulator::EpochAccumulator,
@@ -36,6 +39,7 @@ use trin_validation::{
 const ERA1_DIR_URL: &str = "https://era1.ethportal.net/";
 
 pub struct Era1Bridge {
+    pub mode: BridgeMode,
     pub portal_clients: Vec<HttpClient>,
     pub header_oracle: HeaderOracle,
     pub epoch_acc_path: PathBuf,
@@ -46,6 +50,7 @@ pub struct Era1Bridge {
 // todo: validate via checksum, so we don't have to validate content on a per-value basis
 impl Era1Bridge {
     pub async fn new(
+        mode: BridgeMode,
         portal_clients: Vec<HttpClient>,
         header_oracle: HeaderOracle,
         epoch_acc_path: PathBuf,
@@ -70,6 +75,7 @@ impl Era1Bridge {
             .collect();
         era1_files.shuffle(&mut thread_rng());
         Ok(Self {
+            mode,
             portal_clients,
             header_oracle,
             epoch_acc_path,
@@ -79,50 +85,76 @@ impl Era1Bridge {
     }
 
     pub async fn launch(&self) {
-        info!("Launching era1 bridge");
-        for era1_path in self.era1_files.clone().into_iter() {
-            info!("Processing era1 file at path: {:?}", era1_path);
-            // We are using a semaphore to limit the amount of active gossip transfers to make sure
-            // we don't overwhelm the trin client
-            let gossip_send_semaphore = Arc::new(Semaphore::new(GOSSIP_LIMIT));
-
-            let raw_era1 = self
-                .http_client
-                .get(era1_path.clone())
-                .recv_bytes()
-                .await
-                .unwrap_or_else(|_| panic!("unable to read era1 file at path: {era1_path:?}"));
-            let era1 = Era1::deserialize(&raw_era1).expect("to be able to deserialize era1 file");
-            let epoch_index = era1.block_tuples[0].header.header.number / EPOCH_SIZE as u64;
-            info!("Era1 file read successfully, gossiping block tuples for epoch: {epoch_index}");
-            let epoch_acc = match self.get_epoch_acc(epoch_index).await {
-                Ok(epoch_acc) => epoch_acc,
-                Err(e) => {
-                    error!("Failed to get epoch acc for epoch: {epoch_index}, error: {e}");
-                    continue;
-                }
-            };
-            let master_acc = Arc::new(self.header_oracle.master_acc.clone());
-            let mut serve_block_tuple_handles = vec![];
-            for block_tuple in era1.block_tuples {
-                let permit = gossip_send_semaphore
-                    .clone()
-                    .acquire_owned()
-                    .await
-                    .expect("to be able to acquire semaphore");
-                let serve_block_tuple_handle = Self::spawn_serve_block_tuple(
-                    self.portal_clients.clone(),
-                    block_tuple,
-                    epoch_acc.clone(),
-                    master_acc.clone(),
-                    permit,
-                );
-                serve_block_tuple_handles.push(serve_block_tuple_handle);
+        info!("Launching era1 bridge: {:?}", self.mode);
+        match self.mode.clone() {
+            BridgeMode::FourFours(FourFoursModeType::Random) => self.launch_random().await,
+            BridgeMode::FourFours(FourFoursModeType::Epoch(epoch)) => {
+                self.launch_epoch(epoch).await
             }
-            // Wait till all block tuples are done gossiping.
-            // This can't deadlock, because the tokio::spawn has a timeout.
-            join_all(serve_block_tuple_handles).await;
+            _ => panic!("4444s bridge only supports 4444s modes."),
         }
+        info!("Bridge mode: {:?} complete.", self.mode);
+    }
+
+    pub async fn launch_random(&self) {
+        for era1_path in self.era1_files.clone().into_iter() {
+            self.gossip_era1(era1_path).await;
+        }
+    }
+
+    pub async fn launch_epoch(&self, epoch: u64) {
+        let epoch_string = epoch.to_string() + "-";
+        for era1_path in self.era1_files.clone().into_iter() {
+            if era1_path.contains(&epoch_string) {
+                self.gossip_era1(era1_path).await;
+                return;
+            }
+        }
+        panic!("4444s bridge couldn't find request epoch on era1 file server")
+    }
+
+    pub async fn gossip_era1(&self, era1_path: String) {
+        info!("Processing era1 file at path: {:?}", era1_path);
+        // We are using a semaphore to limit the amount of active gossip transfers to make sure
+        // we don't overwhelm the trin client
+        let gossip_send_semaphore = Arc::new(Semaphore::new(GOSSIP_LIMIT));
+
+        let raw_era1 = self
+            .http_client
+            .get(era1_path.clone())
+            .recv_bytes()
+            .await
+            .unwrap_or_else(|_| panic!("unable to read era1 file at path: {era1_path:?}"));
+        let era1 = Era1::deserialize(&raw_era1).expect("to be able to deserialize era1 file");
+        let epoch_index = era1.block_tuples[0].header.header.number / EPOCH_SIZE as u64;
+        info!("Era1 file read successfully, gossiping block tuples for epoch: {epoch_index}");
+        let epoch_acc = match self.get_epoch_acc(epoch_index).await {
+            Ok(epoch_acc) => epoch_acc,
+            Err(e) => {
+                error!("Failed to get epoch acc for epoch: {epoch_index}, error: {e}");
+                return;
+            }
+        };
+        let master_acc = Arc::new(self.header_oracle.master_acc.clone());
+        let mut serve_block_tuple_handles = vec![];
+        for block_tuple in era1.block_tuples {
+            let permit = gossip_send_semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .expect("to be able to acquire semaphore");
+            let serve_block_tuple_handle = Self::spawn_serve_block_tuple(
+                self.portal_clients.clone(),
+                block_tuple,
+                epoch_acc.clone(),
+                master_acc.clone(),
+                permit,
+            );
+            serve_block_tuple_handles.push(serve_block_tuple_handle);
+        }
+        // Wait till all block tuples are done gossiping.
+        // This can't deadlock, because the tokio::spawn has a timeout.
+        join_all(serve_block_tuple_handles).await;
     }
 
     async fn get_epoch_acc(&self, epoch_index: u64) -> anyhow::Result<Arc<EpochAccumulator>> {

--- a/portal-bridge/src/bridge/history.rs
+++ b/portal-bridge/src/bridge/history.rs
@@ -68,7 +68,7 @@ impl HistoryBridge {
         match self.mode.clone() {
             BridgeMode::Test(path) => self.launch_test(path).await,
             BridgeMode::Latest => self.launch_latest().await,
-            BridgeMode::FourFours => panic!("4444s mode not supported in HistoryBridge."),
+            BridgeMode::FourFours(_) => panic!("4444s mode not supported in HistoryBridge."),
             _ => self.launch_backfill().await,
         }
         info!("Bridge mode: {:?} complete.", self.mode);

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -79,10 +79,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Launch History Network portal bridge
     if bridge_config.network.contains(&NetworkKind::History) {
         match bridge_config.mode {
-            BridgeMode::FourFours => {
+            BridgeMode::FourFours(_) => {
                 let master_acc = MasterAccumulator::default();
                 let header_oracle = HeaderOracle::new(master_acc);
                 let era1_bridge = Era1Bridge::new(
+                    bridge_config.mode,
                     portal_clients.expect("Failed to create history JSON-RPC clients"),
                     header_oracle,
                     bridge_config.epoch_acc_path,

--- a/portal-bridge/src/types/mode.rs
+++ b/portal-bridge/src/types/mode.rs
@@ -69,7 +69,7 @@ impl BridgeMode {
     }
 }
 
-type ParseError = &'static str;
+type ParseError = String;
 
 impl FromStr for BridgeMode {
     type Err = ParseError;
@@ -101,7 +101,7 @@ impl FromStr for BridgeMode {
                             PathBuf::from_str(&val[1..]).map_err(|_| "Invalid test asset path")?;
                         Ok(BridgeMode::Test(path))
                     }
-                    _ => Err("Invalid bridge mode arg: type prefix"),
+                    _ => Err("Invalid bridge mode arg: type prefix".to_string()),
                 }
             }
         }
@@ -142,19 +142,21 @@ impl FromStr for ModeType {
                     .collect::<Vec<u64>>();
 
                 if range_vec.len() != 2 {
-                    return Err("Invalid bridge mode arg: expected 2 numbers in range");
+                    return Err("Invalid bridge mode arg: expected 2 numbers in range".to_string());
                 }
 
                 let start_block = range_vec[0].to_owned();
                 let end_block = range_vec[1].to_owned();
 
                 if start_block > end_block {
-                    return Err("Invalid bridge mode arg: end_block is less than start_block");
+                    return Err(
+                        "Invalid bridge mode arg: end_block is less than start_block".to_string(),
+                    );
                 }
 
                 Ok(ModeType::BlockRange(start_block, end_block))
             }
-            _ => Err("Invalid bridge mode arg: type prefix"),
+            _ => Err("Invalid bridge mode arg: type prefix".to_string()),
         }
     }
 }
@@ -175,11 +177,11 @@ impl FromStr for FourFoursMode {
                     .parse()
                     .map_err(|_| "Invalid 4444s bridge mode arg: era1 epoch number")?;
                 if epoch > 1896 {
-                    return Err("Invalid 4444s bridge mode arg: era1 epoch greater than 1896 was given: {epoch}");
+                    return Err(format!("Invalid 4444s bridge mode arg: era1 epoch greater than 1896 was given: {epoch}"));
                 }
                 Ok(FourFoursMode::Single(epoch))
             }
-            _ => Err("Invalid 4444s bridge mode arg: type prefix"),
+            _ => Err("Invalid 4444s bridge mode arg: type prefix".to_string()),
         }
     }
 }


### PR DESCRIPTION
### What was wrong?
Using a provider is unreliable for testing using kurtosis

Solution? Use era1 files as they remove the provider failure point out of the equation
### How was it fixed?
Adding a optional specifier for epoch.
