### PR TITLE
style(bridge): use trace_span for subnetwork instrument

### DIFF
--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -73,7 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             beacon_bridge
                 .launch()
-                .instrument(tracing::info_span!("beacon"))
+                .instrument(tracing::trace_span!("beacon"))
                 .await;
         });
 
@@ -96,7 +96,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let bridge_handle = tokio::spawn(async move {
                     era1_bridge
                         .launch()
-                        .instrument(tracing::info_span!("history(era1)"))
+                        .instrument(tracing::trace_span!("history(era1)"))
                         .await;
                 });
                 bridge_tasks.push(bridge_handle);
@@ -122,7 +122,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                     bridge
                         .launch()
-                        .instrument(tracing::info_span!("history"))
+                        .instrument(tracing::trace_span!("history"))
                         .await;
                 });
 


### PR DESCRIPTION
### What was wrong?
Our subnetwork logs only have the per/subnetwork `Instrument` set on `info!` level logs. Imo, this is also useful to have on all log-levels, including debug & trace

### How was it fixed?
- `info_span` -> `trace_span`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
