### PR TITLE
feat(bridge): add support to gossip block range from era1 files

### DIFF
--- a/portal-bridge/README.md
+++ b/portal-bridge/README.md
@@ -34,6 +34,7 @@ Current options include `"trin"` / `"fluffy"`.
 - `"--mode single:e100"`: gossip a single epoch #100
 - `"--mode fourfours`: will randomly select era1 files from `era1.ethportal.net` and gossip them
 - `"--mode fourfours:e600`: will select era1 file 600 from `era1.ethportal.net` and gossip it
+- `"--mode fourfours:r100-200`: will gossip a block range from an era1 file, range must be from the same epoch
 
 ### Network
 You can specify the `--network` flag for which network to run the bridge for

--- a/portal-bridge/src/types/mode.rs
+++ b/portal-bridge/src/types/mode.rs
@@ -118,6 +118,9 @@ pub enum ModeType {
 impl FromStr for ModeType {
     type Err = ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err("Invalid bridge mode arg: empty string".to_string());
+        }
         match &s[..1] {
             "e" => {
                 let epoch = s[1..]
@@ -166,11 +169,16 @@ pub enum FourFoursMode {
     Random,
     // Gossips a single epoch
     Single(u64),
+    // Gossips a block range from within a single epoch
+    Range(u64, u64),
 }
 
 impl FromStr for FourFoursMode {
     type Err = ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err("Invalid bridge fourfours mode arg: empty string".to_string());
+        }
         match &s[..1] {
             "e" => {
                 let epoch = s[1..]
@@ -181,6 +189,43 @@ impl FromStr for FourFoursMode {
                 }
                 Ok(FourFoursMode::Single(epoch))
             }
+            "r" => {
+                let range_vec = s[1..]
+                    .split('-')
+                    .map(|range_input| {
+                        range_input.parse().expect(
+                            "Range format invalid, expected fourfours:rX-Y (eg. fourfours:r10-100)",
+                        )
+                    })
+                    .collect::<Vec<u64>>();
+
+                if range_vec.len() != 2 {
+                    return Err(
+                        "Invalid 4444s bridge mode arg: expected 2 numbers in range".to_string()
+                    );
+                }
+                let start_block = range_vec[0].to_owned();
+                let end_block = range_vec[1].to_owned();
+                if start_block > end_block {
+                    return Err(
+                        "Invalid 4444s bridge mode arg: end_block is less than start_block"
+                            .to_string(),
+                    );
+                }
+                let start_epoch = start_block / EPOCH_SIZE as u64;
+                let end_epoch = end_block / EPOCH_SIZE as u64;
+                if start_epoch != end_epoch {
+                    return Err(
+                        "Invalid 4444s bridge mode arg: start_block and end_block are not in the same epoch"
+                            .to_string(),
+                    );
+                }
+                if start_epoch > 1896 {
+                    return Err(format!("Invalid 4444s bridge mode arg: era1 epoch greater than 1896 was given: {start_epoch}"));
+                }
+
+                Ok(FourFoursMode::Range(start_block, end_block))
+            }
             _ => Err("Invalid 4444s bridge mode arg: type prefix".to_string()),
         }
     }
@@ -189,8 +234,6 @@ impl FromStr for FourFoursMode {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::cli::BridgeConfig;
-    use clap::Parser;
     use rstest::rstest;
 
     #[rstest]
@@ -205,26 +248,39 @@ mod test {
     #[case("backfill:e1000", BridgeMode::Backfill(ModeType::Epoch(1000)))]
     #[case("fourfours", BridgeMode::FourFours(FourFoursMode::Random))]
     #[case("fourfours:e1", BridgeMode::FourFours(FourFoursMode::Single(1)))]
+    #[case("fourfours:r1-10", BridgeMode::FourFours(FourFoursMode::Range(1, 10)))]
     #[case(
         "test:/usr/eth/test.json",
         BridgeMode::Test(PathBuf::from("/usr/eth/test.json"))
     )]
     fn test_mode_flag(#[case] actual: String, #[case] expected: BridgeMode) {
-        const EXECUTABLE_PATH: &str = "path/to/executable";
-        const EPOCH_ACC_PATH: &str = "path/to/epoch/accumulator";
-        let bridge_config = BridgeConfig::parse_from([
-            "bridge",
-            "--node-count",
-            "1",
-            "--executable-path",
-            EXECUTABLE_PATH,
-            "--epoch-accumulator-path",
-            EPOCH_ACC_PATH,
-            "--mode",
-            &actual,
-            "trin",
-        ]);
-        assert_eq!(bridge_config.mode, expected);
+        let bridge_mode = BridgeMode::from_str(&actual).unwrap();
+        assert_eq!(bridge_mode, expected);
+    }
+
+    #[rstest]
+    #[case("latest:")]
+    #[case("latest:block")]
+    #[case("backfill:")]
+    #[case("backfill:x")]
+    #[case("backfill:epoch")]
+    #[case("single:")]
+    #[case("single:x")]
+    #[case("fourfours:")]
+    #[case("fourfours:1")]
+    #[case("fourfours:r1")]
+    #[case("fourfours:1-100")]
+    #[case("fourfours:x1-100")]
+    #[case("fourfours:r1-10-100")]
+    // invalid range
+    #[case("fourfours:r100-1")]
+    // range is not within a single epoch
+    #[case("fourfours:r1-10000")]
+    // range is post-merge
+    #[case("fourfours:r19000000-19000100")]
+    fn test_invalid_mode_flag(#[case] actual: String) {
+        let bridge_mode = BridgeMode::from_str(&actual);
+        assert!(bridge_mode.is_err());
     }
 
     #[rstest]


### PR DESCRIPTION
### What was wrong?
Gossiping an entire epoch takes quite a while. In kurtosis, it's useful to have the ability to gossip a small range of blocks. But we also want the ability to do this using era1 files as the provider, since they're more reliable.

### How was it fixed?
- added the ability to gossip a range of blocks, as long as they're all within the same epoch. 
- added some debug logs to help understand what's being gossiped on a more granular level

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
