### PR TITLE
fix(bridge): include fluffy executable in docker image

### DIFF
--- a/docker/Dockerfile.bridge
+++ b/docker/Dockerfile.bridge
@@ -45,6 +45,14 @@ COPY ./rpc ./rpc
 # build for release
 RUN cargo build -p trin -p portal-bridge --release
 
+# Get the fluffy executable.
+# If you're building on a different architecture,
+# you'll need to include the `--platform linux/amd64` flag
+# to the `docker build` command.
+# This isn't an issue for our ci pipeline, as it's already
+# building on an amd64 machine.
+FROM statusim/nimbus-fluffy:amd64-master-latest AS fluffy
+
 # final base
 FROM final_base
 
@@ -53,6 +61,7 @@ COPY --from=builder /trin/target/release/trin /usr/bin/
 COPY --from=builder /trin/target/release/portal-bridge /usr/bin/
 COPY --from=builder /trin/target/release/sample_range /usr/bin/
 COPY --from=builder /trin/target/release/poll_latest /usr/bin/
+COPY --from=fluffy /usr/bin/fluffy /usr/bin/
 
 RUN apt-get update && apt-get install libcurl4 -y
 

--- a/portal-bridge/src/client_handles.rs
+++ b/portal-bridge/src/client_handles.rs
@@ -39,7 +39,7 @@ pub fn fluffy_handle(
     }
     if bridge_config.bootnodes != "default" {
         for enr in bridge_config.bootnodes.split(',') {
-            command.args(["--bootstrap-node", enr]);
+            command.arg(format!("--bootstrap-node:{enr}"));
         }
     }
     if let Some(ip) = bridge_config.external_ip {


### PR DESCRIPTION
### What was wrong?
In our bridge, we support using fluffy as the bridge client. This is done by passing an "executable path" via cli. This is possible when you run the bridge locally, but it's not possible when running a fluffy bridge via docker (eg. in kurtosis). 

Also, our method for adding bootstrap enrs to the fluffy executable was broken.

### How was it fixed?
- Included the fluffy executable inside the bridge docker image
- Fixed the bootstrap enrs cli arg formatting for fluffy

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
