### PR TITLE
refactor: replace PossibleContentValue with error according to spec u…

### DIFF
--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -5,7 +5,7 @@ use crate::{
         enr::Enr,
         portal::{AcceptInfo, DataRadius, FindNodesInfo, PongInfo, TraceGossipInfo},
     },
-    BeaconContentValue, PossibleBeaconContentValue, RoutingTableInfo,
+    BeaconContentValue, RoutingTableInfo,
 };
 use discv5::enr::NodeId;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
@@ -114,8 +114,5 @@ pub trait BeaconNetworkApi {
 
     /// Get a content from the local database
     #[method(name = "beaconLocalContent")]
-    async fn local_content(
-        &self,
-        content_key: BeaconContentKey,
-    ) -> RpcResult<PossibleBeaconContentValue>;
+    async fn local_content(&self, content_key: BeaconContentKey) -> RpcResult<BeaconContentValue>;
 }

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -5,7 +5,7 @@ use crate::{
         history::{ContentInfo, PaginateLocalContentInfo, TraceContentInfo},
         portal::{AcceptInfo, DataRadius, FindNodesInfo, PongInfo, TraceGossipInfo},
     },
-    HistoryContentValue, PossibleHistoryContentValue, RoutingTableInfo,
+    HistoryContentValue, RoutingTableInfo,
 };
 use discv5::enr::NodeId;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
@@ -117,10 +117,8 @@ pub trait HistoryNetworkApi {
         content_value: HistoryContentValue,
     ) -> RpcResult<bool>;
 
-    /// Get a content from the local database
+    /// Get a content value from the local database
     #[method(name = "historyLocalContent")]
-    async fn local_content(
-        &self,
-        content_key: HistoryContentKey,
-    ) -> RpcResult<PossibleHistoryContentValue>;
+    async fn local_content(&self, content_key: HistoryContentKey)
+        -> RpcResult<HistoryContentValue>;
 }

--- a/ethportal-api/src/lib.rs
+++ b/ethportal-api/src/lib.rs
@@ -41,10 +41,8 @@ pub use types::{
     consensus,
     consensus::light_client,
     content_value::{
-        beacon::{BeaconContentValue, PossibleBeaconContentValue},
-        error::ContentValueError,
-        history::{HistoryContentValue, PossibleHistoryContentValue},
-        state::{PossibleStateContentValue, StateContentValue},
+        beacon::BeaconContentValue, error::ContentValueError, history::HistoryContentValue,
+        state::StateContentValue,
     },
     execution::{block_body::*, header::*, receipts::*},
 };

--- a/ethportal-api/src/state.rs
+++ b/ethportal-api/src/state.rs
@@ -5,7 +5,7 @@ use crate::{
         portal::{AcceptInfo, DataRadius, FindNodesInfo, PongInfo, TraceGossipInfo},
         state::{ContentInfo, PaginateLocalContentInfo, TraceContentInfo},
     },
-    PossibleStateContentValue, RoutingTableInfo, StateContentValue,
+    RoutingTableInfo, StateContentValue,
 };
 use discv5::enr::NodeId;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
@@ -112,8 +112,5 @@ pub trait StateNetworkApi {
 
     /// Get a content from the local database
     #[method(name = "stateLocalContent")]
-    async fn local_content(
-        &self,
-        content_key: StateContentKey,
-    ) -> RpcResult<PossibleStateContentValue>;
+    async fn local_content(&self, content_key: StateContentKey) -> RpcResult<StateContentValue>;
 }

--- a/ethportal-api/src/types/beacon.rs
+++ b/ethportal-api/src/types/beacon.rs
@@ -1,5 +1,5 @@
 use super::query_trace::QueryTrace;
-use crate::{types::enr::Enr, BeaconContentKey, PossibleBeaconContentValue};
+use crate::{types::enr::Enr, BeaconContentKey, BeaconContentValue};
 use serde::{Deserialize, Serialize};
 
 /// Response for FindContent & RecursiveFindContent endpoints
@@ -11,7 +11,7 @@ pub enum ContentInfo {
     ConnectionId { connection_id: u16 },
     #[serde(rename_all = "camelCase")]
     Content {
-        content: PossibleBeaconContentValue,
+        content: BeaconContentValue,
         utp_transfer: bool,
     },
     #[serde(rename_all = "camelCase")]
@@ -20,12 +20,12 @@ pub enum ContentInfo {
 
 /// Parsed response for TraceRecursiveFindContent endpoint
 ///
-/// The RPC response encodes absent content as "0x". This struct
-/// represents the content info, using None for absent content.
+/// This struct represents the content info, and is only used
+/// when the content is found locally or on the network.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TraceContentInfo {
-    pub content: PossibleBeaconContentValue,
+    pub content: BeaconContentValue,
     pub utp_transfer: bool,
     pub trace: QueryTrace,
 }

--- a/ethportal-api/src/types/constants.rs
+++ b/ethportal-api/src/types/constants.rs
@@ -1,2 +1,0 @@
-/// Portal network defines "content absent" response as "0x".
-pub const CONTENT_ABSENT: &str = "0x";

--- a/ethportal-api/src/types/history.rs
+++ b/ethportal-api/src/types/history.rs
@@ -1,5 +1,5 @@
 use super::query_trace::QueryTrace;
-use crate::{types::enr::Enr, HistoryContentKey, PossibleHistoryContentValue};
+use crate::{types::enr::Enr, HistoryContentKey, HistoryContentValue};
 use serde::{Deserialize, Serialize};
 
 /// Response for FindContent & RecursiveFindContent endpoints
@@ -10,7 +10,7 @@ pub enum ContentInfo {
     ConnectionId { connection_id: u16 },
     #[serde(rename_all = "camelCase")]
     Content {
-        content: PossibleHistoryContentValue,
+        content: HistoryContentValue,
         utp_transfer: bool,
     },
     #[serde(rename_all = "camelCase")]
@@ -19,12 +19,12 @@ pub enum ContentInfo {
 
 /// Parsed response for TraceRecursiveFindContent endpoint
 ///
-/// The RPC response encodes absent content as "0x". This struct
-/// represents the content info, using None for absent content.
+/// This struct represents the content info, and is only used
+/// when the content is found locally or on the network.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TraceContentInfo {
-    pub content: PossibleHistoryContentValue,
+    pub content: HistoryContentValue,
     pub utp_transfer: bool,
     pub trace: QueryTrace,
 }

--- a/ethportal-api/src/types/mod.rs
+++ b/ethportal-api/src/types/mod.rs
@@ -3,7 +3,6 @@ pub mod bootnodes;
 pub mod bytes;
 pub mod cli;
 pub mod consensus;
-pub mod constants;
 pub mod content_key;
 pub mod content_value;
 pub mod discv5;

--- a/ethportal-api/src/types/state.rs
+++ b/ethportal-api/src/types/state.rs
@@ -1,5 +1,5 @@
 use super::query_trace::QueryTrace;
-use crate::{types::enr::Enr, PossibleStateContentValue, StateContentKey};
+use crate::{types::enr::Enr, StateContentKey, StateContentValue};
 use serde::{Deserialize, Serialize};
 
 /// Response for FindContent & RecursiveFindContent endpoints
@@ -10,7 +10,7 @@ pub enum ContentInfo {
     ConnectionId { connection_id: u16 },
     #[serde(rename_all = "camelCase")]
     Content {
-        content: PossibleStateContentValue,
+        content: StateContentValue,
         utp_transfer: bool,
     },
     #[serde(rename_all = "camelCase")]
@@ -19,12 +19,12 @@ pub enum ContentInfo {
 
 /// Parsed response for TraceRecursiveFindContent endpoint
 ///
-/// The RPC response encodes absent content as "0x". This struct
-/// represents the content info, using None for absent content.
+/// This struct represents the content info, and is only used
+/// when the content is found locally or on the network.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TraceContentInfo {
-    pub content: PossibleStateContentValue,
+    pub content: StateContentValue,
     pub utp_transfer: bool,
     pub trace: QueryTrace,
 }

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -3,7 +3,7 @@ use ethereum_types::{H256, U256};
 use ethportal_api::{
     types::{distance::Distance, portal_wire::ProtocolId},
     BeaconNetworkApiClient, BlockHeaderKey, Discv5ApiClient, HistoryContentKey,
-    HistoryNetworkApiClient, PossibleHistoryContentValue, StateNetworkApiClient, Web3ApiClient,
+    HistoryNetworkApiClient, StateNetworkApiClient, Web3ApiClient,
 };
 use jsonrpsee::async_client::Client;
 use ssz::Encode;
@@ -179,11 +179,10 @@ pub async fn test_history_local_content_absent(target: &Client) {
     let content_key = HistoryContentKey::BlockHeaderWithProof(BlockHeaderKey {
         block_hash: H256::random().into(),
     });
-    let result = HistoryNetworkApiClient::local_content(target, content_key)
+    let error = HistoryNetworkApiClient::local_content(target, content_key)
         .await
-        .unwrap();
-
-    if let PossibleHistoryContentValue::ContentPresent(_) = result {
-        panic!("Expected absent content");
-    };
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("Content not found in local storage"));
 }

--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -2,10 +2,7 @@ use crate::{
     utils::{fixture_header_with_proof_1000010, wait_for_beacon_content, wait_for_history_content},
     Peertest,
 };
-use ethportal_api::{
-    jsonrpsee::http_client::HttpClient, BeaconContentKey, BeaconContentValue,
-    PossibleBeaconContentValue, PossibleHistoryContentValue,
-};
+use ethportal_api::{jsonrpsee::http_client::HttpClient, BeaconContentKey, BeaconContentValue};
 use portal_bridge::{
     api::{consensus::ConsensusApi, execution::ExecutionApi},
     bridge::{beacon::BeaconBridge, history::HistoryBridge},
@@ -38,11 +35,8 @@ pub async fn test_history_bridge(peertest: &Peertest, target: &HttpClient) {
     bridge.launch().await;
     let (content_key, content_value) = fixture_header_with_proof_1000010();
     // Check if the stored content value in bootnode's DB matches the offered
-    let response = wait_for_history_content(&peertest.bootnode.ipc_client, content_key).await;
-    let received_content_value = match response {
-        PossibleHistoryContentValue::ContentPresent(c) => c,
-        PossibleHistoryContentValue::ContentAbsent => panic!("Expected content to be found"),
-    };
+    let received_content_value =
+        wait_for_history_content(&peertest.bootnode.ipc_client, content_key).await;
     assert_eq!(
         content_value, received_content_value,
         "The received content {received_content_value:?}, must match the expected {content_value:?}",
@@ -67,11 +61,8 @@ pub async fn test_beacon_bridge(peertest: &Peertest, target: &HttpClient) {
         serde_json::from_value(value[0].get("content_value").unwrap().clone()).unwrap();
 
     // Check if the stored content value in bootnode's DB matches the offered
-    let response = wait_for_beacon_content(&peertest.bootnode.ipc_client, content_key).await;
-    let received_content_value = match response {
-        PossibleBeaconContentValue::ContentPresent(c) => c,
-        PossibleBeaconContentValue::ContentAbsent => panic!("Expected beacon content to be found"),
-    };
+    let received_content_value =
+        wait_for_beacon_content(&peertest.bootnode.ipc_client, content_key).await;
     assert_eq!(
         content_value, received_content_value,
         "The received beacon content {received_content_value:?}, must match the expected {content_value:?}",

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -8,8 +8,7 @@ use crate::{utils::fixture_header_with_proof, Peertest};
 use ethportal_api::{
     types::{history::ContentInfo, portal_wire::ProtocolId},
     utils::bytes::hex_decode,
-    BeaconNetworkApiClient, Enr, HistoryNetworkApiClient, OverlayContentKey,
-    PossibleHistoryContentValue, StateNetworkApiClient,
+    BeaconNetworkApiClient, Enr, HistoryNetworkApiClient, OverlayContentKey, StateNetworkApiClient,
 };
 
 pub async fn test_recursive_find_nodes_self(protocol: ProtocolId, peertest: &Peertest) {
@@ -106,10 +105,7 @@ pub async fn test_trace_recursive_find_content(peertest: &Peertest) {
     let content = trace_content_info.content;
     let trace = trace_content_info.trace;
 
-    assert_eq!(
-        content,
-        PossibleHistoryContentValue::ContentPresent(content_value)
-    );
+    assert_eq!(content, content_value);
 
     let query_origin_node: NodeId = peertest.nodes[0].enr.node_id();
     let node_with_content: NodeId = peertest.bootnode.enr.node_id();
@@ -143,14 +139,14 @@ pub async fn test_trace_recursive_find_content_for_absent_content(peertest: &Pee
     let client = &peertest.nodes[0].ipc_client;
     let (content_key, _) = fixture_header_with_proof();
 
-    let result = HistoryNetworkApiClient::trace_recursive_find_content(client, content_key)
+    let error = HistoryNetworkApiClient::trace_recursive_find_content(client, content_key)
         .await
-        .unwrap();
-
-    assert!(!result.utp_transfer);
-    assert_eq!(result.content, PossibleHistoryContentValue::ContentAbsent);
-    // Check that at least one route was involved.
-    assert!(result.trace.responses.len() > 1);
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("Content not found"));
+    // test that trace is present
+    assert!(error.contains("respondedWith"));
+    assert!(error.contains("-32001"));
 }
 
 pub async fn test_trace_recursive_find_content_local_db(peertest: &Peertest) {
@@ -173,10 +169,7 @@ pub async fn test_trace_recursive_find_content_local_db(peertest: &Peertest) {
     .await
     .unwrap();
     assert!(!trace_content_info.utp_transfer);
-    assert_eq!(
-        trace_content_info.content,
-        PossibleHistoryContentValue::ContentPresent(content_value)
-    );
+    assert_eq!(trace_content_info.content, content_value);
 
     let origin = trace_content_info.trace.origin;
     assert_eq!(trace_content_info.trace.received_from.unwrap(), origin);

--- a/ethportal-peertest/src/scenarios/gossip.rs
+++ b/ethportal-peertest/src/scenarios/gossip.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use ethportal_api::{
     jsonrpsee::async_client::Client, types::cli::TrinConfig, Discv5ApiClient,
-    HistoryNetworkApiClient, PossibleHistoryContentValue,
+    HistoryNetworkApiClient,
 };
 
 pub async fn test_gossip_with_trace(peertest: &Peertest, target: &Client) {
@@ -26,12 +26,8 @@ pub async fn test_gossip_with_trace(peertest: &Peertest, target: &Client) {
     assert_eq!(result.transferred.len(), 1);
 
     // Check if the stored content value in bootnode's DB matches the offered
-    let response =
+    let received_content_value =
         wait_for_history_content(&peertest.bootnode.ipc_client, content_key.clone()).await;
-    let received_content_value = match response {
-        PossibleHistoryContentValue::ContentPresent(c) => c,
-        PossibleHistoryContentValue::ContentAbsent => panic!("Expected content to be found"),
-    };
     assert_eq!(
         content_value, received_content_value,
         "The received content {received_content_value:?}, must match the expected {content_value:?}",
@@ -83,11 +79,7 @@ pub async fn test_gossip_with_trace(peertest: &Peertest, target: &Client) {
     assert_eq!(result.transferred.len(), 1);
 
     // Check if the stored content value in fresh node's DB matches the offered
-    let response = wait_for_history_content(&fresh_target, content_key.clone()).await;
-    let received_content_value = match response {
-        PossibleHistoryContentValue::ContentPresent(c) => c,
-        PossibleHistoryContentValue::ContentAbsent => panic!("Expected content to be found"),
-    };
+    let received_content_value = wait_for_history_content(&fresh_target, content_key.clone()).await;
     assert_eq!(
         content_value, received_content_value,
         "The received content {received_content_value:?}, must match the expected {content_value:?}",

--- a/ethportal-peertest/src/scenarios/offer_accept.rs
+++ b/ethportal-peertest/src/scenarios/offer_accept.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use ethportal_api::{
     jsonrpsee::async_client::Client, types::enr::Enr, utils::bytes::hex_encode,
-    HistoryNetworkApiClient, PossibleHistoryContentValue,
+    HistoryNetworkApiClient,
 };
 
 pub async fn test_unpopulated_offer(peertest: &Peertest, target: &Client) {
@@ -37,11 +37,8 @@ pub async fn test_unpopulated_offer(peertest: &Peertest, target: &Client) {
     assert_eq!(hex_encode(result.content_keys.into_bytes()), "0x03");
 
     // Check if the stored content value in bootnode's DB matches the offered
-    let response = wait_for_history_content(&peertest.bootnode.ipc_client, content_key).await;
-    let received_content_value = match response {
-        PossibleHistoryContentValue::ContentPresent(c) => c,
-        PossibleHistoryContentValue::ContentAbsent => panic!("Expected content to be found"),
-    };
+    let received_content_value =
+        wait_for_history_content(&peertest.bootnode.ipc_client, content_key).await;
     assert_eq!(
         content_value, received_content_value,
         "The received content {received_content_value:?}, must match the expected {content_value:?}",
@@ -65,11 +62,8 @@ pub async fn test_populated_offer(peertest: &Peertest, target: &Client) {
     assert_eq!(hex_encode(result.content_keys.into_bytes()), "0x03");
 
     // Check if the stored content value in bootnode's DB matches the offered
-    let response = wait_for_history_content(&peertest.bootnode.ipc_client, content_key).await;
-    let received_content_value = match response {
-        PossibleHistoryContentValue::ContentPresent(c) => c,
-        PossibleHistoryContentValue::ContentAbsent => panic!("Expected content to be found"),
-    };
+    let received_content_value =
+        wait_for_history_content(&peertest.bootnode.ipc_client, content_key).await;
     assert_eq!(
         content_value, received_content_value,
         "The received content {received_content_value:?}, must match the expected {content_value:?}",

--- a/ethportal-peertest/src/scenarios/utp.rs
+++ b/ethportal-peertest/src/scenarios/utp.rs
@@ -5,7 +5,7 @@ use crate::{
 use discv5::enr::NodeId;
 use ethportal_api::{
     types::history::{ContentInfo, TraceContentInfo},
-    HistoryNetworkApiClient, PossibleHistoryContentValue,
+    HistoryNetworkApiClient,
 };
 use tracing::info;
 
@@ -43,10 +43,7 @@ pub async fn test_recursive_utp(peertest: &Peertest) {
         utp_transfer,
     } = content_info
     {
-        assert_eq!(
-            content,
-            PossibleHistoryContentValue::ContentPresent(content_value)
-        );
+        assert_eq!(content, content_value);
         assert!(utp_transfer);
     } else {
         panic!("Error: Unexpected content info response");
@@ -86,10 +83,7 @@ pub async fn test_trace_recursive_utp(peertest: &Peertest) {
     let content = trace_content_info.content;
     let trace = trace_content_info.trace;
 
-    assert_eq!(
-        content,
-        PossibleHistoryContentValue::ContentPresent(content_value)
-    );
+    assert_eq!(content, content_value);
 
     let query_origin_node: NodeId = peertest.nodes[0].enr.node_id();
     let node_with_content: NodeId = peertest.bootnode.enr.node_id();

--- a/ethportal-peertest/src/scenarios/validation.rs
+++ b/ethportal-peertest/src/scenarios/validation.rs
@@ -6,7 +6,7 @@ use ethereum_types::H256;
 use ethportal_api::{
     jsonrpsee::async_client::Client,
     types::{content_key::history::BlockHeaderKey, enr::Enr, history::ContentInfo},
-    HistoryContentKey, HistoryNetworkApiClient, PossibleHistoryContentValue,
+    HistoryContentKey, HistoryNetworkApiClient,
 };
 use std::str::FromStr;
 use tracing::info;
@@ -40,10 +40,7 @@ pub async fn test_validate_pre_merge_header_with_proof(peertest: &Peertest, targ
             content,
             utp_transfer,
         } => {
-            assert_eq!(
-                content,
-                PossibleHistoryContentValue::ContentPresent(content_value)
-            );
+            assert_eq!(content, content_value);
             assert!(!utp_transfer);
         }
         _ => panic!("Content values should match"),
@@ -114,10 +111,7 @@ pub async fn test_validate_pre_merge_block_body(peertest: &Peertest, target: &Cl
             content,
             utp_transfer,
         } => {
-            assert_eq!(
-                content,
-                PossibleHistoryContentValue::ContentPresent(content_value)
-            );
+            assert_eq!(content, content_value);
             assert!(utp_transfer);
         }
         _ => panic!("Content values should match"),
@@ -157,10 +151,7 @@ pub async fn test_validate_pre_merge_receipts(peertest: &Peertest, target: &Clie
             content,
             utp_transfer,
         } => {
-            assert_eq!(
-                content,
-                PossibleHistoryContentValue::ContentPresent(content_value)
-            );
+            assert_eq!(content, content_value);
             assert!(utp_transfer);
         }
         _ => panic!("Content values should match"),

--- a/ethportal-peertest/src/utils.rs
+++ b/ethportal-peertest/src/utils.rs
@@ -5,15 +5,15 @@ use serde_yaml::Value;
 use std::fs;
 
 use ethportal_api::{
-    BeaconContentKey, BeaconNetworkApiClient, HistoryContentKey, HistoryContentValue,
-    HistoryNetworkApiClient, PossibleBeaconContentValue, PossibleHistoryContentValue,
+    BeaconContentKey, BeaconContentValue, BeaconNetworkApiClient, HistoryContentKey,
+    HistoryContentValue, HistoryNetworkApiClient,
 };
 
 /// Wait for the history content to be transferred
 pub async fn wait_for_history_content<P: HistoryNetworkApiClient + std::marker::Sync>(
     ipc_client: &P,
     content_key: HistoryContentKey,
-) -> PossibleHistoryContentValue {
+) -> HistoryContentValue {
     let mut received_content_value = ipc_client.local_content(content_key.clone()).await;
 
     let mut counter = 0;
@@ -21,10 +21,7 @@ pub async fn wait_for_history_content<P: HistoryNetworkApiClient + std::marker::
     // If content is absent an error will be returned.
     while counter < 5 {
         let message = match received_content_value {
-            Ok(cp @ PossibleHistoryContentValue::ContentPresent(_)) => return cp,
-            Ok(PossibleHistoryContentValue::ContentAbsent) => {
-                "absent history content response received".to_string()
-            }
+            Ok(val) => return val,
             Err(e) => format!("received an error {e}"),
         };
         error!("Retrying after 0.5s, because {message}");
@@ -40,7 +37,7 @@ pub async fn wait_for_history_content<P: HistoryNetworkApiClient + std::marker::
 pub async fn wait_for_beacon_content<P: BeaconNetworkApiClient + std::marker::Sync>(
     ipc_client: &P,
     content_key: BeaconContentKey,
-) -> PossibleBeaconContentValue {
+) -> BeaconContentValue {
     let mut received_content_value = ipc_client.local_content(content_key.clone()).await;
 
     let mut counter = 0;
@@ -48,10 +45,7 @@ pub async fn wait_for_beacon_content<P: BeaconNetworkApiClient + std::marker::Sy
     // If content is absent an error will be returned.
     while counter < 60 {
         let message = match received_content_value {
-            Ok(cp @ PossibleBeaconContentValue::ContentPresent(_)) => return cp,
-            Ok(PossibleBeaconContentValue::ContentAbsent) => {
-                "absent beacon content response received".to_string()
-            }
+            Ok(val) => return val,
             Err(e) => format!("received an error {e}"),
         };
         counter += 1;

--- a/portal-bridge/src/gossip.rs
+++ b/portal-bridge/src/gossip.rs
@@ -8,7 +8,7 @@ use crate::stats::{BeaconSlotStats, HistoryBlockStats, StatsReporter};
 use ethportal_api::{
     jsonrpsee::core::Error, types::portal::TraceGossipInfo, BeaconContentKey, BeaconContentValue,
     BeaconNetworkApiClient, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
-    OverlayContentKey, PossibleBeaconContentValue, PossibleHistoryContentValue,
+    OverlayContentKey,
 };
 
 const GOSSIP_RETRY_COUNT: u64 = 3;
@@ -63,11 +63,7 @@ async fn beacon_trace_gossip(
         // if not, make rfc request to see if data is available on network
         let result =
             BeaconNetworkApiClient::recursive_find_content(&client, content_key.clone()).await;
-        if let Ok(ethportal_api::types::beacon::ContentInfo::Content {
-            content: PossibleBeaconContentValue::ContentPresent(_),
-            ..
-        }) = result
-        {
+        if let Ok(ethportal_api::types::beacon::ContentInfo::Content { .. }) = result {
             debug!("Found content on network, after failing to gossip, aborting gossip. content key={:?}", content_key.to_hex());
             return Ok((traces, retry_count));
         }
@@ -109,7 +105,6 @@ pub async fn gossip_history_content(
     Ok(())
 }
 
-// todo why doesn't history return PossibleHistoryContentValue?
 async fn history_trace_gossip(
     client: HttpClient,
     content_key: HistoryContentKey,
@@ -134,11 +129,7 @@ async fn history_trace_gossip(
         // if not, make rfc request to see if data is available on network
         let result =
             HistoryNetworkApiClient::recursive_find_content(&client, content_key.clone()).await;
-        if let Ok(ethportal_api::types::history::ContentInfo::Content {
-            content: PossibleHistoryContentValue::ContentPresent(_),
-            ..
-        }) = result
-        {
+        if let Ok(ethportal_api::types::history::ContentInfo::Content { .. }) = result {
             debug!("Found content on network, after failing to gossip, aborting gossip. content key={:?}", content_key.to_hex());
             return Ok((traces, retry_count));
         }

--- a/portalnet/src/find/query_info.rs
+++ b/portalnet/src/find/query_info.rs
@@ -2,7 +2,7 @@ use discv5::{enr::NodeId, kbucket::Key, Enr};
 use futures::channel::oneshot;
 use smallvec::SmallVec;
 
-use crate::find::query_pool::TargetKey;
+use crate::{find::query_pool::TargetKey, overlay_service::OverlayRequestError};
 use ethportal_api::{
     types::{
         portal_wire::{Content, FindContent, FindNodes, Request},
@@ -23,10 +23,10 @@ pub struct QueryInfo<TContentKey> {
     pub trace: Option<QueryTrace>,
 }
 
-// Content, utp_transfer, trace
-// Content is Option<Vec<u8>> because it can be None if the content is not found
-// in a recursive find content query.
-pub type RecursiveFindContentResult = (Option<Vec<u8>>, bool, Option<QueryTrace>);
+// (content_value, utp_transfer, trace)
+// Returns an OverlayRequestError if the content wasn't found on the network
+pub type RecursiveFindContentResult =
+    Result<(Vec<u8>, bool, Option<QueryTrace>), OverlayRequestError>;
 
 // Content, utp_transfer
 // Content is Content type because the response to a simple find content query

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -243,15 +243,13 @@ async fn overlay() {
         .write()
         .put(content_key.clone(), &content)
         .expect("Unable to store content");
-    match overlay_one.lookup_content(content_key, false).await {
-        (Some(found_content), utp_transfer, _) => {
-            assert_eq!(found_content, content);
-            assert!(!utp_transfer);
-        }
-        (None, _, _) => {
-            panic!("Unable to find content stored with peer");
-        }
-    }
+    let (found_content, utp_transfer, _) = overlay_one
+        .lookup_content(content_key, false)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(found_content, content);
+    assert!(!utp_transfer);
 }
 
 #[tokio::test]

--- a/rpc/src/errors.rs
+++ b/rpc/src/errors.rs
@@ -6,6 +6,7 @@ use crate::{
     rpc_server::ServerKind,
     PortalRpcModule,
 };
+use ethportal_api::types::query_trace::QueryTrace;
 use std::io;
 
 /// Rpc Errors.
@@ -51,11 +52,17 @@ impl RpcError {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum RpcServeError {
     /// A generic error with no data
     Message(String),
     /// Method not available
     MethodNotFound(String),
+    /// ContentNotFound
+    ContentNotFound {
+        message: String,
+        trace: Option<QueryTrace>,
+    },
 }
 
 impl From<RpcServeError> for ErrorObjectOwned {
@@ -68,6 +75,9 @@ impl From<RpcServeError> for ErrorObjectOwned {
             // https://docs.infura.io/networks/ethereum/json-rpc-methods#error-codes
             RpcServeError::Message(msg) => ErrorObject::owned(-32099, msg, None::<()>),
             RpcServeError::MethodNotFound(method) => ErrorObject::owned(-32601, method, None::<()>),
+            RpcServeError::ContentNotFound { message, trace } => {
+                ErrorObject::owned(-32001, message, Some(trace))
+            }
         }
     }
 }

--- a/rpc/src/fetch.rs
+++ b/rpc/src/fetch.rs
@@ -5,7 +5,6 @@ use tokio::sync::mpsc;
 
 use ethportal_api::{
     types::{
-        constants::CONTENT_ABSENT,
         execution::{block_body::BlockBody, header::Header},
         jsonrpc::{endpoints::HistoryEndpoint, request::HistoryJsonRpcRequest},
     },
@@ -29,7 +28,27 @@ pub async fn proxy_query_to_history_subnet(
     match resp_rx.recv().await {
         Some(val) => match val {
             Ok(result) => Ok(result),
-            Err(msg) => Err(RpcServeError::Message(msg)),
+            Err(msg) => {
+                if msg.contains("Content not found") {
+                    let error_details: Value = serde_json::from_str(&msg).map_err(|e| {
+                        RpcServeError::Message(format!(
+                            "Failed to parse error message from history subnet: {e:?}",
+                        ))
+                    })?;
+                    let message = error_details["message"]
+                        .as_str()
+                        .expect("Failed to parse error message from history subnet")
+                        .to_string();
+                    let trace = match error_details.get("trace") {
+                        Some(trace) => serde_json::from_value(trace.clone())
+                            .expect("Failed to parse query trace"),
+                        None => None,
+                    };
+                    Err(RpcServeError::ContentNotFound { message, trace })
+                } else {
+                    Err(RpcServeError::Message(msg))
+                }
+            }
         },
         None => Err(RpcServeError::Message(
             "Internal error: No response from chain history subnetwork".to_string(),
@@ -82,9 +101,6 @@ async fn find_content_by_hash(
                 format!("Invalid internal representation of {content_key:?}; json: {wrong_type:?}");
             return Err(RpcServeError::Message(message));
         }
-    };
-    if content == CONTENT_ABSENT {
-        return Err(RpcServeError::Message("Content not found".into()));
     };
     let content: Vec<u8> =
         hex_decode(&content).expect("decoding the trin hex-encoded data failed, odd");

--- a/rpc/src/history_rpc.rs
+++ b/rpc/src/history_rpc.rs
@@ -4,14 +4,12 @@ use crate::jsonrpsee::core::{async_trait, RpcResult};
 use discv5::enr::NodeId;
 use ethportal_api::{
     types::{
-        constants::CONTENT_ABSENT,
         enr::Enr,
         history::{ContentInfo, PaginateLocalContentInfo, TraceContentInfo},
         jsonrpc::{endpoints::HistoryEndpoint, request::HistoryJsonRpcRequest},
         portal::{AcceptInfo, DataRadius, FindNodesInfo, PongInfo, TraceGossipInfo},
     },
-    HistoryContentKey, HistoryContentValue, HistoryNetworkApiServer, PossibleHistoryContentValue,
-    RoutingTableInfo,
+    HistoryContentKey, HistoryContentValue, HistoryNetworkApiServer, RoutingTableInfo,
 };
 use tokio::sync::mpsc;
 
@@ -119,14 +117,7 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
     ) -> RpcResult<ContentInfo> {
         let endpoint = HistoryEndpoint::RecursiveFindContent(content_key);
         let result = proxy_query_to_history_subnet(&self.network, endpoint).await?;
-        if result == serde_json::Value::String(CONTENT_ABSENT.to_string()) {
-            return Ok(ContentInfo::Content {
-                content: PossibleHistoryContentValue::ContentAbsent,
-                utp_transfer: false,
-            });
-        };
-        let result: ContentInfo = from_value(result)?;
-        Ok(result)
+        Ok(from_value(result)?)
     }
 
     /// Lookup a target content key in the network. Return tracing info.
@@ -209,14 +200,10 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
     async fn local_content(
         &self,
         content_key: HistoryContentKey,
-    ) -> RpcResult<PossibleHistoryContentValue> {
+    ) -> RpcResult<HistoryContentValue> {
         let endpoint = HistoryEndpoint::LocalContent(content_key);
         let result = proxy_query_to_history_subnet(&self.network, endpoint).await?;
-        if result == serde_json::Value::String(CONTENT_ABSENT.to_string()) {
-            return Ok(PossibleHistoryContentValue::ContentAbsent);
-        };
-        let content: HistoryContentValue = from_value(result)?;
-        Ok(PossibleHistoryContentValue::ContentPresent(content))
+        Ok(from_value(result)?)
     }
 }
 

--- a/rpc/src/serde.rs
+++ b/rpc/src/serde.rs
@@ -1,6 +1,8 @@
 use crate::errors::RpcServeError;
 use serde_json::{from_value as serde_json_from_value, Value};
 
+// Required for the ContentNotFound error type
+#[allow(clippy::result_large_err)]
 pub fn from_value<T: serde::de::DeserializeOwned>(value: Value) -> Result<T, RpcServeError> {
     serde_json_from_value(value).map_err(|e| RpcServeError::Message(e.to_string()))
 }

--- a/src/bin/poll_latest.rs
+++ b/src/bin/poll_latest.rs
@@ -5,10 +5,7 @@ use ethers::prelude::*;
 use ethers_providers::Ws;
 use ethportal_api::{
     jsonrpsee::http_client::{HttpClient, HttpClientBuilder},
-    types::{
-        content_key::overlay::OverlayContentKey,
-        content_value::history::PossibleHistoryContentValue, history::ContentInfo,
-    },
+    types::{content_key::overlay::OverlayContentKey, history::ContentInfo},
     BlockBodyKey, BlockHeaderKey, BlockReceiptsKey, HistoryContentKey, HistoryNetworkApiClient,
 };
 use std::{
@@ -216,11 +213,11 @@ async fn audit_content_key(
 ) -> anyhow::Result<Instant> {
     let mut attempts = 0;
     while Instant::now() - timestamp < timeout {
-        let content = client.recursive_find_content(content_key.clone()).await?;
-        if let ContentInfo::Content { content, .. } = content {
-            if let PossibleHistoryContentValue::ContentPresent(_) = content {
+        match client.recursive_find_content(content_key.clone()).await? {
+            ContentInfo::Content { .. } => {
                 return Ok(Instant::now());
-            } else {
+            }
+            _ => {
                 attempts += 1;
                 let sleep_time = match backoff {
                     Backoff::Exponential => attempts * 2,

--- a/trin-validation/src/oracle.rs
+++ b/trin-validation/src/oracle.rs
@@ -13,7 +13,7 @@ use ethportal_api::{
             request::{BeaconJsonRpcRequest, HistoryJsonRpcRequest},
         },
     },
-    BlockHeaderKey, HistoryContentKey, HistoryContentValue, PossibleHistoryContentValue,
+    BlockHeaderKey, HistoryContentKey, HistoryContentValue,
 };
 
 /// Responsible for dispatching cross-overlay-network requests
@@ -78,14 +78,7 @@ impl HeaderOracle {
                 ))
             }
         };
-        let content = match content {
-            PossibleHistoryContentValue::ContentPresent(header) => header,
-            PossibleHistoryContentValue::ContentAbsent => {
-                return Err(anyhow!(
-                    "ContentAbsent received from HeaderWithProof lookup"
-                ))
-            }
-        };
+
         match content {
             HistoryContentValue::BlockHeaderWithProof(content) => Ok(content),
             _ => Err(anyhow!(


### PR DESCRIPTION
### What was wrong?
We are unable to distinguish between empty receipts & content not found values in our jsonrpc responses. It was decided to return an `Error` in the case of an unsuccessful content lookup. 

### How was it fixed?
Replaced `PossibleContentValue` strategy with `Error` based strategy for jsonrpc responses with failed content lookups. 

This pr is "sort of" blocked by an upcoming pr to the specs, in which we'll officially define the actual error message, code, and data fields. However, since this pr is very useful w/ regards to 4444s data availability measurement, imo, we are good to push it through, and then revisit any disparities b/w the spec & this implementation after the spec is finalized.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
