### PR TITLE
perf(history storage): decrease `prune_db()` loop iteration time by 40-50s on 8gb database

### DIFF
--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -303,7 +303,7 @@ impl BeaconStorage {
         content_id: &[u8; 32],
         content_key: &String,
         value: &Vec<u8>,
-    ) -> Result<(), ContentStoreError> {
+    ) -> Result<usize, ContentStoreError> {
         let conn = self.sql_connection_pool.get()?;
         insert_value(conn, content_id, content_key, value, u8::from(self.network))
     }

--- a/trin-history/src/storage.rs
+++ b/trin-history/src/storage.rs
@@ -29,7 +29,7 @@ pub struct HistoryStorage {
     node_id: NodeId,
     node_data_dir: PathBuf,
     storage_capacity_in_bytes: u64,
-    network_content_storage_used: u64,
+    storage_occupied_in_bytes: u64,
     radius: Distance,
     sql_connection_pool: Pool<SqliteConnectionManager>,
     distance_fn: DistanceFunction,
@@ -101,14 +101,14 @@ impl HistoryStorage {
             distance_fn: config.distance_fn,
             metrics,
             network: protocol,
-            network_content_storage_used: 0,
+            storage_occupied_in_bytes: 0,
         };
 
         // Set the metrics to the default radius, to start
         storage.metrics.report_radius(storage.radius);
 
         // Set the network content storage used at start
-        storage.network_content_storage_used =
+        storage.storage_occupied_in_bytes =
             storage.get_total_storage_usage_in_bytes_from_network()?;
 
         // Check whether we already have data, and use it to set radius
@@ -218,15 +218,20 @@ impl HistoryStorage {
         // store content key w/o the 0x prefix
         let content_key = hex_encode(content_key).trim_start_matches("0x").to_string();
         let value_size = value.len() as u64;
-        if let Err(err) = self.db_insert(&content_id, &content_key, value) {
-            debug!("Error writing content ID {content_id:?} to db: {err:?}");
-            return Err(err);
-        } else {
-            // we are inserting into the database increase total network storage count
-            self.network_content_storage_used += value_size;
-            self.metrics
-                .report_content_data_storage_bytes(self.network_content_storage_used as f64);
-            self.metrics.increase_entry_count();
+        match self.db_insert(&content_id, &content_key, value) {
+            Ok(result) => {
+                // Insertion successful, increase total network storage count
+                if result == 1 {
+                    self.storage_occupied_in_bytes += value_size;
+                    self.metrics
+                        .report_content_data_storage_bytes(self.storage_occupied_in_bytes as f64);
+                    self.metrics.increase_entry_count();
+                }
+            }
+            Err(err) => {
+                debug!("Error writing content ID {content_id:?} to db: {err:?}");
+                return Err(err);
+            }
         }
         self.prune_db()?;
         let total_bytes_on_disk = self.get_total_storage_usage_in_bytes_on_disk()?;
@@ -250,8 +255,7 @@ impl HistoryStorage {
                 farthest_content_id.expect("Capacity reached, but no farthest id found!");
             // Test if removing the item would put us under capacity
             let bytes_to_remove = self.get_content_size(&id_to_remove)?;
-            if self.network_content_storage_used - bytes_to_remove < self.storage_capacity_in_bytes
-            {
+            if self.storage_occupied_in_bytes - bytes_to_remove < self.storage_capacity_in_bytes {
                 // If so, we're done pruning
                 debug!(
                     "Removing item would drop us below capacity. We target slight overfilling. {}",
@@ -267,10 +271,10 @@ impl HistoryStorage {
             if let Err(err) = self.evict(id_to_remove) {
                 debug!("Error writing content ID {id_to_remove:?} to db: {err:?}",);
             } else {
-                // we are evicting content from the database decrease total network storage count
-                self.network_content_storage_used -= bytes_to_remove;
+                // Eviction successful, decrease total network storage count
+                self.storage_occupied_in_bytes -= bytes_to_remove;
                 self.metrics
-                    .report_content_data_storage_bytes(self.network_content_storage_used as f64);
+                    .report_content_data_storage_bytes(self.storage_occupied_in_bytes as f64);
                 num_removed_items += 1;
             }
             // Calculate new farthest_content_id and reset radius
@@ -371,7 +375,7 @@ impl HistoryStorage {
         content_id: &[u8; 32],
         content_key: &String,
         value: &Vec<u8>,
-    ) -> Result<(), ContentStoreError> {
+    ) -> Result<usize, ContentStoreError> {
         let conn = self.sql_connection_pool.get()?;
         insert_value(conn, content_id, content_key, value, u8::from(self.network))
     }
@@ -386,7 +390,7 @@ impl HistoryStorage {
 
     /// Internal method for determining whether the node is over-capacity.
     fn capacity_reached(&self) -> bool {
-        self.network_content_storage_used > self.storage_capacity_in_bytes
+        self.storage_occupied_in_bytes > self.storage_capacity_in_bytes
     }
 
     /// Internal method for measuring the total amount of requestable data that the node is storing.
@@ -587,6 +591,10 @@ pub mod test {
             let content_key = generate_random_content_key();
             let value: Vec<u8> = vec![0; 32000];
             storage.store(&content_key, &value)?;
+            assert_eq!(
+                storage.storage_occupied_in_bytes,
+                storage.get_total_storage_usage_in_bytes_from_network()?
+            );
         }
 
         let bytes = storage.get_total_storage_usage_in_bytes_from_network()?;
@@ -624,6 +632,71 @@ pub mod test {
 
     #[test_log::test(tokio::test)]
     #[serial]
+    async fn test_inserting_same_key() -> Result<(), ContentStoreError> {
+        let temp_dir = setup_temp_dir().unwrap();
+        let node_id = get_active_node_id(temp_dir.path().to_path_buf());
+        let storage_config =
+            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id).unwrap();
+        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History)?;
+
+        let content_key = generate_random_content_key();
+        let value: Vec<u8> = vec![0; 32000];
+        storage.store(&content_key, &value)?;
+        assert_eq!(
+            storage.storage_occupied_in_bytes,
+            storage.get_total_storage_usage_in_bytes_from_network()?
+        );
+
+        storage.store(&content_key, &value)?;
+        assert_eq!(
+            storage.storage_occupied_in_bytes,
+            storage.get_total_storage_usage_in_bytes_from_network()?
+        );
+
+        std::mem::drop(storage);
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    #[serial]
+    async fn test_evict_content_keys_and_check_we_track_the_right_number(
+    ) -> Result<(), ContentStoreError> {
+        let temp_dir = setup_temp_dir().unwrap();
+        let node_id = get_active_node_id(temp_dir.path().to_path_buf());
+        let storage_config =
+            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id).unwrap();
+        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History)?;
+
+        for _ in 0..50 {
+            let content_key = generate_random_content_key();
+            let value: Vec<u8> = vec![0; 32000];
+            storage.store(&content_key, &value)?;
+            assert_eq!(
+                storage.storage_occupied_in_bytes,
+                storage.get_total_storage_usage_in_bytes_from_network()?
+            );
+        }
+
+        storage.storage_capacity_in_bytes = 1;
+        let num_removed_items = storage.prune_db().unwrap();
+        assert_eq!(49, num_removed_items);
+
+        let bytes = storage.get_total_storage_usage_in_bytes_from_network()?;
+        assert_eq!(32000, bytes);
+
+        storage.storage_capacity_in_bytes = 0;
+        let num_removed_items = storage.prune_db().unwrap();
+        assert_eq!(1, num_removed_items);
+
+        let bytes = storage.get_total_storage_usage_in_bytes_from_network()?;
+        assert_eq!(0, bytes);
+        std::mem::drop(storage);
+        temp_dir.close()?;
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    #[serial]
     async fn test_restarting_full_storage_with_same_capacity() -> Result<(), ContentStoreError> {
         // test a node that gets full and then restarts with the same capacity
         let temp_dir = setup_temp_dir().unwrap();
@@ -640,6 +713,10 @@ pub mod test {
             let content_key = generate_random_content_key();
             let value: Vec<u8> = vec![0; 32000];
             storage.store(&content_key, &value)?;
+            assert_eq!(
+                storage.storage_occupied_in_bytes,
+                storage.get_total_storage_usage_in_bytes_from_network()?
+            );
             // Speed up the test by ending the loop as soon as possible
             if storage.capacity_reached() {
                 break;

--- a/trin-storage/src/utils.rs
+++ b/trin-storage/src/utils.rs
@@ -102,7 +102,7 @@ pub fn insert_value(
     content_key: &String,
     value: &Vec<u8>,
     network_id: u8,
-) -> Result<(), ContentStoreError> {
+) -> Result<usize, ContentStoreError> {
     let content_id_as_u32: u32 = byte_slice_to_u32(content_id);
     let value_size = value.len();
     if content_key.starts_with("0x") {
@@ -121,7 +121,7 @@ pub fn insert_value(
             value_size
         ],
     ) {
-        Ok(_) => Ok(()),
+        Ok(result) => Ok(result),
         Err(err) => Err(err.into()),
     }
 }


### PR DESCRIPTION
### What was wrong?
The main performance bottleneck in `prune_db()` was calling `get_total_storage_usage_in_bytes_from_network()` twice per iteration of the loop in `prune_db()` (once in `does_eviction_cause_under_capacity()` and once in `capacity_reached()`). Which was taking 40-50 seconds in total (2 x 20-25s). We should only be calling `get_total_storage_usage_in_bytes_from_network()` at the initialization of `HistoryStorage` and maintaining the count from their in memory.

This 40-50 second result was taken from one of our testnet nodes with a ~8GB sqlite database doing the inital prune_db() at startup initalization.
### How was it fixed?
We only insert data or evict data in 2 spots in the code. So we can just keep a count of how much storage we use in memory and increment it or decrement it from there. We will only call `get_total_storage_usage_in_bytes_from_network()` once during initialization of the database.
