### PR TITLE
fix: add network column to indices

### DIFF
--- a/trin-storage/src/sql.rs
+++ b/trin-storage/src/sql.rs
@@ -1,7 +1,7 @@
 // SQLite Statements
 
 // NOTE: The indices `content_size_idx`, `content_id_short_idx` and `content_id_long_idx` weren't
-// felpful mostly because they didn't have `network` column in them.
+// helpful mostly because they didn't have `network` column in them.
 pub const CREATE_QUERY_DB: &str = "CREATE TABLE IF NOT EXISTS content_data (
                                 content_id_long TEXT PRIMARY KEY,
                                 content_id_short INTEGER NOT NULL,

--- a/trin-storage/src/sql.rs
+++ b/trin-storage/src/sql.rs
@@ -1,5 +1,7 @@
 // SQLite Statements
 
+// NOTE: The indices `content_size_idx`, `content_id_short_idx` and `content_id_long_idx` didn't
+// have `network` column in them and weren't very helpful with the queries.
 pub const CREATE_QUERY_DB: &str = "CREATE TABLE IF NOT EXISTS content_data (
                                 content_id_long TEXT PRIMARY KEY,
                                 content_id_short INTEGER NOT NULL,
@@ -8,9 +10,12 @@ pub const CREATE_QUERY_DB: &str = "CREATE TABLE IF NOT EXISTS content_data (
                                 network INTEGER NOT NULL DEFAULT 0,
                                 content_size INTEGER
                             );
-                            CREATE INDEX IF NOT EXISTS content_size_idx ON content_data(content_size);
-                            CREATE INDEX IF NOT EXISTS content_id_short_idx ON content_data(content_id_short);
-                            CREATE INDEX IF NOT EXISTS content_id_long_idx ON content_data(content_id_long);
+                            DROP INDEX IF EXISTS content_size_idx;
+                            CREATE INDEX IF NOT EXISTS content_size_idx_2 ON content_data(network, content_size);
+                            DROP INDEX IF EXISTS content_id_short_idx;
+                            CREATE INDEX IF NOT EXISTS content_id_short_idx_2 ON content_data(network, content_id_short);
+                            DROP INDEX IF EXISTS content_id_long_idx;
+                            CREATE INDEX IF NOT EXISTS content_id_long_idx_2 ON content_data(network, content_id_long);
                             CREATE INDEX IF NOT EXISTS network_idx ON content_data(network);";
 
 pub const INSERT_QUERY_NETWORK: &str =

--- a/trin-storage/src/sql.rs
+++ b/trin-storage/src/sql.rs
@@ -13,10 +13,11 @@ pub const CREATE_QUERY_DB: &str = "CREATE TABLE IF NOT EXISTS content_data (
                             DROP INDEX IF EXISTS content_size_idx;
                             CREATE INDEX IF NOT EXISTS content_size_idx_2 ON content_data(network, content_size);
                             DROP INDEX IF EXISTS content_id_short_idx;
-                            CREATE INDEX IF NOT EXISTS content_id_short_idx_2 ON content_data(network, content_id_short);
+                            CREATE INDEX IF NOT EXISTS content_id_short_idx_2 ON content_data(network, content_id_short, content_id_long);
                             DROP INDEX IF EXISTS content_id_long_idx;
                             CREATE INDEX IF NOT EXISTS content_id_long_idx_2 ON content_data(network, content_id_long);
-                            CREATE INDEX IF NOT EXISTS network_idx ON content_data(network);";
+                            CREATE INDEX IF NOT EXISTS network_idx ON content_data(network);
+                            CREATE INDEX IF NOT EXISTS content_key_idx ON content_data(content_key);";
 
 pub const INSERT_QUERY_NETWORK: &str =
     "INSERT OR IGNORE INTO content_data (content_id_long, content_id_short, content_key, content_value, network, content_size)
@@ -60,7 +61,7 @@ pub const LC_UPDATE_CREATE_TABLE: &str = "CREATE TABLE IF NOT EXISTS lc_update (
                                           update_size INTEGER
                                       );
                                      CREATE INDEX IF NOT EXISTS update_size_idx ON lc_update(update_size);
-                                     CREATE INDEX IF NOT EXISTS period_idx ON lc_update(period);";
+                                     DROP INDEX IF EXISTS period_idx;";
 
 pub const LC_UPDATE_LOOKUP_QUERY: &str = "SELECT value FROM lc_update WHERE period = (?1) LIMIT 1";
 

--- a/trin-storage/src/sql.rs
+++ b/trin-storage/src/sql.rs
@@ -1,7 +1,7 @@
 // SQLite Statements
 
-// NOTE: The indices `content_size_idx`, `content_id_short_idx` and `content_id_long_idx` didn't
-// have `network` column in them and weren't very helpful with the queries.
+// NOTE: The indices `content_size_idx`, `content_id_short_idx` and `content_id_long_idx` weren't
+// felpful mostly because they didn't have `network` column in them.
 pub const CREATE_QUERY_DB: &str = "CREATE TABLE IF NOT EXISTS content_data (
                                 content_id_long TEXT PRIMARY KEY,
                                 content_id_short INTEGER NOT NULL,
@@ -15,7 +15,6 @@ pub const CREATE_QUERY_DB: &str = "CREATE TABLE IF NOT EXISTS content_data (
                             DROP INDEX IF EXISTS content_id_short_idx;
                             CREATE INDEX IF NOT EXISTS content_id_short_idx_2 ON content_data(network, content_id_short, content_id_long);
                             DROP INDEX IF EXISTS content_id_long_idx;
-                            CREATE INDEX IF NOT EXISTS content_id_long_idx_2 ON content_data(network, content_id_long);
                             CREATE INDEX IF NOT EXISTS network_idx ON content_data(network);
                             CREATE INDEX IF NOT EXISTS content_key_idx ON content_data(content_key);";
 
@@ -46,7 +45,7 @@ pub const TOTAL_DATA_SIZE_QUERY_DB: &str =
     "SELECT TOTAL(content_size) FROM content_data WHERE network = (?1)";
 
 pub const TOTAL_ENTRY_COUNT_QUERY_NETWORK: &str =
-    "SELECT COUNT(content_id_long) FROM content_data WHERE network = (?1)";
+    "SELECT COUNT(*) FROM content_data WHERE network = (?1)";
 
 pub const PAGINATE_QUERY_DB: &str =
     "SELECT content_key FROM content_data ORDER BY content_key LIMIT :limit OFFSET :offset";


### PR DESCRIPTION
### What was wrong?

Some of our queries were very slow because our db indices weren't setup correctly.
For example, the `TOTAL_DATA_SIZE_QUERY_DB` query took 20-25 seconds on 4GB database.

### How was it fixed?

I added `network` column to the indices. Based on Kolby's measurements on the same db, we noticed following improvements:

| query | before (sec) | after (sec) |
|---|---|---|
| TOTAL_DATA_SIZE_QUERY_DB | 23.087 | 0.008 |
| XOR_FIND_FARTHEST_QUERY_NETWORK | 6.154 | 0.017 |

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
