### PR TITLE
feat: content valid for storing and recursive gossip

### DIFF
--- a/trin-beacon/src/validation.rs
+++ b/trin-beacon/src/validation.rs
@@ -4,7 +4,10 @@ use async_trait::async_trait;
 use ethportal_api::BeaconContentKey;
 use tokio::sync::RwLock;
 
-use trin_validation::{oracle::HeaderOracle, validator::Validator};
+use trin_validation::{
+    oracle::HeaderOracle,
+    validator::{ValidationResult, Validator},
+};
 
 pub struct BeaconValidator {
     // TODO: HeaderOracle is not network agnostic name
@@ -17,11 +20,11 @@ impl Validator<BeaconContentKey> for BeaconValidator {
         &self,
         _content_key: &BeaconContentKey,
         _content: &[u8],
-    ) -> anyhow::Result<()>
+    ) -> anyhow::Result<ValidationResult<BeaconContentKey>>
     where
         BeaconContentKey: 'async_trait,
     {
         // todo: implement beacon network validation
-        Ok(())
+        Ok(ValidationResult::new(true))
     }
 }

--- a/trin-state/src/validation.rs
+++ b/trin-state/src/validation.rs
@@ -4,7 +4,10 @@ use async_trait::async_trait;
 use tokio::sync::RwLock;
 
 use ethportal_api::StateContentKey;
-use trin_validation::{oracle::HeaderOracle, validator::Validator};
+use trin_validation::{
+    oracle::HeaderOracle,
+    validator::{ValidationResult, Validator},
+};
 
 pub struct StateValidator {
     pub header_oracle: Arc<RwLock<HeaderOracle>>,
@@ -16,11 +19,11 @@ impl Validator<StateContentKey> for StateValidator {
         &self,
         _content_key: &StateContentKey,
         _content: &[u8],
-    ) -> anyhow::Result<()>
+    ) -> anyhow::Result<ValidationResult<StateContentKey>>
     where
         StateContentKey: 'async_trait,
     {
         // todo: implement state network validation
-        Ok(())
+        Ok(ValidationResult::new(true))
     }
 }

--- a/trin-validation/src/validator.rs
+++ b/trin-validation/src/validator.rs
@@ -2,14 +2,58 @@ use async_trait::async_trait;
 
 use ethportal_api::types::content_key::overlay::IdentityContentKey;
 
+/// The result of the content key/value validation.
+#[derive(Debug)]
+pub struct ValidationResult<TContentKey> {
+    /// Whether validation proved that content is canonical, in which case it's safe to store it.
+    ///
+    /// Content obtained via Offer/Accept should always be provable, but that's not always the case
+    /// for content obtained via Find/Found Content (e.g.for the state network, we can verify that
+    /// content-value corresponds to the content-key, but not that it's canonical).
+    pub valid_for_storing: bool,
+
+    /// The optional content key/value pair to be propagated (together with original content
+    /// key/value). This is used for Recursive Gossip in the state network (see [specs](
+    /// https://github.com/ethereum/portal-network-specs/blob/04cc360179aeda179e0b1cac6fea900a74e87f2b/state-network.md#gossip
+    /// ) for details.).
+    pub additional_content_to_propagate: Option<(TContentKey, Vec<u8>)>,
+}
+
+impl<TContentKey> ValidationResult<TContentKey> {
+    pub fn new(valid_for_storing: bool) -> Self {
+        Self {
+            valid_for_storing,
+            additional_content_to_propagate: None,
+        }
+    }
+
+    pub fn new_with_additional_content_to_propagate(
+        additional_content_key: TContentKey,
+        additional_content_value: Vec<u8>,
+    ) -> Self {
+        Self {
+            valid_for_storing: true,
+            additional_content_to_propagate: Some((
+                additional_content_key,
+                additional_content_value,
+            )),
+        }
+    }
+}
+
 /// Used by all overlay-network Validators to validate content in the overlay service.
 #[async_trait]
 pub trait Validator<TContentKey> {
+    /// The `Ok` indicates that `content` corresponds to the `content_key`, but not necessarily
+    /// that content is canonical. See `ValidationResult` for details.
+    ///
+    /// The `Err` indicates that either content is not valid or that validation failed for some
+    /// other reason.
     async fn validate_content(
         &self,
         content_key: &TContentKey,
         content: &[u8],
-    ) -> anyhow::Result<()>
+    ) -> anyhow::Result<ValidationResult<TContentKey>>
     where
         TContentKey: 'async_trait;
 }
@@ -23,10 +67,10 @@ impl Validator<IdentityContentKey> for MockValidator {
         &self,
         _content_key: &IdentityContentKey,
         _content: &[u8],
-    ) -> anyhow::Result<()>
+    ) -> anyhow::Result<ValidationResult<IdentityContentKey>>
     where
         IdentityContentKey: 'async_trait,
     {
-        Ok(())
+        Ok(ValidationResult::new(true))
     }
 }


### PR DESCRIPTION
### What was wrong?

Implementation of `Validator` and `OverlayService` weren't flexible enough for the state network.

For the state network, content-value that is sent via `Offer/Accept` and `Find/Found Content` is not the same, and doesn't have the same validation properties. The `Offer/Accept` should always be provable that is part of a canonical chain, while that's not the case for the content from `Find/Found Content` (we can prove that content corresponds to the content-key).

Another issue is that Recursive Gossip that is part of the state network was not possible.

### How was it fixed?

Created `ValidationResult` object that is returned by the validator that contains all important information. Overlay Service now knows if content is canonical and it's safe for storing locally, and if there is additional content to be propagated (to be used for Recursive Gossip).

There should be no changes for current implementations (they all return the same result and everything should behave as before). Added logic will be used once validator for the state network is implemented.

NOTE: I would also like to add more validation metrics to grafana, but I would prefer to do that in a separate PR (maybe only once state network is implemented so I can test more functionality).

### To-Do

- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
