### PR TITLE
fix: accepting offer with multiple keys

### DIFF
--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -1308,6 +1308,8 @@ where
                 )
             })?;
 
+        let mut accepted_keys: Vec<TContentKey> = Vec::default();
+
         for (i, key) in content_keys.iter().enumerate() {
             // Accept content if within radius and not already present in the data store.
             let accept = self
@@ -1320,6 +1322,9 @@ where
                         "Unable to check content availability {err}"
                     ))
                 })?;
+            if accept {
+                accepted_keys.push(key.clone());
+            }
             requested_keys.set(i, accept).map_err(|err| {
                 OverlayRequestError::AcceptError(format!(
                     "Unable to set requested keys bits: {err:?}"
@@ -1404,7 +1409,7 @@ where
                 metrics,
                 kbuckets,
                 command_tx,
-                content_keys,
+                accepted_keys,
                 data,
                 utp.clone(),
             )


### PR DESCRIPTION
### What was wrong?

Partially accepting `Offer` request doesn't work.
The `process_accept_utp_payload` function expects to receive keys and values that were accepted, while we send all requested keys (even the ones that are not accepted).

I noticed this while implementing the state network, as this logic is used during Recursive gossip.

### How was it fixed?
Propagated correct keys.

**NOTE: Testing**

- I tried for at least 8 hours to make a test for this but I failed. I'm open for suggestions on how to do it.
- I was mostly trying to make a test inside `overlay_service.rs`
  -  I still have the branch and I can push it to my github if someone wants to see and try to make it work (I think I got close)
- I thought about doing with via `ethportal-peertest`, but none of the public facing apis exposes this functionality.

I verified that it works on the local implementation of the state network with recursive gossip

### To-Do

- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
