### PR TITLE
fix(storage): uses milos find of blobs + proposal 1 for history/beacon

### DIFF
--- a/ethportal-api/src/types/distance.rs
+++ b/ethportal-api/src/types/distance.rs
@@ -41,10 +41,8 @@ impl Distance {
 
     /// Returns the top 4 bytes representation of `self`.
     pub fn big_endian_u32(&self) -> u32 {
-        let mut be: [u8; 32] = [0; 32];
-        self.0.to_big_endian(&mut be);
         let mut be_bytes = [0u8; 4];
-        be_bytes.copy_from_slice(&be[..4]);
+        be_bytes.copy_from_slice(&self.big_endian()[..4]);
         u32::from_be_bytes(be_bytes)
     }
 }

--- a/ethportal-api/src/types/distance.rs
+++ b/ethportal-api/src/types/distance.rs
@@ -38,6 +38,15 @@ impl Distance {
         self.0.to_big_endian(&mut be);
         be
     }
+
+    /// Returns the top 4 bytes representation of `self`.
+    pub fn big_endian_u32(&self) -> u32 {
+        let mut be: [u8; 32] = [0; 32];
+        self.0.to_big_endian(&mut be);
+        let mut be_bytes = [0u8; 4];
+        be_bytes.copy_from_slice(&be[..4]);
+        u32::from_be_bytes(be_bytes)
+    }
 }
 
 impl From<U256> for Distance {

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -303,13 +303,15 @@ impl BeaconStorage {
         value: &Vec<u8>,
     ) -> Result<usize, ContentStoreError> {
         let conn = self.sql_connection_pool.get()?;
-        match conn.execute(
+        Ok(conn.execute(
             INSERT_QUERY_BEACON,
-            params![content_id.to_vec(), content_key, value, value.len()],
-        ) {
-            Ok(result) => Ok(result),
-            Err(err) => Err(err.into()),
-        }
+            params![
+                content_id.to_vec(),
+                content_key,
+                value,
+                32 + content_key.len() + value.len()
+            ],
+        )?)
     }
 
     fn db_insert_lc_update(&self, period: &u64, value: &Vec<u8>) -> Result<(), ContentStoreError> {

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -337,7 +337,6 @@ impl BeaconStorage {
 
         match content_key.first() {
             Some(&LIGHT_CLIENT_BOOTSTRAP_KEY_PREFIX) => {
-                // store content key w/o the 0x prefix
                 if let Err(err) = self.db_insert(&content_id, &content_key, value) {
                     debug!("Error writing light client bootstrap content ID {content_id:?} to beacon network db: {err:?}");
                     return Err(err);

--- a/trin-history/src/storage.rs
+++ b/trin-history/src/storage.rs
@@ -208,13 +208,14 @@ impl HistoryStorage {
 
         // Store the data in db
         let content_key: Vec<u8> = key.clone().into();
-        let value_size = value.len() as u64;
+        let value_size = value.len();
         match self.db_insert(&content_id, &content_key, value) {
             Ok(result) => {
                 // Insertion successful, increase total network storage count
                 if result == 1 {
                     // adding 32 bytes for content_id and 32 for content_key
-                    self.storage_occupied_in_bytes += value_size + CONTENT_ID_AND_KEY_LENGTH as u64;
+                    self.storage_occupied_in_bytes +=
+                        (value_size + CONTENT_ID_AND_KEY_LENGTH) as u64;
                     self.metrics
                         .report_content_data_storage_bytes(self.storage_occupied_in_bytes as f64);
                     self.metrics.increase_entry_count();

--- a/trin-storage/src/lib.rs
+++ b/trin-storage/src/lib.rs
@@ -160,7 +160,7 @@ impl PortalStorageConfig {
         node_data_dir: PathBuf,
         node_id: NodeId,
     ) -> anyhow::Result<Self> {
-        let sql_connection_pool = setup_sql(&node_data_dir)?;
+        let sql_connection_pool: Pool<SqliteConnectionManager> = setup_sql(&node_data_dir)?;
         Ok(Self {
             storage_capacity_mb,
             node_id,

--- a/trin-storage/src/sql.rs
+++ b/trin-storage/src/sql.rs
@@ -99,6 +99,7 @@ pub const DROP_CONTENT_DATA_QUERY_DB: &str = "DROP TABLE IF EXISTS content_data;
     DROP INDEX IF EXISTS content_size_idx_2;
     DROP INDEX IF EXISTS content_id_short_idx;
     DROP INDEX IF EXISTS content_id_short_idx_2;
+    DROP INDEX IF EXISTS content_id_short_idx_3;
     DROP INDEX IF EXISTS content_id_long_idx;
     DROP INDEX IF EXISTS network_idx;
     DROP INDEX IF EXISTS content_key_idx;";

--- a/trin-storage/src/sql.rs
+++ b/trin-storage/src/sql.rs
@@ -1,67 +1,90 @@
 // SQLite Statements
+// History
+pub const CREATE_QUERY_DB_HISTORY: &str = "CREATE TABLE IF NOT EXISTS history (
+    content_id blob PRIMARY KEY,
+    content_key blob NOT NULL,
+    content_value blob NOT NULL,
+    distance_short INTEGER NOT NULL,
+    content_size INTEGER NOT NULL
+);
+    CREATE INDEX IF NOT EXISTS history_distance_short_idx ON history(content_size);
+    CREATE INDEX IF NOT EXISTS history_content_size_idx ON history(distance_short);
+";
 
-// NOTE: The indices `content_size_idx`, `content_id_short_idx` and `content_id_long_idx` weren't
-// helpful mostly because they didn't have `network` column in them.
-pub const CREATE_QUERY_DB: &str = "CREATE TABLE IF NOT EXISTS content_data (
-                                content_id_long TEXT PRIMARY KEY,
-                                content_id_short INTEGER NOT NULL,
-                                content_key TEXT NOT NULL,
-                                content_value TEXT NOT NULL,
-                                network INTEGER NOT NULL DEFAULT 0,
-                                content_size INTEGER
-                            );
-                            DROP INDEX IF EXISTS content_size_idx;
-                            CREATE INDEX IF NOT EXISTS content_size_idx_2 ON content_data(network, content_size);
-                            DROP INDEX IF EXISTS content_id_short_idx;
-                            DROP INDEX IF EXISTS content_id_short_idx_2;
-                            CREATE INDEX IF NOT EXISTS content_id_short_idx_3 ON content_data(network, content_id_short);
-                            DROP INDEX IF EXISTS content_id_long_idx;
-                            CREATE INDEX IF NOT EXISTS network_idx ON content_data(network);
-                            CREATE INDEX IF NOT EXISTS content_key_idx ON content_data(content_key);";
+pub const INSERT_QUERY_HISTORY: &str =
+    "INSERT OR IGNORE INTO history (content_id, content_key, content_value, distance_short, content_size)
+                            VALUES (?1, ?2, ?3, ?4, ?5)";
 
-pub const INSERT_QUERY_NETWORK: &str =
-    "INSERT OR IGNORE INTO content_data (content_id_long, content_id_short, content_key, content_value, network, content_size)
-                            VALUES (?1, ?2, ?3, ?4, ?5, ?6)";
+pub const DELETE_QUERY_HISTORY: &str = "DELETE FROM history
+                            WHERE content_id = (?1)";
+
+pub const XOR_FIND_FARTHEST_QUERY_HISTORY: &str = "SELECT
+                                    content_id
+                                    FROM history
+                                    ORDER BY distance_short DESC LIMIT 1";
+
+pub const CONTENT_KEY_LOOKUP_QUERY_HISTORY: &str =
+    "SELECT content_key FROM history WHERE content_id = (?1) LIMIT 1";
+
+pub const CONTENT_VALUE_LOOKUP_QUERY_HISTORY: &str =
+    "SELECT content_value FROM history WHERE content_id = (?1) LIMIT 1";
+
+pub const TOTAL_DATA_SIZE_QUERY_HISTORY: &str = "SELECT TOTAL(content_size) FROM history";
+
+pub const TOTAL_ENTRY_COUNT_QUERY_HISTORY: &str = "SELECT COUNT(*) FROM history";
+
+pub const PAGINATE_QUERY_HISTORY: &str =
+    "SELECT content_key FROM history ORDER BY content_key LIMIT (?1) OFFSET (?2)";
+
+pub const CONTENT_SIZE_LOOKUP_QUERY_HISTORY: &str =
+    "SELECT content_size FROM history WHERE content_id = (?1)";
+
+// Beacon Specific SQL
+
+pub const CREATE_QUERY_DB_BEACON: &str = "CREATE TABLE IF NOT EXISTS beacon (
+    content_id blob PRIMARY KEY,
+    content_key blob NOT NULL,
+    content_value blob NOT NULL,
+    content_size INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS beacon_content_size_idx ON beacon(content_size);
+";
+
+pub const INSERT_QUERY_BEACON: &str =
+    "INSERT OR IGNORE INTO beacon (content_id, content_key, content_value, content_size)
+                            VALUES (?1, ?2, ?3, ?4)";
+
+pub const DELETE_QUERY_BEACON: &str = "DELETE FROM beacon
+    WHERE content_id = (?1)";
+
+pub const CONTENT_KEY_LOOKUP_QUERY_BEACON: &str =
+    "SELECT content_key FROM beacon WHERE content_id = (?1) LIMIT 1";
+
+pub const CONTENT_VALUE_LOOKUP_QUERY_BEACON: &str =
+    "SELECT content_value FROM beacon WHERE content_id = (?1) LIMIT 1";
+
+pub const TOTAL_DATA_SIZE_QUERY_BEACON: &str = "SELECT TOTAL(content_size) FROM beacon";
+
+pub const TOTAL_ENTRY_COUNT_QUERY_BEACON: &str = "SELECT COUNT(*) FROM beacon";
+
+pub const PAGINATE_QUERY_BEACON: &str =
+    "SELECT content_key FROM beacon ORDER BY content_key LIMIT (?1) OFFSET (?2)";
+
+pub const CONTENT_SIZE_LOOKUP_QUERY_BEACON: &str =
+    "SELECT content_size FROM beacon WHERE content_id = (?1)";
+
+pub const LC_UPDATE_CREATE_TABLE: &str = "CREATE TABLE IF NOT EXISTS lc_update (
+        period INTEGER PRIMARY KEY,
+        value BLOB NOT NULL,
+        score INTEGER NOT NULL,
+        update_size INTEGER
+    );
+    CREATE INDEX IF NOT EXISTS update_size_idx ON lc_update(update_size);
+    DROP INDEX IF EXISTS period_idx;";
 
 pub const INSERT_LC_UPDATE_QUERY: &str =
     "INSERT OR IGNORE INTO lc_update (period, value, score, update_size)
-                            VALUES (?1, ?2, ?3, ?4)";
-
-pub const DELETE_QUERY_DB: &str = "DELETE FROM content_data
-                            WHERE content_id_long = (?1)";
-
-pub const XOR_FIND_FARTHEST_QUERY_NETWORK: &str = "SELECT
-                                    content_id_long
-                                    FROM content_data
-                                    WHERE network = (?2)
-                                    ORDER BY ((?1 | content_id_short) - (?1 & content_id_short)) DESC LIMIT 1";
-
-pub const CONTENT_KEY_LOOKUP_QUERY_DB: &str =
-    "SELECT content_key FROM content_data WHERE content_id_long = (?1) LIMIT 1";
-
-pub const CONTENT_VALUE_LOOKUP_QUERY_DB: &str =
-    "SELECT content_value FROM content_data WHERE content_id_long = (?1) LIMIT 1";
-
-pub const TOTAL_DATA_SIZE_QUERY_DB: &str =
-    "SELECT TOTAL(content_size) FROM content_data WHERE network = (?1)";
-
-pub const TOTAL_ENTRY_COUNT_QUERY_NETWORK: &str =
-    "SELECT COUNT(*) FROM content_data WHERE network = (?1)";
-
-pub const PAGINATE_QUERY_DB: &str =
-    "SELECT content_key FROM content_data ORDER BY content_key LIMIT :limit OFFSET :offset";
-
-pub const CONTENT_SIZE_LOOKUP_QUERY_DB: &str =
-    "SELECT content_size FROM content_data WHERE content_id_long = (?1)";
-
-pub const LC_UPDATE_CREATE_TABLE: &str = "CREATE TABLE IF NOT EXISTS lc_update (
-                                          period INTEGER PRIMARY KEY,
-                                          value BLOB NOT NULL,
-                                          score INTEGER NOT NULL,
-                                          update_size INTEGER
-                                      );
-                                     CREATE INDEX IF NOT EXISTS update_size_idx ON lc_update(update_size);
-                                     DROP INDEX IF EXISTS period_idx;";
+                      VALUES (?1, ?2, ?3, ?4)";
 
 pub const LC_UPDATE_LOOKUP_QUERY: &str = "SELECT value FROM lc_update WHERE period = (?1) LIMIT 1";
 
@@ -69,3 +92,13 @@ pub const LC_UPDATE_PERIOD_LOOKUP_QUERY: &str =
     "SELECT period FROM lc_update WHERE period = (?1) LIMIT 1";
 
 pub const LC_UPDATE_TOTAL_SIZE_QUERY: &str = "SELECT TOTAL(update_size) FROM lc_update";
+
+// todo: remove this in the future
+pub const DROP_CONTENT_DATA_QUERY_DB: &str = "DROP TABLE IF EXISTS content_data;
+    DROP INDEX IF EXISTS content_size_idx;
+    DROP INDEX IF EXISTS content_size_idx_2;
+    DROP INDEX IF EXISTS content_id_short_idx;
+    DROP INDEX IF EXISTS content_id_short_idx_2;
+    DROP INDEX IF EXISTS content_id_long_idx;
+    DROP INDEX IF EXISTS network_idx;
+    DROP INDEX IF EXISTS content_key_idx;";

--- a/trin-storage/src/sql.rs
+++ b/trin-storage/src/sql.rs
@@ -94,12 +94,4 @@ pub const LC_UPDATE_PERIOD_LOOKUP_QUERY: &str =
 pub const LC_UPDATE_TOTAL_SIZE_QUERY: &str = "SELECT TOTAL(update_size) FROM lc_update";
 
 // todo: remove this in the future
-pub const DROP_CONTENT_DATA_QUERY_DB: &str = "DROP TABLE IF EXISTS content_data;
-    DROP INDEX IF EXISTS content_size_idx;
-    DROP INDEX IF EXISTS content_size_idx_2;
-    DROP INDEX IF EXISTS content_id_short_idx;
-    DROP INDEX IF EXISTS content_id_short_idx_2;
-    DROP INDEX IF EXISTS content_id_short_idx_3;
-    DROP INDEX IF EXISTS content_id_long_idx;
-    DROP INDEX IF EXISTS network_idx;
-    DROP INDEX IF EXISTS content_key_idx;";
+pub const DROP_CONTENT_DATA_QUERY_DB: &str = "DROP TABLE IF EXISTS content_data;";

--- a/trin-storage/src/utils.rs
+++ b/trin-storage/src/utils.rs
@@ -1,20 +1,14 @@
 use crate::{
     error::ContentStoreError,
     sql::{
-        CONTENT_VALUE_LOOKUP_QUERY_DB, CREATE_QUERY_DB, INSERT_QUERY_NETWORK,
+        CREATE_QUERY_DB_BEACON, CREATE_QUERY_DB_HISTORY, DROP_CONTENT_DATA_QUERY_DB,
         LC_UPDATE_CREATE_TABLE,
     },
     versioned::sql::STORE_INFO_CREATE_TABLE,
     DATABASE_NAME,
 };
-use anyhow::Error;
-use ethportal_api::{
-    types::distance::Distance,
-    utils::bytes::{hex_decode, hex_encode},
-};
-use r2d2::{Pool, PooledConnection};
+use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
-use rusqlite::params;
 use std::{fs, path::Path};
 use tracing::info;
 
@@ -26,7 +20,9 @@ pub fn setup_sql(node_data_dir: &Path) -> Result<Pool<SqliteConnectionManager>, 
     let manager = SqliteConnectionManager::file(sql_path);
     let pool = Pool::new(manager)?;
     let conn = pool.get()?;
-    conn.execute_batch(CREATE_QUERY_DB)?;
+    conn.execute_batch(CREATE_QUERY_DB_HISTORY)?;
+    conn.execute_batch(CREATE_QUERY_DB_BEACON)?;
+    conn.execute_batch(DROP_CONTENT_DATA_QUERY_DB)?;
     conn.execute_batch(LC_UPDATE_CREATE_TABLE)?;
     conn.execute_batch(STORE_INFO_CREATE_TABLE)?;
     Ok(pool)
@@ -63,68 +59,4 @@ pub fn get_total_size_of_directory_in_bytes(
     }
 
     Ok(size)
-}
-
-/// Internal method for looking up a content value by its content id
-pub fn lookup_content_value(
-    id: [u8; 32],
-    conn: PooledConnection<SqliteConnectionManager>,
-) -> Result<Result<Option<Vec<u8>>, Error>, Error> {
-    let mut query = conn.prepare(CONTENT_VALUE_LOOKUP_QUERY_DB)?;
-    let id = id.to_vec();
-    let result: Result<Vec<Vec<u8>>, ContentStoreError> = query
-        .query_map([id], |row| {
-            let row: String = row.get(0)?;
-            Ok(row)
-        })?
-        .map(|row| hex_decode(row?.as_str()).map_err(ContentStoreError::ByteUtilsError))
-        .collect();
-
-    Ok(match result?.first() {
-        Some(val) => Ok(Some(val.to_vec())),
-        None => Ok(None),
-    })
-}
-
-/// Converts 4 most significant bytes of a byte slice to a u32.
-pub fn byte_slice_to_u32(slice: &[u8; 32]) -> u32 {
-    let mut be_bytes = [0u8; 4];
-    be_bytes.copy_from_slice(&slice[..4]);
-    u32::from_be_bytes(be_bytes)
-}
-
-/// Converts 4 most significant bytes of distance to a u32.
-pub fn distance_to_u32(distance: &Distance) -> u32 {
-    byte_slice_to_u32(&distance.big_endian())
-}
-
-/// Inserts a content  into the database.
-pub fn insert_value(
-    conn: PooledConnection<SqliteConnectionManager>,
-    content_id: &[u8; 32],
-    content_key: &String,
-    value: &Vec<u8>,
-    network_id: u8,
-) -> Result<usize, ContentStoreError> {
-    let content_id_as_u32: u32 = byte_slice_to_u32(content_id);
-    let value_size = value.len();
-    if content_key.starts_with("0x") {
-        return Err(ContentStoreError::InvalidData {
-            message: "Content key should not start with 0x".to_string(),
-        });
-    }
-    match conn.execute(
-        INSERT_QUERY_NETWORK,
-        params![
-            content_id.to_vec(),
-            content_id_as_u32,
-            content_key,
-            hex_encode(value),
-            network_id,
-            value_size
-        ],
-    ) {
-        Ok(result) => Ok(result),
-        Err(err) => Err(err.into()),
-    }
 }

--- a/trin-storage/src/utils.rs
+++ b/trin-storage/src/utils.rs
@@ -22,9 +22,9 @@ pub fn setup_sql(node_data_dir: &Path) -> Result<Pool<SqliteConnectionManager>, 
     let conn = pool.get()?;
     conn.execute_batch(CREATE_QUERY_DB_HISTORY)?;
     conn.execute_batch(CREATE_QUERY_DB_BEACON)?;
-    conn.execute_batch(DROP_CONTENT_DATA_QUERY_DB)?;
     conn.execute_batch(LC_UPDATE_CREATE_TABLE)?;
     conn.execute_batch(STORE_INFO_CREATE_TABLE)?;
+    conn.execute_batch(DROP_CONTENT_DATA_QUERY_DB)?;
     Ok(pool)
 }
 


### PR DESCRIPTION
### What was wrong?
Most of the improvements were found/discovered by milos and discussed here https://github.com/ethereum/trin/issues/1157

![image](https://github.com/ethereum/trin/assets/31669092/54839a6c-da4b-4b6b-b1e0-a0a5de1d02b9)
This was caused because of `XOR_FIND_FARTHEST_QUERY_NETWORK`
- we were calculating distance on every value in the database
![image](https://github.com/ethereum/trin/assets/31669092/c6374997-2e76-4790-aef5-4a2eaa01bc7f)
- We are doing `hex_encode(value)` which is making us store double the values
- `hex_encode`/`hex_decode` also makes inserts/reads slower as well
### How was it fixed?
I implemented 2 new tables `content_data_history` and `content_data_beacon` which now uses blobs instead of text

The biggest improvement though in terms of eff is `XOR_FIND_FARTHEST_QUERY_NETWORK` now we precalculate the distance values