### PR TITLE
refactor(perf): fix indexes with 10x increase in performance for find_farthest_content_id

### DIFF
--- a/trin-storage/src/sql.rs
+++ b/trin-storage/src/sql.rs
@@ -14,7 +14,7 @@ pub const CREATE_QUERY_DB: &str = "CREATE TABLE IF NOT EXISTS content_data (
                             CREATE INDEX IF NOT EXISTS content_size_idx_2 ON content_data(network, content_size);
                             DROP INDEX IF EXISTS content_id_short_idx;
                             DROP INDEX IF EXISTS content_id_short_idx_2;
-                            CREATE INDEX IF NOT EXISTS content_id_short_idxf_2 ON content_data(network, content_id_short);
+                            CREATE INDEX IF NOT EXISTS content_id_short_idx_3 ON content_data(network, content_id_short);
                             DROP INDEX IF EXISTS content_id_long_idx;
                             CREATE INDEX IF NOT EXISTS network_idx ON content_data(network);
                             CREATE INDEX IF NOT EXISTS content_key_idx ON content_data(content_key);";

--- a/trin-storage/src/sql.rs
+++ b/trin-storage/src/sql.rs
@@ -13,7 +13,8 @@ pub const CREATE_QUERY_DB: &str = "CREATE TABLE IF NOT EXISTS content_data (
                             DROP INDEX IF EXISTS content_size_idx;
                             CREATE INDEX IF NOT EXISTS content_size_idx_2 ON content_data(network, content_size);
                             DROP INDEX IF EXISTS content_id_short_idx;
-                            CREATE INDEX IF NOT EXISTS content_id_short_idx_2 ON content_data(network, content_id_short, content_id_long);
+                            DROP INDEX IF EXISTS content_id_short_idx_2;
+                            CREATE INDEX IF NOT EXISTS content_id_short_idxf_2 ON content_data(network, content_id_short);
                             DROP INDEX IF EXISTS content_id_long_idx;
                             CREATE INDEX IF NOT EXISTS network_idx ON content_data(network);
                             CREATE INDEX IF NOT EXISTS content_key_idx ON content_data(content_key);";
@@ -33,7 +34,7 @@ pub const XOR_FIND_FARTHEST_QUERY_NETWORK: &str = "SELECT
                                     content_id_long
                                     FROM content_data
                                     WHERE network = (?2)
-                                    ORDER BY ((?1 | content_id_short) - (?1 & content_id_short)) DESC";
+                                    ORDER BY ((?1 | content_id_short) - (?1 & content_id_short)) DESC LIMIT 1";
 
 pub const CONTENT_KEY_LOOKUP_QUERY_DB: &str =
     "SELECT content_key FROM content_data WHERE content_id_long = (?1) LIMIT 1";


### PR DESCRIPTION
### What was wrong?
![image](https://github.com/ethereum/trin/assets/31669092/2c8f3608-4c0f-401b-be08-7fddf42fce7d)

### How was it fixed?
![image](https://github.com/ethereum/trin/assets/31669092/6f8be71e-aedb-4e31-8b5d-4e0de08f1964)
![image](https://github.com/ethereum/trin/assets/31669092/a45e3f53-6902-4788-93f4-02aa1556be86)
![image](https://github.com/ethereum/trin/assets/31669092/241e3f1c-54e5-4397-9d15-f4fca5cc995c)

Non optimal sql indexes which were made in the last PR.

With this fix we are getting 10x faster find_farthest_content_id and up to 20-40x more database calls per minute
