### PR TITLE
feat(bridge): add single random epoch mode to fourfours bridge

### DIFF
--- a/portal-bridge/README.md
+++ b/portal-bridge/README.md
@@ -33,6 +33,7 @@ Current options include `"trin"` / `"fluffy"`.
 - `"--mode single:b100"`: gossip a single block #100
 - `"--mode single:e100"`: gossip a single epoch #100
 - `"--mode fourfours`: will randomly select era1 files from `era1.ethportal.net` and gossip them
+- `"--mode fourfours:random_epoch"`: will randomly select a single era1 file from `era1.ethportal.net` and then gossip it
 - `"--mode fourfours:e600`: will select era1 file 600 from `era1.ethportal.net` and gossip it
 - `"--mode fourfours:r100-200`: will gossip a block range from an era1 file, range must be from the same epoch
 

--- a/portal-bridge/src/types/mode.rs
+++ b/portal-bridge/src/types/mode.rs
@@ -167,17 +167,24 @@ impl FromStr for ModeType {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FourFoursMode {
     Random,
-    // Gossips a single epoch
+    // Gossips a single, randomly selected epoch
+    RandomSingle,
+    // Gossips the single epoch given
     Single(u64),
     // Gossips a block range from within a single epoch
     Range(u64, u64),
 }
+
+const RANDOM_SINGLE_MODE: &str = "random_epoch";
 
 impl FromStr for FourFoursMode {
     type Err = ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty() {
             return Err("Invalid bridge fourfours mode arg: empty string".to_string());
+        }
+        if s == RANDOM_SINGLE_MODE {
+            return Ok(FourFoursMode::RandomSingle);
         }
         match &s[..1] {
             "e" => {
@@ -247,6 +254,9 @@ mod test {
     #[case("backfill:e0", BridgeMode::Backfill(ModeType::Epoch(0)))]
     #[case("backfill:e1000", BridgeMode::Backfill(ModeType::Epoch(1000)))]
     #[case("fourfours", BridgeMode::FourFours(FourFoursMode::Random))]
+    #[case(format!("fourfours:{RANDOM_SINGLE_MODE}"), 
+        BridgeMode::FourFours(FourFoursMode::RandomSingle)
+    )]
     #[case("fourfours:e1", BridgeMode::FourFours(FourFoursMode::Single(1)))]
     #[case("fourfours:r1-10", BridgeMode::FourFours(FourFoursMode::Range(1, 10)))]
     #[case(


### PR DESCRIPTION
### What was wrong?
We know we have some issues with our bridge when it's run as a long-running service. When our "latest" audit was switched to Infura, it still witnessed some stability issues. However, these were always resolved by rebooting the bridge, since the Infura provider is reliable. But debugging long-running processes is difficult. 

This solution is a bit of a hack, but effectively it turns our "backfill" bridges into short-term (aka the time it takes to gossip a single epoch) processes rather than long-running processes. With this new mode, after gossiping a **single** randomly selected epoch, the bridge process will naturally terminate. In which case the `docker_container` process used in our Ansible deployment scripts, will automatically restart the container, due to the `restart_policy: always` setting. Then the bridge will select another random epoch, gossip it, terminate, etc. 

### How was it fixed?
- Added a mode to the four fours bridge to gossip a single, random epoch and then terminate.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
