### PR TITLE
feat: make our storage async from blocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +697,16 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atomic-write-file"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcdbedc2236483ab103a53415653d6b4442ea6141baf1ffa85df29635e88436"
+dependencies = [
+ "nix",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "attohttpc"
@@ -1760,6 +1779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1905,7 +1925,7 @@ dependencies = [
  "enr 0.10.0",
  "fnv",
  "futures 0.3.30",
- "hashlink 0.8.4",
+ "hashlink",
  "hex",
  "hkdf 0.12.4",
  "lazy_static",
@@ -1922,6 +1942,12 @@ dependencies = [
  "uint",
  "zeroize",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtoa"
@@ -1994,6 +2020,9 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -2126,6 +2155,17 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if 1.0.0",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2647,18 +2687,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2715,6 +2743,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "finl_unicode"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2740,6 +2774,17 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2851,6 +2896,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api 0.4.11",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -3146,15 +3202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692eaaf7f7607518dd3cef090f1474b61edc5301d8012f09579920df68b725ee"
-dependencies = [
- "hashbrown 0.14.3",
-]
-
-[[package]]
 name = "hdrhistogram"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3169,6 +3216,9 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -3920,6 +3970,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "lazycell"
@@ -3981,9 +4034,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4327,6 +4380,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4369,12 +4433,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec 1.12.0",
+ "zeroize",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg 1.1.0",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-integer",
  "num-traits",
 ]
 
@@ -4688,6 +4780,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4845,6 +4946,17 @@ dependencies = [
  "atomic-waker",
  "fastrand 2.0.1",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -5208,28 +5320,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "r2d2"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
-dependencies = [
- "log",
- "parking_lot 0.12.1",
- "scheduled-thread-pool",
-]
-
-[[package]]
-name = "r2d2_sqlite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a982edf65c129796dba72f8775b292ef482b40d035e827a9825b3bc07ccc5f2"
-dependencies = [
- "r2d2",
- "rusqlite",
- "uuid 1.6.1",
 ]
 
 [[package]]
@@ -5820,6 +5910,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rstest"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5877,20 +5987,6 @@ name = "ruint-macro"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
-
-[[package]]
-name = "rusqlite"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
-dependencies = [
- "bitflags 2.4.1",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink 0.9.0",
- "libsqlite3-sys",
- "smallvec 1.12.0",
-]
 
 [[package]]
 name = "rust-embed"
@@ -6116,15 +6212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "scheduled-thread-pool"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
-dependencies = [
- "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -6690,6 +6777,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api 0.4.11",
+]
 
 [[package]]
 name = "spki"
@@ -6699,6 +6789,213 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
+dependencies = [
+ "itertools 0.12.1",
+ "nom 7.1.3",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dba03c279da73694ef99763320dea58b51095dfe87d001b1d4b5fe78ba8763cf"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d84b0a3c3739e220d94b3239fd69fb1f74bc36e16643423bd99de3b43c21bfbd"
+dependencies = [
+ "ahash 0.8.7",
+ "atoi",
+ "byteorder",
+ "bytes 1.5.0",
+ "crc 3.0.1",
+ "crossbeam-queue",
+ "dotenvy",
+ "either",
+ "event-listener 2.5.3",
+ "futures-channel",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashlink",
+ "hex",
+ "indexmap 2.2.3",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "smallvec 1.12.0",
+ "sqlformat",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89961c00dc4d7dffb7aee214964b065072bff69e36ddb9e2c107541f75e4f2a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0bd4519486723648186a08785143599760f7cc81c52334a55d6a83ea1e20841"
+dependencies = [
+ "atomic-write-file",
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-sqlite",
+ "syn 1.0.109",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags 2.4.1",
+ "byteorder",
+ "bytes 1.5.0",
+ "crc 3.0.1",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1 0.10.6",
+ "sha2 0.10.8",
+ "smallvec 1.12.0",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags 2.4.1",
+ "byteorder",
+ "crc 3.0.1",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha1 0.10.6",
+ "sha2 0.10.8",
+ "smallvec 1.12.0",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "210976b7d948c7ba9fced8ca835b11cbb2d677c59c79de41ac0d397e14547490"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "tracing",
+ "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -6837,6 +7134,17 @@ dependencies = [
  "phf_shared 0.10.0",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+dependencies = [
+ "finl_unicode",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -7706,7 +8014,6 @@ dependencies = [
  "futures 0.3.30",
  "jsonrpsee",
  "lazy_static",
- "parking_lot 0.11.2",
  "portal-bridge",
  "portalnet",
  "prometheus_exporter",
@@ -7744,12 +8051,9 @@ dependencies = [
  "ethereum_ssz",
  "ethportal-api",
  "light-client",
- "parking_lot 0.11.2",
  "portalnet",
- "r2d2",
- "r2d2_sqlite",
- "rusqlite",
  "serde_json",
+ "sqlx",
  "ssz_types",
  "tokio",
  "tracing",
@@ -7771,15 +8075,12 @@ dependencies = [
  "ethereum-types",
  "ethereum_ssz",
  "ethportal-api",
- "parking_lot 0.11.2",
  "portalnet",
- "quickcheck",
- "r2d2",
- "r2d2_sqlite",
  "rand 0.8.5",
  "rstest",
  "serde_json",
  "serial_test",
+ "sqlx",
  "ssz_types",
  "test-log",
  "tokio",
@@ -7817,7 +8118,6 @@ dependencies = [
  "ethereum-types",
  "ethportal-api",
  "keccak-hash",
- "parking_lot 0.11.2",
  "portalnet",
  "rlp",
  "rstest",
@@ -7825,6 +8125,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
+ "sqlx",
  "test-log",
  "thiserror",
  "tokio",
@@ -7843,11 +8144,9 @@ dependencies = [
  "discv5",
  "ethereum-types",
  "ethportal-api",
- "r2d2",
- "r2d2_sqlite",
  "rand 0.8.5",
  "rstest",
- "rusqlite",
+ "sqlx",
  "strum 0.26.1",
  "tempfile",
  "thiserror",
@@ -8014,6 +8313,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
 name = "universal-hash"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8070,6 +8375,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -8131,7 +8442,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom 0.2.12",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -8346,6 +8656,12 @@ dependencies = [
  "once_cell",
  "rustix 0.38.30",
 ]
+
+[[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ ethportal-api = { path = "ethportal-api" }
 futures = "0.3.21"
 jsonrpsee = "0.20.0"
 lazy_static = "1.4.0"
-parking_lot = "0.11.2"
 portalnet = { path = "portalnet" }
 portal-bridge = { path = "portal-bridge" }
 prometheus_exporter = "0.8.4"

--- a/ethportal-api/src/types/content_key/overlay.rs
+++ b/ethportal-api/src/types/content_key/overlay.rs
@@ -8,7 +8,13 @@ use std::{fmt, ops::Deref};
 /// Types whose values represent keys to lookup content items in an overlay network.
 /// Keys are serializable.
 pub trait OverlayContentKey:
-    Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ContentKeyError> + Clone + fmt::Debug + fmt::Display
+    Into<Vec<u8>>
+    + TryFrom<Vec<u8>, Error = ContentKeyError>
+    + Clone
+    + fmt::Debug
+    + fmt::Display
+    + std::marker::Sync
+    + std::marker::Send
 {
     /// Returns the identifier for the content referred to by the key.
     /// The identifier locates the content in the overlay.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,8 @@ pub async fn run_trin(
         trin_config.mb.into(),
         node_data_dir,
         discovery.local_enr().node_id(),
-    )?;
+    )
+    .await?;
 
     // Initialize validation oracle
     let master_accumulator = MasterAccumulator::try_from_file(trin_config.master_acc_path.clone())?;

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -16,13 +16,10 @@ async-trait = "0.1.53"
 discv5 = { version = "0.4.0", features = ["serde"] }
 ethereum_ssz = "0.5.3"
 ethportal-api = { path = "../ethportal-api" }
-parking_lot = "0.11.2"
 portalnet = { path = "../portalnet" }
-r2d2 = "0.8.9"
-r2d2_sqlite = "0.24.0"
-rusqlite = { version = "0.31.0", features = ["bundled"] }
 light-client = { path = "../light-client" }
 serde_json = "1.0.89"
+sqlx = { version = "0.7", features = [ "runtime-tokio", "sqlite" ] }
 ssz_types = "0.5.4"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"

--- a/trin-beacon/src/lib.rs
+++ b/trin-beacon/src/lib.rs
@@ -114,7 +114,7 @@ pub fn spawn_beacon_heartbeat(network: Arc<BeaconNetwork>) {
             // this wait at the top. Otherwise, we get two log lines immediately on startup.
             heart_interval.tick().await;
 
-            let storage_log = network.overlay.store.read().get_summary_info();
+            let storage_log = network.overlay.store.read().await.get_summary_info();
             let message_log = network.overlay.get_message_summary();
             let utp_log = network.overlay.get_utp_summary();
             info!("reports~ data: {storage_log}; msgs: {message_log}");

--- a/trin-beacon/src/network.rs
+++ b/trin-beacon/src/network.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use parking_lot::RwLock as PLRwLock;
 use tokio::sync::RwLock;
 
 use crate::{storage::BeaconStorage, sync::BeaconSync, validation::BeaconValidator};
@@ -37,7 +36,7 @@ impl BeaconNetwork {
             bootnode_enrs,
             ..Default::default()
         };
-        let storage = Arc::new(PLRwLock::new(BeaconStorage::new(storage_config)?));
+        let storage = Arc::new(RwLock::new(BeaconStorage::new(storage_config).await?));
         let validator = Arc::new(BeaconValidator { header_oracle });
         let overlay = OverlayProtocol::new(
             config,

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -17,11 +17,9 @@ discv5 = { version = "0.4.0", features = ["serde"] }
 ethereum-types = "0.14.1"
 ethereum_ssz = "0.5.3"
 ethportal-api = {path = "../ethportal-api"}
-parking_lot = "0.11.2"
 portalnet = { path = "../portalnet" }
-r2d2 = "0.8.9"
-r2d2_sqlite = "0.24.0"
 serde_json = "1.0.89"
+sqlx = { version = "0.7", features = [ "runtime-tokio", "sqlite" ] }
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
 tree_hash = "0.5.2"
@@ -33,7 +31,6 @@ utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.11" }
 
 [dev-dependencies]
 env_logger = "0.9.0"
-quickcheck = "1.0.3"
 rand = "0.8.4"
 rstest = "0.18.2"
 serial_test = "0.5.1"

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -116,7 +116,7 @@ pub fn spawn_history_heartbeat(network: Arc<HistoryNetwork>) {
             // this wait at the top. Otherwise, we get two log lines immediately on startup.
             heart_interval.tick().await;
 
-            let storage_log = network.overlay.store.read().get_summary_info();
+            let storage_log = network.overlay.store.read().await.get_summary_info();
             let message_log = network.overlay.get_message_summary();
             let utp_log = network.overlay.get_utp_summary();
             info!("reports~ data: {storage_log}; msgs: {message_log}");

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use parking_lot::RwLock as PLRwLock;
 use tokio::sync::RwLock;
 
 use crate::storage::HistoryStorage;
@@ -41,10 +40,9 @@ impl HistoryNetwork {
             disable_poke: portal_config.disable_poke,
             ..Default::default()
         };
-        let storage = Arc::new(PLRwLock::new(HistoryStorage::new(
-            storage_config,
-            ProtocolId::History,
-        )?));
+        let storage = Arc::new(RwLock::new(
+            HistoryStorage::new(storage_config, ProtocolId::History).await?,
+        ));
         let validator = Arc::new(ChainHistoryValidator { header_oracle });
         let overlay = OverlayProtocol::new(
             config,

--- a/trin-history/src/storage.rs
+++ b/trin-history/src/storage.rs
@@ -1,12 +1,10 @@
-use crate::storage::rusqlite::params;
 use discv5::enr::NodeId;
 use ethportal_api::{
     types::{distance::Distance, history::PaginateLocalContentInfo, portal_wire::ProtocolId},
     utils::bytes::hex_encode,
     HistoryContentKey, OverlayContentKey,
 };
-use r2d2::Pool;
-use r2d2_sqlite::{rusqlite, SqliteConnectionManager};
+use sqlx::{query, sqlite::SqliteRow, Row, SqlitePool};
 use std::path::PathBuf;
 use tracing::debug;
 use trin_metrics::storage::StorageMetricsReporter;
@@ -19,7 +17,7 @@ use trin_storage::{
         XOR_FIND_FARTHEST_QUERY_HISTORY,
     },
     utils::get_total_size_of_directory_in_bytes,
-    ContentId, ContentStore, DataSize, DistanceFunction, EntryCount, PortalStorageConfig,
+    ContentId, ContentStore, DistanceFunction, EntryCount, PortalStorageConfig,
     ShouldWeStoreContent, BYTES_IN_MB_U64,
 };
 
@@ -34,28 +32,31 @@ pub struct HistoryStorage {
     storage_capacity_in_bytes: u64,
     storage_occupied_in_bytes: u64,
     radius: Distance,
-    sql_connection_pool: Pool<SqliteConnectionManager>,
+    sql_connection_pool: SqlitePool,
     distance_fn: DistanceFunction,
     metrics: StorageMetricsReporter,
 }
 
 impl ContentStore for HistoryStorage {
-    fn get<K: OverlayContentKey>(&self, key: &K) -> Result<Option<Vec<u8>>, ContentStoreError> {
+    async fn get<K: OverlayContentKey>(
+        &self,
+        key: &K,
+    ) -> Result<Option<Vec<u8>>, ContentStoreError> {
         let content_id = key.content_id();
-        self.lookup_content_value(content_id).map_err(|err| {
+        self.lookup_content_value(content_id).await.map_err(|err| {
             ContentStoreError::Database(format!("Error looking up content value: {err:?}"))
         })
     }
 
-    fn put<K: OverlayContentKey, V: AsRef<[u8]>>(
+    async fn put<K: OverlayContentKey>(
         &mut self,
         key: K,
-        value: V,
+        value: Vec<u8>,
     ) -> Result<(), ContentStoreError> {
-        self.store(&key, &value.as_ref().to_vec())
+        self.store(&key, &value).await
     }
 
-    fn is_key_within_radius_and_unavailable<K: OverlayContentKey>(
+    async fn is_key_within_radius_and_unavailable<K: OverlayContentKey>(
         &self,
         key: &K,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
@@ -67,6 +68,7 @@ impl ContentStore for HistoryStorage {
         let key = key.content_id();
         let is_key_available = self
             .lookup_content_key(key)
+            .await
             .map_err(|err| {
                 ContentStoreError::Database(format!("Error looking up content key: {err:?}"))
             })?
@@ -85,7 +87,7 @@ impl ContentStore for HistoryStorage {
 impl HistoryStorage {
     /// Public constructor for building a `HistoryStorage` object.
     /// Checks whether a populated database already exists vs a fresh instance.
-    pub fn new(
+    pub async fn new(
         config: PortalStorageConfig,
         protocol: ProtocolId,
     ) -> Result<Self, ContentStoreError> {
@@ -104,11 +106,12 @@ impl HistoryStorage {
         storage.metrics.report_radius(storage.radius);
 
         // Set the network content storage used at start
-        storage.storage_occupied_in_bytes =
-            storage.get_total_storage_usage_in_bytes_from_network()?;
+        storage.storage_occupied_in_bytes = storage
+            .get_total_storage_usage_in_bytes_from_network()
+            .await?;
 
         // Check whether we already have data, and use it to set radius
-        match storage.total_entry_count()? {
+        match storage.total_entry_count().await? {
             0 => {
                 // Default radius is left in place, unless user selected 0mb capacity
                 if storage.storage_capacity_in_bytes == 0 {
@@ -119,7 +122,7 @@ impl HistoryStorage {
             entry_count => {
                 storage.metrics.report_entry_count(entry_count);
 
-                let _ = storage.prune_db()?;
+                let _ = storage.prune_db().await?;
             }
         }
 
@@ -145,45 +148,44 @@ impl HistoryStorage {
 
     /// Returns a paginated list of all available content keys from local storage (from any
     /// subnetwork) according to the provided offset and limit.
-    pub fn paginate(
+    pub async fn paginate(
         &self,
-        offset: &u64,
-        limit: &u64,
+        offset: u64,
+        limit: u64,
     ) -> Result<PaginateLocalContentInfo, ContentStoreError> {
-        let conn = self.sql_connection_pool.get()?;
-        let mut query = conn.prepare(PAGINATE_QUERY_HISTORY)?;
+        let content_keys = query(PAGINATE_QUERY_HISTORY)
+            .bind(limit as i64)
+            .bind(offset as i64)
+            .map(|row: SqliteRow| {
+                let row: Vec<u8> = row.get(0);
+                row
+            })
+            .fetch_all(&self.sql_connection_pool)
+            .await?;
 
-        let content_keys: Result<Vec<HistoryContentKey>, ContentStoreError> = query
-            .query_map([limit, offset], |row| {
-                let row: Vec<u8> = row.get(0)?;
-                Ok(row)
-            })?
-            .map(|row| HistoryContentKey::try_from(row?).map_err(ContentStoreError::ContentKey))
+        let content_keys: Result<Vec<HistoryContentKey>, ContentStoreError> = content_keys
+            .into_iter()
+            .map(|bytes| HistoryContentKey::try_from(bytes).map_err(ContentStoreError::ContentKey))
             .collect();
+
         Ok(PaginateLocalContentInfo {
             content_keys: content_keys?,
-            total_entries: self.total_entry_count()?,
+            total_entries: self.total_entry_count().await?,
         })
     }
 
-    fn total_entry_count(&self) -> Result<u64, ContentStoreError> {
+    async fn total_entry_count(&self) -> Result<u64, ContentStoreError> {
         let timer = self.metrics.start_process_timer("total_entry_count");
-        let conn = self.sql_connection_pool.get()?;
-        let mut query = conn.prepare(TOTAL_ENTRY_COUNT_QUERY_HISTORY)?;
-        let result: Result<Vec<EntryCount>, rusqlite::Error> = query
-            .query_map([], |row| Ok(EntryCount(row.get(0)?)))?
-            .collect();
+        let result = query(TOTAL_ENTRY_COUNT_QUERY_HISTORY)
+            .map(|row: SqliteRow| EntryCount(row.get(0)))
+            .fetch_one(&self.sql_connection_pool)
+            .await?;
         self.metrics.stop_process_timer(timer);
-        match result?.first() {
-            Some(val) => Ok(val.0),
-            None => Err(ContentStoreError::InvalidData {
-                message: "Invalid total entries count returned from sql query.".to_string(),
-            }),
-        }
+        Ok(result.0 as u64)
     }
 
     /// Method for storing a given value for a given content-key.
-    fn store(
+    async fn store(
         &mut self,
         key: &impl OverlayContentKey,
         value: &Vec<u8>,
@@ -204,7 +206,7 @@ impl HistoryStorage {
         // Store the data in db
         let content_key: Vec<u8> = key.clone().into();
         let value_size = value.len();
-        match self.db_insert(&content_id, &content_key, value) {
+        match self.db_insert(&content_id, &content_key, value).await {
             Ok(result) => {
                 // Insertion successful, increase total network storage count
                 if result == 1 {
@@ -222,7 +224,7 @@ impl HistoryStorage {
             }
         }
         self.metrics.stop_process_timer(store_timer);
-        self.prune_db()?;
+        self.prune_db().await?;
         let total_bytes_on_disk = self.get_total_storage_usage_in_bytes_on_disk()?;
         self.metrics
             .report_total_storage_usage_bytes(total_bytes_on_disk as f64);
@@ -233,9 +235,9 @@ impl HistoryStorage {
     /// Internal method for pruning any data that falls outside of the radius of the store.
     /// Resets the data radius if it prunes any data. Does nothing if the store is empty.
     /// Returns the number of items removed during pruning
-    fn prune_db(&mut self) -> Result<usize, ContentStoreError> {
+    async fn prune_db(&mut self) -> Result<usize, ContentStoreError> {
         let timer = self.metrics.start_process_timer("prune_db");
-        let mut farthest_content_id: Option<[u8; 32]> = self.find_farthest_content_id()?;
+        let mut farthest_content_id: Option<[u8; 32]> = self.find_farthest_content_id().await?;
         let mut num_removed_items = 0;
         // Delete furthest data until our data usage is less than capacity.
         while self.capacity_reached() {
@@ -244,7 +246,7 @@ impl HistoryStorage {
             let id_to_remove =
                 farthest_content_id.expect("Capacity reached, but no farthest id found!");
             // Test if removing the item would put us under capacity
-            let bytes_to_remove = self.get_content_size(&id_to_remove)?;
+            let bytes_to_remove = self.get_content_size(&id_to_remove).await?;
             if self.storage_occupied_in_bytes - bytes_to_remove < self.storage_capacity_in_bytes {
                 // If so, we're done pruning
                 debug!(
@@ -258,7 +260,7 @@ impl HistoryStorage {
                 "Capacity reached, deleting farthest: {}",
                 hex_encode(id_to_remove)
             );
-            if let Err(err) = self.db_remove(&id_to_remove) {
+            if let Err(err) = self.db_remove(&id_to_remove).await {
                 debug!("Error removing content ID {id_to_remove:?} from db: {err:?}");
             } else {
                 // Eviction successful, decrease total network storage count
@@ -268,7 +270,7 @@ impl HistoryStorage {
                 num_removed_items += 1;
             }
             // Calculate new farthest_content_id and reset radius
-            match self.find_farthest_content_id()? {
+            match self.find_farthest_content_id().await? {
                 None => {
                     // We get here if the entire db has been pruned,
                     // eg. user selected 0mb capacity for storage
@@ -288,62 +290,61 @@ impl HistoryStorage {
     /// Internal method for getting the size of a content item in bytes.
     /// Returns the size of the content item in bytes.
     /// Raises an error if there is a problem accessing the database.
-    fn get_content_size(&self, id: &[u8; 32]) -> Result<u64, ContentStoreError> {
+    async fn get_content_size(&self, id: &[u8; 32]) -> Result<u64, ContentStoreError> {
         let timer = self.metrics.start_process_timer("get_content_size");
-        let conn = self.sql_connection_pool.get()?;
-        let mut query = conn.prepare(CONTENT_SIZE_LOOKUP_QUERY_HISTORY)?;
-        let id_vec = id.to_vec();
-        let result = query.query_map([id_vec], |row| {
-            Ok(DataSize {
-                num_bytes: row.get(0)?,
+        let result = query(CONTENT_SIZE_LOOKUP_QUERY_HISTORY)
+            .bind(id.as_slice())
+            .map(|row: SqliteRow| {
+                let num_bytes: i64 = row.get(0);
+                num_bytes
             })
-        });
-        let byte_size = match result?.next() {
+            .fetch_optional(&self.sql_connection_pool)
+            .await?;
+        let byte_size = match result {
             Some(data_size) => data_size,
             None => {
                 // Build error message with hex encoded content id
                 let err = format!("Unable to determine size of item {}", hex_encode(id));
                 return Err(ContentStoreError::Database(err));
             }
-        }?
-        .num_bytes;
+        };
         self.metrics.stop_process_timer(timer);
         Ok(byte_size as u64)
     }
 
     /// Internal method for looking up a content key by its content id
-    fn lookup_content_key(&self, id: [u8; 32]) -> anyhow::Result<Option<Vec<u8>>> {
+    async fn lookup_content_key(&self, id: [u8; 32]) -> anyhow::Result<Option<Vec<u8>>> {
         let timer = self.metrics.start_process_timer("lookup_content_key");
-        let conn = self.sql_connection_pool.get()?;
-        let mut query = conn.prepare(CONTENT_KEY_LOOKUP_QUERY_HISTORY)?;
-        let result: Result<Vec<HistoryContentKey>, ContentStoreError> = query
-            .query_map([id.as_slice()], |row| {
-                let row: Vec<u8> = row.get(0)?;
-                Ok(row)
-            })?
-            .map(|row| HistoryContentKey::try_from(row?).map_err(ContentStoreError::ContentKey))
-            .collect();
-        self.metrics.stop_process_timer(timer);
-        match result?.first() {
-            Some(val) => Ok(Some(val.into())),
+        let result = query(CONTENT_KEY_LOOKUP_QUERY_HISTORY)
+            .bind(id.as_slice())
+            .map(|row: SqliteRow| {
+                let row: Vec<u8> = row.get(0);
+                row
+            })
+            .fetch_optional(&self.sql_connection_pool)
+            .await?;
+        let key = match result {
+            Some(bytes) => match HistoryContentKey::try_from(bytes) {
+                Ok(key) => Ok(Some(key.into())),
+                Err(err) => Err(ContentStoreError::ContentKey(err)),
+            },
             None => Ok(None),
-        }
+        };
+        self.metrics.stop_process_timer(timer);
+        Ok(key?)
     }
 
     /// Internal method for looking up a content value by its content id
-    fn lookup_content_value(&self, id: [u8; 32]) -> anyhow::Result<Option<Vec<u8>>> {
+    async fn lookup_content_value(&self, id: [u8; 32]) -> anyhow::Result<Option<Vec<u8>>> {
         let timer = self.metrics.start_process_timer("lookup_content_value");
-        let conn = self.sql_connection_pool.get()?;
-        let mut query = conn.prepare(CONTENT_VALUE_LOOKUP_QUERY_HISTORY)?;
-        let result: Result<Vec<Vec<u8>>, ContentStoreError> = query
-            .query_map([id.as_slice()], |row| {
-                let row: Vec<u8> = row.get(0)?;
-                Ok(row)
-            })?
-            .map(|row| row.map_err(ContentStoreError::Rusqlite))
-            .collect();
-
-        let result = result?.first().map(|val| val.to_vec());
+        let result = query(CONTENT_VALUE_LOOKUP_QUERY_HISTORY)
+            .bind(id.as_slice())
+            .map(|row: SqliteRow| {
+                let bytes: Vec<u8> = row.get(0);
+                bytes
+            })
+            .fetch_optional(&self.sql_connection_pool)
+            .await?;
         self.metrics.stop_process_timer(timer);
         Ok(result)
     }
@@ -366,34 +367,33 @@ impl HistoryStorage {
     }
 
     /// Internal method for inserting data into the db.
-    fn db_insert(
+    async fn db_insert(
         &self,
         content_id: &[u8; 32],
         content_key: &Vec<u8>,
         value: &Vec<u8>,
-    ) -> Result<usize, ContentStoreError> {
+    ) -> Result<u64, ContentStoreError> {
         let timer = self.metrics.start_process_timer("db_insert");
-        let conn = self.sql_connection_pool.get()?;
-        let result = conn.execute(
-            INSERT_QUERY_HISTORY,
-            params![
-                content_id.as_slice(),
-                content_key,
-                value,
-                self.distance_to_content_id(content_id).big_endian_u32(),
-                CONTENT_ID_AND_KEY_LENGTH + value.len()
-            ],
-        )?;
+        let result = query(INSERT_QUERY_HISTORY)
+            .bind(content_id.as_slice())
+            .bind(content_key)
+            .bind(value)
+            .bind(self.distance_to_content_id(content_id).big_endian_u32())
+            .bind((CONTENT_ID_AND_KEY_LENGTH + value.len()) as i64)
+            .execute(&self.sql_connection_pool)
+            .await?
+            .rows_affected();
         self.metrics.stop_process_timer(timer);
         Ok(result)
     }
 
     /// Internal method for removing a given content-id from the db.
-    fn db_remove(&self, content_id: &[u8; 32]) -> Result<(), ContentStoreError> {
+    async fn db_remove(&self, content_id: &[u8; 32]) -> Result<(), ContentStoreError> {
         let timer = self.metrics.start_process_timer("db_remove");
-        self.sql_connection_pool
-            .get()?
-            .execute(DELETE_QUERY_HISTORY, [content_id.as_slice()])?;
+        query(DELETE_QUERY_HISTORY)
+            .bind(content_id.as_slice())
+            .execute(&self.sql_connection_pool)
+            .await?;
         self.metrics.stop_process_timer(timer);
         self.metrics.decrease_entry_count();
         Ok(())
@@ -405,29 +405,28 @@ impl HistoryStorage {
     }
 
     /// Internal method for measuring the total amount of requestable data that the node is storing.
-    fn get_total_storage_usage_in_bytes_from_network(&self) -> Result<u64, ContentStoreError> {
+    async fn get_total_storage_usage_in_bytes_from_network(
+        &self,
+    ) -> Result<u64, ContentStoreError> {
         let timer = self
             .metrics
             .start_process_timer("get_total_storage_usage_in_bytes_from_network");
-        let conn = self.sql_connection_pool.get()?;
-        let mut query = conn.prepare(TOTAL_DATA_SIZE_QUERY_HISTORY)?;
-
-        let result = query.query_map([], |row| {
-            Ok(DataSize {
-                num_bytes: row.get(0)?,
+        let result = query(TOTAL_DATA_SIZE_QUERY_HISTORY)
+            .map(|row: SqliteRow| {
+                let num_bytes: f32 = row.get(0);
+                num_bytes
             })
-        });
-
-        let sum = match result?.next() {
+            .fetch_optional(&self.sql_connection_pool)
+            .await?;
+        let sum = match result {
             Some(total) => total,
             None => {
                 let err = "Unable to compute sum over content item sizes".to_string();
                 return Err(ContentStoreError::Database(err));
             }
-        }?
-        .num_bytes;
+        };
 
-        self.metrics.report_content_data_storage_bytes(sum);
+        self.metrics.report_content_data_storage_bytes(sum as f64);
         self.metrics.stop_process_timer(timer);
         Ok(sum as u64)
     }
@@ -435,30 +434,22 @@ impl HistoryStorage {
     /// Internal method for finding the piece of stored data that has the farthest content id from
     /// our node id, according to xor distance. Used to determine which data to drop when at a
     /// capacity.
-    fn find_farthest_content_id(&self) -> Result<Option<[u8; 32]>, ContentStoreError> {
+    async fn find_farthest_content_id(&self) -> Result<Option<[u8; 32]>, ContentStoreError> {
         let timer = self.metrics.start_process_timer("find_farthest_content_id");
         let result = match self.distance_fn {
             DistanceFunction::Xor => {
-                let conn = self.sql_connection_pool.get()?;
-                let mut query = conn.prepare(XOR_FIND_FARTHEST_QUERY_HISTORY)?;
-
-                let mut result = query.query_map([], |row| {
-                    let content_id: ContentId = row.get(0)?;
-                    Ok(content_id)
-                })?;
-
-                let result = match result.next() {
-                    Some(row) => row,
-                    None => {
-                        return Ok(None);
-                    }
-                };
-                result?.to_fixed_bytes()
+                query(XOR_FIND_FARTHEST_QUERY_HISTORY)
+                    .map(|row: SqliteRow| {
+                        let content_id: ContentId = row.get(0);
+                        content_id.to_fixed_bytes()
+                    })
+                    .fetch_optional(&self.sql_connection_pool)
+                    .await?
             }
         };
 
         self.metrics.stop_process_timer(timer);
-        Ok(Some(result))
+        Ok(result)
     }
 
     /// Method that returns the distance between our node ID and a given content ID.
@@ -482,7 +473,6 @@ pub mod test {
         BlockHeaderKey, HistoryContentKey, IdentityContentKey,
     };
     use portalnet::utils::db::{configure_node_data_dir, setup_temp_dir};
-    use quickcheck::{quickcheck, QuickCheck, TestResult};
     use rand::RngCore;
     use serial_test::serial;
 
@@ -501,8 +491,10 @@ pub mod test {
         let node_id = get_active_node_id(temp_dir.path().to_path_buf());
 
         let storage_config =
-            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id).unwrap();
-        let storage = HistoryStorage::new(storage_config, ProtocolId::History)?;
+            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id)
+                .await
+                .unwrap();
+        let storage = HistoryStorage::new(storage_config, ProtocolId::History).await?;
 
         // Assert that configs match the storage object's fields
         assert_eq!(storage.node_id, node_id);
@@ -519,27 +511,26 @@ pub mod test {
 
     #[test_log::test(tokio::test)]
     #[serial]
-    async fn test_store() {
-        fn test_store_random_bytes() -> TestResult {
+    async fn test_store() -> anyhow::Result<()> {
+        for _ in 0..=10 {
             let temp_dir = setup_temp_dir().unwrap();
             let node_id = get_active_node_id(temp_dir.path().to_path_buf());
             let storage_config =
                 PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id)
+                    .await
                     .unwrap();
-            let mut storage = HistoryStorage::new(storage_config, ProtocolId::History).unwrap();
+            let mut storage = HistoryStorage::new(storage_config, ProtocolId::History)
+                .await
+                .unwrap();
             let content_key = IdentityContentKey::random();
             let mut value = [0u8; 32];
             rand::thread_rng().fill_bytes(&mut value);
-            storage.store(&content_key, &value.to_vec()).unwrap();
+            storage.store(&content_key, &value.to_vec()).await.unwrap();
 
             std::mem::drop(storage);
             temp_dir.close().unwrap();
-
-            TestResult::passed()
         }
-        QuickCheck::new()
-            .tests(10)
-            .quickcheck(test_store_random_bytes as fn() -> _);
+        Ok(())
     }
 
     #[test_log::test(tokio::test)]
@@ -548,13 +539,15 @@ pub mod test {
         let temp_dir = setup_temp_dir().unwrap();
         let node_id = get_active_node_id(temp_dir.path().to_path_buf());
         let storage_config =
-            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id).unwrap();
-        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History)?;
+            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id)
+                .await
+                .unwrap();
+        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History).await?;
         let content_key = HistoryContentKey::BlockHeaderWithProof(BlockHeaderKey::default());
         let value: Vec<u8> = "OGFWs179fWnqmjvHQFGHszXloc3Wzdb4".into();
-        storage.store(&content_key, &value)?;
+        storage.store(&content_key, &value).await?;
 
-        let result = storage.get(&content_key).unwrap().unwrap();
+        let result = storage.get(&content_key).await.unwrap().unwrap();
 
         assert_eq!(result, value);
 
@@ -569,14 +562,18 @@ pub mod test {
         let temp_dir = setup_temp_dir().unwrap();
         let node_id = get_active_node_id(temp_dir.path().to_path_buf());
         let storage_config =
-            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id).unwrap();
-        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History)?;
+            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id)
+                .await
+                .unwrap();
+        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History).await?;
 
         let content_key = IdentityContentKey::random();
         let value: Vec<u8> = "OGFWs179fWnqmjvHQFGHszXloc3Wzdb4".into();
-        storage.store(&content_key, &value)?;
+        storage.store(&content_key, &value).await?;
 
-        let bytes = storage.get_total_storage_usage_in_bytes_from_network()?;
+        let bytes = storage
+            .get_total_storage_usage_in_bytes_from_network()
+            .await?;
 
         assert_eq!(96, bytes);
 
@@ -591,33 +588,43 @@ pub mod test {
         let temp_dir = setup_temp_dir().unwrap();
         let node_id = get_active_node_id(temp_dir.path().to_path_buf());
         let storage_config =
-            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id).unwrap();
-        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History)?;
+            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id)
+                .await
+                .unwrap();
+        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History).await?;
 
         for _ in 0..50 {
             let content_key = IdentityContentKey::random();
             let value: Vec<u8> = vec![0; 32000];
-            storage.store(&content_key, &value)?;
+            storage.store(&content_key, &value).await?;
             assert_eq!(
                 storage.storage_occupied_in_bytes,
-                storage.get_total_storage_usage_in_bytes_from_network()?
+                storage
+                    .get_total_storage_usage_in_bytes_from_network()
+                    .await?
             );
         }
 
-        let bytes = storage.get_total_storage_usage_in_bytes_from_network()?;
+        let bytes = storage
+            .get_total_storage_usage_in_bytes_from_network()
+            .await?;
         assert_eq!(1603200, bytes); // (32kb + CONTENT_ID_AND_KEY_LENGTH) * 50
         assert_eq!(storage.radius, Distance::MAX);
         std::mem::drop(storage);
 
         // test with 1mb capacity
         let new_storage_config =
-            PortalStorageConfig::new(1, temp_dir.path().to_path_buf(), node_id).unwrap();
-        let new_storage = HistoryStorage::new(new_storage_config, ProtocolId::History)?;
+            PortalStorageConfig::new(1, temp_dir.path().to_path_buf(), node_id)
+                .await
+                .unwrap();
+        let new_storage = HistoryStorage::new(new_storage_config, ProtocolId::History).await?;
 
         // test that previously set value has been pruned
-        let bytes = new_storage.get_total_storage_usage_in_bytes_from_network()?;
+        let bytes = new_storage
+            .get_total_storage_usage_in_bytes_from_network()
+            .await?;
         assert_eq!(1026048, bytes);
-        assert_eq!(32, new_storage.total_entry_count().unwrap());
+        assert_eq!(32, new_storage.total_entry_count().await.unwrap());
         assert_eq!(new_storage.storage_capacity_in_bytes, BYTES_IN_MB_U64);
         // test that radius has decreased now that we're at capacity
         assert!(new_storage.radius < Distance::MAX);
@@ -625,8 +632,10 @@ pub mod test {
 
         // test with 0mb capacity
         let new_storage_config =
-            PortalStorageConfig::new(0, temp_dir.path().to_path_buf(), node_id).unwrap();
-        let new_storage = HistoryStorage::new(new_storage_config, ProtocolId::History)?;
+            PortalStorageConfig::new(0, temp_dir.path().to_path_buf(), node_id)
+                .await
+                .unwrap();
+        let new_storage = HistoryStorage::new(new_storage_config, ProtocolId::History).await?;
 
         // test that previously set value has been pruned
         assert_eq!(new_storage.storage_capacity_in_bytes, 0);
@@ -643,21 +652,27 @@ pub mod test {
         let temp_dir = setup_temp_dir().unwrap();
         let node_id = get_active_node_id(temp_dir.path().to_path_buf());
         let storage_config =
-            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id).unwrap();
-        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History)?;
+            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id)
+                .await
+                .unwrap();
+        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History).await?;
 
         let content_key = IdentityContentKey::random();
         let value: Vec<u8> = vec![0; 32000];
-        storage.store(&content_key, &value)?;
+        storage.store(&content_key, &value).await?;
         assert_eq!(
             storage.storage_occupied_in_bytes,
-            storage.get_total_storage_usage_in_bytes_from_network()?
+            storage
+                .get_total_storage_usage_in_bytes_from_network()
+                .await?
         );
 
-        storage.store(&content_key, &value)?;
+        storage.store(&content_key, &value).await?;
         assert_eq!(
             storage.storage_occupied_in_bytes,
-            storage.get_total_storage_usage_in_bytes_from_network()?
+            storage
+                .get_total_storage_usage_in_bytes_from_network()
+                .await?
         );
 
         std::mem::drop(storage);
@@ -671,32 +686,40 @@ pub mod test {
         let temp_dir = setup_temp_dir().unwrap();
         let node_id = get_active_node_id(temp_dir.path().to_path_buf());
         let storage_config =
-            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id).unwrap();
-        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History)?;
+            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id)
+                .await
+                .unwrap();
+        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History).await?;
 
         for _ in 0..50 {
             let content_key = IdentityContentKey::random();
             let value: Vec<u8> = vec![0; 32000];
-            storage.store(&content_key, &value)?;
+            storage.store(&content_key, &value).await?;
             assert_eq!(
                 storage.storage_occupied_in_bytes,
-                storage.get_total_storage_usage_in_bytes_from_network()?
+                storage
+                    .get_total_storage_usage_in_bytes_from_network()
+                    .await?
             );
         }
 
         storage.storage_capacity_in_bytes = 1;
-        let num_removed_items = storage.prune_db().unwrap();
+        let num_removed_items = storage.prune_db().await.unwrap();
         assert_eq!(49, num_removed_items);
 
-        let bytes = storage.get_total_storage_usage_in_bytes_from_network()?;
+        let bytes = storage
+            .get_total_storage_usage_in_bytes_from_network()
+            .await?;
         assert_eq!(32064, storage.storage_occupied_in_bytes);
         assert_eq!(32064, bytes);
 
         storage.storage_capacity_in_bytes = 0;
-        let num_removed_items = storage.prune_db().unwrap();
+        let num_removed_items = storage.prune_db().await.unwrap();
         assert_eq!(1, num_removed_items);
 
-        let bytes = storage.get_total_storage_usage_in_bytes_from_network()?;
+        let bytes = storage
+            .get_total_storage_usage_in_bytes_from_network()
+            .await?;
         assert_eq!(0, storage.storage_occupied_in_bytes);
         assert_eq!(0, bytes);
         std::mem::drop(storage);
@@ -714,17 +737,21 @@ pub mod test {
         let min_capacity = 1;
         // Use a tiny storage capacity, to fill up as quickly as possible
         let storage_config =
-            PortalStorageConfig::new(min_capacity, temp_dir.path().to_path_buf(), node_id).unwrap();
-        let mut storage = HistoryStorage::new(storage_config.clone(), ProtocolId::History)?;
+            PortalStorageConfig::new(min_capacity, temp_dir.path().to_path_buf(), node_id)
+                .await
+                .unwrap();
+        let mut storage = HistoryStorage::new(storage_config.clone(), ProtocolId::History).await?;
 
         // Fill up the storage.
         for _ in 0..32 {
             let content_key = IdentityContentKey::random();
             let value: Vec<u8> = vec![0; 32000];
-            storage.store(&content_key, &value)?;
+            storage.store(&content_key, &value).await?;
             assert_eq!(
                 storage.storage_occupied_in_bytes,
-                storage.get_total_storage_usage_in_bytes_from_network()?
+                storage
+                    .get_total_storage_usage_in_bytes_from_network()
+                    .await?
             );
             // Speed up the test by ending the loop as soon as possible
             if storage.capacity_reached() {
@@ -734,16 +761,19 @@ pub mod test {
         assert!(storage.capacity_reached());
 
         // Save the number of items, to compare with the restarted storage
-        let total_entry_count = storage.total_entry_count().unwrap();
+        let total_entry_count = storage.total_entry_count().await.unwrap();
         // Save the radius, to compare with the restarted storage
         let radius = storage.radius;
         assert!(radius < Distance::MAX);
 
         // Restart a filled-up store with the same capacity
-        let new_storage = HistoryStorage::new(storage_config, ProtocolId::History)?;
+        let new_storage = HistoryStorage::new(storage_config, ProtocolId::History).await?;
 
         // The restarted store should have the same number of items
-        assert_eq!(total_entry_count, new_storage.total_entry_count().unwrap());
+        assert_eq!(
+            total_entry_count,
+            new_storage.total_entry_count().await.unwrap()
+        );
         // The restarted store should be full
         assert!(new_storage.capacity_reached());
         // The restarted store should have the same radius as the original
@@ -763,32 +793,41 @@ pub mod test {
             configure_node_data_dir(temp_dir.path().to_path_buf(), None).unwrap();
         let private_key = CombinedKey::secp256k1_from_bytes(private_key.0.as_mut_slice()).unwrap();
         let node_id = Discv5Enr::empty(&private_key).unwrap().node_id();
-        let storage_config =
-            PortalStorageConfig::new(CAPACITY_MB, node_data_dir.clone(), node_id).unwrap();
-        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History)?;
+        let storage_config = PortalStorageConfig::new(CAPACITY_MB, node_data_dir.clone(), node_id)
+            .await
+            .unwrap();
+        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History).await?;
 
         for _ in 0..50 {
             let content_key = IdentityContentKey::random();
             let value: Vec<u8> = vec![0; 32000];
-            storage.store(&content_key, &value)?;
+            storage.store(&content_key, &value).await?;
         }
 
-        let bytes = storage.get_total_storage_usage_in_bytes_from_network()?;
+        let bytes = storage
+            .get_total_storage_usage_in_bytes_from_network()
+            .await?;
         assert_eq!(1603200, bytes); // (32kb + CONTENT_ID_AND_KEY_LENGTH) * 50
         assert_eq!(storage.radius, Distance::MAX);
         // Save the number of items, to compare with the restarted storage
-        let total_entry_count = storage.total_entry_count().unwrap();
+        let total_entry_count = storage.total_entry_count().await.unwrap();
         std::mem::drop(storage);
 
         // test with increased capacity
-        let new_storage_config =
-            PortalStorageConfig::new(2 * CAPACITY_MB, node_data_dir, node_id).unwrap();
-        let new_storage = HistoryStorage::new(new_storage_config, ProtocolId::History)?;
+        let new_storage_config = PortalStorageConfig::new(2 * CAPACITY_MB, node_data_dir, node_id)
+            .await
+            .unwrap();
+        let new_storage = HistoryStorage::new(new_storage_config, ProtocolId::History).await?;
 
         // test that previously set value has not been pruned
-        let bytes = new_storage.get_total_storage_usage_in_bytes_from_network()?;
+        let bytes = new_storage
+            .get_total_storage_usage_in_bytes_from_network()
+            .await?;
         assert_eq!(1603200, bytes);
-        assert_eq!(new_storage.total_entry_count().unwrap(), total_entry_count);
+        assert_eq!(
+            new_storage.total_entry_count().await.unwrap(),
+            total_entry_count
+        );
         assert_eq!(
             new_storage.storage_capacity_in_bytes,
             2 * CAPACITY_MB * BYTES_IN_MB_U64
@@ -806,15 +845,18 @@ pub mod test {
     async fn test_new_storage_with_zero_capacity() -> Result<(), ContentStoreError> {
         let temp_dir = setup_temp_dir().unwrap();
         let node_id = get_active_node_id(temp_dir.path().to_path_buf());
-        let storage_config =
-            PortalStorageConfig::new(0, temp_dir.path().to_path_buf(), node_id).unwrap();
-        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History)?;
+        let storage_config = PortalStorageConfig::new(0, temp_dir.path().to_path_buf(), node_id)
+            .await
+            .unwrap();
+        let mut storage = HistoryStorage::new(storage_config, ProtocolId::History).await?;
 
         let content_key = IdentityContentKey::random();
         let value: Vec<u8> = "OGFWs179fWnqmjvHQFGHszXloc3Wzdb4".into();
-        assert!(storage.store(&content_key, &value).is_err());
+        assert!(storage.store(&content_key, &value).await.is_err());
 
-        let bytes = storage.get_total_storage_usage_in_bytes_from_network()?;
+        let bytes = storage
+            .get_total_storage_usage_in_bytes_from_network()
+            .await?;
 
         assert_eq!(0, bytes);
         assert_eq!(storage.radius, Distance::ZERO);
@@ -830,10 +872,11 @@ pub mod test {
         let temp_dir = setup_temp_dir().unwrap();
         let node_id = get_active_node_id(temp_dir.path().to_path_buf());
         let storage_config =
-            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id).unwrap();
-        let storage = HistoryStorage::new(storage_config, ProtocolId::History)?;
-
-        let result = storage.find_farthest_content_id()?;
+            PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id)
+                .await
+                .unwrap();
+        let storage = HistoryStorage::new(storage_config, ProtocolId::History).await?;
+        let result = storage.find_farthest_content_id().await?;
         assert!(result.is_none());
 
         std::mem::drop(storage);
@@ -843,18 +886,23 @@ pub mod test {
 
     #[test_log::test(tokio::test)]
     #[serial]
-    async fn test_find_farthest() {
-        fn prop(x: IdentityContentKey, y: IdentityContentKey) -> TestResult {
+    async fn test_find_farthest() -> anyhow::Result<()> {
+        for _ in 0..=10 {
+            let x = IdentityContentKey::random();
+            let y = IdentityContentKey::random();
             let temp_dir = setup_temp_dir().unwrap();
             let node_id = get_active_node_id(temp_dir.path().to_path_buf());
 
             let val = vec![0x00, 0x01, 0x02, 0x03, 0x04];
             let storage_config =
                 PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id)
+                    .await
                     .unwrap();
-            let mut storage = HistoryStorage::new(storage_config, ProtocolId::History).unwrap();
-            storage.store(&x, &val).unwrap();
-            storage.store(&y, &val).unwrap();
+            let mut storage = HistoryStorage::new(storage_config, ProtocolId::History)
+                .await
+                .unwrap();
+            storage.store(&x, &val).await.unwrap();
+            storage.store(&y, &val).await.unwrap();
 
             let expected_farthest = if storage.distance_to_content_id(&x.content_id())
                 > storage.distance_to_content_id(&y.content_id())
@@ -864,14 +912,13 @@ pub mod test {
                 y.content_id()
             };
 
-            let farthest = storage.find_farthest_content_id();
+            let farthest = storage.find_farthest_content_id().await;
 
             std::mem::drop(storage);
             temp_dir.close().unwrap();
 
-            TestResult::from_bool(farthest.unwrap().unwrap() == expected_farthest)
+            assert_eq!(farthest.unwrap().unwrap(), expected_farthest);
         }
-
-        quickcheck(prop as fn(IdentityContentKey, IdentityContentKey) -> TestResult);
+        Ok(())
     }
 }

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -18,11 +18,11 @@ eth_trie = { git = "https://github.com/morph-dev/eth-trie.rs.git", branch = "tri
 ethereum-types = "0.14.1"
 ethportal-api = { path = "../ethportal-api" }
 keccak-hash = "0.10.0"
-parking_lot = "0.11.2"
 portalnet = { path = "../portalnet" }
 rlp = "0.5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.89"
+sqlx = { version = "0.7", features = [ "runtime-tokio", "sqlite" ] }
 thiserror = "1.0.57"
 tokio = {version = "1.14.0", features = ["full"]}
 tracing = "0.1.36"

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -117,7 +117,7 @@ pub fn spawn_state_heartbeat(network: Arc<StateNetwork>) {
             // this wait at the top. Otherwise, we get two log lines immediately on startup.
             heart_interval.tick().await;
 
-            let storage_log = network.overlay.store.read().get_summary_info();
+            let storage_log = network.overlay.store.read().await.get_summary_info().await;
             let message_log = network.overlay.get_message_summary();
             let utp_log = network.overlay.get_utp_summary();
             info!("reports~ data: {storage_log}; msgs: {message_log}");

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -1,4 +1,3 @@
-use parking_lot::RwLock as PLRwLock;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::debug;
@@ -46,7 +45,7 @@ impl StateNetwork {
             disable_poke: DISABLE_POKE,
             ..Default::default()
         };
-        let storage = Arc::new(PLRwLock::new(StateStorage::new(storage_config)?));
+        let storage = Arc::new(RwLock::new(StateStorage::new(storage_config).await?));
         let validator = Arc::new(StateValidator { header_oracle });
         let overlay = OverlayProtocol::new(
             config,

--- a/trin-state/src/storage.rs
+++ b/trin-state/src/storage.rs
@@ -21,14 +21,19 @@ pub struct StateStorage {
 }
 
 impl ContentStore for StateStorage {
-    fn get<K: OverlayContentKey>(&self, key: &K) -> Result<Option<Vec<u8>>, ContentStoreError> {
-        self.store.lookup_content_value(&key.content_id().into())
+    async fn get<K: OverlayContentKey>(
+        &self,
+        key: &K,
+    ) -> Result<Option<Vec<u8>>, ContentStoreError> {
+        self.store
+            .lookup_content_value(&key.content_id().into())
+            .await
     }
 
-    fn put<K: OverlayContentKey, V: AsRef<[u8]>>(
+    async fn put<K: OverlayContentKey>(
         &mut self,
         key: K,
-        value: V,
+        value: Vec<u8>,
     ) -> Result<(), ContentStoreError> {
         let key = StateContentKey::try_from(key.to_bytes())?;
         let value = StateContentValue::decode(value.as_ref())?;
@@ -36,24 +41,27 @@ impl ContentStore for StateStorage {
         match &key {
             StateContentKey::AccountTrieNode(account_trie_node_key) => {
                 self.put_account_trie_node(&key, account_trie_node_key, value)
+                    .await
             }
             StateContentKey::ContractStorageTrieNode(contract_storage_trie_key) => {
                 self.put_contract_storage_trie_node(&key, contract_storage_trie_key, value)
+                    .await
             }
             StateContentKey::ContractBytecode(contract_bytecode_key) => {
                 self.put_contract_bytecode(&key, contract_bytecode_key, value)
+                    .await
             }
         }
     }
 
-    fn is_key_within_radius_and_unavailable<K: OverlayContentKey>(
+    async fn is_key_within_radius_and_unavailable<K: OverlayContentKey>(
         &self,
         key: &K,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
         let content_id = ContentId::from(key.content_id());
         if self.store.distance_to_content_id(&content_id) > self.store.radius() {
             Ok(ShouldWeStoreContent::NotWithinRadius)
-        } else if self.store.has_content(&content_id)? {
+        } else if self.store.has_content(&content_id).await? {
             Ok(ShouldWeStoreContent::AlreadyStored)
         } else {
             Ok(ShouldWeStoreContent::Store)
@@ -66,7 +74,7 @@ impl ContentStore for StateStorage {
 }
 
 impl StateStorage {
-    pub fn new(config: PortalStorageConfig) -> Result<Self, ContentStoreError> {
+    pub async fn new(config: PortalStorageConfig) -> Result<Self, ContentStoreError> {
         let sql_connection_pool = config.sql_connection_pool.clone();
         let config = IdIndexedV1StoreConfig {
             content_type: ContentType::State,
@@ -78,16 +86,16 @@ impl StateStorage {
             storage_capacity_bytes: config.storage_capacity_mb * BYTES_IN_MB_U64,
         };
         Ok(Self {
-            store: create_store(ContentType::State, config, sql_connection_pool)?,
+            store: create_store(ContentType::State, config, sql_connection_pool).await?,
         })
     }
 
     /// Get a summary of the current state of storage
-    pub fn get_summary_info(&self) -> String {
-        self.store.get_summary_info()
+    pub async fn get_summary_info(&self) -> String {
+        self.store.get_summary_info().await
     }
 
-    fn put_account_trie_node(
+    async fn put_account_trie_node(
         &mut self,
         content_key: &StateContentKey,
         key: &AccountTrieNodeKey,
@@ -121,9 +129,10 @@ impl StateStorage {
         };
         self.store
             .insert(content_key, StateContentValue::TrieNode(trie_node).encode())
+            .await
     }
 
-    fn put_contract_storage_trie_node(
+    async fn put_contract_storage_trie_node(
         &mut self,
         content_key: &StateContentKey,
         key: &ContractStorageTrieNodeKey,
@@ -157,9 +166,10 @@ impl StateStorage {
         };
         self.store
             .insert(content_key, StateContentValue::TrieNode(trie_node).encode())
+            .await
     }
 
-    fn put_contract_bytecode(
+    async fn put_contract_bytecode(
         &mut self,
         content_key: &StateContentKey,
         key: &ContractBytecodeKey,
@@ -185,10 +195,12 @@ impl StateStorage {
 
         let contract_code = ContractBytecode { code: value.code };
 
-        self.store.insert(
-            content_key,
-            StateContentValue::ContractBytecode(contract_code).encode(),
-        )
+        self.store
+            .insert(
+                content_key,
+                StateContentValue::ContractBytecode(contract_code).encode(),
+            )
+            .await
     }
 }
 
@@ -207,11 +219,11 @@ pub mod test {
 
     const STORAGE_CAPACITY_MB: u64 = 10;
 
-    #[test]
-    fn account_trie_node() -> Result<()> {
+    #[tokio::test]
+    async fn account_trie_node() -> Result<()> {
         let (temp_dir, config) =
-            create_test_portal_storage_config_with_capacity(STORAGE_CAPACITY_MB)?;
-        let mut storage = StateStorage::new(config)?;
+            create_test_portal_storage_config_with_capacity(STORAGE_CAPACITY_MB).await?;
+        let mut storage = StateStorage::new(config).await?;
 
         let key_yaml = read_yaml_file("account_trie_node_key.yaml")?;
         let key = StateContentKey::deserialize(&key_yaml["content_key"])?;
@@ -221,10 +233,10 @@ pub mod test {
 
         let expected_stored_value = "0x04000000f8719d20a65bd257638cf8cf09b8238888947cc3c0bea2aa2cc3f1c4ac7a3002b851f84f018b02b4f32ee2f03d31ee3fbba046d5eb15d44b160805e80d05e2a47d434053e6c4b3ef9d1111773039e9586661a0d0a06b12ac47863b5c7be4185c2deaad1c61557033f56c7d4ea74429cbb25e23";
 
-        storage.put(key.clone(), value.encode())?;
+        storage.put(key.clone(), value.encode()).await?;
 
         assert_eq!(
-            storage.get(&key).unwrap(),
+            storage.get(&key).await.unwrap(),
             Some(hex_decode(expected_stored_value)?)
         );
 
@@ -232,11 +244,11 @@ pub mod test {
         Ok(())
     }
 
-    #[test]
-    fn contract_storage_trie_node() -> Result<()> {
+    #[tokio::test]
+    async fn contract_storage_trie_node() -> Result<()> {
         let (temp_dir, config) =
-            create_test_portal_storage_config_with_capacity(STORAGE_CAPACITY_MB)?;
-        let mut storage = StateStorage::new(config)?;
+            create_test_portal_storage_config_with_capacity(STORAGE_CAPACITY_MB).await?;
+        let mut storage = StateStorage::new(config).await?;
 
         let key_yaml = read_yaml_file("contract_storage_trie_node_key.yaml")?;
         let key = StateContentKey::deserialize(&key_yaml["content_key"])?;
@@ -247,10 +259,10 @@ pub mod test {
         let expected_stored_value =
             "0x04000000e09e20fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5ace12";
 
-        storage.put(key.clone(), value.encode())?;
+        storage.put(key.clone(), value.encode()).await?;
 
         assert_eq!(
-            storage.get(&key).unwrap(),
+            storage.get(&key).await.unwrap(),
             Some(hex_decode(expected_stored_value)?)
         );
 
@@ -258,11 +270,11 @@ pub mod test {
         Ok(())
     }
 
-    #[test]
-    fn contract_bytecode() -> Result<()> {
+    #[tokio::test]
+    async fn contract_bytecode() -> Result<()> {
         let (temp_dir, config) =
-            create_test_portal_storage_config_with_capacity(STORAGE_CAPACITY_MB)?;
-        let mut storage = StateStorage::new(config)?;
+            create_test_portal_storage_config_with_capacity(STORAGE_CAPACITY_MB).await?;
+        let mut storage = StateStorage::new(config).await?;
 
         let key_yaml = read_yaml_file("contract_bytecode_key.yaml")?;
         let key = StateContentKey::deserialize(&key_yaml["content_key"])?;
@@ -272,10 +284,10 @@ pub mod test {
 
         let expected_stored_value = "0x040000006060604052600436106100af576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306fdde03146100b9578063095ea7b31461014757806318160ddd146101a157806323b872dd146101ca5780632e1a7d4d14610243578063313ce5671461026657806370a082311461029557806395d89b41146102e2578063a9059cbb14610370578063d0e30db0146103ca578063dd62ed3e146103d4575b6100b7610440565b005b34156100c457600080fd5b6100cc6104dd565b6040518080602001828103825283818151815260200191508051906020019080838360005b8381101561010c5780820151818401526020810190506100f1565b50505050905090810190601f1680156101395780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561015257600080fd5b610187600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190505061057b565b604051808215151515815260200191505060405180910390f35b34156101ac57600080fd5b6101b461066d565b6040518082815260200191505060405180910390f35b34156101d557600080fd5b610229600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190505061068c565b604051808215151515815260200191505060405180910390f35b341561024e57600080fd5b61026460048080359060200190919050506109d9565b005b341561027157600080fd5b610279610b05565b604051808260ff1660ff16815260200191505060405180910390f35b34156102a057600080fd5b6102cc600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610b18565b6040518082815260200191505060405180910390f35b34156102ed57600080fd5b6102f5610b30565b6040518080602001828103825283818151815260200191508051906020019080838360005b8381101561033557808201518184015260208101905061031a565b50505050905090810190601f1680156103625780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561037b57600080fd5b6103b0600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050610bce565b604051808215151515815260200191505060405180910390f35b6103d2610440565b005b34156103df57600080fd5b61042a600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610be3565b6040518082815260200191505060405180910390f35b34600360003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825401925050819055503373ffffffffffffffffffffffffffffffffffffffff167fe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c346040518082815260200191505060405180910390a2565b60008054600181600116156101000203166002900480601f0160208091040260200160405190810160405280929190818152602001828054600181600116156101000203166002900480156105735780601f1061054857610100808354040283529160200191610573565b820191906000526020600020905b81548152906001019060200180831161055657829003601f168201915b505050505081565b600081600460003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925846040518082815260200191505060405180910390a36001905092915050565b60003073ffffffffffffffffffffffffffffffffffffffff1631905090565b600081600360008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054101515156106dc57600080fd5b3373ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff16141580156107b457507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600460008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205414155b156108cf5781600460008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020541015151561084457600080fd5b81600460008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825403925050819055505b81600360008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600360008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825401925050819055508273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a3600190509392505050565b80600360003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410151515610a2757600080fd5b80600360003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825403925050819055503373ffffffffffffffffffffffffffffffffffffffff166108fc829081150290604051600060405180830381858888f193505050501515610ab457600080fd5b3373ffffffffffffffffffffffffffffffffffffffff167f7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65826040518082815260200191505060405180910390a250565b600260009054906101000a900460ff1681565b60036020528060005260406000206000915090505481565b60018054600181600116156101000203166002900480601f016020809104026020016040519081016040528092919081815260200182805460018160011615610100020316600290048015610bc65780601f10610b9b57610100808354040283529160200191610bc6565b820191906000526020600020905b815481529060010190602001808311610ba957829003601f168201915b505050505081565b6000610bdb33848461068c565b905092915050565b60046020528160005260406000206020528060005260406000206000915091505054815600a165627a7a72305820deb4c2ccab3c2fdca32ab3f46728389c2fe2c165d5fafa07661e4e004f6c344a0029";
 
-        storage.put(key.clone(), value.encode())?;
+        storage.put(key.clone(), value.encode()).await?;
 
         assert_eq!(
-            storage.get(&key).unwrap(),
+            storage.get(&key).await.unwrap(),
             Some(hex_decode(expected_stored_value)?)
         );
 

--- a/trin-storage/Cargo.toml
+++ b/trin-storage/Cargo.toml
@@ -15,10 +15,8 @@ anyhow = "1.0.68"
 discv5 = { version = "0.4.0", features = ["serde"] }
 ethereum-types = "0.14.1"
 ethportal-api = {path = "../ethportal-api"}
-r2d2 = "0.8.9"
-r2d2_sqlite = "0.24.0"
+sqlx = { version = "0.7", features = [ "runtime-tokio", "sqlite" ] }
 rand = "0.8.4"
-rusqlite = { version = "0.31.0", features = ["bundled"] }
 strum = { version = "0.26.1", features = ["derive"] }
 tempfile = "3.3.0"
 thiserror = "1.0.57"

--- a/trin-storage/src/error.rs
+++ b/trin-storage/src/error.rs
@@ -27,14 +27,14 @@ pub enum ContentStoreError {
     #[error("data invalid {message}")]
     InvalidData { message: String },
 
-    #[error("rusqlite error {0}")]
-    Rusqlite(#[from] rusqlite::Error),
-
-    #[error("r2d2 error {0}")]
-    R2D2(#[from] r2d2::Error),
-
     #[error("unable to use byte utils {0}")]
     ByteUtilsError(#[from] ByteUtilsError),
+
+    #[error("sqlx error {0}")]
+    Sqlx(#[from] sqlx::Error),
+
+    #[error("Generic Decode error {0}")]
+    GenerticDecode(#[from] anyhow::Error),
 
     #[error("unable to use content key {0}")]
     ContentKey(#[from] ContentKeyError),

--- a/trin-storage/src/sql.rs
+++ b/trin-storage/src/sql.rs
@@ -13,10 +13,10 @@ pub const CREATE_QUERY_DB_HISTORY: &str = "CREATE TABLE IF NOT EXISTS history (
 
 pub const INSERT_QUERY_HISTORY: &str =
     "INSERT OR IGNORE INTO history (content_id, content_key, content_value, distance_short, content_size)
-                            VALUES (?1, ?2, ?3, ?4, ?5)";
+                            VALUES (?, ?, ?, ?, ?)";
 
 pub const DELETE_QUERY_HISTORY: &str = "DELETE FROM history
-                            WHERE content_id = (?1)";
+                            WHERE content_id = (?)";
 
 pub const XOR_FIND_FARTHEST_QUERY_HISTORY: &str = "SELECT
                                     content_id
@@ -24,20 +24,20 @@ pub const XOR_FIND_FARTHEST_QUERY_HISTORY: &str = "SELECT
                                     ORDER BY distance_short DESC LIMIT 1";
 
 pub const CONTENT_KEY_LOOKUP_QUERY_HISTORY: &str =
-    "SELECT content_key FROM history WHERE content_id = (?1) LIMIT 1";
+    "SELECT content_key FROM history WHERE content_id = (?) LIMIT 1";
 
 pub const CONTENT_VALUE_LOOKUP_QUERY_HISTORY: &str =
-    "SELECT content_value FROM history WHERE content_id = (?1) LIMIT 1";
+    "SELECT content_value FROM history WHERE content_id = (?) LIMIT 1";
 
 pub const TOTAL_DATA_SIZE_QUERY_HISTORY: &str = "SELECT TOTAL(content_size) FROM history";
 
 pub const TOTAL_ENTRY_COUNT_QUERY_HISTORY: &str = "SELECT COUNT(*) FROM history";
 
 pub const PAGINATE_QUERY_HISTORY: &str =
-    "SELECT content_key FROM history ORDER BY content_key LIMIT (?1) OFFSET (?2)";
+    "SELECT content_key FROM history ORDER BY content_key LIMIT (?) OFFSET (?)";
 
 pub const CONTENT_SIZE_LOOKUP_QUERY_HISTORY: &str =
-    "SELECT content_size FROM history WHERE content_id = (?1)";
+    "SELECT content_size FROM history WHERE content_id = (?)";
 
 // Beacon Specific SQL
 
@@ -52,26 +52,26 @@ CREATE INDEX IF NOT EXISTS beacon_content_size_idx ON beacon(content_size);
 
 pub const INSERT_QUERY_BEACON: &str =
     "INSERT OR IGNORE INTO beacon (content_id, content_key, content_value, content_size)
-                            VALUES (?1, ?2, ?3, ?4)";
+                            VALUES (?, ?, ?, ?)";
 
 pub const DELETE_QUERY_BEACON: &str = "DELETE FROM beacon
     WHERE content_id = (?1)";
 
 pub const CONTENT_KEY_LOOKUP_QUERY_BEACON: &str =
-    "SELECT content_key FROM beacon WHERE content_id = (?1) LIMIT 1";
+    "SELECT content_key FROM beacon WHERE content_id = (?) LIMIT 1";
 
 pub const CONTENT_VALUE_LOOKUP_QUERY_BEACON: &str =
-    "SELECT content_value FROM beacon WHERE content_id = (?1) LIMIT 1";
+    "SELECT content_value FROM beacon WHERE content_id = (?) LIMIT 1";
 
 pub const TOTAL_DATA_SIZE_QUERY_BEACON: &str = "SELECT TOTAL(content_size) FROM beacon";
 
 pub const TOTAL_ENTRY_COUNT_QUERY_BEACON: &str = "SELECT COUNT(*) FROM beacon";
 
 pub const PAGINATE_QUERY_BEACON: &str =
-    "SELECT content_key FROM beacon ORDER BY content_key LIMIT (?1) OFFSET (?2)";
+    "SELECT content_key FROM beacon ORDER BY content_key LIMIT (?) OFFSET (?)";
 
 pub const CONTENT_SIZE_LOOKUP_QUERY_BEACON: &str =
-    "SELECT content_size FROM beacon WHERE content_id = (?1)";
+    "SELECT content_size FROM beacon WHERE content_id = (?)";
 
 pub const LC_UPDATE_CREATE_TABLE: &str = "CREATE TABLE IF NOT EXISTS lc_update (
         period INTEGER PRIMARY KEY,
@@ -84,12 +84,12 @@ pub const LC_UPDATE_CREATE_TABLE: &str = "CREATE TABLE IF NOT EXISTS lc_update (
 
 pub const INSERT_LC_UPDATE_QUERY: &str =
     "INSERT OR IGNORE INTO lc_update (period, value, score, update_size)
-                      VALUES (?1, ?2, ?3, ?4)";
+                      VALUES (?, ?, ?, ?)";
 
-pub const LC_UPDATE_LOOKUP_QUERY: &str = "SELECT value FROM lc_update WHERE period = (?1) LIMIT 1";
+pub const LC_UPDATE_LOOKUP_QUERY: &str = "SELECT value FROM lc_update WHERE period = (?) LIMIT 1";
 
 pub const LC_UPDATE_PERIOD_LOOKUP_QUERY: &str =
-    "SELECT period FROM lc_update WHERE period = (?1) LIMIT 1";
+    "SELECT period FROM lc_update WHERE period = (?) LIMIT 1";
 
 pub const LC_UPDATE_TOTAL_SIZE_QUERY: &str = "SELECT TOTAL(update_size) FROM lc_update";
 

--- a/trin-storage/src/test_utils.rs
+++ b/trin-storage/src/test_utils.rs
@@ -4,12 +4,13 @@ use tempfile::TempDir;
 use crate::{error::ContentStoreError, PortalStorageConfig};
 
 /// Creates temporary directory and PortalStorageConfig.
-pub fn create_test_portal_storage_config_with_capacity(
+pub async fn create_test_portal_storage_config_with_capacity(
     capacity_mb: u64,
 ) -> Result<(TempDir, PortalStorageConfig), ContentStoreError> {
     let temp_dir = TempDir::new()?;
     let config =
-        PortalStorageConfig::new(capacity_mb, temp_dir.path().to_path_buf(), NodeId::random())?;
+        PortalStorageConfig::new(capacity_mb, temp_dir.path().to_path_buf(), NodeId::random())
+            .await?;
     Ok((temp_dir, config))
 }
 

--- a/trin-storage/src/versioned/id_indexed_v1/mod.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/mod.rs
@@ -6,9 +6,8 @@ use std::path::PathBuf;
 
 use discv5::enr::NodeId;
 use ethportal_api::types::portal_wire::ProtocolId;
-use r2d2::Pool;
-use r2d2_sqlite::SqliteConnectionManager;
 
+use sqlx::SqlitePool;
 pub use store::IdIndexedV1Store;
 
 use crate::DistanceFunction;
@@ -29,7 +28,7 @@ pub struct IdIndexedV1StoreConfig {
     pub node_id: NodeId,
     pub node_data_dir: PathBuf,
     pub storage_capacity_bytes: u64,
-    pub sql_connection_pool: Pool<SqliteConnectionManager>,
+    pub sql_connection_pool: SqlitePool,
     pub distance_fn: DistanceFunction,
 }
 

--- a/trin-storage/src/versioned/id_indexed_v1/sql.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/sql.rs
@@ -33,11 +33,11 @@ pub fn insert(content_type: &ContentType) -> String {
             content_size
         )
         VALUES (
-            :content_id,
-            :content_key,
-            :content_value,
-            :distance_short,
-            :content_size
+            ?,
+            ?,
+            ?,
+            ?,
+            ?
         )",
         table_name(content_type)
     )
@@ -45,21 +45,21 @@ pub fn insert(content_type: &ContentType) -> String {
 
 pub fn delete(content_type: &ContentType) -> String {
     format!(
-        "DELETE FROM {} WHERE content_id = :content_id",
+        "DELETE FROM {} WHERE content_id = ?",
         table_name(content_type)
     )
 }
 
 pub fn lookup_key(content_type: &ContentType) -> String {
     format!(
-        "SELECT content_key FROM {} WHERE content_id = :content_id LIMIT 1",
+        "SELECT content_key FROM {} WHERE content_id = ? LIMIT 1",
         table_name(content_type)
     )
 }
 
 pub fn lookup_value(content_type: &ContentType) -> String {
     format!(
-        "SELECT content_value FROM {} WHERE content_id = :content_id LIMIT 1",
+        "SELECT content_value FROM {} WHERE content_id = ? LIMIT 1",
         table_name(content_type)
     )
 }
@@ -67,7 +67,7 @@ pub fn lookup_value(content_type: &ContentType) -> String {
 pub fn delete_farthest(content_type: &ContentType) -> String {
     format!(
         "DELETE FROM {0} WHERE rowid IN (
-            SELECT rowid FROM {0} ORDER BY distance_short DESC LIMIT :limit)",
+            SELECT rowid FROM {0} ORDER BY distance_short DESC LIMIT ?)",
         table_name(content_type)
     )
 }
@@ -76,7 +76,7 @@ pub fn lookup_farthest(content_type: &ContentType) -> String {
     format!(
         "SELECT content_id, distance_short FROM {}
         ORDER BY distance_short DESC
-        LIMIT :limit",
+        LIMIT ?",
         table_name(content_type)
     )
 }

--- a/trin-storage/src/versioned/mod.rs
+++ b/trin-storage/src/versioned/mod.rs
@@ -3,7 +3,6 @@ pub mod sql;
 pub mod store;
 mod utils;
 
-use rusqlite::types::{FromSql, FromSqlError, ValueRef};
 use strum::{AsRefStr, Display, EnumString};
 
 pub use id_indexed_v1::{IdIndexedV1Store, IdIndexedV1StoreConfig};
@@ -29,7 +28,8 @@ pub enum ContentType {
 /// completely different type of content (e.g. portal network content key/value
 /// vs. light client updates). Compatible versions might implement logic for
 /// transitioning from one version to another (towards newer version).
-#[derive(Clone, Debug, Display, Eq, PartialEq, EnumString, AsRefStr)]
+#[derive(Clone, Debug, Display, Eq, PartialEq, EnumString, AsRefStr, sqlx::Type)]
+#[sqlx(type_name = "version", rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum StoreVersion {
     /// The original SQLite version of the store. Main issue that it had was
@@ -40,11 +40,4 @@ pub enum StoreVersion {
     /// The content from different subnetwork (expressed with `ContentType`)
     /// uses different table. NOTE: implementation is in progress.
     IdIndexedV1,
-}
-
-impl FromSql for StoreVersion {
-    fn column_result(value: ValueRef<'_>) -> Result<Self, FromSqlError> {
-        let text = value.as_str()?;
-        StoreVersion::try_from(text).map_err(|err| FromSqlError::Other(err.into()))
-    }
 }

--- a/trin-storage/src/versioned/sql.rs
+++ b/trin-storage/src/versioned/sql.rs
@@ -6,9 +6,9 @@ pub const STORE_INFO_CREATE_TABLE: &str = "
 
 pub const STORE_INFO_UPDATE: &str = "
     INSERT OR REPLACE INTO store_info (content_type, version)
-    VALUES (:content_type, :version)";
+    VALUES (?, ?)";
 
 pub const STORE_INFO_LOOKUP: &str = "
     SELECT version
     FROM store_info
-    WHERE content_type = :content_type LIMIT 1";
+    WHERE content_type = ? LIMIT 1";

--- a/trin-storage/src/versioned/store.rs
+++ b/trin-storage/src/versioned/store.rs
@@ -19,5 +19,8 @@ pub trait VersionedContentStore: Sized {
 
     /// Creates the instance of the store. This shouldn't be used directly. Store should be
     /// created using `create_store` function.
-    fn create(content_type: ContentType, config: Self::Config) -> Result<Self, ContentStoreError>;
+    fn create(
+        content_type: ContentType,
+        config: Self::Config,
+    ) -> impl std::future::Future<Output = Result<Self, ContentStoreError>> + Send;
 }


### PR DESCRIPTION
### What was wrong?
Are application is written in Rust using the Tokio runtime. A green threads runtime like you can find in languages like golang.

Our 2 main sources of IO are
- network io
- storage io

But we were doing all our storage io calls non-async.
https://dtantsur.github.io/rust-openstack/tokio/task/fn.spawn_blocking.html
> In general, issuing a blocking call or performing a lot of compute in a future without yielding is not okay, as it may prevent the executor from driving other futures forward

So all of our storage calls to sqlite are issuing blocking calls which by Tokio's own documentation is `not okay`.

You can see the affects of us using a blocking library by looking for io wait on the graphs from what I see it is 5-30%. With this PR iowait will/should become 0%

### How was it fixed?
At first I posted about the find we don't handle this to the discord and Ogenev let me know about `tokio::spawn_blocking`
#### investigation 1: `tokio::spawn_blocking`
The issue with this is because of the spread nature of SQL queries it would be very hard to maintain code using it as `tokio::spawn_blocking` need to go in a lot of places.

The other issue with this is `tokio::spawn_blocking` wouldn't stop our sql connection thread from blocking if it is hitting the limit which is a real concern once we get more networks online as they will all share the same pool of connections.

From the maintainability and amount of work to properly handle the issue this way this route was a no go

#### investigation 2: deadpool-r2d2/deadpool-sqlite a async wrapper for r2d2
I implemented a small proof of concept but once I got to more complex queries this solution had a lot of the same issues as `tokio::spawn_blocking`. Because deadpool is basically a pool which then wraps blocking commands with calls like `tokio::spawn_blocking` its usability wasn't that good and required moving variables to deadpools calls which was a big no no.

#### note on another option: async-sqlite
async-sqlite is basically the same as deadpool but with basically 1 dev behind it. It has all the same problems I had with deadpool

#### investigation 3: sqlx the option I choose
Well sqlx is a little different then what we were used it provides a lot:
- native async interface to the deveopler making it a lot easier to maintain
  -  much better code readability over the other options
- has the biggest community out of the options I could find so the project is very active.

#### final notes
Sqlx is the best option I could find and I believe it is the right path for the future of our codebase

The change is in the title I migrated us from a blocking sqlite library to an async one which will reduce the amount of wasted cpu cycles we are currently getting on storage calls

- [x] passed all portal hive tests

From my testing on machines with faster storage speeds and hence less less iowait times performance is the same.

Noticable improvements in performance are found on machines which have slower storage like hard drives or sd cards end up with much higher iowait times where a performance increases are much more noticable 
