### PR TITLE
fix: remove duplicate ids when propagating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3629,6 +3629,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4971,6 +4980,7 @@ dependencies = [
  "futures 0.3.30",
  "hex",
  "igd-next",
+ "itertools 0.12.1",
  "lazy_static",
  "leb128",
  "local-ip-address",

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -26,6 +26,7 @@ fnv = "1.0.7"
 futures = "0.3.21"
 hex = "0.4.3"
 igd-next = "0.14.2"
+itertools = "0.12.1"
 lazy_static = "1.4.0"
 leb128 = "0.2.1"
 local-ip-address = "0.5.6"
@@ -41,15 +42,15 @@ stunclient = "0.1.2"
 tempfile = "3.3.0"
 thiserror = "1.0.29"
 tokio = { version = "1.14.0", features = ["full"] }
+tokio-stream = { version = "0.1.14", features = ["sync"] }
 tracing = "0.1.36"
 trin-metrics = { path = "../trin-metrics" }
 trin-storage = { path = "../trin-storage" }
 trin-utils = { path = "../trin-utils" }
 trin-validation = { path = "../trin-validation" }
-validator = { version = "0.13.0", features = ["derive"] }
 url = "2.3.1"
 utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.11" }
-tokio-stream = { version = "0.1.14", features = ["sync"] }
+validator = { version = "0.13.0", features = ["derive"] }
 
 [target.'cfg(windows)'.dependencies]
 uds_windows = "1.0.1"

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -19,6 +19,7 @@ use discv5::{
     rpc::RequestId,
 };
 use futures::{channel::oneshot, future::join_all, prelude::*};
+use itertools::Itertools;
 use lazy_static::lazy_static;
 use parking_lot::RwLock;
 use rand::seq::SliceRandom;
@@ -1906,7 +1907,9 @@ where
                     None => vec![(content_key, content_value)],
                 }
             })
+            .unique_by(|(key, _)| key.content_id())
             .collect();
+
         let ids_to_propagate: Vec<String> = content_to_propagate
             .iter()
             .map(|(k, _)| hex_encode_compact(k.content_id()))


### PR DESCRIPTION
### What was wrong?

It's possible to propagate the same content id multiple times within the same offer.

The #1176 added functionality to propagate additional content key/value, which made this more likely to occur (originally it was possible only if offer contained duplicates).

### How was it fixed?

Now we are keeping only unique content ids.

NOTE: Similar to other functionality that involves offer with multiple entries, I don't know how to test this.
I tested it using state network and recursive gossip on my local machine (that's how I noticed issue to begin with).
Once, #1187 is in, I will create peer-to-peer tests that will test this and other similar functionality.

### To-Do

- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
