### PR TITLE
chore: update utp to v0.1.0-alpha.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8073,7 +8073,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 [[package]]
 name = "utp-rs"
 version = "0.1.0-alpha.8"
-source = "git+https://github.com/ethereum/utp?tag=v0.1.0-alpha.10#6001fefa4e2bddb8437dfd0049758381c3e131f5"
+source = "git+https://github.com/ethereum/utp?tag=v0.1.0-alpha.11#37177d83e399f26f284676a7665929c65b246085"
 dependencies = [
  "async-trait",
  "delay_map 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ trin-storage = { path = "trin-storage" }
 trin-utils = { path = "trin-utils" }
 trin-validation = { path = "trin-validation" }
 url = "2.3.1"
-utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.10" }
+utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.11" }
 
 [dev-dependencies]
 ethers-core = { version = "2.0", default-features = false}

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -48,7 +48,7 @@ trin-utils = { path = "../trin-utils" }
 trin-validation = { path = "../trin-validation" }
 validator = { version = "0.13.0", features = ["derive"] }
 url = "2.3.1"
-utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.10" }
+utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.11" }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -30,4 +30,4 @@ trin-metrics = { path = "../trin-metrics" }
 trin-storage = { path = "../trin-storage" }
 trin-validation = { path = "../trin-validation" }
 trin-utils = { path = "../trin-utils" }
-utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.10" }
+utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.11" }

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -29,7 +29,7 @@ trin-metrics = { path = "../trin-metrics" }
 trin-storage = { path = "../trin-storage" }
 trin-utils = { path = "../trin-utils" }
 trin-validation = { path = "../trin-validation" }
-utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.10" }
+utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.11" }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -22,7 +22,7 @@ tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 trin-utils = { path = "../trin-utils" }
 tokio = {version = "1.14.0", features = ["full"]}
-utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.10" }
+utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.11" }
 
 [[bin]]
 name = "utp-test-app"


### PR DESCRIPTION
### What was wrong?
wee are using an old version
### How was it fixed?
by updating it
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
