### PR TITLE
refactor: remove async_trait from validators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7739,7 +7739,6 @@ name = "trin-beacon"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "discv5",
  "ethereum_ssz",
  "ethportal-api",
@@ -7765,7 +7764,6 @@ name = "trin-history"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "discv5",
  "env_logger 0.9.3",
  "ethereum-types",
@@ -7810,7 +7808,6 @@ name = "trin-state"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "discv5",
  "env_logger 0.9.3",
  "eth_trie",
@@ -7869,7 +7866,6 @@ name = "trin-validation"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "eth2_hashing",
  "ethereum-types",
  "ethereum_ssz",

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -12,7 +12,6 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
-async-trait = "0.1.53"
 discv5 = { version = "0.4.0", features = ["serde"] }
 ethereum_ssz = "0.5.3"
 ethportal-api = { path = "../ethportal-api" }

--- a/trin-beacon/src/validation.rs
+++ b/trin-beacon/src/validation.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use ethportal_api::BeaconContentKey;
 use tokio::sync::RwLock;
 
@@ -14,16 +13,12 @@ pub struct BeaconValidator {
     pub header_oracle: Arc<RwLock<HeaderOracle>>,
 }
 
-#[async_trait]
 impl Validator<BeaconContentKey> for BeaconValidator {
     async fn validate_content(
         &self,
         _content_key: &BeaconContentKey,
         _content: &[u8],
-    ) -> anyhow::Result<ValidationResult<BeaconContentKey>>
-    where
-        BeaconContentKey: 'async_trait,
-    {
+    ) -> anyhow::Result<ValidationResult<BeaconContentKey>> {
         // todo: implement beacon network validation
         Ok(ValidationResult::new(true))
     }

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -12,7 +12,6 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
-async-trait = "0.1.53"
 discv5 = { version = "0.4.0", features = ["serde"] }
 ethereum-types = "0.14.1"
 ethereum_ssz = "0.5.3"

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::anyhow;
-use async_trait::async_trait;
 use ethereum_types::H256;
 use ssz::Decode;
 use tokio::sync::RwLock;
@@ -26,16 +25,12 @@ pub struct ChainHistoryValidator {
     pub header_oracle: Arc<RwLock<HeaderOracle>>,
 }
 
-#[async_trait]
 impl Validator<HistoryContentKey> for ChainHistoryValidator {
     async fn validate_content(
         &self,
         content_key: &HistoryContentKey,
         content: &[u8],
-    ) -> anyhow::Result<ValidationResult<HistoryContentKey>>
-    where
-        HistoryContentKey: 'async_trait,
-    {
+    ) -> anyhow::Result<ValidationResult<HistoryContentKey>> {
         match content_key {
             HistoryContentKey::BlockHeaderWithProof(key) => {
                 let header_with_proof =

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -12,7 +12,6 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
-async-trait = "0.1.53"
 discv5 = { version = "0.4.0", features = ["serde"] }
 eth_trie = { git = "https://github.com/morph-dev/eth-trie.rs.git", branch = "trin" }
 ethereum-types = "0.14.1"

--- a/trin-state/src/validation/validator.rs
+++ b/trin-state/src/validation/validator.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::anyhow;
-use async_trait::async_trait;
 use ethportal_api::{
     types::{
         content_key::state::{AccountTrieNodeKey, ContractBytecodeKey, ContractStorageTrieNodeKey},
@@ -27,16 +26,12 @@ pub struct StateValidator {
     pub header_oracle: Arc<RwLock<HeaderOracle>>,
 }
 
-#[async_trait]
 impl Validator<StateContentKey> for StateValidator {
     async fn validate_content(
         &self,
         content_key: &StateContentKey,
         content_value: &[u8],
-    ) -> anyhow::Result<ValidationResult<StateContentKey>>
-    where
-        StateContentKey: 'async_trait,
-    {
+    ) -> anyhow::Result<ValidationResult<StateContentKey>> {
         let content_value = StateContentValue::decode(content_value)
             .map_err(|err| anyhow!("Error decoding StateContentValue: {err}"))?;
 

--- a/trin-validation/Cargo.toml
+++ b/trin-validation/Cargo.toml
@@ -12,7 +12,6 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 anyhow = "1.0.68"
-async-trait = "0.1.53"
 eth2_hashing = "0.2.0"
 ethereum-types = "0.14.1"
 ethereum_ssz = "0.5.3"


### PR DESCRIPTION
### What was wrong?

We were using `async_trait` in our validators, which I was told should no longer be needed.

### How was it fixed?

Removed the `async_trait` from validators.

I didn't test this in any way, I'm counting on our tests catching if there is any issue.

### To-Do

- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
