### PR TITLE
feat: create usage_stats table and triggers to update it

### DIFF
--- a/trin-storage/src/utils.rs
+++ b/trin-storage/src/utils.rs
@@ -4,7 +4,7 @@ use crate::{
         CREATE_QUERY_DB_BEACON, CREATE_QUERY_DB_HISTORY, DROP_CONTENT_DATA_QUERY_DB,
         LC_UPDATE_CREATE_TABLE,
     },
-    versioned::sql::STORE_INFO_CREATE_TABLE,
+    versioned::sql::{STORE_INFO_CREATE_TABLE, USAGE_STATS_CREATE_TABLE},
     DATABASE_NAME,
 };
 use r2d2::Pool;
@@ -24,6 +24,7 @@ pub fn setup_sql(node_data_dir: &Path) -> Result<Pool<SqliteConnectionManager>, 
     conn.execute_batch(CREATE_QUERY_DB_BEACON)?;
     conn.execute_batch(LC_UPDATE_CREATE_TABLE)?;
     conn.execute_batch(STORE_INFO_CREATE_TABLE)?;
+    conn.execute_batch(USAGE_STATS_CREATE_TABLE)?;
     conn.execute_batch(DROP_CONTENT_DATA_QUERY_DB)?;
     Ok(pool)
 }

--- a/trin-storage/src/versioned/id_indexed_v1/config.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/config.rs
@@ -1,57 +1,71 @@
-use super::IdIndexedV1StoreConfig;
+use std::path::PathBuf;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct UsageStats {
-    /// The total count of the content items stored.
-    pub content_count: u64,
-    /// The sum of the `content_size` of all stored content items.
-    pub used_storage_bytes: u64,
+use discv5::enr::NodeId;
+use ethportal_api::types::portal_wire::ProtocolId;
+use r2d2::Pool;
+use r2d2_sqlite::SqliteConnectionManager;
+
+use crate::{
+    versioned::{usage_stats::UsageStats, ContentType},
+    DistanceFunction,
+};
+
+/// The fraction of the storage capacity that we should aim for when pruning.
+const TARGET_CAPACITY_FRACTION: f64 = 0.9;
+
+/// The fraction of the storage capacity that we need to pass in order to start pruning.
+const PRUNING_CAPACITY_THRESHOLD_FRACTION: f64 = 0.95;
+
+/// The config for the IdIndexedV1Store
+#[derive(Debug, Clone)]
+pub struct IdIndexedV1StoreConfig {
+    pub content_type: ContentType,
+    pub network: ProtocolId,
+    pub node_id: NodeId,
+    pub node_data_dir: PathBuf,
+    pub storage_capacity_bytes: u64,
+    pub sql_connection_pool: Pool<SqliteConnectionManager>,
+    pub distance_fn: DistanceFunction,
 }
 
-impl UsageStats {
-    pub fn is_above_pruning_capacity_threshold(&self, config: &IdIndexedV1StoreConfig) -> bool {
-        self.used_storage_bytes > config.pruning_capacity_threshold()
+impl IdIndexedV1StoreConfig {
+    pub fn target_capacity(&self) -> u64 {
+        (self.storage_capacity_bytes as f64 * TARGET_CAPACITY_FRACTION).round() as u64
     }
 
-    pub fn is_above_target_capacity(&self, config: &IdIndexedV1StoreConfig) -> bool {
-        self.used_storage_bytes > config.target_capacity()
-    }
-
-    pub fn estimated_full_capacity_count(&self, config: &IdIndexedV1StoreConfig) -> Option<u64> {
-        self.average_content_size_bytes()
-            .map(|average_content_size_bytes| {
-                (config.storage_capacity_bytes as f64 / average_content_size_bytes).floor() as u64
-            })
-    }
-
-    pub fn estimated_target_capacity_count(&self, config: &IdIndexedV1StoreConfig) -> Option<u64> {
-        self.average_content_size_bytes()
-            .map(|average_content_size_bytes| {
-                (config.target_capacity() as f64 / average_content_size_bytes).floor() as u64
-            })
+    pub fn pruning_capacity_threshold(&self) -> u64 {
+        (self.storage_capacity_bytes as f64 * PRUNING_CAPACITY_THRESHOLD_FRACTION).round() as u64
     }
 
     /// Returns the estimated number of items to insert to reach full capacity. This value will not
     /// exceed the number of currently stored items.
-    pub fn estimate_insert_until_full(&self, config: &IdIndexedV1StoreConfig) -> u64 {
-        self.estimated_full_capacity_count(config)
+    pub fn estimate_to_insert_until_full(&self, usage_stats: &UsageStats) -> u64 {
+        self.estimated_full_capacity_count(usage_stats)
             .map(|full_capacity_count| {
-                if full_capacity_count > self.content_count {
-                    (full_capacity_count - self.content_count).min(self.content_count)
+                if full_capacity_count > usage_stats.entry_count {
+                    (full_capacity_count - usage_stats.entry_count).min(usage_stats.entry_count)
                 } else {
                     0
                 }
             })
             .unwrap_or(0)
+    }
+
+    fn estimated_full_capacity_count(&self, usage_stats: &UsageStats) -> Option<u64> {
+        usage_stats
+            .average_entry_size_bytes()
+            .map(|average_entry_size_bytes| {
+                (self.storage_capacity_bytes as f64 / average_entry_size_bytes).floor() as u64
+            })
     }
 
     /// Returns the estimated number of items to delete to reach target capacity. If we are below
     /// target capacity, it will return 0.
-    pub fn delete_until_target(&self, config: &IdIndexedV1StoreConfig) -> u64 {
-        self.estimated_target_capacity_count(config)
+    pub fn estimate_to_delete_until_target(&self, usage_stats: &UsageStats) -> u64 {
+        self.estimated_target_capacity_count(usage_stats)
             .map(|target_capacity_count| {
-                if self.content_count > target_capacity_count {
-                    self.content_count - target_capacity_count
+                if usage_stats.entry_count > target_capacity_count {
+                    usage_stats.entry_count - target_capacity_count
                 } else {
                     0
                 }
@@ -59,12 +73,12 @@ impl UsageStats {
             .unwrap_or(0)
     }
 
-    fn average_content_size_bytes(&self) -> Option<f64> {
-        if self.content_count == 0 {
-            Option::None
-        } else {
-            Option::Some(self.used_storage_bytes as f64 / self.content_count as f64)
-        }
+    fn estimated_target_capacity_count(&self, usage_stats: &UsageStats) -> Option<u64> {
+        usage_stats
+            .average_entry_size_bytes()
+            .map(|average_entry_size_bytes| {
+                (self.target_capacity() as f64 / average_entry_size_bytes).floor() as u64
+            })
     }
 }
 
@@ -107,26 +121,26 @@ mod tests {
     #[case::full(100, 1000, true, true)]
     #[case::above_full(110, 1100, true, true)]
     fn is_above_capacity(
-        #[case] content_count: u64,
-        #[case] used_storage_bytes: u64,
+        #[case] entry_count: u64,
+        #[case] total_entry_size_bytes: u64,
         #[case] is_above_pruning_capacity_threshold: bool,
         #[case] is_above_target_capacity: bool,
     ) {
         let config = create_config();
         let usage_stats = UsageStats {
-            content_count,
-            used_storage_bytes,
+            entry_count,
+            total_entry_size_bytes,
         };
 
         assert_eq!(
-            usage_stats.is_above_pruning_capacity_threshold(&config),
+            usage_stats.is_above(config.pruning_capacity_threshold()),
             is_above_pruning_capacity_threshold,
             "testing is_above_pruning_capacity_threshold"
         );
         assert_eq!(
-            usage_stats.is_above_target_capacity(&config),
+            usage_stats.is_above(config.target_capacity()),
             is_above_target_capacity,
-            "is_above_target_capacity"
+            "testing is_above_target_capacity"
         );
     }
 
@@ -134,19 +148,19 @@ mod tests {
     fn estimate_capacity_count_no_usage() {
         let config = create_config();
         let usage_stats = UsageStats {
-            content_count: 0,
-            used_storage_bytes: 0,
+            entry_count: 0,
+            total_entry_size_bytes: 0,
         };
 
         assert_eq!(
-            usage_stats.estimated_full_capacity_count(&config),
+            config.estimated_full_capacity_count(&usage_stats),
             None,
             "testing estimated_full_capacity_count"
         );
         assert_eq!(
-            usage_stats.estimated_target_capacity_count(&config),
+            config.estimated_target_capacity_count(&usage_stats),
             None,
-            "estimated_target_capacity_count"
+            "testing estimated_target_capacity_count"
         );
     }
 
@@ -167,26 +181,26 @@ mod tests {
     #[case::above_full_2(20, 1050, 19, 17)]
     #[case::above_full_3(50, 1050, 47, 42)]
     fn estimate_capacity_count(
-        #[case] content_count: u64,
-        #[case] used_storage_bytes: u64,
+        #[case] entry_count: u64,
+        #[case] total_entry_size_bytes: u64,
         #[case] estimated_full_capacity_count: u64,
         #[case] estimated_target_capacity_count: u64,
     ) {
         let config = create_config();
         let usage_stats = UsageStats {
-            content_count,
-            used_storage_bytes,
+            entry_count,
+            total_entry_size_bytes,
         };
 
         assert_eq!(
-            usage_stats.estimated_full_capacity_count(&config),
+            config.estimated_full_capacity_count(&usage_stats),
             Some(estimated_full_capacity_count),
             "testing estimated_full_capacity_count"
         );
         assert_eq!(
-            usage_stats.estimated_target_capacity_count(&config),
+            config.estimated_target_capacity_count(&usage_stats),
             Some(estimated_target_capacity_count),
-            "estimated_target_capacity_count"
+            "testing estimated_target_capacity_count"
         );
     }
 
@@ -209,20 +223,20 @@ mod tests {
     #[case::above_full_1(10, 1050, 0)]
     #[case::above_full_2(20, 1050, 0)]
     #[case::above_full_3(50, 1050, 0)]
-    fn insert_until_full(
-        #[case] content_count: u64,
-        #[case] used_storage_bytes: u64,
-        #[case] expected_insert_until_full: u64,
+    fn to_insert_until_full(
+        #[case] entry_count: u64,
+        #[case] total_entry_size_bytes: u64,
+        #[case] expected_to_insert_until_full: u64,
     ) {
         let config = create_config();
         let usage_stats = UsageStats {
-            content_count,
-            used_storage_bytes,
+            entry_count,
+            total_entry_size_bytes,
         };
 
         assert_eq!(
-            usage_stats.estimate_insert_until_full(&config),
-            expected_insert_until_full
+            config.estimate_to_insert_until_full(&usage_stats),
+            expected_to_insert_until_full
         );
     }
 
@@ -244,20 +258,20 @@ mod tests {
     #[case::above_full_1(10, 1050, 2)]
     #[case::above_full_2(20, 1050, 3)]
     #[case::above_full_3(50, 1050, 8)]
-    fn delete_until_target(
-        #[case] content_count: u64,
-        #[case] used_storage_bytes: u64,
-        #[case] expected_delete_until_target: u64,
+    fn to_delete_until_target(
+        #[case] entry_count: u64,
+        #[case] total_entry_size_bytes: u64,
+        #[case] expected_to_delete_until_target: u64,
     ) {
         let config = create_config();
         let usage_stats = UsageStats {
-            content_count,
-            used_storage_bytes,
+            entry_count,
+            total_entry_size_bytes,
         };
 
         assert_eq!(
-            usage_stats.delete_until_target(&config),
-            expected_delete_until_target
+            config.estimate_to_delete_until_target(&usage_stats),
+            expected_to_delete_until_target
         );
     }
 }

--- a/trin-storage/src/versioned/id_indexed_v1/mod.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/mod.rs
@@ -1,44 +1,6 @@
+mod config;
 mod sql;
 mod store;
-mod usage_stats;
 
-use std::path::PathBuf;
-
-use discv5::enr::NodeId;
-use ethportal_api::types::portal_wire::ProtocolId;
-use r2d2::Pool;
-use r2d2_sqlite::SqliteConnectionManager;
-
+pub use config::IdIndexedV1StoreConfig;
 pub use store::IdIndexedV1Store;
-
-use crate::DistanceFunction;
-
-use super::ContentType;
-
-/// The fraction of the storage capacity that we should aim for when pruning.
-const TARGET_CAPACITY_FRACTION: f64 = 0.9;
-
-/// The fraction of the storage capacity that we need to pass in order to start pruning.
-const PRUNING_CAPACITY_THRESHOLD_FRACTION: f64 = 0.95;
-
-/// The config for the IdIndexedV1Store
-#[derive(Debug, Clone)]
-pub struct IdIndexedV1StoreConfig {
-    pub content_type: ContentType,
-    pub network: ProtocolId,
-    pub node_id: NodeId,
-    pub node_data_dir: PathBuf,
-    pub storage_capacity_bytes: u64,
-    pub sql_connection_pool: Pool<SqliteConnectionManager>,
-    pub distance_fn: DistanceFunction,
-}
-
-impl IdIndexedV1StoreConfig {
-    fn target_capacity(&self) -> u64 {
-        (self.storage_capacity_bytes as f64 * TARGET_CAPACITY_FRACTION).round() as u64
-    }
-
-    fn pruning_capacity_threshold(&self) -> u64 {
-        (self.storage_capacity_bytes as f64 * PRUNING_CAPACITY_THRESHOLD_FRACTION).round() as u64
-    }
-}

--- a/trin-storage/src/versioned/id_indexed_v1/sql.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/sql.rs
@@ -1,7 +1,7 @@
 use crate::versioned::ContentType;
 
 /// The name of the sql table. The `ii1` stands for `id_indexed_v1`.
-fn table_name(content_type: &ContentType) -> String {
+pub fn table_name(content_type: &ContentType) -> String {
     format!("ii1_{content_type}")
 }
 

--- a/trin-storage/src/versioned/mod.rs
+++ b/trin-storage/src/versioned/mod.rs
@@ -1,6 +1,7 @@
 mod id_indexed_v1;
 pub mod sql;
 pub mod store;
+mod usage_stats;
 mod utils;
 
 use rusqlite::types::{FromSql, FromSqlError, ValueRef};

--- a/trin-storage/src/versioned/sql.rs
+++ b/trin-storage/src/versioned/sql.rs
@@ -1,3 +1,5 @@
+use super::ContentType;
+
 pub const STORE_INFO_CREATE_TABLE: &str = "
     CREATE TABLE IF NOT EXISTS store_info (
         content_type TEXT PRIMARY KEY,
@@ -11,4 +13,62 @@ pub const STORE_INFO_UPDATE: &str = "
 pub const STORE_INFO_LOOKUP: &str = "
     SELECT version
     FROM store_info
-    WHERE content_type = :content_type LIMIT 1";
+    WHERE content_type = :content_type
+    LIMIT 1";
+
+pub const USAGE_STATS_CREATE_TABLE: &str = "
+    CREATE TABLE IF NOT EXISTS usage_stats (
+        content_type TEXT PRIMARY KEY,
+        count INTEGER NOT NULL,
+        size INTEGER NOT NULL
+    );";
+
+pub const USAGE_STATS_UPDATE: &str = "
+    INSERT OR REPLACE INTO usage_stats (content_type, count, size)
+    VALUES (?1, ?2, ?3)";
+
+pub const USAGE_STATS_LOOKUP: &str = "
+    SELECT count, size
+    FROM usage_stats
+    WHERE content_type = (?1)
+    LIMIT 1";
+
+pub fn create_usage_stats_triggers(
+    content_type: &ContentType,
+    table_name: &str,
+    entry_size_column: &str,
+) -> String {
+    format!(
+        "
+        CREATE TRIGGER IF NOT EXISTS {table_name}_on_insert_update_usage_stats_trigger
+        AFTER INSERT ON {table_name}
+        FOR EACH ROW
+        BEGIN
+            UPDATE usage_stats
+            SET count = count + 1, size = size + NEW.{entry_size_column}
+            WHERE content_type = '{content_type}';
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS {table_name}_on_delete_update_usage_stats_trigger
+        AFTER DELETE ON {table_name}
+        FOR EACH ROW
+        BEGIN
+            UPDATE usage_stats
+            SET count = count - 1, size = size - OLD.{entry_size_column}
+            WHERE content_type = '{content_type}';
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS {table_name}_on_update_update_usage_stats_trigger
+        AFTER UPDATE ON {table_name}
+        FOR EACH ROW
+        BEGIN
+            UPDATE usage_stats
+            SET size = size - OLD.size + NEW.size
+            WHERE content_type = '{content_type}';
+        END;
+
+        INSERT OR IGNORE INTO usage_stats (content_type, count, size)
+        VALUES ('{content_type}', 0, 0);
+        "
+    )
+}

--- a/trin-storage/src/versioned/usage_stats.rs
+++ b/trin-storage/src/versioned/usage_stats.rs
@@ -1,0 +1,299 @@
+use r2d2::PooledConnection;
+use r2d2_sqlite::SqliteConnectionManager;
+use rusqlite::params;
+use trin_metrics::storage::StorageMetricsReporter;
+
+use super::{sql, ContentType};
+
+pub use sql::create_usage_stats_triggers;
+
+/// Contains information about number and size of entries that is stored.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UsageStats {
+    /// The total count of stored entries
+    pub entry_count: u64,
+    /// The total sum of sizes of stored entries
+    pub total_entry_size_bytes: u64,
+}
+
+impl UsageStats {
+    /// Returns the average entry size
+    pub fn average_entry_size_bytes(&self) -> Option<f64> {
+        if self.entry_count == 0 {
+            Option::None
+        } else {
+            Option::Some(self.total_entry_size_bytes as f64 / self.entry_count as f64)
+        }
+    }
+
+    /// Returns whether total entry size is above provided value
+    pub fn is_above(&self, size_bytes: u64) -> bool {
+        self.total_entry_size_bytes > size_bytes
+    }
+
+    /// Reports entry count and content data storage to the metrics reporter
+    pub fn report_metrics(&self, metrics: &StorageMetricsReporter) {
+        metrics.report_entry_count(self.entry_count);
+        metrics.report_content_data_storage_bytes(self.total_entry_size_bytes as f64);
+    }
+}
+
+/// Sets the usage stats for the given content type. This can be done during startup to make sure
+/// that values are up to date.
+pub fn update_usage_stats(
+    conn: &PooledConnection<SqliteConnectionManager>,
+    content_type: &ContentType,
+    usage_stats: &UsageStats,
+) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        sql::USAGE_STATS_UPDATE,
+        params![
+            content_type.to_string(),
+            usage_stats.entry_count,
+            usage_stats.total_entry_size_bytes
+        ],
+    )?;
+    Ok(())
+}
+
+/// Returns the usage stats for a given content type.
+pub fn get_usage_stats(
+    conn: &PooledConnection<SqliteConnectionManager>,
+    content_type: &ContentType,
+) -> Result<UsageStats, rusqlite::Error> {
+    conn.query_row(
+        sql::USAGE_STATS_LOOKUP,
+        params![content_type.to_string()],
+        |row| {
+            Ok(UsageStats {
+                entry_count: row.get("count")?,
+                total_entry_size_bytes: row.get("size")?,
+            })
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use r2d2::Pool;
+    use tempfile::TempDir;
+
+    use crate::utils::setup_sql;
+
+    use super::*;
+
+    const TABLE_NAME: &str = "test";
+    const ENTRY_SIZE_COLUMN_NAME: &str = "size";
+    const TEST_TABLE_CREATE: &str = "CREATE TABLE test (id TEXT NOT NULL, size INTEGER NOT NULL)";
+    const TEST_TABLE_INSERT: &str = "INSERT INTO test (id, size) VALUES (?1, ?2)";
+    const TEST_TABLE_UPDATE: &str = "UPDATE test SET size = (?2) WHERE id = (?1)";
+    const TEST_TABLE_DELETE: &str = "DELETE FROM test WHERE id = (?1)";
+
+    fn setup_for_tests(temp_dir: &TempDir) -> Pool<SqliteConnectionManager> {
+        let pool = setup_sql(temp_dir.path()).unwrap();
+        let conn = pool.get().unwrap();
+        conn.execute_batch(TEST_TABLE_CREATE).unwrap();
+        conn.execute_batch(&create_usage_stats_triggers(
+            &ContentType::History,
+            TABLE_NAME,
+            ENTRY_SIZE_COLUMN_NAME,
+        ))
+        .unwrap();
+        pool
+    }
+
+    fn assert_usage_stats(
+        conn: &PooledConnection<SqliteConnectionManager>,
+        expected_entry_count: u64,
+        expected_total_entry_size_bytes: u64,
+    ) -> Result<()> {
+        assert_eq!(
+            get_usage_stats(conn, &ContentType::History)?,
+            UsageStats {
+                entry_count: expected_entry_count,
+                total_entry_size_bytes: expected_total_entry_size_bytes,
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn average_entry_size_bytes() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let pool = setup_for_tests(&temp_dir);
+        let conn = pool.get()?;
+
+        assert_eq!(
+            get_usage_stats(&conn, &ContentType::History)?.average_entry_size_bytes(),
+            None
+        );
+
+        conn.execute(TEST_TABLE_INSERT, params!["a", 100])?;
+        assert_eq!(
+            get_usage_stats(&conn, &ContentType::History)?.average_entry_size_bytes(),
+            Some(100.0)
+        );
+
+        conn.execute(TEST_TABLE_INSERT, params!["b", 200])?;
+        assert_eq!(
+            get_usage_stats(&conn, &ContentType::History)?.average_entry_size_bytes(),
+            Some(150.0)
+        );
+
+        conn.execute(TEST_TABLE_INSERT, params!["c", 300])?;
+        assert_eq!(
+            get_usage_stats(&conn, &ContentType::History)?.average_entry_size_bytes(),
+            Some(200.0)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn empty() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let pool = setup_for_tests(&temp_dir);
+        let conn = pool.get()?;
+        assert_usage_stats(&conn, 0, 0)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn insert_simple() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let pool = setup_for_tests(&temp_dir);
+        let conn = pool.get()?;
+
+        conn.execute(TEST_TABLE_INSERT, params!["a", 100])?;
+        assert_usage_stats(&conn, 1, 100)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn insert_multiple() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let pool = setup_for_tests(&temp_dir);
+        let conn = pool.get()?;
+
+        conn.execute(TEST_TABLE_INSERT, params!["a", 100])?;
+        assert_usage_stats(&conn, 1, 100)?;
+
+        conn.execute(TEST_TABLE_INSERT, params!["b", 200])?;
+        assert_usage_stats(&conn, 2, 300)?;
+
+        conn.execute(TEST_TABLE_INSERT, params!["c", 300])?;
+        assert_usage_stats(&conn, 3, 600)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn delete_simple() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let pool = setup_for_tests(&temp_dir);
+        let conn = pool.get()?;
+
+        conn.execute(TEST_TABLE_INSERT, params!["a", 100])?;
+        assert_usage_stats(&conn, 1, 100)?;
+
+        conn.execute(TEST_TABLE_DELETE, params!["a"])?;
+        assert_usage_stats(&conn, 0, 0)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn delete_multiple() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let pool = setup_for_tests(&temp_dir);
+        let conn = pool.get()?;
+
+        conn.execute(TEST_TABLE_INSERT, params!["a", 100])?;
+        conn.execute(TEST_TABLE_INSERT, params!["b", 200])?;
+        conn.execute(TEST_TABLE_INSERT, params!["c", 300])?;
+        assert_usage_stats(&conn, 3, 600)?;
+
+        conn.execute(TEST_TABLE_DELETE, params!["b"])?;
+        assert_usage_stats(&conn, 2, 400)?;
+
+        conn.execute(TEST_TABLE_DELETE, params!["a"])?;
+        assert_usage_stats(&conn, 1, 300)?;
+
+        conn.execute(TEST_TABLE_DELETE, params!["c"])?;
+        assert_usage_stats(&conn, 0, 0)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn update_simple() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let pool = setup_for_tests(&temp_dir);
+        let conn = pool.get()?;
+
+        conn.execute(TEST_TABLE_INSERT, params!["a", 100])?;
+        assert_usage_stats(&conn, 1, 100)?;
+
+        conn.execute(TEST_TABLE_UPDATE, params!["a", 200])?;
+        assert_usage_stats(&conn, 1, 200)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn update_comples() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let pool = setup_for_tests(&temp_dir);
+        let conn = pool.get()?;
+
+        conn.execute(TEST_TABLE_INSERT, params!["a", 100])?;
+        conn.execute(TEST_TABLE_INSERT, params!["b", 200])?;
+        conn.execute(TEST_TABLE_INSERT, params!["c", 300])?;
+        assert_usage_stats(&conn, 3, 600)?;
+
+        conn.execute(TEST_TABLE_UPDATE, params!["b", 500])?;
+        assert_usage_stats(&conn, 3, 900)?;
+        conn.execute(TEST_TABLE_UPDATE, params!["c", 100])?;
+        assert_usage_stats(&conn, 3, 700)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn update_usage_stats_on_empty() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let pool = setup_for_tests(&temp_dir);
+        let conn = pool.get()?;
+
+        let usage_stats = UsageStats {
+            entry_count: 1,
+            total_entry_size_bytes: 100,
+        };
+        update_usage_stats(&conn, &ContentType::History, &usage_stats)?;
+        assert_eq!(get_usage_stats(&conn, &ContentType::History)?, usage_stats);
+
+        Ok(())
+    }
+
+    #[test]
+    fn update_usage_stats_after_insert() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let pool = setup_for_tests(&temp_dir);
+        let conn = pool.get()?;
+
+        conn.execute(TEST_TABLE_INSERT, params!["a", 100])?;
+        assert_usage_stats(&conn, 1, 100)?;
+
+        let usage_stats = UsageStats {
+            entry_count: 3,
+            total_entry_size_bytes: 1000,
+        };
+        update_usage_stats(&conn, &ContentType::History, &usage_stats)?;
+        assert_eq!(get_usage_stats(&conn, &ContentType::History)?, usage_stats);
+
+        Ok(())
+    }
+}

--- a/trin-storage/src/versioned/usage_stats.rs
+++ b/trin-storage/src/versioned/usage_stats.rs
@@ -40,6 +40,7 @@ impl UsageStats {
 
 /// Sets the usage stats for the given content type. This can be done during startup to make sure
 /// that values are up to date.
+#[allow(dead_code)] // this is currently not used but it can be useful
 pub fn update_usage_stats(
     conn: &PooledConnection<SqliteConnectionManager>,
     content_type: &ContentType,


### PR DESCRIPTION
### What was wrong?

As described in #1157, we could use sql triggers to track count and size of content that is stored, instead of doing:
- it manually (what history does) 
- making expensive queries (what history used to do and what `id_indexed_v1` does now)

### How was it fixed?

Created `usage_stats` table and provided utility functions for interaction.
We already had `struct UsageStats` as part of the `id_indexed_v1` store, that I repurposed. As a consequence I had to refactor some of it's logic (mostly move it inside `IdIndexedV1StoreConfig`).

I created dedicated tests for it, but it's indirectly tested by tests in `id_indexed_v1`.

### To-Do

- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
