### PR TITLE
feat(bin): add script to extract `HistoricalBatch` from nimbus Era files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7695,6 +7695,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "dirs",
  "discv5",
  "ethereum-types",
  "ethereum_ssz",
@@ -7711,6 +7712,7 @@ dependencies = [
  "portalnet",
  "prometheus_exporter",
  "rand 0.8.5",
+ "regex",
  "reth-ipc",
  "rlp",
  "rpc",
@@ -7723,6 +7725,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tree_hash",
  "trin-beacon",
  "trin-history",
  "trin-state",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ description = "A Rust implementation of the Ethereum Portal Network"
 [dependencies]
 anyhow = "1.0.68"
 clap = { version = "4.2.1", features = ["derive"] }
+dirs = "5.0.1"
 discv5 = { version = "0.4.0", features = ["serde"] }
 ethereum-types = "0.14.1"
 ethereum_ssz = "0.5.3"
@@ -29,6 +30,7 @@ portalnet = { path = "portalnet" }
 portal-bridge = { path = "portal-bridge" }
 prometheus_exporter = "0.8.4"
 rand = "0.8.4"
+regex = "1.10.2"
 reth-ipc = { tag = "v0.1.0-alpha.10", git = "https://github.com/paradigmxyz/reth.git"}
 rlp = "0.5.0"
 rpc = { path = "rpc"}
@@ -39,6 +41,7 @@ tempfile = "3.3.0"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
+tree_hash = "0.5.2"
 trin-beacon = { path = "trin-beacon" }
 trin-history = { path = "trin-history" }
 trin-state = { path = "trin-state" }

--- a/ethportal-api/src/types/consensus/beacon_state.rs
+++ b/ethportal-api/src/types/consensus/beacon_state.rs
@@ -239,6 +239,12 @@ pub struct Validator {
     pub withdrawable_epoch: Epoch,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash)]
+pub struct HistoricalBatch {
+    pub block_roots: FixedVector<H256, SlotsPerHistoricalRoot>,
+    pub state_roots: FixedVector<H256, SlotsPerHistoricalRoot>,
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {

--- a/portal-bridge/src/types/e2s.rs
+++ b/portal-bridge/src/types/e2s.rs
@@ -5,19 +5,19 @@ const _SLOTS_PER_HISTORICAL_ROOT: usize = 8192;
 const HEADER_SIZE: u16 = 8;
 const VALUE_SIZE_LIMIT: usize = 1024 * 1024 * 50; // 50 MB
 
-pub struct E2storeFile {
+pub struct E2StoreFile {
     pub entries: Vec<Entry>,
 }
 
-impl TryFrom<E2storeFile> for Vec<u8> {
+impl TryFrom<E2StoreFile> for Vec<u8> {
     type Error = anyhow::Error;
-    fn try_from(e2store_file: E2storeFile) -> Result<Vec<u8>, Self::Error> {
+    fn try_from(e2store_file: E2StoreFile) -> Result<Vec<u8>, Self::Error> {
         e2store_file.serialize()
     }
 }
 
 #[allow(dead_code)]
-impl E2storeFile {
+impl E2StoreFile {
     /// Serialize to a byte vector.
     fn serialize(&self) -> anyhow::Result<Vec<u8>> {
         let length = self.entries.iter().map(|e| e.length() as u32).sum::<u32>() as usize;
@@ -207,7 +207,7 @@ mod test {
     #[test]
     fn test_entry_multiple() {
         let expected = "0x2a00020000000000beef0900040000000000abcdabcd";
-        let file = E2storeFile::deserialize(&hex_decode(expected).unwrap()).unwrap();
+        let file = E2StoreFile::deserialize(&hex_decode(expected).unwrap()).unwrap();
         assert_eq!(file.entries.len(), 2);
         assert_eq!(file.entries[0].header.type_, 0x2a); // 42
         assert_eq!(file.entries[0].header.length, 2);
@@ -226,6 +226,6 @@ mod test {
     #[case("0xbeef010000000000")] // length exceeds buffer
     fn test_entry_invalid_decoding(#[case] input: &str) {
         let buf = hex_decode(input).unwrap();
-        assert!(E2storeFile::deserialize(&buf).is_err());
+        assert!(E2StoreFile::deserialize(&buf).is_err());
     }
 }

--- a/portal-bridge/src/types/era1.rs
+++ b/portal-bridge/src/types/era1.rs
@@ -1,4 +1,4 @@
-use crate::types::e2s::{E2storeFile, Entry};
+use crate::types::e2s::{E2StoreFile, Entry};
 use anyhow::ensure;
 use ethereum_types::{H256, U256};
 use ethportal_api::types::execution::{
@@ -40,7 +40,7 @@ impl Era1 {
     }
 
     pub fn deserialize(buf: &[u8]) -> anyhow::Result<Self> {
-        let file = E2storeFile::deserialize(buf)?;
+        let file = E2StoreFile::deserialize(buf)?;
         ensure!(
             file.entries.len() == ERA1_ENTRY_COUNT,
             "invalid era1 file: incorrect entry count"
@@ -78,7 +78,7 @@ impl Era1 {
         entries.push(accumulator_entry);
         let block_index_entry: Entry = self.block_index.clone().try_into()?;
         entries.push(block_index_entry);
-        let file = E2storeFile { entries };
+        let file = E2StoreFile { entries };
         ensure!(
             file.entries.len() == ERA1_ENTRY_COUNT,
             "invalid era1 file: incorrect entry count"

--- a/src/bin/historical_batch.rs
+++ b/src/bin/historical_batch.rs
@@ -1,0 +1,104 @@
+use anyhow::ensure;
+use ethportal_api::{consensus::beacon_state::HistoricalBatch, utils::bytes::hex_encode};
+use portal_bridge::types::era::Era;
+use regex::Regex;
+use ssz::Encode;
+use std::{
+    fs::{File, OpenOptions},
+    io,
+    io::{BufRead, Write},
+};
+use surf::get;
+use tree_hash::TreeHash;
+
+const _BELLATRIX_SLOT: u64 = 4700013;
+const _CAPELLA_SLOT: u64 = 6209536;
+
+const ERA_URL: &str = "https://mainnet.era.nimbus.team/";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let download_dir = dirs::download_dir().unwrap();
+    let file_path = download_dir.join("historical_batches");
+
+    let body = get(ERA_URL).recv_string().await.unwrap();
+    // Match era files with epoch between 00573 and 00759
+    let re =
+        Regex::new(r#"".*((0057[3-9])|(005[8-9][0-9])|006[0-9][0-9]|(007[0-5][0-9])).*\.era""#)
+            .unwrap();
+
+    let mut file_urls = vec![];
+
+    for cap in re.captures_iter(&body) {
+        let file_name = &cap[0].strip_prefix('"').unwrap().strip_suffix('"').unwrap();
+        let file_url = format!("{ERA_URL}{file_name}");
+        file_urls.push(file_url);
+    }
+
+    ensure!(
+        file_urls.len() == 187,
+        "Expected 187 era files, found {:?}",
+        file_urls.len()
+    );
+
+    for url in &file_urls {
+        let mut url_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(file_path.join("era_urls.txt"))
+            .unwrap();
+
+        let re = Regex::new(r#"\d+"#).unwrap();
+        let cap = re.captures(url).unwrap();
+        let era_number = cap[0].parse::<u64>().unwrap();
+        println!("Downloading Era number: {:?}", era_number);
+
+        if url_exists_in_file(url_file.try_clone().unwrap(), url).unwrap() {
+            println!("Era number: {:?} already exists", era_number);
+            continue;
+        }
+
+        let res = get(url).recv_bytes().await.unwrap();
+        let beacon_state = Era::deserialize_to_beacon_state(&res).unwrap();
+        let historical_batch = HistoricalBatch {
+            block_roots: beacon_state.block_roots().clone(),
+            state_roots: beacon_state.state_roots().clone(),
+        };
+
+        let hash = hex_encode(historical_batch.tree_hash_root().as_bytes())
+            .strip_prefix("0x")
+            .unwrap()
+            .to_string();
+
+        let first_eight_chars = hash.chars().take(8).collect::<String>();
+
+        // save `HistoricalBatch` to file
+        let mut file = File::create(file_path.join(format!(
+            "historical_batch-{}-{}.ssz",
+            era_number, first_eight_chars
+        )))
+        .unwrap();
+        file.write_all(&historical_batch.as_ssz_bytes()).unwrap();
+        // append url to file_url file
+        url_file.write_all(format!("{}\n", url).as_bytes()).unwrap();
+    }
+
+    Ok(())
+}
+
+fn url_exists_in_file(file: File, url: &str) -> io::Result<bool> {
+    let reader = io::BufReader::new(file);
+
+    // Iterate over the lines in the file
+    for line in reader.lines() {
+        let line = line?;
+
+        // Check if the line contains the URL
+        if line.contains(url) {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}


### PR DESCRIPTION
Adding the script used to extract `HistoricalBatch` from [Nimbus era ](https://mainnet.era.nimbus.team/) files.

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
