### PR TITLE
fix:change ponginfo enr_seq type to u64

### DIFF
--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -18,7 +18,7 @@ pub struct NodeInfo {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PongInfo {
-    pub enr_seq: u32,
+    pub enr_seq: u64,
     pub data_radius: DataRadius,
 }
 

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -354,7 +354,7 @@ async fn ping(
     let overlay = network.read().await.overlay.clone();
     match overlay.send_ping(enr).await {
         Ok(pong) => Ok(json!(PongInfo {
-            enr_seq: pong.enr_seq as u32,
+            enr_seq: pong.enr_seq,
             data_radius: *Distance::from(pong.custom_payload),
         })),
         Err(msg) => Err(format!("Ping request timeout: {msg:?}")),

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -373,7 +373,7 @@ async fn ping(
     let overlay = network.read().await.overlay.clone();
     match overlay.send_ping(enr).await {
         Ok(pong) => Ok(json!(PongInfo {
-            enr_seq: pong.enr_seq as u32,
+            enr_seq: pong.enr_seq,
             data_radius: *Distance::from(pong.custom_payload),
         })),
         Err(msg) => Err(format!("Ping request timeout: {msg:?}")),

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -100,7 +100,7 @@ async fn ping(network: Arc<StateNetwork>, enr: Enr) -> Result<Value, String> {
     to_json_result(
         "Ping",
         network.overlay.send_ping(enr).await.map(|pong| PongInfo {
-            enr_seq: pong.enr_seq as u32,
+            enr_seq: pong.enr_seq,
             data_radius: *Distance::from(pong.custom_payload),
         }),
     )


### PR DESCRIPTION
### What was wrong?
According to spec enr_seq should be u64.

### How was it fixed?
Change `PongInfo` struct `enr_seq` type to u64.
fix #1197 

### To-Do
