### PR TITLE
fix: updates ContentNotFound error code to match spec

### DIFF
--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -146,7 +146,7 @@ pub async fn test_trace_recursive_find_content_for_absent_content(peertest: &Pee
     assert!(error.contains("Content not found"));
     // test that trace is present
     assert!(error.contains("respondedWith"));
-    assert!(error.contains("-32001"));
+    assert!(error.contains("-39001"));
 }
 
 pub async fn test_trace_recursive_find_content_local_db(peertest: &Peertest) {

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -143,7 +143,7 @@ pub async fn test_trace_recursive_find_content_for_absent_content(peertest: &Pee
         .await
         .unwrap_err()
         .to_string();
-    assert!(error.contains("Content not found"));
+    assert!(error.contains("Unable to locate content on the network"));
     // test that trace is present
     assert!(error.contains("respondedWith"));
     assert!(error.contains("-39001"));

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -814,7 +814,7 @@ where
                     FindContentQueryResult::ClosestNodes(_closest_nodes) => {
                         if let Some(responder) = callback {
                             let _ = responder.send(Err(OverlayRequestError::ContentNotFound {
-                                message: "Content not found".to_string(),
+                                message: "Unable to locate content on the network".to_string(),
                                 utp: false,
                                 trace: query_info.trace,
                             }));
@@ -864,7 +864,7 @@ where
                                 if let Some(responder) = callback {
                                     let _ =
                                         responder.send(Err(OverlayRequestError::ContentNotFound {
-                                            message: "Content not found: received utp payload from unknown peer"
+                                            message: "Unable to locate content on the network: received utp payload from unknown peer"
                                                 .to_string(),
                                             utp: true,
                                             trace: query_info.trace,
@@ -906,7 +906,7 @@ where
                                         let _ = responder
                                             .send(Err(OverlayRequestError::ContentNotFound {
                                             message:
-                                                "Content not found: unable to establish utp conn"
+                                                "Unable to locate content on the network: unable to establish utp conn"
                                                     .to_string(),
                                             utp: true,
                                             trace: query_info.trace,
@@ -927,7 +927,7 @@ where
                                     let _ = responder
                                         .send(Err(OverlayRequestError::ContentNotFound {
                                         message:
-                                            "Content not found: error reading data from utp stream"
+                                            "Unable to locate content on the network: error reading data from utp stream"
                                                 .to_string(),
                                         utp: true,
                                         trace: query_info.trace,
@@ -2099,7 +2099,9 @@ where
                     );
                     if let Some(responder) = responder {
                         let _ = responder.send(Err(OverlayRequestError::ContentNotFound {
-                            message: "Content not found: error validating content".to_string(),
+                            message:
+                                "Unable to locate content on the network: error validating content"
+                                    .to_string(),
                             utp: utp_transfer,
                             trace,
                         }));
@@ -2688,7 +2690,7 @@ where
             warn!("No connected nodes in routing table, find content query cannot proceed.");
             if let Some(callback) = callback {
                 let _ = callback.send(Err(OverlayRequestError::ContentNotFound {
-                    message: "Content not found: no connected nodes in the routing table"
+                    message: "Unable to locate content on the network: no connected nodes in the routing table"
                         .to_string(),
                     utp: false,
                     trace: None,

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -39,7 +39,7 @@ impl BeaconNetworkApi {
             Some(val) => match val {
                 Ok(result) => Ok(result),
                 Err(msg) => {
-                    if msg.contains("Content not found") {
+                    if msg.contains("Unable to locate content on the network") {
                         let error_details: Value = serde_json::from_str(&msg).map_err(|e| {
                             RpcServeError::Message(format!(
                                 "Failed to parse error message from history subnet: {e:?}",

--- a/rpc/src/errors.rs
+++ b/rpc/src/errors.rs
@@ -76,7 +76,7 @@ impl From<RpcServeError> for ErrorObjectOwned {
             RpcServeError::Message(msg) => ErrorObject::owned(-32099, msg, None::<()>),
             RpcServeError::MethodNotFound(method) => ErrorObject::owned(-32601, method, None::<()>),
             RpcServeError::ContentNotFound { message, trace } => {
-                ErrorObject::owned(-32001, message, Some(trace))
+                ErrorObject::owned(-39001, message, Some(trace))
             }
         }
     }

--- a/rpc/src/fetch.rs
+++ b/rpc/src/fetch.rs
@@ -29,7 +29,7 @@ pub async fn proxy_query_to_history_subnet(
         Some(val) => match val {
             Ok(result) => Ok(result),
             Err(msg) => {
-                if msg.contains("Content not found") {
+                if msg.contains("Unable to locate content on the network") {
                     let error_details: Value = serde_json::from_str(&msg).map_err(|e| {
                         RpcServeError::Message(format!(
                             "Failed to parse error message from history subnet: {e:?}",


### PR DESCRIPTION
### What was wrong?

[Spec proposal](https://github.com/ethereum/portal-network-specs/pull/276) proposes different error code than trin currently uses

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
