### PR TITLE
Revert "refactor: wait for semaphore permit only if accepting content"

### DIFF
--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -1283,6 +1283,15 @@ where
             })?;
 
         // Attempt to get semaphore permit if fails we return an empty accept
+        // `try_acquire_owned()` isn't blocking and will instantly return with
+        // `Some(TryAcquireError::NoPermits)` error if there isn't a permit avaliable
+        // The reason we get the permit before checking if we can store it is because
+        // * checking if a semaphore is avaliable is basically free it doesn't block and will return
+        //   instantly
+        // * filling the `requested_keys` is expensive because it requires calls to disk which
+        //   should be avoided.
+        // so by trying to acquire the semaphore before the storage call we avoid unnecessary work
+        // **Note:** if we are not accepting any content `requested_keys` should be empty
         let permit = match self
             .utp_controller
             .inbound_utp_transfer_semaphore


### PR DESCRIPTION
This reverts commit 3094fbb2a9b937eb1e5e57e543910610da080570.

### What was wrong?
Tons of uTP requests are "failing" reporting trying to connect to connection id 0 

This bug was introduced in https://github.com/ethereum/trin/pull/1189

The bug basically was there wouldn't be a semaphore avaliable but the bitlist would already be filled with data
### How was it fixed?
by reverting https://github.com/ethereum/trin/pull/1189

As stated https://github.com/ethereum/trin/pull/1189#issuecomment-1971881083 `try_acquire_owned` is none blocking it instantly fails if a semaphore isn't avaliable which is the intended behavior.

We should check if a semaphore is avaliable first because the call `try_acquire_owned` is instant and free, we don't have to wait because if there are no semaphores avaliable it instantly returns with `Some(TryAcquireError::NoPermits)`. Where as filling the bitlist requires storage calls which are much more expensive. So if we can't obtain a semaphore we shouldn't waste cpu reading from disk


I would like to give a big thanks to @mrferris for practically telling me the problem.
