### PR TITLE
refactor(portalnet): extract basic utp stream handling into utp controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7833,6 +7833,7 @@ dependencies = [
  "trin-storage",
  "trin-utils",
  "trin-validation",
+ "utp-rs",
 ]
 
 [[package]]

--- a/portalnet/src/config.rs
+++ b/portalnet/src/config.rs
@@ -2,7 +2,11 @@ use std::net::SocketAddr;
 
 use ethereum_types::H256;
 
-use ethportal_api::types::{bootnodes::Bootnodes, cli::TrinConfig, distance::Distance};
+use ethportal_api::types::{
+    bootnodes::Bootnodes,
+    cli::{TrinConfig, DEFAULT_UTP_TRANSFER_LIMIT},
+    distance::Distance,
+};
 
 /// Capacity of the cache for observed `NodeAddress` values.
 /// Provides capacity for 32 full k-buckets. This capacity will be shared among all active portal
@@ -22,6 +26,7 @@ pub struct PortalnetConfig {
     pub node_addr_cache_capacity: usize,
     pub disable_poke: bool,
     pub trusted_block_root: Option<String>,
+    pub utp_transfer_limit: usize,
 }
 
 impl Default for PortalnetConfig {
@@ -38,6 +43,7 @@ impl Default for PortalnetConfig {
             node_addr_cache_capacity: NODE_ADDR_CACHE_CAPACITY,
             disable_poke: false,
             trusted_block_root: None,
+            utp_transfer_limit: DEFAULT_UTP_TRANSFER_LIMIT,
         }
     }
 }
@@ -53,6 +59,7 @@ impl PortalnetConfig {
             bootnodes: trin_config.bootnodes.clone(),
             disable_poke: trin_config.disable_poke,
             trusted_block_root: trin_config.trusted_block_root.clone(),
+            utp_transfer_limit: trin_config.utp_transfer_limit,
             ..Default::default()
         }
     }

--- a/portalnet/src/config.rs
+++ b/portalnet/src/config.rs
@@ -26,6 +26,7 @@ pub struct PortalnetConfig {
     pub node_addr_cache_capacity: usize,
     pub disable_poke: bool,
     pub trusted_block_root: Option<String>,
+    // the max number of concurrent utp transfers
     pub utp_transfer_limit: usize,
 }
 

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -541,8 +541,13 @@ where
         conn_id: u16,
     ) -> Result<Vec<u8>, OverlayRequestError> {
         self.utp_controller
-            .connect_inbound_stream(conn_id, enr, /* query_trace */ None)
+            .connect_inbound_stream(conn_id, enr)
             .await
+            .map_err(|err| OverlayRequestError::ContentNotFound {
+                message: format!("Unable to locate content on the network: {err:?}"),
+                utp: true,
+                trace: None,
+            })
     }
 
     /// Offer is sent in order to store content to k nodes with radii that contain content-id

--- a/portalnet/src/overlay.rs
+++ b/portalnet/src/overlay.rs
@@ -540,8 +540,13 @@ where
         enr: Enr,
         conn_id: u16,
     ) -> Result<Vec<u8>, OverlayRequestError> {
+        let cid = utp_rs::cid::ConnectionId {
+            recv: conn_id,
+            send: conn_id.wrapping_add(1),
+            peer: UtpEnr(enr),
+        };
         self.utp_controller
-            .connect_inbound_stream(conn_id, enr)
+            .connect_inbound_stream(cid)
             .await
             .map_err(|err| OverlayRequestError::ContentNotFound {
                 message: format!("Unable to locate content on the network: {err:?}"),

--- a/portalnet/src/overlay_service.rs
+++ b/portalnet/src/overlay_service.rs
@@ -871,10 +871,12 @@ where
                         let utp_controller = self.utp_controller.clone();
                         tokio::spawn(async move {
                             let trace = query_info.trace;
-                            let data = match utp_controller
-                                .connect_inbound_stream(connection_id, source)
-                                .await
-                            {
+                            let cid = utp_rs::cid::ConnectionId {
+                                recv: connection_id,
+                                send: connection_id.wrapping_add(1),
+                                peer: UtpEnr(source),
+                            };
+                            let data = match utp_controller.connect_inbound_stream(cid).await {
                                 Ok(data) => data,
                                 Err(e) => {
                                     if let Some(responder) = callback {

--- a/portalnet/src/utp_controller.rs
+++ b/portalnet/src/utp_controller.rs
@@ -1,15 +1,13 @@
-use crate::discovery::UtpEnr;
-use anyhow::anyhow;
-use ethportal_api::types::enr::Enr;
+use crate::{discovery::UtpEnr, overlay_service::OverlayRequestError};
 use lazy_static::lazy_static;
-use std::{io, sync::Arc};
+use std::sync::Arc;
 use tokio::sync::Semaphore;
 use tracing::debug;
 use trin_metrics::{
     labels::{UtpDirectionLabel, UtpOutcomeLabel},
     overlay::OverlayMetricsReporter,
 };
-use utp_rs::{cid::ConnectionId, conn::ConnectionConfig, socket::UtpSocket, stream::UtpStream};
+use utp_rs::{cid::ConnectionId, conn::ConnectionConfig, socket::UtpSocket};
 
 /// UtpController is meant to be a container which contains all code related to/for managing uTP
 /// streams We are implementing this because we want the utils of controlling uTP connection to be
@@ -31,6 +29,14 @@ lazy_static! {
     pub static ref UTP_CONN_CFG: ConnectionConfig = ConnectionConfig { max_packet_size: 1024, ..Default::default()};
 }
 
+/// An enum for deciding to initiate the uTP connection as connecting or accepting.
+/// The selection is specified in the Portal Wire spec, depending upon whether the
+/// data is being transferred inbound or outbound.
+enum UtpConnectionSide {
+    Connect,
+    Accept,
+}
+
 impl UtpController {
     pub fn new(
         utp_transfer_limit: usize,
@@ -45,52 +51,90 @@ impl UtpController {
         }
     }
 
-    /// Connect with a peer given the connection id, and return the data received from the peer.
-    pub async fn connect_inbound_stream(
+    async fn inbound_stream(
         &self,
-        connection_id: u16,
-        peer: Enr,
-    ) -> anyhow::Result<Vec<u8>> {
+        cid: ConnectionId<UtpEnr>,
+        side: UtpConnectionSide,
+    ) -> anyhow::Result<Vec<u8>, OverlayRequestError> {
+        // Wait for an incoming connection with the given CID. Then, read the data from the uTP
+        // stream.
         self.metrics
             .report_utp_active_inc(UtpDirectionLabel::Inbound);
-        let cid = utp_rs::cid::ConnectionId {
-            recv: connection_id,
-            send: connection_id.wrapping_add(1),
-            peer: UtpEnr(peer),
+        let (stream, message) = match side {
+            UtpConnectionSide::Connect => (
+                self.utp_socket
+                    .connect_with_cid(cid.clone(), *UTP_CONN_CFG)
+                    .await,
+                "connect inbound uTP stream",
+            ),
+            UtpConnectionSide::Accept => (
+                self.utp_socket
+                    .accept_with_cid(cid.clone(), *UTP_CONN_CFG)
+                    .await,
+                "accept inbound uTP stream",
+            ),
         };
-        let stream = match self.connect_with_cid(cid.clone(), *UTP_CONN_CFG).await {
+        let mut stream = match stream {
             Ok(stream) => stream,
             Err(err) => {
                 self.metrics.report_utp_outcome(
                     UtpDirectionLabel::Inbound,
                     UtpOutcomeLabel::FailedConnection,
                 );
-                debug!(
-                    %err,
-                    cid.send,
-                    cid.recv,
-                    peer = ?cid.peer.client(),
-                    "Unable to establish uTP conn based on Content response",
-                );
-                return Err(anyhow!("unable to establish utp conn"));
+                debug!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), "unable to {message}");
+                return Err(OverlayRequestError::ContentNotFound {
+                    message: format!(
+                        "Unable to locate content on the network: unable to {message}"
+                    ),
+                    utp: true,
+                    trace: None,
+                });
             }
         };
 
-        // receive_utp_content handles metrics reporting of successful & failed rx
-        match Self::receive_utp_content(stream, self.metrics.clone()).await {
-            Ok(data) => Ok(data),
-            Err(err) => {
-                debug!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), "error reading data from uTP stream, while handling a FindContent request.");
-                Err(anyhow!("error reading data from uTP stream"))
-            }
+        let mut data = vec![];
+        if let Err(err) = stream.read_to_eof(&mut data).await {
+            self.metrics
+                .report_utp_outcome(UtpDirectionLabel::Inbound, UtpOutcomeLabel::FailedDataTx);
+            debug!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), "error reading data from {message}");
+            return Err(OverlayRequestError::ContentNotFound {
+                message: format!(
+                    "Unable to locate content on the network: error reading data from {message}"
+                ),
+                utp: true,
+                trace: None,
+            });
         }
+
+        // report utp tx as successful, even if we go on to fail to process the payload
+        self.metrics
+            .report_utp_outcome(UtpDirectionLabel::Inbound, UtpOutcomeLabel::Success);
+        Ok(data)
     }
 
-    /// Connect with a peer given the connection id, and transfer the data to the peer.
-    pub async fn connect_outbound_stream(&self, cid: ConnectionId<UtpEnr>, data: Vec<u8>) -> bool {
+    async fn outbound_stream(
+        &self,
+        cid: ConnectionId<UtpEnr>,
+        data: Vec<u8>,
+        side: UtpConnectionSide,
+    ) -> bool {
         self.metrics
             .report_utp_active_inc(UtpDirectionLabel::Outbound);
-        let stream = match self.connect_with_cid(cid.clone(), *UTP_CONN_CFG).await {
+        let (stream, message) = match side {
+            UtpConnectionSide::Connect => (
+                self.utp_socket
+                    .connect_with_cid(cid.clone(), *UTP_CONN_CFG)
+                    .await,
+                "outbound connect with cid",
+            ),
+            UtpConnectionSide::Accept => (
+                self.utp_socket
+                    .accept_with_cid(cid.clone(), *UTP_CONN_CFG)
+                    .await,
+                "outbound accept with cid",
+            ),
+        };
+        let mut stream = match stream {
             Ok(stream) => stream,
             Err(err) => {
                 self.metrics.report_utp_outcome(
@@ -102,156 +146,86 @@ impl UtpController {
                     cid.send,
                     cid.recv,
                     peer = ?cid.peer.client(),
-                    "Unable to establish uTP conn based on Accept",
+                    "Unable to establish uTP conn based on {message}",
                 );
                 return false;
             }
         };
 
-        // send_utp_content handles metrics reporting of successful & failed txs
-        match Self::send_utp_content(stream, &data, self.metrics.clone()).await {
-            Ok(_) => true,
-            Err(err) => {
-                debug!(
-                    %err,
-                    %cid.send,
-                    %cid.recv,
-                    peer = ?cid.peer.client(),
-                    "Error sending content over uTP, in response to ACCEPT"
-                );
-                false
-            }
-        }
-    }
-
-    /// Accept an outbound stream given the connection id, and transfer the data to the peer.
-    pub async fn accept_outbound_stream(&self, cid: ConnectionId<UtpEnr>, data: Vec<u8>) {
-        self.metrics
-            .report_utp_active_inc(UtpDirectionLabel::Outbound);
-        let stream = match self.accept_with_cid(cid.clone(), *UTP_CONN_CFG).await {
-            Ok(stream) => stream,
-            Err(err) => {
-                self.metrics.report_utp_outcome(
-                    UtpDirectionLabel::Outbound,
-                    UtpOutcomeLabel::FailedConnection,
-                );
-                debug!(
-                    %err,
-                    %cid.send,
-                    %cid.recv,
-                    peer = ?cid.peer.client(),
-                    "unable to accept uTP stream for CID"
-                );
-                return;
-            }
-        };
-        // send_utp_content handles metrics reporting of successful & failed txs
-        if let Err(err) = Self::send_utp_content(stream, &data, self.metrics.clone()).await {
-            debug!(
-                %err,
-                %cid.send,
-                %cid.recv,
-                peer = ?cid.peer.client(),
-                "Error sending content over uTP, in response to FindContent"
-            );
-        };
-    }
-
-    /// Accept an inbound stream given the connection id, and return the data received from the
-    /// peer.
-    pub async fn accept_inbound_stream(
-        &self,
-        cid: ConnectionId<UtpEnr>,
-    ) -> anyhow::Result<Vec<u8>> {
-        // Wait for an incoming connection with the given CID. Then, read the data from the uTP
-        // stream.
-        self.metrics
-            .report_utp_active_inc(UtpDirectionLabel::Inbound);
-        let stream = match self.accept_with_cid(cid.clone(), *UTP_CONN_CFG).await {
-            Ok(stream) => stream,
-            Err(_) => {
-                self.metrics.report_utp_outcome(
-                    UtpDirectionLabel::Inbound,
-                    UtpOutcomeLabel::FailedConnection,
-                );
-                return Err(anyhow!("unable to accept uTP stream"));
-            }
-        };
-
-        // receive_utp_content handles metrics reporting of successful & failed rx
-        match Self::receive_utp_content(stream, self.metrics.clone()).await {
-            Ok(data) => Ok(data),
-            Err(_) => Err(anyhow!("error reading data from uTP stream")),
-        }
-    }
-
-    async fn send_utp_content(
-        mut stream: UtpStream<UtpEnr>,
-        content: &[u8],
-        metrics: OverlayMetricsReporter,
-    ) -> anyhow::Result<()> {
-        match stream.write(content).await {
+        match stream.write(&data).await {
             Ok(write_size) => {
-                if write_size != content.len() {
-                    metrics.report_utp_outcome(
+                if write_size != data.len() {
+                    self.metrics.report_utp_outcome(
                         UtpDirectionLabel::Outbound,
                         UtpOutcomeLabel::FailedDataTx,
                     );
-                    return Err(anyhow!(
-                        "uTP write exited before sending all content: {write_size} bytes written, {} bytes expected",
-                        content.len()
-                    ));
+                    debug!(
+                        %cid.send,
+                        %cid.recv,
+                        peer = ?cid.peer.client(),
+                        "Error sending content over uTP, in response to uTP write exited before sending all content: {write_size} bytes written, {} bytes expected",
+                        data.len()
+                    );
+                    return false;
                 }
             }
             Err(err) => {
-                metrics
+                self.metrics
                     .report_utp_outcome(UtpDirectionLabel::Outbound, UtpOutcomeLabel::FailedDataTx);
-                return Err(anyhow!("Error writing content to uTP stream: {err}"));
+                debug!(
+                    %err,
+                    %cid.send,
+                    %cid.recv,
+                    peer = ?cid.peer.client(),
+                    "Error sending content over uTP, in response to Error writing content to uTP stream: {err}"
+                );
+                return false;
             }
         }
 
         // close uTP connection
         if let Err(err) = stream.close().await {
-            metrics
+            self.metrics
                 .report_utp_outcome(UtpDirectionLabel::Outbound, UtpOutcomeLabel::FailedShutdown);
-            return Err(anyhow!("Error closing uTP connection: {err}"));
+            debug!(
+                %err,
+                %cid.send,
+                %cid.recv,
+                peer = ?cid.peer.client(),
+                "Error sending content over uTP, in response to Error closing uTP connection: {err}"
+            );
+            return false;
         };
-        metrics.report_utp_outcome(UtpDirectionLabel::Outbound, UtpOutcomeLabel::Success);
-        Ok(())
-    }
-
-    async fn receive_utp_content(
-        mut stream: UtpStream<UtpEnr>,
-        metrics: OverlayMetricsReporter,
-    ) -> anyhow::Result<Vec<u8>> {
-        let mut data = vec![];
-        if let Err(err) = stream.read_to_eof(&mut data).await {
-            metrics.report_utp_outcome(UtpDirectionLabel::Inbound, UtpOutcomeLabel::FailedDataTx);
-            return Err(anyhow!("Error reading data from uTP stream: {err}"));
-        }
-
-        // report utp tx as successful, even if we go on to fail to process the payload
-        metrics.report_utp_outcome(UtpDirectionLabel::Inbound, UtpOutcomeLabel::Success);
-        Ok(data)
-    }
-
-    async fn connect_with_cid(
-        &self,
-        cid: ConnectionId<UtpEnr>,
-        config: ConnectionConfig,
-    ) -> io::Result<UtpStream<UtpEnr>> {
-        self.utp_socket.connect_with_cid(cid, config).await
-    }
-
-    async fn accept_with_cid(
-        &self,
-        cid: ConnectionId<UtpEnr>,
-        config: ConnectionConfig,
-    ) -> io::Result<UtpStream<UtpEnr>> {
-        self.utp_socket.accept_with_cid(cid, config).await
+        self.metrics
+            .report_utp_outcome(UtpDirectionLabel::Outbound, UtpOutcomeLabel::Success);
+        true
     }
 
     pub fn cid(&self, peer: UtpEnr, is_initiator: bool) -> ConnectionId<UtpEnr> {
         self.utp_socket.cid(peer, is_initiator)
+    }
+
+    pub async fn connect_inbound_stream(
+        &self,
+        cid: ConnectionId<UtpEnr>,
+    ) -> anyhow::Result<Vec<u8>, OverlayRequestError> {
+        self.inbound_stream(cid, UtpConnectionSide::Connect).await
+    }
+
+    pub async fn accept_inbound_stream(
+        &self,
+        cid: ConnectionId<UtpEnr>,
+    ) -> anyhow::Result<Vec<u8>, OverlayRequestError> {
+        self.inbound_stream(cid, UtpConnectionSide::Accept).await
+    }
+
+    pub async fn connect_outbound_stream(&self, cid: ConnectionId<UtpEnr>, data: Vec<u8>) -> bool {
+        self.outbound_stream(cid, data, UtpConnectionSide::Connect)
+            .await
+    }
+
+    pub async fn accept_outbound_stream(&self, cid: ConnectionId<UtpEnr>, data: Vec<u8>) -> bool {
+        self.outbound_stream(cid, data, UtpConnectionSide::Accept)
+            .await
     }
 }

--- a/portalnet/src/utp_controller.rs
+++ b/portalnet/src/utp_controller.rs
@@ -1,8 +1,18 @@
+use crate::{discovery::UtpEnr, overlay_service::OverlayRequestError};
+use anyhow::anyhow;
+use ethportal_api::{
+    types::{enr::Enr, query_trace::QueryTrace},
+    utils::bytes::hex_encode,
+};
+use lazy_static::lazy_static;
 use std::{io, sync::Arc};
 use tokio::sync::Semaphore;
+use tracing::debug;
+use trin_metrics::{
+    labels::{UtpDirectionLabel, UtpOutcomeLabel},
+    overlay::OverlayMetricsReporter,
+};
 use utp_rs::{cid::ConnectionId, conn::ConnectionConfig, socket::UtpSocket, stream::UtpStream};
-
-use crate::discovery::UtpEnr;
 
 /// UtpController is meant to be a container which contains all code related to/for managing uTP
 /// streams We are implementing this because we want the utils of controlling uTP connection to be
@@ -15,33 +25,253 @@ use crate::discovery::UtpEnr;
 pub struct UtpController {
     pub inbound_utp_transfer_semaphore: Arc<Semaphore>,
     pub outbound_utp_transfer_semaphore: Arc<Semaphore>,
-    /// uTP socket.
     utp_socket: Arc<UtpSocket<UtpEnr>>,
+    metrics: OverlayMetricsReporter,
+}
+
+lazy_static! {
+    /// The default configuration to use for uTP connections.
+    pub static ref UTP_CONN_CFG: ConnectionConfig = ConnectionConfig { max_packet_size: 1024, ..Default::default()};
 }
 
 impl UtpController {
-    pub fn new(utp_transfer_limit: usize, utp_socket: Arc<UtpSocket<UtpEnr>>) -> Self {
+    pub fn new(
+        utp_transfer_limit: usize,
+        utp_socket: Arc<UtpSocket<UtpEnr>>,
+        metrics: OverlayMetricsReporter,
+    ) -> Self {
         Self {
             utp_socket,
             inbound_utp_transfer_semaphore: Arc::new(Semaphore::new(utp_transfer_limit)),
             outbound_utp_transfer_semaphore: Arc::new(Semaphore::new(utp_transfer_limit)),
+            metrics,
         }
     }
 
-    pub async fn connect_with_cid(
+    /// Connect with a peer given the connection id, and return the data received from the peer.
+    pub async fn connect_inbound_stream(
+        &self,
+        connection_id: u16,
+        peer: Enr,
+        trace: Option<QueryTrace>,
+    ) -> Result<Vec<u8>, OverlayRequestError> {
+        self.metrics
+            .report_utp_active_inc(UtpDirectionLabel::Inbound);
+        let cid = utp_rs::cid::ConnectionId {
+            recv: connection_id,
+            send: connection_id.wrapping_add(1),
+            peer: UtpEnr(peer),
+        };
+        let mut stream = match self.connect_with_cid(cid.clone(), *UTP_CONN_CFG).await {
+            Ok(stream) => stream,
+            Err(err) => {
+                self.metrics.report_utp_outcome(
+                    UtpDirectionLabel::Inbound,
+                    UtpOutcomeLabel::FailedConnection,
+                );
+                debug!(
+                    %err,
+                    cid.send,
+                    cid.recv,
+                    peer = ?cid.peer.client(),
+                    "Unable to establish uTP conn based on Content response",
+                );
+                return Err(OverlayRequestError::ContentNotFound {
+                    message:
+                        "Unable to locate content on the network: unable to establish utp conn"
+                            .to_string(),
+                    utp: true,
+                    trace,
+                });
+            }
+        };
+
+        let mut data = vec![];
+        if let Err(err) = stream.read_to_eof(&mut data).await {
+            self.metrics
+                .report_utp_outcome(UtpDirectionLabel::Inbound, UtpOutcomeLabel::FailedDataTx);
+            debug!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), "error reading data from uTP stream, while handling a FindContent request.");
+            return Err(OverlayRequestError::ContentNotFound {
+                message:
+                    "Unable to locate content on the network: error reading data from utp stream"
+                        .to_string(),
+                utp: true,
+                trace,
+            });
+        }
+
+        // report utp tx as successful, even if we go on to fail to process the
+        // payload
+        self.metrics
+            .report_utp_outcome(UtpDirectionLabel::Inbound, UtpOutcomeLabel::Success);
+        Ok(data)
+    }
+
+    /// Connect with a peer given the connection id, and transfer the data to the peer.
+    pub async fn connect_outbound_stream(&self, cid: ConnectionId<UtpEnr>, data: Vec<u8>) -> bool {
+        self.metrics
+            .report_utp_active_inc(UtpDirectionLabel::Outbound);
+        let stream = match self.connect_with_cid(cid.clone(), *UTP_CONN_CFG).await {
+            Ok(stream) => stream,
+            Err(err) => {
+                self.metrics.report_utp_outcome(
+                    UtpDirectionLabel::Outbound,
+                    UtpOutcomeLabel::FailedConnection,
+                );
+                debug!(
+                    %err,
+                    cid.send,
+                    cid.recv,
+                    peer = ?cid.peer.client(),
+                    "Unable to establish uTP conn based on Accept",
+                );
+                return false;
+            }
+        };
+
+        // send_utp_content handles metrics reporting of successful & failed txs
+        match Self::send_utp_content(stream, &data, self.metrics.clone()).await {
+            Ok(_) => true,
+            Err(err) => {
+                debug!(
+                    %err,
+                    %cid.send,
+                    %cid.recv,
+                    peer = ?cid.peer.client(),
+                    "Error sending content over uTP, in response to ACCEPT"
+                );
+                false
+            }
+        }
+    }
+
+    /// Accept an outbound stream given the connection id, and transfer the data to the peer.
+    pub async fn accept_outbound_stream(
+        &self,
+        cid: ConnectionId<UtpEnr>,
+        content_id: [u8; 32],
+        data: Vec<u8>,
+    ) {
+        self.metrics
+            .report_utp_active_inc(UtpDirectionLabel::Outbound);
+        let stream = match self.accept_with_cid(cid.clone(), *UTP_CONN_CFG).await {
+            Ok(stream) => stream,
+            Err(err) => {
+                self.metrics.report_utp_outcome(
+                    UtpDirectionLabel::Outbound,
+                    UtpOutcomeLabel::FailedConnection,
+                );
+                debug!(
+                    %err,
+                    %cid.send,
+                    %cid.recv,
+                    peer = ?cid.peer.client(),
+                    "unable to accept uTP stream for CID"
+                );
+                return;
+            }
+        };
+        // send_utp_content handles metrics reporting of successful & failed txs
+        if let Err(err) = Self::send_utp_content(stream, &data, self.metrics.clone()).await {
+            debug!(
+                %err,
+                %cid.send,
+                %cid.recv,
+                peer = ?cid.peer.client(),
+                content_id = %hex_encode(content_id),
+                "Error sending content over uTP, in response to FindContent"
+            );
+        };
+    }
+
+    /// Accept an inbound stream given the connection id, and return the data received from the
+    /// peer.
+    pub async fn accept_inbound_stream(
+        &self,
+        cid: ConnectionId<UtpEnr>,
+        content_keys_string: Vec<String>,
+    ) -> anyhow::Result<Vec<u8>> {
+        // Wait for an incoming connection with the given CID. Then, read the data from the uTP
+        // stream.
+        self.metrics
+            .report_utp_active_inc(UtpDirectionLabel::Inbound);
+        let mut stream = match self.accept_with_cid(cid.clone(), *UTP_CONN_CFG).await {
+            Ok(stream) => stream,
+            Err(err) => {
+                self.metrics.report_utp_outcome(
+                    UtpDirectionLabel::Inbound,
+                    UtpOutcomeLabel::FailedConnection,
+                );
+                debug!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), content_keys = ?content_keys_string, "unable to accept uTP stream");
+                return Err(anyhow!("unable to accept uTP stream"));
+            }
+        };
+
+        let mut data = vec![];
+        if let Err(err) = stream.read_to_eof(&mut data).await {
+            self.metrics
+                .report_utp_outcome(UtpDirectionLabel::Inbound, UtpOutcomeLabel::FailedDataTx);
+            debug!(%err, cid.send, cid.recv, peer = ?cid.peer.client(), content_keys = ?content_keys_string, "error reading data from uTP stream, while handling an Offer request.");
+            return Err(anyhow!("error reading data from uTP stream"));
+        }
+
+        // report utp tx as successful, even if we go on to fail to process the payload
+        self.metrics
+            .report_utp_outcome(UtpDirectionLabel::Inbound, UtpOutcomeLabel::Success);
+        Ok(data)
+    }
+
+    async fn send_utp_content(
+        mut stream: UtpStream<UtpEnr>,
+        content: &[u8],
+        metrics: OverlayMetricsReporter,
+    ) -> anyhow::Result<()> {
+        match stream.write(content).await {
+            Ok(write_size) => {
+                if write_size != content.len() {
+                    metrics.report_utp_outcome(
+                        UtpDirectionLabel::Outbound,
+                        UtpOutcomeLabel::FailedDataTx,
+                    );
+                    return Err(anyhow!(
+                        "uTP write exited before sending all content: {write_size} bytes written, {} bytes expected",
+                        content.len()
+                    ));
+                }
+            }
+            Err(err) => {
+                metrics
+                    .report_utp_outcome(UtpDirectionLabel::Outbound, UtpOutcomeLabel::FailedDataTx);
+                return Err(anyhow!("Error writing content to uTP stream: {err}"));
+            }
+        }
+
+        // close uTP connection
+        if let Err(err) = stream.close().await {
+            metrics
+                .report_utp_outcome(UtpDirectionLabel::Outbound, UtpOutcomeLabel::FailedShutdown);
+            return Err(anyhow!("Error closing uTP connection: {err}"));
+        };
+        metrics.report_utp_outcome(UtpDirectionLabel::Outbound, UtpOutcomeLabel::Success);
+        Ok(())
+    }
+
+    async fn connect_with_cid(
         &self,
         cid: ConnectionId<UtpEnr>,
         config: ConnectionConfig,
     ) -> io::Result<UtpStream<UtpEnr>> {
         self.utp_socket.connect_with_cid(cid, config).await
     }
-    pub async fn accept_with_cid(
+
+    async fn accept_with_cid(
         &self,
         cid: ConnectionId<UtpEnr>,
         config: ConnectionConfig,
     ) -> io::Result<UtpStream<UtpEnr>> {
         self.utp_socket.accept_with_cid(cid, config).await
     }
+
     pub fn cid(&self, peer: UtpEnr, is_initiator: bool) -> ConnectionId<UtpEnr> {
         self.utp_socket.cid(peer, is_initiator)
     }

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -6,7 +6,6 @@ use std::{
 
 use discv5::TalkRequest;
 use parking_lot::RwLock;
-use portalnet::utp_controller::UtpController;
 use tokio::{
     sync::{mpsc, mpsc::unbounded_channel},
     time::{self, Duration},
@@ -15,7 +14,6 @@ use utp_rs::socket::UtpSocket;
 
 use ethportal_api::{
     types::{
-        cli::DEFAULT_UTP_TRANSFER_LIMIT,
         content_key::overlay::IdentityContentKey,
         distance::XorMetric,
         enr::{Enr, SszEnr},
@@ -44,16 +42,14 @@ async fn init_overlay(
 
     let (_utp_talk_req_tx, utp_talk_req_rx) = unbounded_channel();
     let discv5_utp = Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx);
-    let utp_socket = UtpSocket::with_socket(discv5_utp);
-    let utp_controller = UtpController::new(DEFAULT_UTP_TRANSFER_LIMIT, Arc::new(utp_socket));
-    let utp_controller = Arc::new(utp_controller);
+    let utp_socket = Arc::new(UtpSocket::with_socket(discv5_utp));
 
     let validator = Arc::new(MockValidator {});
 
     OverlayProtocol::new(
         overlay_config,
         discovery,
-        utp_controller,
+        utp_socket,
         store,
         protocol,
         validator,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 
 use std::sync::Arc;
 
-use portalnet::utp_controller::UtpController;
 use rpc::{launch_jsonrpc_server, RpcServerHandle};
 use tokio::sync::{mpsc, RwLock};
 use tracing::info;
@@ -84,10 +83,7 @@ pub async fn run_trin(
         if trin_config.networks.iter().any(|val| val == STATE_NETWORK) {
             initialize_state_network(
                 &discovery,
-                Arc::new(UtpController::new(
-                    trin_config.utp_transfer_limit,
-                    utp_socket.clone(),
-                )),
+                utp_socket.clone(),
                 portalnet_config.clone(),
                 storage_config.clone(),
                 header_oracle.clone(),
@@ -107,10 +103,7 @@ pub async fn run_trin(
     ) = if trin_config.networks.iter().any(|val| val == BEACON_NETWORK) {
         initialize_beacon_network(
             &discovery,
-            Arc::new(UtpController::new(
-                trin_config.utp_transfer_limit,
-                utp_socket.clone(),
-            )),
+            utp_socket.clone(),
             portalnet_config.clone(),
             storage_config.clone(),
             header_oracle.clone(),
@@ -134,10 +127,7 @@ pub async fn run_trin(
     {
         initialize_history_network(
             &discovery,
-            Arc::new(UtpController::new(
-                trin_config.utp_transfer_limit,
-                utp_socket.clone(),
-            )),
+            utp_socket.clone(),
             portalnet_config.clone(),
             storage_config.clone(),
             header_oracle.clone(),

--- a/trin-beacon/src/lib.rs
+++ b/trin-beacon/src/lib.rs
@@ -16,14 +16,14 @@ use tokio::{
     time::{interval, Duration},
 };
 use tracing::info;
+use utp_rs::socket::UtpSocket;
 
 use crate::{events::BeaconEvents, jsonrpc::BeaconRequestHandler, network::BeaconNetwork};
 use ethportal_api::types::{enr::Enr, jsonrpc::request::BeaconJsonRpcRequest};
 use portalnet::{
     config::PortalnetConfig,
-    discovery::Discovery,
+    discovery::{Discovery, UtpEnr},
     events::{EventEnvelope, OverlayRequest},
-    utp_controller::UtpController,
 };
 use trin_storage::PortalStorageConfig;
 use trin_validation::oracle::HeaderOracle;
@@ -36,7 +36,7 @@ type BeaconEventStream = Option<broadcast::Receiver<EventEnvelope>>;
 
 pub async fn initialize_beacon_network(
     discovery: &Arc<Discovery>,
-    utp_controller: Arc<UtpController>,
+    utp_socket: Arc<UtpSocket<UtpEnr>>,
     portalnet_config: PortalnetConfig,
     storage_config: PortalStorageConfig,
     header_oracle: Arc<RwLock<HeaderOracle>>,
@@ -52,7 +52,7 @@ pub async fn initialize_beacon_network(
     let (beacon_message_tx, beacon_message_rx) = mpsc::unbounded_channel::<OverlayRequest>();
     let beacon_network = BeaconNetwork::new(
         Arc::clone(discovery),
-        utp_controller,
+        utp_socket,
         storage_config,
         portalnet_config.clone(),
         header_oracle,

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -17,14 +17,14 @@ use tokio::{
     time::{interval, Duration},
 };
 use tracing::info;
+use utp_rs::socket::UtpSocket;
 
 use crate::{events::HistoryEvents, jsonrpc::HistoryRequestHandler};
 use ethportal_api::types::{enr::Enr, jsonrpc::request::HistoryJsonRpcRequest};
 use portalnet::{
     config::PortalnetConfig,
-    discovery::Discovery,
+    discovery::{Discovery, UtpEnr},
     events::{EventEnvelope, OverlayRequest},
-    utp_controller::UtpController,
 };
 use trin_storage::PortalStorageConfig;
 use trin_validation::oracle::HeaderOracle;
@@ -37,7 +37,7 @@ type HistoryEventStream = Option<broadcast::Receiver<EventEnvelope>>;
 
 pub async fn initialize_history_network(
     discovery: &Arc<Discovery>,
-    utp_controller: Arc<UtpController>,
+    utp_socket: Arc<UtpSocket<UtpEnr>>,
     portalnet_config: PortalnetConfig,
     storage_config: PortalStorageConfig,
     header_oracle: Arc<RwLock<HeaderOracle>>,
@@ -54,7 +54,7 @@ pub async fn initialize_history_network(
     let (history_event_tx, history_event_rx) = mpsc::unbounded_channel::<OverlayRequest>();
     let history_network = HistoryNetwork::new(
         Arc::clone(discovery),
-        utp_controller,
+        utp_socket,
         storage_config,
         portalnet_config.clone(),
         header_oracle,

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -27,6 +27,7 @@ tokio = {version = "1.14.0", features = ["full"]}
 tracing = "0.1.36"
 trin-storage = { path = "../trin-storage" }
 trin-validation = { path = "../trin-validation" }
+utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.11" }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -10,14 +10,14 @@ use tokio::{
     time::interval,
 };
 use tracing::info;
+use utp_rs::socket::UtpSocket;
 
 use crate::{events::StateEvents, jsonrpc::StateRequestHandler};
 use ethportal_api::types::{enr::Enr, jsonrpc::request::StateJsonRpcRequest};
 use portalnet::{
     config::PortalnetConfig,
-    discovery::Discovery,
+    discovery::{Discovery, UtpEnr},
     events::{EventEnvelope, OverlayRequest},
-    utp_controller::UtpController,
 };
 use trin_storage::PortalStorageConfig;
 use trin_validation::oracle::HeaderOracle;
@@ -36,7 +36,7 @@ type StateEventStream = Option<broadcast::Receiver<EventEnvelope>>;
 
 pub async fn initialize_state_network(
     discovery: &Arc<Discovery>,
-    utp_controller: Arc<UtpController>,
+    utp_socket: Arc<UtpSocket<UtpEnr>>,
     portalnet_config: PortalnetConfig,
     storage_config: PortalStorageConfig,
     header_oracle: Arc<RwLock<HeaderOracle>>,
@@ -52,7 +52,7 @@ pub async fn initialize_state_network(
 
     let state_network = StateNetwork::new(
         Arc::clone(discovery),
-        utp_controller,
+        utp_socket,
         storage_config,
         portalnet_config.clone(),
         header_oracle,


### PR DESCRIPTION
### What was wrong?
Initial refactor of `OverlayService`. Fairly straightforward extracting of all utp stream handling logic into the `UtpController`.

Coming up in a following pr will be the "offer" queue to eliminate concurrent utp streams for the same content key.

### How was it fixed?
- extracted logic from `OverlayService` -> `UtpController`
- tested locally via kurtosis & resolved a bug in metrics reporting

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
