### PR TITLE
fix(bridge): fix bridge cli args to be compatible with client metrics

### DIFF
--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, str::FromStr};
+use std::{net::SocketAddr, path::PathBuf, str::FromStr};
 
 use clap::{Parser, Subcommand};
 use ethereum_types::H256;
@@ -53,8 +53,11 @@ pub struct BridgeConfig {
     )]
     pub network: Vec<NetworkKind>,
 
-    #[arg(long, help = "Url for metrics reporting")]
-    pub metrics_url: Option<Url>,
+    #[arg(
+        long,
+        help = "Socket address for metrics reporting, ex: 127.0.0.1:9090"
+    )]
+    pub metrics_url: Option<SocketAddr>,
 
     #[arg(
         default_value = "default",

--- a/portal-bridge/src/client_handles.rs
+++ b/portal-bridge/src/client_handles.rs
@@ -1,6 +1,5 @@
 use std::net::SocketAddr;
 
-use anyhow::bail;
 use tokio::process::{Child, Command};
 
 use crate::cli::BridgeConfig;
@@ -24,14 +23,8 @@ pub fn fluffy_handle(
         .arg(format!("--nat:extip:{}", ip.ip()))
         .arg(format!("--netkey-unsafe:{private_key}"));
     if let Some(metrics_url) = bridge_config.metrics_url {
-        let address = match metrics_url.host_str() {
-            Some(address) => address,
-            None => bail!("Invalid metrics url address"),
-        };
-        let port = match metrics_url.port() {
-            Some(port) => port,
-            None => bail!("Invalid metrics url port"),
-        };
+        let address = metrics_url.ip().to_string();
+        let port = metrics_url.port();
         command
             .arg("--metrics")
             .arg(format!("--metrics-address:{address}"))
@@ -79,7 +72,7 @@ pub fn trin_handle(
         command.args(["--external-address", &format!("{ip}:{udp_port}")]);
     }
     if let Some(metrics_url) = bridge_config.metrics_url {
-        let url: String = metrics_url.into();
+        let url: String = metrics_url.to_string();
         command.args(["--enable-metrics-with-url", &url]);
     }
     Ok(command.spawn()?)


### PR DESCRIPTION
### What was wrong?
`portal-bridge` was using `url::Url` for the metrics url, when core `trin` uses `SocketAddr`. 

### How was it fixed?
To avoid some extra string parsing, I just updated the bridge's metrics url to be a `SocketAddr` as well

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
