### PR TITLE
refactor(portalnet): split out overlay_service into submodules

### DIFF
--- a/light-client/src/consensus/rpc/portal_rpc.rs
+++ b/light-client/src/consensus/rpc/portal_rpc.rs
@@ -18,7 +18,7 @@ use ethportal_api::{
     LightClientUpdatesByRangeKey,
 };
 use futures::channel::oneshot;
-use portalnet::overlay_service::OverlayCommand;
+use portalnet::overlay::command::OverlayCommand;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::warn;

--- a/portalnet/src/find/query_info.rs
+++ b/portalnet/src/find/query_info.rs
@@ -2,7 +2,7 @@ use discv5::{enr::NodeId, kbucket::Key, Enr};
 use futures::channel::oneshot;
 use smallvec::SmallVec;
 
-use crate::{find::query_pool::TargetKey, overlay_service::OverlayRequestError};
+use crate::{find::query_pool::TargetKey, overlay::errors::OverlayRequestError};
 use ethportal_api::{
     types::{
         portal_wire::{Content, FindContent, FindNodes, Request},

--- a/portalnet/src/gossip.rs
+++ b/portalnet/src/gossip.rs
@@ -12,7 +12,10 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, warn};
 
 use crate::{
-    overlay_service::{OverlayCommand, OverlayRequest, RequestDirection},
+    overlay::{
+        command::OverlayCommand,
+        request::{OverlayRequest, RequestDirection},
+    },
     types::node::Node,
     utp_controller::UtpController,
 };

--- a/portalnet/src/lib.rs
+++ b/portalnet/src/lib.rs
@@ -7,7 +7,6 @@ pub mod events;
 pub mod find;
 pub mod gossip;
 pub mod overlay;
-pub mod overlay_service;
 pub mod socket;
 pub mod types;
 pub mod utils;

--- a/portalnet/src/overlay/command.rs
+++ b/portalnet/src/overlay/command.rs
@@ -1,0 +1,42 @@
+use discv5::enr::NodeId;
+use futures::channel::oneshot;
+use tokio::sync::broadcast;
+
+use super::request::OverlayRequest;
+use crate::{events::EventEnvelope, find::query_info::RecursiveFindContentResult};
+use ethportal_api::types::enr::Enr;
+
+/// A network-based action that the overlay may perform.
+///
+/// The overlay performs network-based actions on behalf of the command issuer. The issuer may be
+/// the overlay itself. The overlay manages network requests and responses and sends the result
+/// back to the issuer upon completion.
+#[derive(Debug)]
+pub enum OverlayCommand<TContentKey> {
+    /// Send a single portal request through the overlay.
+    ///
+    /// A `Request` corresponds to a single request message defined in the portal wire spec.
+    Request(OverlayRequest),
+    /// Perform a find content query through the overlay.
+    ///
+    /// A `FindContentQuery` issues multiple requests to find the content identified by `target`.
+    /// The result is sent to the issuer over `callback`.
+    FindContentQuery {
+        /// The query target.
+        target: TContentKey,
+        /// A callback channel to transmit the result of the query.
+        callback: oneshot::Sender<RecursiveFindContentResult>,
+        /// Whether or not a trace for the content query should be kept and returned.
+        is_trace: bool,
+    },
+    FindNodeQuery {
+        /// The query target.
+        target: NodeId,
+        /// A callback channel to transmit the result of the query.
+        callback: oneshot::Sender<Vec<Enr>>,
+    },
+    /// Sets up an event stream where the overlay server will return various events.
+    RequestEventStream(oneshot::Sender<broadcast::Receiver<EventEnvelope>>),
+    /// Handle an event sent from another overlay.
+    Event(EventEnvelope),
+}

--- a/portalnet/src/overlay/config.rs
+++ b/portalnet/src/overlay/config.rs
@@ -1,0 +1,46 @@
+#![allow(clippy::result_large_err)]
+
+use std::time::Duration;
+
+use discv5::kbucket::{Filter, MAX_NODES_PER_BUCKET};
+
+use crate::types::node::Node;
+use ethportal_api::types::{cli::DEFAULT_UTP_TRANSFER_LIMIT, enr::Enr};
+
+/// Configuration parameters for the overlay network.
+#[derive(Clone)]
+pub struct OverlayConfig {
+    pub bootnode_enrs: Vec<Enr>,
+    pub bucket_pending_timeout: Duration,
+    pub max_incoming_per_bucket: usize,
+    pub table_filter: Option<Box<dyn Filter<Node>>>,
+    pub bucket_filter: Option<Box<dyn Filter<Node>>>,
+    pub ping_queue_interval: Option<Duration>,
+    pub query_parallelism: usize,
+    pub query_timeout: Duration,
+    pub query_peer_timeout: Duration,
+    pub query_num_results: usize,
+    pub findnodes_query_distances_per_peer: usize,
+    pub disable_poke: bool,
+    pub utp_transfer_limit: usize,
+}
+
+impl Default for OverlayConfig {
+    fn default() -> Self {
+        Self {
+            bootnode_enrs: vec![],
+            bucket_pending_timeout: Duration::from_secs(60),
+            max_incoming_per_bucket: 16,
+            table_filter: None,
+            bucket_filter: None,
+            ping_queue_interval: None,
+            query_parallelism: 3, // (recommended α from kademlia paper)
+            query_peer_timeout: Duration::from_secs(2),
+            query_timeout: Duration::from_secs(60),
+            query_num_results: MAX_NODES_PER_BUCKET,
+            findnodes_query_distances_per_peer: 3,
+            disable_poke: false,
+            utp_transfer_limit: DEFAULT_UTP_TRANSFER_LIMIT,
+        }
+    }
+}

--- a/portalnet/src/overlay/errors.rs
+++ b/portalnet/src/overlay/errors.rs
@@ -1,0 +1,76 @@
+use thiserror::Error;
+
+use ethportal_api::types::query_trace::QueryTrace;
+
+/// An overlay request error.
+#[derive(Clone, Error, Debug)]
+// required for the ContentNotFound error response
+#[allow(clippy::large_enum_variant)]
+pub enum OverlayRequestError {
+    /// A failure to transmit or receive a message on a channel.
+    #[error("Channel failure: {0}")]
+    ChannelFailure(String),
+
+    /// An invalid request was received.
+    #[error("Invalid request: {0}")]
+    InvalidRequest(String),
+
+    /// An invalid response was received.
+    #[error("Invalid response")]
+    InvalidResponse,
+
+    /// Received content failed validation for a response.
+    #[error("Response content failed validation: {0}")]
+    FailedValidation(String),
+
+    #[error("The request returned an empty response")]
+    EmptyResponse,
+
+    /// A failure to decode a message.
+    #[error("The message was unable to be decoded")]
+    DecodeError,
+
+    /// The request timed out.
+    #[error("The request timed out")]
+    Timeout,
+
+    /// The request was unable to be served.
+    #[error("Failure to serve request: {0}")]
+    Failure(String),
+
+    /// The request  Discovery v5 request error.
+    #[error("Internal Discovery v5 error: {0}")]
+    Discv5Error(discv5::RequestError),
+
+    /// Error types resulting from building ACCEPT message
+    #[error("Error while building accept message: {0}")]
+    AcceptError(String),
+
+    /// Error types resulting from building ACCEPT message
+    #[error("Error while sending offer message: {0}")]
+    OfferError(String),
+
+    /// uTP request error
+    #[error("uTP request error: {0}")]
+    UtpError(String),
+
+    #[error("Received invalid remote discv5 packet")]
+    InvalidRemoteDiscv5Packet,
+
+    #[error("Content wasn't found on the network: {message}")]
+    ContentNotFound {
+        message: String,
+        utp: bool,
+        trace: Option<QueryTrace>,
+    },
+}
+
+impl From<discv5::RequestError> for OverlayRequestError {
+    fn from(err: discv5::RequestError) -> Self {
+        match err {
+            discv5::RequestError::Timeout => Self::Timeout,
+            discv5::RequestError::InvalidRemotePacket => Self::InvalidRemoteDiscv5Packet,
+            err => Self::Discv5Error(err),
+        }
+    }
+}

--- a/portalnet/src/overlay/mod.rs
+++ b/portalnet/src/overlay/mod.rs
@@ -1,0 +1,6 @@
+pub mod command;
+pub mod config;
+pub mod errors;
+pub mod protocol;
+pub mod request;
+pub mod service;

--- a/portalnet/src/overlay/request.rs
+++ b/portalnet/src/overlay/request.rs
@@ -1,0 +1,89 @@
+use std::fmt::Debug;
+
+use discv5::{enr::NodeId, rpc::RequestId};
+use futures::channel::oneshot;
+use tokio::sync::OwnedSemaphorePermit;
+
+use super::errors::OverlayRequestError;
+use crate::find::query_pool::QueryId;
+use ethportal_api::types::{
+    enr::Enr,
+    portal_wire::{Request, Response},
+};
+
+/// An incoming or outgoing request.
+#[derive(Debug, PartialEq)]
+pub enum RequestDirection {
+    /// An incoming request from `source`.
+    Incoming { id: RequestId, source: NodeId },
+    /// An outgoing request to `destination`.
+    Outgoing { destination: Enr },
+}
+
+/// An identifier for an overlay network request. The ID is used to track active outgoing requests.
+// We only have visibility on the request IDs for incoming Discovery v5 talk requests. Here we use
+// a separate identifier to track outgoing talk requests.
+pub type OverlayRequestId = u128;
+
+/// An overlay request response channel.
+type OverlayResponder = oneshot::Sender<Result<Response, OverlayRequestError>>;
+
+/// A request to pass through the overlay.
+#[derive(Debug)]
+pub struct OverlayRequest {
+    /// The request identifier.
+    pub id: OverlayRequestId,
+    /// The inner request.
+    pub request: Request,
+    /// The direction of the request.
+    pub direction: RequestDirection,
+    /// An optional responder to send a result of the request.
+    /// The responder may be None if the request was initiated internally.
+    pub responder: Option<OverlayResponder>,
+    /// ID of query that request's response will advance.
+    /// Will be None for requests that are not associated with a query.
+    pub query_id: Option<QueryId>,
+    /// An optional permit to allow for transfer caps
+    pub request_permit: Option<OwnedSemaphorePermit>,
+}
+
+impl OverlayRequest {
+    /// Creates a new overlay request.
+    pub fn new(
+        request: Request,
+        direction: RequestDirection,
+        responder: Option<OverlayResponder>,
+        query_id: Option<QueryId>,
+        request_permit: Option<OwnedSemaphorePermit>,
+    ) -> Self {
+        OverlayRequest {
+            id: rand::random(),
+            request,
+            direction,
+            responder,
+            query_id,
+            request_permit,
+        }
+    }
+}
+
+/// An active outgoing overlay request.
+pub struct ActiveOutgoingRequest {
+    /// The ENR of the destination (target) node.
+    pub destination: Enr,
+    /// An optional responder to send the result of the associated request.
+    pub responder: Option<OverlayResponder>,
+    pub request: Request,
+    /// An optional QueryID for the query that this request is associated with.
+    pub query_id: Option<QueryId>,
+    /// An optional permit to allow for transfer caps
+    pub request_permit: Option<OwnedSemaphorePermit>,
+}
+
+/// A response for a particular overlay request.
+pub struct OverlayResponse {
+    /// The identifier of the associated request.
+    pub request_id: OverlayRequestId,
+    /// The result of the associated request.
+    pub response: Result<Response, OverlayRequestError>,
+}

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -24,7 +24,7 @@ use ethportal_api::{
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, Discv5UdpSocket},
-    overlay::{OverlayConfig, OverlayProtocol},
+    overlay::{config::OverlayConfig, protocol::OverlayProtocol},
     utils::db::setup_temp_dir,
 };
 use trin_storage::{ContentStore, DistanceFunction, MemoryContentStore};

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -14,7 +14,7 @@ use ethportal_api::{
     utils::bytes::hex_encode,
     BeaconContentKey, BeaconContentValue, OverlayContentKey, RawContentKey,
 };
-use portalnet::overlay_service::OverlayRequestError;
+use portalnet::overlay::errors::OverlayRequestError;
 use serde_json::{json, Value};
 use tokio::sync::{mpsc, Mutex, RwLock};
 use tracing::error;

--- a/trin-beacon/src/network.rs
+++ b/trin-beacon/src/network.rs
@@ -12,7 +12,7 @@ use ethportal_api::{
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
-    overlay::{OverlayConfig, OverlayProtocol},
+    overlay::{config::OverlayConfig, protocol::OverlayProtocol},
 };
 use trin_storage::PortalStorageConfig;
 use trin_validation::oracle::HeaderOracle;

--- a/trin-beacon/src/sync.rs
+++ b/trin-beacon/src/sync.rs
@@ -3,7 +3,7 @@ use light_client::{
     config::networks, consensus::rpc::portal_rpc::PortalRpc, database::FileDB, Client,
     ClientBuilder,
 };
-use portalnet::overlay_service::OverlayCommand;
+use portalnet::overlay::command::OverlayCommand;
 use std::path::PathBuf;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{error, info};

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -13,7 +13,7 @@ use ethportal_api::{
     utils::bytes::hex_encode,
     ContentValue, HistoryContentKey, OverlayContentKey, RawContentKey,
 };
-use portalnet::overlay_service::OverlayRequestError;
+use portalnet::overlay::errors::OverlayRequestError;
 use serde_json::{json, Value};
 use tokio::sync::{mpsc, Mutex, RwLock};
 use tracing::error;

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -12,7 +12,7 @@ use ethportal_api::{
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
-    overlay::{OverlayConfig, OverlayProtocol},
+    overlay::{config::OverlayConfig, protocol::OverlayProtocol},
 };
 use trin_validation::oracle::HeaderOracle;
 

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use discv5::{enr::NodeId, Enr};
-use portalnet::overlay_service::OverlayRequestError;
+use portalnet::overlay::errors::OverlayRequestError;
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
 use tracing::error;

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -12,7 +12,7 @@ use ethportal_api::{
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
-    overlay::{OverlayConfig, OverlayProtocol},
+    overlay::{config::OverlayConfig, protocol::OverlayProtocol},
 };
 use trin_validation::oracle::HeaderOracle;
 


### PR DESCRIPTION
### What was wrong?
`overlay_service.rs` is too big.

### How was it fixed?
Split out the components inside `overlay_service.rs` into their own separate modules.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
