### PR TITLE
chore: remove non-needed mutex from rpc handler

### DIFF
--- a/trin-beacon/src/lib.rs
+++ b/trin-beacon/src/lib.rs
@@ -11,7 +11,7 @@ pub mod validation;
 use std::sync::Arc;
 
 use tokio::{
-    sync::{broadcast, mpsc, Mutex, RwLock},
+    sync::{broadcast, mpsc, RwLock},
     task::JoinHandle,
     time::{interval, Duration},
 };
@@ -61,7 +61,7 @@ pub async fn initialize_beacon_network(
     let beacon_event_stream = beacon_network.overlay.event_stream().await?;
     let beacon_handler = BeaconRequestHandler {
         network: Arc::new(RwLock::new(beacon_network.clone())),
-        rpc_rx: Arc::new(Mutex::new(beacon_jsonrpc_rx)),
+        rpc_rx: beacon_jsonrpc_rx,
     };
     let beacon_network = Arc::new(beacon_network);
     let beacon_network_task =

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use network::HistoryNetwork;
 use tokio::{
-    sync::{broadcast, mpsc, Mutex, RwLock},
+    sync::{broadcast, mpsc, RwLock},
     task::JoinHandle,
     time::{interval, Duration},
 };
@@ -63,7 +63,7 @@ pub async fn initialize_history_network(
     let event_stream = history_network.overlay.event_stream().await?;
     let history_handler = HistoryRequestHandler {
         network: Arc::new(RwLock::new(history_network.clone())),
-        history_rx: Arc::new(Mutex::new(history_jsonrpc_rx)),
+        history_rx: history_jsonrpc_rx,
     };
     let history_network = Arc::new(history_network);
     let history_network_task =

--- a/utp-testing/src/lib.rs
+++ b/utp-testing/src/lib.rs
@@ -22,7 +22,10 @@ use portalnet::{
     utils::db::setup_temp_dir,
 };
 use std::{io::ErrorKind, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{
+    mpsc::{self, Receiver},
+    RwLock,
+};
 use utp_rs::{conn::ConnectionConfig, socket::UtpSocket};
 
 /// uTP test app
@@ -132,7 +135,7 @@ impl RpcServer for TestApp {
 }
 
 impl TestApp {
-    pub async fn start(&self, mut talk_req_rx: mpsc::Receiver<TalkRequest>) {
+    pub async fn start(&self, mut talk_req_rx: Receiver<TalkRequest>) {
         let utp_talk_reqs_tx = self.utp_talk_req_tx.clone();
 
         // Forward discv5 uTP packets to uTP socket


### PR DESCRIPTION
### What was wrong?
we had a non needed mutex
### How was it fixed?
removed it
