### PR TITLE
style: reduce bridge debug logs

### DIFF
--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -229,7 +229,9 @@ impl Era1Bridge {
                 Ok(result) => match result {
                     Ok(_) => {
                         debug!("Done serving block: {number}");
-                        block_stats.lock().unwrap().report();
+                        if let Ok(stats) = block_stats.lock() {
+                            stats.report();
+                        }
                     }
                     Err(msg) => warn!("Error serving block: {number}: {msg:?}"),
                 },

--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -227,7 +227,10 @@ impl Era1Bridge {
                 )).await
                 {
                 Ok(result) => match result {
-                    Ok(_) => debug!("Done serving block: {number} - {:?}", block_stats),
+                    Ok(_) => {
+                        debug!("Done serving block: {number}");
+                        block_stats.lock().unwrap().report();
+                    }
                     Err(msg) => warn!("Error serving block: {number}: {msg:?}"),
                 },
                 Err(_) => error!("serve_full_block() timed out on height {number}: this is an indication a bug is present")

--- a/portal-bridge/src/stats.rs
+++ b/portal-bridge/src/stats.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, str::FromStr};
 
-use tracing::{info, trace};
+use tracing::{debug, info};
 
 use ethportal_api::{
     jsonrpsee::core::Error,
@@ -36,93 +36,22 @@ impl StatsReporter<BeaconContentKey> for BeaconSlotStats {
     }
 
     fn report(&self) {
+        let slot_number = self.slot_number;
         if let Some(stats) = &self.bootstrap {
-            info!(
-                "GossipReport: slot#{} - bootstrap - {}",
-                self.slot_number,
-                stats.report()
-            );
-            trace!(
-                "GossipReport: slot#{} - bootstrap - offered {:?}",
-                self.slot_number,
-                stats.offered
-            );
-            trace!(
-                "GossipReport: slot#{} - bootstrap - accepted {:?}",
-                self.slot_number,
-                stats.accepted
-            );
-            trace!(
-                "GossipReport: slot#{} - bootstrap - transferred {:?}",
-                self.slot_number,
-                stats.transferred
-            );
+            info!("GossipReport: slot#{slot_number} - bootstrap - {stats}");
+            debug!("GossipReport: slot#{slot_number} - bootstrap - offered {stats:?}");
         }
         if let Some(stats) = &self.update {
-            info!(
-                "GossipReport: slot#{} - update - {}",
-                self.slot_number,
-                stats.report()
-            );
-            trace!(
-                "GossipReport: slot#{} - update - offered {:?}",
-                self.slot_number,
-                stats.offered
-            );
-            trace!(
-                "GossipReport: slot#{} - update - accepted {:?}",
-                self.slot_number,
-                stats.accepted
-            );
-            trace!(
-                "GossipReport: slot#{} - update - transferred {:?}",
-                self.slot_number,
-                stats.transferred
-            );
+            info!("GossipReport: slot#{slot_number} - update - {stats}");
+            debug!("GossipReport: slot#{slot_number} - update - offered {stats:?}");
         }
         if let Some(stats) = &self.finality_update {
-            info!(
-                "GossipReport: slot#{} - finality_update - {}",
-                self.slot_number,
-                stats.report()
-            );
-            trace!(
-                "GossipReport: slot#{} - finality_update - offered {:?}",
-                self.slot_number,
-                stats.offered
-            );
-            trace!(
-                "GossipReport: slot#{} - finality_update - accepted {:?}",
-                self.slot_number,
-                stats.accepted
-            );
-            trace!(
-                "GossipReport: slot#{} - finality_update - transferred {:?}",
-                self.slot_number,
-                stats.transferred
-            );
+            info!("GossipReport: slot#{slot_number} - finality_update - {stats}");
+            debug!("GossipReport: slot#{slot_number} - finality_update - offered {stats:?}");
         }
         if let Some(stats) = &self.optimistic_update {
-            info!(
-                "GossipReport: slot#{} - optimistic_update - {}",
-                self.slot_number,
-                stats.report()
-            );
-            trace!(
-                "GossipReport: slot#{} - optimistic_update - offered {:?}",
-                self.slot_number,
-                stats.offered
-            );
-            trace!(
-                "GossipReport: slot#{} - optimistic_update - accepted {:?}",
-                self.slot_number,
-                stats.accepted
-            );
-            trace!(
-                "GossipReport: slot#{} - optimistic_update - transferred {:?}",
-                self.slot_number,
-                stats.transferred
-            );
+            info!("GossipReport: slot#{slot_number} - optimistic_update - {stats}");
+            debug!("GossipReport: slot#{slot_number} - optimistic_update - {stats:?}");
         }
     }
 
@@ -163,93 +92,22 @@ impl StatsReporter<HistoryContentKey> for HistoryBlockStats {
     }
 
     fn report(&self) {
+        let block_number = self.block_number;
         if let Some(stats) = &self.header_with_proof {
-            info!(
-                "GossipReport: block#{}: header_with_proof - {}",
-                self.block_number,
-                stats.report()
-            );
-            trace!(
-                "GossipReport: block#{}: header_with_proof - offered {:?}",
-                self.block_number,
-                stats.offered
-            );
-            trace!(
-                "GossipReport: block#{}: header_with_proof - accepted {:?}",
-                self.block_number,
-                stats.accepted
-            );
-            trace!(
-                "GossipReport: block#{}: header_with_proof - transferred {:?}",
-                self.block_number,
-                stats.transferred
-            );
+            info!("GossipReport: block#{block_number}: header_with_proof - {stats}");
+            debug!("GossipReport: block#{block_number}: header_with_proof - {stats:?}",);
         }
         if let Some(stats) = &self.block_body {
-            info!(
-                "GossipReport: block#{}: block_body - {}",
-                self.block_number,
-                stats.report()
-            );
-            trace!(
-                "GossipReport: block#{}: block_body - offered {:?}",
-                self.block_number,
-                stats.offered
-            );
-            trace!(
-                "GossipReport: block#{}: block_body - accepted {:?}",
-                self.block_number,
-                stats.accepted
-            );
-            trace!(
-                "GossipReport: block#{}: block_body - transferred {:?}",
-                self.block_number,
-                stats.transferred
-            );
+            info!("GossipReport: block#{block_number}: block_body - {stats}");
+            debug!("GossipReport: block#{block_number}: block_body - {stats:?}",);
         }
         if let Some(stats) = &self.receipts {
-            info!(
-                "GossipReport: block#{}: receipts - {}",
-                self.block_number,
-                stats.report()
-            );
-            trace!(
-                "GossipReport: block#{}: receipts - offered {:?}",
-                self.block_number,
-                stats.offered
-            );
-            trace!(
-                "GossipReport: block#{}: receipts - accepted {:?}",
-                self.block_number,
-                stats.accepted
-            );
-            trace!(
-                "GossipReport: block#{}: receipts - transferred {:?}",
-                self.block_number,
-                stats.transferred
-            );
+            info!("GossipReport: block#{block_number}: receipts - {stats}");
+            debug!("GossipReport: block#{block_number}: receipts - {stats:?}",);
         }
         if let Some(stats) = &self.epoch_accumulator {
-            info!(
-                "GossipReport: block#{}: epoch_accumulator - {}",
-                self.block_number,
-                stats.report()
-            );
-            trace!(
-                "GossipReport: block#{}: epoch_accumulator - offered {:?}",
-                self.block_number,
-                stats.offered
-            );
-            trace!(
-                "GossipReport: block#{}: epoch_accumulator - accepted {:?}",
-                self.block_number,
-                stats.accepted
-            );
-            trace!(
-                "GossipReport: block#{}: epoch_accumulator - transferred {:?}",
-                self.block_number,
-                stats.transferred
-            );
+            info!("GossipReport: block#{block_number}: epoch_accumulator - {stats}");
+            debug!("GossipReport: block#{block_number}: epoch_accumulator - {stats:?}");
         }
     }
 
@@ -279,7 +137,7 @@ impl StatsReporter<HistoryContentKey> for HistoryBlockStats {
 // Currently, this is just to simplify, but if there's a use case where it makes sense to record
 // duplicate offers to the same peer, we can change this, by removing the double count check in the
 // From impl below.
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct ContentStats {
     // use hashset so peers aren't double-counted across clients
     pub offered: HashSet<Enr>,
@@ -289,9 +147,34 @@ pub struct ContentStats {
     pub failures: u64,
 }
 
-impl ContentStats {
-    pub fn report(&self) -> String {
-        format!(
+impl std::fmt::Debug for ContentStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let offered_enrs = self
+            .offered
+            .iter()
+            .map(|enr| enr.to_string())
+            .collect::<Vec<String>>();
+        let accepted_enrs = self
+            .accepted
+            .iter()
+            .map(|enr| enr.to_string())
+            .collect::<Vec<String>>();
+        let transferred_enrs = self
+            .transferred
+            .iter()
+            .map(|enr| enr.to_string())
+            .collect::<Vec<String>>();
+        let message = format!(
+            "\noffered: {offered_enrs:?}\naccepted: {accepted_enrs:?}\ntransferred: {transferred_enrs:?}"
+        );
+        write!(f, "{message}")
+    }
+}
+
+impl std::fmt::Display for ContentStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
             "offered: {}, accepted: {}, transferred: {}, retries: {}, failures: {}",
             self.offered.len(),
             self.accepted.len(),


### PR DESCRIPTION
### What was wrong?
`GossipReport` logs on the bridge are far too excessive, since it simply calls `Debug` on the `BlockStats` object rather than using the `report()` method. eg..
```
Done serving block: 2647790 - Mutex { data: HistoryBlockStats { block_number: 2647790, header_with_proof: Some(ContentStats { offered: {Enr { id: Some("v4"), seq: 9, NodeId: 0xa0cd2d177067f663bd06b351219591ec0bab274f020e0964035a3006d47c298a, signature: "ea9ee579b2bf56ffc3939b02c7846d5982f57c5447d51faf8359d6f28723c39a59813cf1e011626ddbd2840292cb0daddcc160f29b5ab1384cb95661c3d50339", IpV4 UDP Socket: Some(159.223.210.116:9009), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "967420302e312e312d616c7068612e312d343736636237"), ("secp256k1", "a103f9aabba81def13fbf11a237753aaf449fc23ce6143e0ba84fe94e4130d7c21de")] }, Enr { id: Some("v4"), seq: 1, NodeId: 0xc06b283ad920f1ec09172993c90e50e22536d21340f07999f1a61429658d7982, signature: "ef59bbcce2d23752dde16ebfbfc50f790196549181376e7c7cd4bb106b105c2d18cfb7fb54cef4e9585417021a072236b28d3f14346f5fb7cbfa8b74099e7022", IpV4 UDP Socket: Some(194.33.40.238:9129), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "66"), ("secp256k1", "a10360d388ab185a5f088080a616fabfe583ce218c40689ef112cd638b00b9c46d7d")] }, Enr { id: Some("v4"), seq: 1, NodeId: 0xb46b09a36e2318900e142c36128b39651eb8ff908f1fe6830e7b3cd343f18ed3, signature: "d69aa10b871917803092a80dde836d028c6d0e0c91e7771a2dc645ab708115553d7ca73e53bffa024a445fd94ae26bdf0c877f0307c890db77aab5c594156769", IpV4 UDP Socket: Some(194.33.40.238:9102), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("secp256k1", "a103369011d3e6cfd487882c36239c9500ef2cae243e9a10b9c81ede6b5bb8bb9419")] }, Enr { id: Some("v4"), seq: 1, NodeId: 0x6fa256bfd92b51be52ab2c7bb6dd940f24dc9b10a75e56eec9d570edf1939834, signature: "1009a911fa388c606b1dea98084a51028498ed920d9bae3edacf0f2dda1abcd61aacb94730dbc6d2664b46660d37bfd8bd43e62342b45229d6c5b1a470d4fe25", IpV4 UDP Socket: Some(167.172.244.51:9009), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "977420302e312e312d616c7068612e312d756e6b6e6f776e"), ("secp256k1", "a1020e3964928a77c421fa266607c261c20d581c9b4d7b3bd61092a41c40e8c2604c")] }, Enr { id: Some("v4"), seq: 8, NodeId: 0x8767d6952ab1bea701cbf6fe70922faf63a6ad2c4128f0369f6fe74a331012aa, signature: "3381276a5759ab90c4161250b4b32f5eda76030cca9c30191089470a93f555bd570a00e8bd8def5a5112f7e5247d928425cf1708d4813c0e33f1eba2fdb52af2", IpV4 UDP Socket: Some(178.128.245.184:9009), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "967420302e312e312d616c7068612e312d343736636237"), ("secp256k1", "a1030743525ebc5c3adcd96832a01bdf5ad07c7327dc2331b6a6fd11cf19a1abda97")] }}, accepted: {Enr { id: Some("v4"), seq: 1, NodeId: 0x6fa256bfd92b51be52ab2c7bb6dd940f24dc9b10a75e56eec9d570edf1939834, signature: "1009a911fa388c606b1dea98084a51028498ed920d9bae3edacf0f2dda1abcd61aacb94730dbc6d2664b46660d37bfd8bd43e62342b45229d6c5b1a470d4fe25", IpV4 UDP Socket: Some(167.172.244.51:9009), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "977420302e312e312d616c7068612e312d756e6b6e6f776e"), ("secp256k1", "a1020e3964928a77c421fa266607c261c20d581c9b4d7b3bd61092a41c40e8c2604c")] }}, transferred: {Enr { id: Some("v4"), seq: 1, NodeId: 0x6fa256bfd92b51be52ab2c7bb6dd940f24dc9b10a75e56eec9d570edf1939834, signature: "1009a911fa388c606b1dea98084a51028498ed920d9bae3edacf0f2dda1abcd61aacb94730dbc6d2664b46660d37bfd8bd43e62342b45229d6c5b1a470d4fe25", IpV4 UDP Socket: Some(167.172.244.51:9009), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "977420302e312e312d616c7068612e312d756e6b6e6f776e"), ("secp256k1", "a1020e3964928a77c421fa266607c261c20d581c9b4d7b3bd61092a41c40e8c2604c")] }}, retries: 0, failures: 0 }), block_body: Some(ContentStats { offered: {Enr { id: Some("v4"), seq: 1, NodeId: 0x751ca67eb420f9554634e04949911776a92b21c9fe84826ac5db21089f3d0e2a, signature: "d10f5c251b151189a4cea8a6c17a69ecb587487b8fdddcd959618c8848f0c22454d72ee862676c2a7873d2d8e5265b55c29ac8c95897e11ae86d6cea57b6d6ea", IpV4 UDP Socket: Some(194.33.40.238:9110), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "66"), ("secp256k1", "a1028e1a58505df357660013ead48c092a3feaaa287ccc263cc36f76dbcb44f54bc9")] }, Enr { id: Some("v4"), seq: 1, NodeId: 0x6fa256bfd92b51be52ab2c7bb6dd940f24dc9b10a75e56eec9d570edf1939834, signature: "1009a911fa388c606b1dea98084a51028498ed920d9bae3edacf0f2dda1abcd61aacb94730dbc6d2664b46660d37bfd8bd43e62342b45229d6c5b1a470d4fe25", IpV4 UDP Socket: Some(167.172.244.51:9009), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "977420302e312e312d616c7068612e312d756e6b6e6f776e"), ("secp256k1", "a1020e3964928a77c421fa266607c261c20d581c9b4d7b3bd61092a41c40e8c2604c")] }, Enr { id: Some("v4"), seq: 8, NodeId: 0x8767d6952ab1bea701cbf6fe70922faf63a6ad2c4128f0369f6fe74a331012aa, signature: "3381276a5759ab90c4161250b4b32f5eda76030cca9c30191089470a93f555bd570a00e8bd8def5a5112f7e5247d928425cf1708d4813c0e33f1eba2fdb52af2", IpV4 UDP Socket: Some(178.128.245.184:9009), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "967420302e312e312d616c7068612e312d343736636237"), ("secp256k1", "a1030743525ebc5c3adcd96832a01bdf5ad07c7327dc2331b6a6fd11cf19a1abda97")] }, Enr { id: Some("v4"), seq: 1, NodeId: 0xc06b283ad920f1ec09172993c90e50e22536d21340f07999f1a61429658d7982, signature: "ef59bbcce2d23752dde16ebfbfc50f790196549181376e7c7cd4bb106b105c2d18cfb7fb54cef4e9585417021a072236b28d3f14346f5fb7cbfa8b74099e7022", IpV4 UDP Socket: Some(194.33.40.238:9129), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "66"), ("secp256k1", "a10360d388ab185a5f088080a616fabfe583ce218c40689ef112cd638b00b9c46d7d")] }}, accepted: {Enr { id: Some("v4"), seq: 1, NodeId: 0x6fa256bfd92b51be52ab2c7bb6dd940f24dc9b10a75e56eec9d570edf1939834, signature: "1009a911fa388c606b1dea98084a51028498ed920d9bae3edacf0f2dda1abcd61aacb94730dbc6d2664b46660d37bfd8bd43e62342b45229d6c5b1a470d4fe25", IpV4 UDP Socket: Some(167.172.244.51:9009), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "977420302e312e312d616c7068612e312d756e6b6e6f776e"), ("secp256k1", "a1020e3964928a77c421fa266607c261c20d581c9b4d7b3bd61092a41c40e8c2604c")] }}, transferred: {Enr { id: Some("v4"), seq: 1, NodeId: 0x6fa256bfd92b51be52ab2c7bb6dd940f24dc9b10a75e56eec9d570edf1939834, signature: "1009a911fa388c606b1dea98084a51028498ed920d9bae3edacf0f2dda1abcd61aacb94730dbc6d2664b46660d37bfd8bd43e62342b45229d6c5b1a470d4fe25", IpV4 UDP Socket: Some(167.172.244.51:9009), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "977420302e312e312d616c7068612e312d756e6b6e6f776e"), ("secp256k1", "a1020e3964928a77c421fa266607c261c20d581c9b4d7b3bd61092a41c40e8c2604c")] }}, retries: 0, failures: 0 }), receipts: Some(ContentStats { offered: {Enr { id: Some("v4"), seq: 1, NodeId: 0xc06b283ad920f1ec09172993c90e50e22536d21340f07999f1a61429658d7982, signature: "ef59bbcce2d23752dde16ebfbfc50f790196549181376e7c7cd4bb106b105c2d18cfb7fb54cef4e9585417021a072236b28d3f14346f5fb7cbfa8b74099e7022", IpV4 UDP Socket: Some(194.33.40.238:9129), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "66"), ("secp256k1", "a10360d388ab185a5f088080a616fabfe583ce218c40689ef112cd638b00b9c46d7d")] }, Enr { id: Some("v4"), seq: 1, NodeId: 0x51b33f6037cc1f2e83f7e320748c1c3e28bb6325f1b270c93de272800e367563, signature: "a0aa4c1af82a39266924d6740c8da110d12cf6d4fdaaa570397dc03aa089af73721c19e63d9a102f3f92c8d11eea4e65fb4e1c775e089f785fc96a962e6831dc", IpV4 UDP Socket: Some(194.33.40.239:9130), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "66"), ("secp256k1", "a1028a21eb99d290fe5442cfc1576bb63a4cc9443f39cca8bf88b28786615f12f3a4")] }, Enr { id: Some("v4"), seq: 8, NodeId: 0x572d6806aeaaf0074ce899de10d29df8349e594f4585e6d4deb3e1064b2a1fa3, signature: "362d72ae0e0d7bf4aede0a78bf8bd8c0e834536bf8c212f92a9b6796868e477508a5d99427a507d409014f4623bfb584247fd873c6b9d41e3629e3d37bd2e277", IpV4 UDP Socket: Some(137.184.149.229:9009), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "967420302e312e312d616c7068612e312d333365613939"), ("secp256k1", "a1039b01a489f1e7e20b4d393df102ff4d416cad65c5d1129f3695918cd8b8eb3b20")] }, Enr { id: Some("v4"), seq: 1, NodeId: 0x6fa256bfd92b51be52ab2c7bb6dd940f24dc9b10a75e56eec9d570edf1939834, signature: "1009a911fa388c606b1dea98084a51028498ed920d9bae3edacf0f2dda1abcd61aacb94730dbc6d2664b46660d37bfd8bd43e62342b45229d6c5b1a470d4fe25", IpV4 UDP Socket: Some(167.172.244.51:9009), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "977420302e312e312d616c7068612e312d756e6b6e6f776e"), ("secp256k1", "a1020e3964928a77c421fa266607c261c20d581c9b4d7b3bd61092a41c40e8c2604c")] }, Enr { id: Some("v4"), seq: 1, NodeId: 0x5dd2fba6c174a74cd815a884a7c33d92d79e6379ae2ffaaee749cdda0e2c922d, signature: "360577a0199af14a8235d053022500cb0fe2a1d493633d70040453d72a3e1f3f6d8fbc5de1de034af77ab32a81eb94faebf7f942e9203e76cb23e63d5f0d5320", IpV4 UDP Socket: Some(194.33.40.239:9113), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "66"), ("secp256k1", "a103fc811d766eadbc555d614f42e1f428a188d612370705a8837f39a5f62eb5371b")] }, Enr { id: Some("v4"), seq: 8, NodeId: 0x5d89843cd35753ba791665ac6ff5fb1bec44ae0a90d4a7a9c8c94f9f26ced0c6, signature: "1ec4fc4a2fde79b0e79de0d5040875040fc79f981d56d649efa7c722ca612c8d04d0812086883f7643ee81b51a825a305fa43e9bee9f8461652ffdbfcb5a2f32", IpV4 UDP Socket: Some(146.190.24.41:9009), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "967420302e312e312d616c7068612e312d343736636237"), ("secp256k1", "a103ebd5139cd03782ec48c83378280c9d219021490cea370b986899524d3e9a385a")] }, Enr { id: Some("v4"), seq: 7, NodeId: 0x54dd39b782ab69cf2a403c1a5d47533f86f6b9425dd9e1391acac2ad352f5974, signature: "e9774882fd500ad1e56bc6b7d228603f59d2339c0c62dd8b8ae2c7c1e32b07f623da5144183f15e3409c0c9e7cfd89374d7717916540fe446fabcb69e02e7a6f", IpV4 UDP Socket: Some(178.128.253.63:9009), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "967420302e312e312d616c7068612e312d333365613939"), ("secp256k1", "a103c73a6718f35d1ac0d63727b135233b3a1fe64aadb69ff58ce4d9330f4e4139d3")] }, Enr { id: Some("v4"), seq: 1, NodeId: 0x53f08e3cf92b770155d107aec8e95a4e5f8ce18f651579adcf53732b03ee9bbe, signature: "c35c1585731a5b5173703b1541fe4551a218732d67890751a9b5a800d1ca048f6ebc1247f49c3b0cf0aa307797dcc42627a968d39395a33eba1bf41273f8f596", IpV4 UDP Socket: Some(194.33.40.238:9106), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "66"), ("secp256k1", "a10236266c94ad788b80853180471b13e41ff677556b1d7f7660d0ae6dd90ba7311f")] }}, accepted: {Enr { id: Some("v4"), seq: 1, NodeId: 0x6fa256bfd92b51be52ab2c7bb6dd940f24dc9b10a75e56eec9d570edf1939834, signature: "1009a911fa388c606b1dea98084a51028498ed920d9bae3edacf0f2dda1abcd61aacb94730dbc6d2664b46660d37bfd8bd43e62342b45229d6c5b1a470d4fe25", IpV4 UDP Socket: Some(167.172.244.51:9009), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "977420302e312e312d616c7068612e312d756e6b6e6f776e"), ("secp256k1", "a1020e3964928a77c421fa266607c261c20d581c9b4d7b3bd61092a41c40e8c2604c")] }}, transferred: {Enr { id: Some("v4"), seq: 1, NodeId: 0x6fa256bfd92b51be52ab2c7bb6dd940f24dc9b10a75e56eec9d570edf1939834, signature: "1009a911fa388c606b1dea98084a51028498ed920d9bae3edacf0f2dda1abcd61aacb94730dbc6d2664b46660d37bfd8bd43e62342b45229d6c5b1a470d4fe25", IpV4 UDP Socket: Some(167.172.244.51:9009), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "977420302e312e312d616c7068612e312d756e6b6e6f776e"), ("secp256k1", "a1020e3964928a77c421fa266607c261c20d581c9b4d7b3bd61092a41c40e8c2604c")] }}, retries: 0, failures: 0 }), epoch_accumulator: None }, poisoned: false, .. }
```

### How was it fixed?
Switched to using custom `Debug` and `Display` trait implementations to calculate messages.

```
2024-03-19T14:02:46.731657Z  INFO portal_bridge::stats: GossipReport: block#819224: receipts - offered: 8, accepted: 0, transferred: 0, retries: 0, failures: 0
2024-03-19T14:02:46.731664Z DEBUG portal_bridge::stats: GossipReport: block#819224: receipts -
offered: ["enr:-Ia4QFfVRbe-OnWtSeu9g72727T_CUKkHFYo7JUe_9MDNdVmMl1iQWc86idKjabxtQwNmDz0l2ESIhoqkctvl2CxGDwBY2aCaWSCdjSCaXCEwiEo7olzZWNwMjU2azGhAxLctFdulBjEOLnS6-4E3zdND4Zxnh05UFMjp_DOzF6cg3VkcIIjnw", "enr:-Jy4QJ-yoSEm-IhttrN_2_IEq_gRbcK5_yKh2XlPfw1H1bXjRQFANON2rJ5tAe-z42sRvl9rmXOeyO3xLgYicuQVdUwIY5Z0IDAuMS4xLWFscGhhLjEtNDc2Y2I3gmlkgnY0gmlwhLKA_pSJc2VjcDI1NmsxoQIOLxw1JFLpS6HbZaZictMXic-RFgIzmal9dUHcQSrKQYN1ZHCCIzE", "enr:-Jy4QKsbcrMkTv6MgOWyyokKRonKaAYufLtABLl4xvCzQvPNdsJZX2GDoCcyWzgo0uObbHu5v5zyDjvckJFPxOUhdPcIY5Z0IDAuMS4xLWFscGhhLjEtNDc2Y2I3gmlkgnY0gmlwhJO2oc6Jc2VjcDI1NmsxoQLMSGVlxXL62N3sPtaV-n_TbZFCEM5AR7RDyIwOadbQK4N1ZHCCIyg", "enr:-Ia4QAKxL3pM0pPDPo_UI1ZAR-mX1zOnHp4wbs3SwqDh5Rt_QWu_PhZd3XkoZVawd7y7IGVXyVBy6eQn2NCzxB42YVEBY2aCaWSCdjSCaXCEwiEo7olzZWNwMjU2azGhAp6NX9PKx57aZJ4INTO7a7aSOJiMqrDXxM0DA84H5H3kg3VkcIIjmQ", "enr:-Ia4QC1GNiI0ahvdTWL8B0CcESS4HZT_Y6uJHYv7AL_eALZlBdD-ZBDZa_OkvQMCHKfVxPoqnLlfm9fkJoRf1G399KsBY2aCaWSCdjSCaXCEwiEo7olzZWNwMjU2azGhA4fDkSIwe4yXcnQV8TnoSbLntr11FBqthZPO7samfMidg3VkcIIjlQ", "enr:-Ia4QJRngZgMQubg38Og5VBhyjInMr-NosIObKo4Bhcw767vGBqiA-WUP2OTnOiwFdlMQhbOEvy15Qtzc1tr61bnQJsBY2aCaWSCdjSCaXCEwiEo7olzZWNwMjU2azGhAurgsIaBMmqDmGeNpvfK8Sr8HvZElpESqTnrWPnB2lFmg3VkcIIjlw", "enr:-Ia4QJXeYhdEij8b2G3rkjv5Fuo1og1cF3t73lWivGrqQ474cZwwbTqFW5MU0W-unimK7KjJ2tvK_chjngaBKXZE7ZgBY2aCaWSCdjSCaXCEwiEo74lzZWNwMjU2azGhAoY24QoOpxep2mvxfXWlm4RrimjQCllKp4ZYNaP7_H46g3VkcIIjow", "enr:-Ia4QOKCO-2S9SOHixw9mW684_NYmpF5e4oWLV-Mu2yzOwL6fd_VgEZXHvLNCcRKTPiFWFWkXIjPfYDlJwQMlp-jQtsBY2aCaWSCdjSCaXCEwiEo7olzZWNwMjU2azGhAiDOdo5yZNdn8-zokbmUQy_12HyyMlSbj4LU7rafjAOng3VkcIIjkw"]
accepted: []
transferred: []
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
