### PR TITLE
feat(bridge): launch bridge with custom discovery and http ports

### DIFF
--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -2,13 +2,15 @@ use std::{net::SocketAddr, path::PathBuf, str::FromStr};
 
 use clap::{Parser, Subcommand};
 use ethereum_types::H256;
-use ethportal_api::types::cli::check_private_key_length;
 use tokio::process::Child;
 use url::Url;
 
 use crate::{
     client_handles::{fluffy_handle, trin_handle},
     types::{mode::BridgeMode, network::NetworkKind},
+};
+use ethportal_api::types::cli::{
+    check_private_key_length, DEFAULT_DISCOVERY_PORT, DEFAULT_WEB3_HTTP_PORT,
 };
 
 // max value of 16 b/c...
@@ -95,6 +97,20 @@ pub struct BridgeConfig {
         help = "Data provider for consensus layer data. (\"pandaops\" / local node url)"
     )]
     pub cl_provider: Provider,
+
+    #[arg(
+        default_value_t = DEFAULT_DISCOVERY_PORT,
+        long = "base-discovery-port",
+        help = "The UDP port to listen on. If more than one node is launched, the additional ports will be incremented by 1."
+    )]
+    pub base_discovery_port: u16,
+
+    #[arg(
+        default_value_t = DEFAULT_WEB3_HTTP_PORT,
+        long = "base-rpc-port",
+        help = "The base jsonrpc port to listen on. If more than one node is launched, the additional ports will be incremented by 1."
+    )]
+    pub base_rpc_port: u16,
 }
 
 fn check_node_count(val: &str) -> Result<u8, String> {

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -4,10 +4,7 @@ use clap::Parser;
 use tokio::time::{sleep, Duration};
 use tracing::Instrument;
 
-use ethportal_api::{
-    jsonrpsee::http_client::{HttpClient, HttpClientBuilder},
-    types::cli::{DEFAULT_DISCOVERY_PORT, DEFAULT_WEB3_HTTP_PORT},
-};
+use ethportal_api::jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use portal_bridge::{
     api::{consensus::ConsensusApi, execution::ExecutionApi},
     bridge::{beacon::BeaconBridge, era1::Era1Bridge, history::HistoryBridge},
@@ -28,8 +25,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut handles = vec![];
     let mut http_addresses = vec![];
     for (i, key) in private_keys.into_iter().enumerate() {
-        let web3_http_port = DEFAULT_WEB3_HTTP_PORT + i as u16;
-        let discovery_port = DEFAULT_DISCOVERY_PORT + i as u16;
+        let web3_http_port = bridge_config.base_rpc_port + i as u16;
+        let discovery_port = bridge_config.base_discovery_port + i as u16;
         let handle = bridge_config.client_type.build_handle(
             key,
             web3_http_port,


### PR DESCRIPTION
### What was wrong?
Our bridge is currently stuck inbetween two paradigms. 
- a single bridge gossiping via a single node
- a single bridge gossiping via more than one nodes

Personally, I'd like to only support the first use case. Especially, if you want to run two bridges in different modes (as I do). But, that's a different discussion. This pr basically allows for a user to run two bridges from the same machine, which isn't possible unless you can configure the discovery port.

### How was it fixed?
- added ability to customize discovery port & http port via cli
- custom http port is not necessarily a feature I need, but it's so closely related to the discovery port, that I figured it was better to update the functionality for both ports to maintain consistency

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
