### PR TITLE
refactor: remove RwLock from History/Beacon rpc handler

### DIFF
--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -16,7 +16,7 @@ use ethportal_api::{
 };
 use portalnet::overlay::errors::OverlayRequestError;
 use serde_json::{json, Value};
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::mpsc;
 use tracing::error;
 use trin_storage::ContentStore;
 
@@ -24,7 +24,7 @@ use crate::network::BeaconNetwork;
 
 /// Handles Beacon network JSON-RPC requests
 pub struct BeaconRequestHandler {
-    pub network: Arc<RwLock<BeaconNetwork>>,
+    pub network: Arc<BeaconNetwork>,
     pub rpc_rx: mpsc::UnboundedReceiver<BeaconJsonRpcRequest>,
 }
 
@@ -39,7 +39,7 @@ impl BeaconRequestHandler {
 }
 
 /// Generates a response for a given request and sends it to the receiver.
-async fn complete_request(network: Arc<RwLock<BeaconNetwork>>, request: BeaconJsonRpcRequest) {
+async fn complete_request(network: Arc<BeaconNetwork>, request: BeaconJsonRpcRequest) {
     let response: Result<Value, String> = match request.endpoint {
         BeaconEndpoint::LocalContent(content_key) => local_content(network, content_key).await,
         BeaconEndpoint::PaginateLocalContentKeys(offset, limit) => {
@@ -56,7 +56,7 @@ async fn complete_request(network: Arc<RwLock<BeaconNetwork>>, request: BeaconJs
         }
         BeaconEndpoint::AddEnr(enr) => add_enr(network, enr).await,
         BeaconEndpoint::DataRadius => {
-            let radius = network.read().await.overlay.data_radius();
+            let radius = network.overlay.data_radius();
             Ok(json!(*radius))
         }
         BeaconEndpoint::DeleteEnr(node_id) => delete_enr(network, node_id).await,
@@ -77,7 +77,7 @@ async fn complete_request(network: Arc<RwLock<BeaconNetwork>>, request: BeaconJs
         }
         BeaconEndpoint::Ping(enr) => ping(network, enr).await,
         BeaconEndpoint::RoutingTableInfo => {
-            serde_json::to_value(network.read().await.overlay.routing_table_info())
+            serde_json::to_value(network.overlay.routing_table_info())
                 .map_err(|err| err.to_string())
         }
         BeaconEndpoint::RecursiveFindNodes(node_id) => recursive_find_nodes(network, node_id).await,
@@ -87,13 +87,12 @@ async fn complete_request(network: Arc<RwLock<BeaconNetwork>>, request: BeaconJs
 
 /// Constructs a JSON call for the RecursiveFindContent method.
 async fn recursive_find_content(
-    network: Arc<RwLock<BeaconNetwork>>,
+    network: Arc<BeaconNetwork>,
     content_key: BeaconContentKey,
     is_trace: bool,
 ) -> Result<Value, String> {
     // Check whether we have the data locally.
-    let overlay = network.read().await.overlay.clone();
-    let local_content: Option<Vec<u8>> = match overlay.store.read().get(&content_key) {
+    let local_content: Option<Vec<u8>> = match network.overlay.store.read().get(&content_key) {
         Ok(Some(data)) => Some(data),
         Ok(None) => None,
         Err(err) => {
@@ -107,13 +106,14 @@ async fn recursive_find_content(
     };
     let (content_bytes, utp_transfer, trace) = match local_content {
         Some(val) => {
-            let local_enr = overlay.local_enr();
-            let mut trace = QueryTrace::new(&overlay.local_enr(), content_key.content_id());
+            let local_enr = network.overlay.local_enr();
+            let mut trace = QueryTrace::new(&network.overlay.local_enr(), content_key.content_id());
             trace.node_responded_with_content(&local_enr);
             (val, false, if is_trace { Some(trace) } else { None })
         }
         // data is not available locally, make network request
-        None => match overlay
+        None => match network
+            .overlay
             .lookup_content(content_key.clone(), is_trace)
             .await
             .map_err(|err| err.to_string())?
@@ -166,11 +166,10 @@ async fn recursive_find_content(
 
 /// Constructs a JSON call for the LocalContent method.
 async fn local_content(
-    network: Arc<RwLock<BeaconNetwork>>,
+    network: Arc<BeaconNetwork>,
     content_key: BeaconContentKey,
 ) -> Result<Value, String> {
-    let store = network.read().await.overlay.store.clone();
-    let response = match store.read().get(&content_key)
+    let response = match network.overlay.store.read().get(&content_key)
         {
             Ok(val) => match val {
                 Some(val) => {
@@ -187,12 +186,11 @@ async fn local_content(
 
 /// Constructs a JSON call for the PaginateLocalContentKeys method.
 async fn paginate_local_content_keys(
-    network: Arc<RwLock<BeaconNetwork>>,
+    network: Arc<BeaconNetwork>,
     offset: u64,
     limit: u64,
 ) -> Result<Value, String> {
-    let store = network.read().await.overlay.store.clone();
-    let response = match store.read().paginate(&offset, &limit)
+    let response = match network.overlay.store.read().paginate(&offset, &limit)
         {
             Ok(val) => Ok(json!(val)),
             Err(err) => Err(format!(
@@ -204,13 +202,14 @@ async fn paginate_local_content_keys(
 
 /// Constructs a JSON call for the Store method.
 async fn store(
-    network: Arc<RwLock<BeaconNetwork>>,
+    network: Arc<BeaconNetwork>,
     content_key: BeaconContentKey,
     content_value: BeaconContentValue,
 ) -> Result<Value, String> {
     let data = content_value.encode();
-    let store = network.read().await.overlay.store.clone();
-    let response = match store
+    let response = match network
+        .overlay
+        .store
         .write()
         .put::<BeaconContentKey, Vec<u8>>(content_key, data)
     {
@@ -222,36 +221,32 @@ async fn store(
 
 /// Constructs a JSON call for the AddEnr method.
 async fn add_enr(
-    network: Arc<RwLock<BeaconNetwork>>,
+    network: Arc<BeaconNetwork>,
     enr: discv5::enr::Enr<discv5::enr::CombinedKey>,
 ) -> Result<Value, String> {
-    let overlay = network.read().await.overlay.clone();
-    match overlay.add_enr(enr) {
+    match network.overlay.add_enr(enr) {
         Ok(_) => Ok(json!(true)),
         Err(err) => Err(format!("AddEnr failed: {err:?}")),
     }
 }
 
 /// Constructs a JSON call for the GetEnr method.
-async fn get_enr(network: Arc<RwLock<BeaconNetwork>>, node_id: NodeId) -> Result<Value, String> {
-    let overlay = network.read().await.overlay.clone();
-    match overlay.get_enr(node_id) {
+async fn get_enr(network: Arc<BeaconNetwork>, node_id: NodeId) -> Result<Value, String> {
+    match network.overlay.get_enr(node_id) {
         Ok(enr) => Ok(json!(enr)),
         Err(err) => Err(format!("GetEnr failed: {err:?}")),
     }
 }
 
 /// Constructs a JSON call for the deleteEnr method.
-async fn delete_enr(network: Arc<RwLock<BeaconNetwork>>, node_id: NodeId) -> Result<Value, String> {
-    let overlay = network.read().await.overlay.clone();
-    let is_deleted = overlay.delete_enr(node_id);
+async fn delete_enr(network: Arc<BeaconNetwork>, node_id: NodeId) -> Result<Value, String> {
+    let is_deleted = network.overlay.delete_enr(node_id);
     Ok(json!(is_deleted))
 }
 
 /// Constructs a JSON call for the LookupEnr method.
-async fn lookup_enr(network: Arc<RwLock<BeaconNetwork>>, node_id: NodeId) -> Result<Value, String> {
-    let overlay = network.read().await.overlay.clone();
-    match overlay.lookup_enr(node_id).await {
+async fn lookup_enr(network: Arc<BeaconNetwork>, node_id: NodeId) -> Result<Value, String> {
+    match network.overlay.lookup_enr(node_id).await {
         Ok(enr) => Ok(json!(enr)),
         Err(err) => Err(format!("LookupEnr failed: {err:?}")),
     }
@@ -259,12 +254,11 @@ async fn lookup_enr(network: Arc<RwLock<BeaconNetwork>>, node_id: NodeId) -> Res
 
 /// Constructs a JSON call for the FindContent method.
 async fn find_content(
-    network: Arc<RwLock<BeaconNetwork>>,
+    network: Arc<BeaconNetwork>,
     enr: discv5::enr::Enr<discv5::enr::CombinedKey>,
     content_key: BeaconContentKey,
 ) -> Result<Value, String> {
-    let overlay = network.read().await.overlay.clone();
-    match overlay.send_find_content(enr, content_key.into()).await {
+    match network.overlay.send_find_content(enr, content_key.into()).await {
         Ok((content, utp_transfer)) => match content{
             Content::ConnectionId(id) => Err(format!(
                 "FindContent request returned a connection id ({id:?}) instead of conducting utp transfer."
@@ -283,12 +277,11 @@ async fn find_content(
 
 /// Constructs a JSON call for the FindNodes method.
 async fn find_nodes(
-    network: Arc<RwLock<BeaconNetwork>>,
+    network: Arc<BeaconNetwork>,
     enr: discv5::enr::Enr<discv5::enr::CombinedKey>,
     distances: Vec<u16>,
 ) -> Result<Value, String> {
-    let overlay = network.read().await.overlay.clone();
-    match overlay.send_find_nodes(enr, distances).await {
+    match network.overlay.send_find_nodes(enr, distances).await {
         Ok(nodes) => Ok(json!(nodes
             .enrs
             .into_iter()
@@ -300,32 +293,37 @@ async fn find_nodes(
 
 /// Constructs a JSON call for the Gossip method.
 async fn gossip(
-    network: Arc<RwLock<BeaconNetwork>>,
+    network: Arc<BeaconNetwork>,
     content_key: BeaconContentKey,
     content_value: BeaconContentValue,
     is_trace: bool,
 ) -> Result<Value, String> {
     let data = content_value.encode();
-    let overlay = network.read().await.overlay.clone();
     match is_trace {
         true => Ok(json!(
-            overlay.propagate_gossip_trace(content_key, data).await
+            network
+                .overlay
+                .propagate_gossip_trace(content_key, data)
+                .await
         )),
-        false => Ok(overlay.propagate_gossip(vec![(content_key, data)]).into()),
+        false => Ok(network
+            .overlay
+            .propagate_gossip(vec![(content_key, data)])
+            .into()),
     }
 }
 
 /// Constructs a JSON call for the Offer method.
 async fn offer(
-    network: Arc<RwLock<BeaconNetwork>>,
+    network: Arc<BeaconNetwork>,
     enr: discv5::enr::Enr<discv5::enr::CombinedKey>,
     content_key: BeaconContentKey,
     content_value: Option<BeaconContentValue>,
 ) -> Result<Value, String> {
-    let overlay = network.read().await.overlay.clone();
     if let Some(content_value) = content_value {
         let content_value = content_value.encode();
-        match overlay
+        match network
+            .overlay
             .send_populated_offer(enr, content_key.into(), content_value)
             .await
         {
@@ -336,7 +334,7 @@ async fn offer(
         }
     } else {
         let content_key: Vec<RawContentKey> = vec![content_key.to_bytes()];
-        match overlay.send_offer(content_key, enr).await {
+        match network.overlay.send_offer(content_key, enr).await {
             Ok(accept) => Ok(json!(AcceptInfo {
                 content_keys: accept.content_keys,
             })),
@@ -347,11 +345,10 @@ async fn offer(
 
 /// Constructs a JSON call for the Ping method.
 async fn ping(
-    network: Arc<RwLock<BeaconNetwork>>,
+    network: Arc<BeaconNetwork>,
     enr: discv5::enr::Enr<discv5::enr::CombinedKey>,
 ) -> Result<Value, String> {
-    let overlay = network.read().await.overlay.clone();
-    match overlay.send_ping(enr).await {
+    match network.overlay.send_ping(enr).await {
         Ok(pong) => Ok(json!(PongInfo {
             enr_seq: pong.enr_seq,
             data_radius: *Distance::from(pong.custom_payload),
@@ -362,10 +359,9 @@ async fn ping(
 
 /// Constructs a JSON call for the RecursiveFindNodes method.
 async fn recursive_find_nodes(
-    network: Arc<RwLock<BeaconNetwork>>,
+    network: Arc<BeaconNetwork>,
     node_id: NodeId,
 ) -> Result<Value, String> {
-    let overlay = network.read().await.overlay.clone();
-    let nodes = overlay.lookup_node(node_id).await;
+    let nodes = network.overlay.lookup_node(node_id).await;
     Ok(json!(nodes))
 }

--- a/trin-beacon/src/lib.rs
+++ b/trin-beacon/src/lib.rs
@@ -59,11 +59,11 @@ pub async fn initialize_beacon_network(
     )
     .await?;
     let beacon_event_stream = beacon_network.overlay.event_stream().await?;
+    let beacon_network = Arc::new(beacon_network);
     let beacon_handler = BeaconRequestHandler {
-        network: Arc::new(RwLock::new(beacon_network.clone())),
+        network: beacon_network.clone(),
         rpc_rx: beacon_jsonrpc_rx,
     };
-    let beacon_network = Arc::new(beacon_network);
     let beacon_network_task =
         spawn_beacon_network(beacon_network.clone(), portalnet_config, beacon_message_rx);
     spawn_beacon_heartbeat(beacon_network);

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -61,11 +61,11 @@ pub async fn initialize_history_network(
     )
     .await?;
     let event_stream = history_network.overlay.event_stream().await?;
+    let history_network = Arc::new(history_network);
     let history_handler = HistoryRequestHandler {
-        network: Arc::new(RwLock::new(history_network.clone())),
+        network: history_network.clone(),
         history_rx: history_jsonrpc_rx,
     };
-    let history_network = Arc::new(history_network);
     let history_network_task =
         spawn_history_network(history_network.clone(), portalnet_config, history_event_rx);
     spawn_history_heartbeat(history_network);


### PR DESCRIPTION
### What was wrong?
As said here https://github.com/ethereum/trin/pull/1215#discussion_r1527267279 we also don't need the RwLock held on the rpc handler for the beacon and history rpc handler's
### How was it fixed?

By removing the rwlock
