### PR TITLE
feat: add pagination to the id_indexed_v1 store

### DIFF
--- a/trin-state/src/storage.rs
+++ b/trin-state/src/storage.rs
@@ -4,6 +4,7 @@ use ethportal_api::{
         content_value::state::{ContractBytecode, TrieNode},
         distance::Distance,
         portal_wire::ProtocolId,
+        state::PaginateLocalContentInfo,
     },
     ContentValue, OverlayContentKey, StateContentKey, StateContentValue,
 };
@@ -79,6 +80,20 @@ impl StateStorage {
         };
         Ok(Self {
             store: create_store(ContentType::State, config, sql_connection_pool)?,
+        })
+    }
+
+    /// Returns a paginated list of all locally available content keys, according to the provided
+    /// offset and limit.
+    pub fn paginate(
+        &self,
+        offset: u64,
+        limit: u64,
+    ) -> Result<PaginateLocalContentInfo, ContentStoreError> {
+        let paginate_result = self.store.paginate(offset, limit)?;
+        Ok(PaginateLocalContentInfo {
+            content_keys: paginate_result.content_keys,
+            total_entries: paginate_result.entry_count,
         })
     }
 

--- a/trin-storage/src/versioned/id_indexed_v1/sql.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/sql.rs
@@ -81,6 +81,16 @@ pub fn lookup_farthest(content_type: &ContentType) -> String {
     )
 }
 
+pub fn paginate(content_type: &ContentType) -> String {
+    format!(
+        "SELECT content_key FROM {}
+        ORDER BY content_key
+        LIMIT :limit
+        OFFSET :offset",
+        table_name(content_type)
+    )
+}
+
 pub fn entry_count_and_size(content_type: &ContentType) -> String {
     format!(
         "SELECT COUNT(*) as count, TOTAL(content_size) as used_capacity FROM {}",


### PR DESCRIPTION
### What was wrong?

The `id_indexed_v1` store didn't support pagination.
This is a requirement before transitioning history storage to this store as well.

### How was it fixed?

Implemented pagination and using it from state network.
I added tests and tested JSON api locally.

### To-Do
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
