### PR TITLE
Display correct Trin version in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,6 +1439,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
+name = "const_format"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,6 +2596,7 @@ dependencies = [
  "base64 0.13.1",
  "bytes 1.6.0",
  "clap",
+ "const_format",
  "discv5",
  "env_logger 0.9.3",
  "eth_trie",
@@ -2609,6 +2631,7 @@ dependencies = [
  "tracing-subscriber",
  "tree_hash",
  "tree_hash_derive",
+ "trin-utils",
  "ureq",
  "url",
  "validator",
@@ -3084,6 +3107,19 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "git2"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "glob"
@@ -3664,6 +3700,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_debug"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3943,6 +3985,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330f0e13e6483b8c34885f7e6c9f19b1a7bd449c673fbb948a51c99d66ef74f4"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4013,6 +4070,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.16.2+1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4035,6 +4104,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -4420,6 +4501,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.58",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -6515,6 +6605,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "shadow-rs"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7960cbd6ba74691bb15e7ebf97f7136bd02d1115f5695a58c1f31d5645750128"
+dependencies = [
+ "const_format",
+ "git2",
+ "is_debug",
+ "time 0.3.34",
+ "tzdb",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7143,7 +7246,9 @@ checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -7814,6 +7919,7 @@ version = "0.1.1-alpha.1"
 dependencies = [
  "ansi_term",
  "atty",
+ "shadow-rs",
  "tracing-subscriber",
 ]
 
@@ -7873,6 +7979,35 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "tz-rs"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
+dependencies = [
+ "const_fn",
+]
+
+[[package]]
+name = "tzdb"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b580f6b365fa89f5767cdb619a55d534d04a4e14c2d7e5b9a31e94598687fb1"
+dependencies = [
+ "iana-time-zone",
+ "tz-rs",
+ "tzdb_data",
+]
+
+[[package]]
+name = "tzdb_data"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1889fdffac09d65c1d95c42d5202e9b21ad8c758f426e9fe09088817ea998d6"
+dependencies = [
+ "tz-rs",
+]
 
 [[package]]
 name = "ucd-trie"

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1.0.68"
 base64 = "0.13.0"
 bytes = "1.3.0"
 clap = { version = "4.2.1", features = ["derive"] }
+const_format = {version = "0.2.0", features = ["rust_1_64"]}
 discv5 = { version = "0.4.1", features = ["serde"] }
 eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "11ec003e3276e1413f06328ab746af5d99f112bb" }
 ethereum_serde_utils = { git = "https://github.com/KolbyML/ethereum_serde_utils.git", rev = "b0f9fcf3ed6a983561925f1b520a725cfe2191f2" }
@@ -45,6 +46,7 @@ ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "e2af01ba6
 thiserror = "1.0.57"
 tree_hash = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }
 tree_hash_derive = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }
+trin-utils = { path = "../trin-utils" }
 tokio = { version = "1.14.0", features = ["full"] }
 ureq = { version = "2.5.0", features = ["json"] }
 url = "2.3.1"

--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -5,6 +5,7 @@ use clap::{
     Args, Parser, Subcommand,
 };
 use std::{env, ffi::OsString, fmt, net::SocketAddr, path::PathBuf, str::FromStr};
+use trin_utils::build_info;
 use url::Url;
 
 use crate::types::bootnodes::Bootnodes;
@@ -52,13 +53,29 @@ impl FromStr for Web3TransportType {
     }
 }
 
+const APP_NAME: &str = "trin";
+const VERSION: &str = const_format::formatcp!(
+    "{version}-{hash} {build_os} {rust_version}",
+    // Remove -alpha.1 versioning if it is present.
+    // This must be done as it can conflict with eth versioning
+    version = const_format::str_split!(build_info::PKG_VERSION, '-')[0],
+    hash = build_info::short_commit(),
+    build_os = build_info::BUILD_OS,
+    // the rust version looks like that:
+    // rustc 1.77.0 (aedd173a2 2024-03-17)
+    // we remove everything in the brackets and replace spaces with nothing
+    rust_version = const_format::str_replace!(
+        const_format::str_split!(build_info::RUST_VERSION, '(')[0],
+        ' ',
+        ""
+    )
+);
+
 #[derive(Parser, Debug, PartialEq, Clone)]
-#[command(
-    name = "trin",
-    version = "0.0.1",
-    author = "carver",
-    about = "Run an eth portal client"
-)]
+#[command(name = APP_NAME,
+    author = "https://github.com/ethereum/trin/graphs/contributors",
+    about = "Run an eth portal client",
+    version = VERSION)]
 pub struct TrinConfig {
     #[arg(
         default_value = DEFAULT_WEB3_TRANSPORT,

--- a/portalnet/src/events.rs
+++ b/portalnet/src/events.rs
@@ -122,15 +122,21 @@ impl PortalnetEvents {
 
         match protocol_id {
             Ok(protocol) => match protocol {
-                ProtocolId::History => {
-                    self.send_overlay_request(&self.history_handle.tx, request.into(), "history")
-                }
-                ProtocolId::Beacon => {
-                    self.send_overlay_request(&self.beacon_handle.tx, request.into(), "beacon")
-                }
-                ProtocolId::State => {
-                    self.send_overlay_request(&self.state_handle.tx, request.into(), "state")
-                }
+                ProtocolId::History => self.send_overlay_request(
+                    self.history_handle.tx.as_ref(),
+                    request.into(),
+                    "history",
+                ),
+                ProtocolId::Beacon => self.send_overlay_request(
+                    self.beacon_handle.tx.as_ref(),
+                    request.into(),
+                    "beacon",
+                ),
+                ProtocolId::State => self.send_overlay_request(
+                    self.state_handle.tx.as_ref(),
+                    request.into(),
+                    "state",
+                ),
                 ProtocolId::Utp => {
                     if let Err(err) = self.utp_talk_reqs.send(request) {
                         error!(%err, "Error forwarding talk request to uTP socket");
@@ -166,19 +172,27 @@ impl PortalnetEvents {
         }
 
         if recipients.contains(&ProtocolId::Beacon) {
-            self.send_overlay_request(&self.beacon_handle.tx, Event(event.clone()), "beacon");
+            self.send_overlay_request(
+                self.beacon_handle.tx.as_ref(),
+                Event(event.clone()),
+                "beacon",
+            );
         }
         if recipients.contains(&ProtocolId::State) {
-            self.send_overlay_request(&self.state_handle.tx, Event(event.clone()), "state");
+            self.send_overlay_request(self.state_handle.tx.as_ref(), Event(event.clone()), "state");
         }
         if recipients.contains(&ProtocolId::History) {
-            self.send_overlay_request(&self.history_handle.tx, Event(event.clone()), "history");
+            self.send_overlay_request(
+                self.history_handle.tx.as_ref(),
+                Event(event.clone()),
+                "history",
+            );
         }
     }
 
     fn send_overlay_request(
         &self,
-        tx: &Option<mpsc::UnboundedSender<OverlayRequest>>,
+        tx: Option<&mpsc::UnboundedSender<OverlayRequest>>,
         msg: OverlayRequest,
         dest: &'static str,
     ) {

--- a/trin-utils/Cargo.toml
+++ b/trin-utils/Cargo.toml
@@ -12,7 +12,11 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 build = "build.rs"
 
 [dependencies]
+shadow-rs = "0.27"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
+
+[build-dependencies]
+shadow-rs = "0.27"
 
 [target.'cfg(windows)'.dependencies]
 # The crates for detecting whether the terminal supports colors are OS-specific.

--- a/trin-utils/src/lib.rs
+++ b/trin-utils/src/lib.rs
@@ -4,3 +4,5 @@
 pub mod log;
 pub mod submodules;
 pub mod version;
+
+shadow_rs::shadow!(build_info);

--- a/trin-utils/src/version.rs
+++ b/trin-utils/src/version.rs
@@ -1,12 +1,6 @@
-pub const TRIN_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const TRIN_VERSION: &str = crate::build_info::PKG_VERSION;
 
 /// Returns the trin version and git revision.
-pub fn get_trin_version() -> String {
-    let git_hash = env!("GIT_HASH");
-    let git_revision_short = if git_hash.len() == 40 {
-        git_hash[..6].to_string()
-    } else {
-        "unknown".to_string()
-    };
-    format!("{TRIN_VERSION}-{git_revision_short}")
+pub const fn get_trin_version() -> &'static str {
+    crate::build_info::short_commit()
 }


### PR DESCRIPTION
### What was wrong?
This PR resolves one issue and adds a small improvement.
The improvement is small; it replaces the ref Option with Option ref. It might seem unreasonable, but from the API standpoint, the ref option leaks implementation details; on the other hand, option ref just asks for optional data.

Resolves: [#9](https://github.com/ethereum/trin/issues/995)

### How was it fixed?
The shadow_rs collects data at compile time; I use this data to generate a `VERSION` const that is embedded in the clap library.
Everything is working on compile time.

### Example
```
yurtur@pc:~/projects/trin$ cargo run -- --version | tail -1 | sed "s/ /\//g"
    Finished dev [unoptimized + debuginfo] target(s) in 0.44s
     Running `target/debug/trin --version`
trin/0.2.2-e66c5c2c/linux-x86_64/rustc1.77.0
```

### To-Do
[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
