### PR TITLE
feat: migrate history to id_indexed_v1 store

### DIFF
--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -196,7 +196,7 @@ async fn paginate_local_content_keys(
     offset: u64,
     limit: u64,
 ) -> Result<Value, String> {
-    let response = match network.overlay.store.read().paginate(&offset, &limit)
+    let response = match network.overlay.store.read().paginate(offset, limit)
         {
             Ok(val) => Ok(json!(val)),
             Err(err) => Err(format!(

--- a/trin-storage/src/versioned/id_indexed_v1/migration.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/migration.rs
@@ -1,4 +1,4 @@
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::{
     error::ContentStoreError,
@@ -19,7 +19,7 @@ pub fn migrate_legacy_history_store(
     }
     let content_type = &config.content_type;
 
-    debug!(content_type = %content_type, "Migration started");
+    info!(content_type = %content_type, "Migration started");
 
     let new_table_name = sql::table_name(content_type);
 
@@ -56,7 +56,7 @@ pub fn migrate_legacy_history_store(
     })?;
     update_usage_stats(&conn, content_type, &usage_stats)?;
 
-    debug!(content_type = %content_type, "Migrating finished");
+    info!(content_type = %content_type, "Migration finished");
     Ok(())
 }
 

--- a/trin-storage/src/versioned/id_indexed_v1/migration.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/migration.rs
@@ -1,3 +1,5 @@
+use tracing::debug;
+
 use crate::{
     error::ContentStoreError,
     versioned::{
@@ -17,15 +19,34 @@ pub fn migrate_legacy_history_store(
     }
     let content_type = &config.content_type;
 
-    // Rename old table and drop old indicies (they can't be renamed).
+    debug!(content_type = %content_type, "Migration started");
+
+    let new_table_name = sql::table_name(content_type);
+
+    // Rename table
+    debug!(content_type = %content_type, "Renaming table: history -> {new_table_name}");
     config.sql_connection_pool.get()?.execute_batch(&format!(
-        "ALTER TABLE history RENAME TO {};
-        DROP INDEX history_distance_short_idx;
+        "ALTER TABLE history RENAME TO {};",
+        new_table_name
+    ))?;
+
+    // Drop old indicies (they can't be renamed)
+    debug!(content_type = %content_type, "Dropping old indices");
+    config.sql_connection_pool.get()?.execute_batch(
+        "DROP INDEX history_distance_short_idx;
         DROP INDEX history_content_size_idx;",
-        sql::table_name(content_type)
+    )?;
+
+    // Create new indicies
+    debug!(content_type = %content_type, "Creating new indices");
+    config.sql_connection_pool.get()?.execute_batch(&format!(
+        "CREATE INDEX IF NOT EXISTS {0}_distance_short_idx ON {0} (distance_short);
+        CREATE INDEX IF NOT EXISTS {0}_content_size_idx ON {0} (content_size);",
+        new_table_name
     ))?;
 
     // Update usage stats
+    debug!(content_type = %content_type, "Updating usage stats");
     let conn = config.sql_connection_pool.get()?;
     let usage_stats = conn.query_row(&sql::entry_count_and_size(content_type), [], |row| {
         Ok(UsageStats {
@@ -35,6 +56,7 @@ pub fn migrate_legacy_history_store(
     })?;
     update_usage_stats(&conn, content_type, &usage_stats)?;
 
+    debug!(content_type = %content_type, "Migrating finished");
     Ok(())
 }
 


### PR DESCRIPTION
### What was wrong?

History storage is still using the legacy store.

### How was it fixed?

This PR migrates it to the new storage scheme.

Remaining work afterwards will be to remove legacy store and cleanup code where applicable.

### To-Do

- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
