### PR TITLE
bugfix: broken blob transaction ssz decoding

### DIFF
--- a/ethportal-api/src/types/execution/block_body.rs
+++ b/ethportal-api/src/types/execution/block_body.rs
@@ -339,6 +339,8 @@ impl Decodable for BlockBodyMerge {
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct BlockBodyShanghai {
     pub txs: Vec<Transaction>,
+    // post-shanghai block bodies are expected to have empty uncles, but we skip that here
+    // and simply encode an empty list during the encoding/decoding process
     pub withdrawals: Vec<Withdrawal>,
 }
 
@@ -395,6 +397,7 @@ impl ssz::Decode for BlockBodyShanghai {
                     "Shanghai block body contains invalid transactions: {e:?}",
                 ))
             })?;
+        // shanghai block bodies are expected to have empty uncles
         let uncles = rlp::decode_list::<Header>(&uncles);
         if !uncles.is_empty() {
             return Err(ssz::DecodeError::BytesInvalid(

--- a/ethportal-api/src/types/execution/transaction.rs
+++ b/ethportal-api/src/types/execution/transaction.rs
@@ -61,7 +61,7 @@ impl Decodable for Transaction {
             TransactionId::EIP1559 => Ok(Self::EIP1559(rlp::decode(&rlp.as_raw()[1..])?)),
             TransactionId::AccessList => Ok(Self::AccessList(rlp::decode(&rlp.as_raw()[1..])?)),
             TransactionId::Legacy => Ok(Self::Legacy(rlp::decode(rlp.as_raw())?)),
-            TransactionId::Blob => Ok(Self::Blob(rlp::decode(rlp.as_raw())?)),
+            TransactionId::Blob => Ok(Self::Blob(rlp::decode(&rlp.as_raw()[1..])?)),
         }
     }
 }

--- a/portal-bridge/src/types/full_header.rs
+++ b/portal-bridge/src/types/full_header.rs
@@ -120,6 +120,7 @@ mod tests {
         BlockBody, BlockBodyLegacy, BlockBodyShanghai,
     };
     use serde_json::Value;
+    use ssz::{Decode, Encode};
 
     #[test]
     fn full_header_from_get_block_response() {
@@ -179,6 +180,10 @@ mod tests {
             withdrawals: full_header.withdrawals.unwrap(),
         });
         block_body.validate_against_header(&header).unwrap();
+        // test ssz roundtrip
+        let ssz = block_body.as_ssz_bytes();
+        let decoded_block_body = BlockBody::from_ssz_bytes(&ssz).unwrap();
+        assert_eq!(block_body, decoded_block_body);
     }
 
     #[test_log::test]


### PR DESCRIPTION
### What was wrong?
Bug in blob transaction ssz decoding was preventing glados from hitting 100% on block bodies.

### How was it fixed?
Fixed broken decoding and added test case.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
