### PR TITLE
fix: era1 typed-(transaction/receipt) encode/decode (open-ethereum/rlp version)

### DIFF
--- a/portal-bridge/src/types/era1.rs
+++ b/portal-bridge/src/types/era1.rs
@@ -1,11 +1,7 @@
 use crate::types::e2s::{E2StoreFile, Entry};
 use anyhow::ensure;
 use ethereum_types::{H256, U256};
-use ethportal_api::types::execution::{
-    block_body::BlockBody,
-    header::Header,
-    receipts::{LegacyReceipt, Receipt, Receipts},
-};
+use ethportal_api::types::execution::{block_body::BlockBody, header::Header, receipts::Receipts};
 use std::{
     fs,
     io::{Read, Write},
@@ -263,12 +259,7 @@ impl TryFrom<&Entry> for ReceiptsEntry {
         let mut decoder = snap::read::FrameDecoder::new(&entry.value[..]);
         let mut buf: Vec<u8> = vec![];
         decoder.read_to_end(&mut buf)?;
-        let encoded_receipts: Vec<LegacyReceipt> = rlp::decode_list(&buf);
-        let receipt_list = encoded_receipts
-            .iter()
-            .map(|r| Receipt::Legacy(r.clone()))
-            .collect();
-        let receipts = Receipts { receipt_list };
+        let receipts: Receipts = rlp::decode(&buf)?;
         Ok(Self { receipts })
     }
 }

--- a/portalnet/src/gossip.rs
+++ b/portalnet/src/gossip.rs
@@ -211,7 +211,7 @@ pub async fn trace_propagate_gossip_cross_thread<TContentKey: OverlayContentKey>
 /// Filter all nodes from overlay routing table where XOR_distance(content_id, nodeId) < node radius
 fn calculate_interested_enrs<TContentKey: OverlayContentKey>(
     content_key: &TContentKey,
-    all_nodes: &Vec<&kbucket::Node<NodeId, Node>>,
+    all_nodes: &[&kbucket::Node<NodeId, Node>],
 ) -> Vec<Enr> {
     // HashMap to temporarily store all interested ENRs and the content.
     // Key is base64 string of node's ENR.
@@ -219,8 +219,7 @@ fn calculate_interested_enrs<TContentKey: OverlayContentKey>(
     // Filter all nodes from overlay routing table where XOR_distance(content_id, nodeId) < node
     // radius
     let mut interested_enrs: Vec<Enr> = all_nodes
-        .clone()
-        .into_iter()
+        .iter()
         .filter(|node| {
             XorMetric::distance(&content_key.content_id(), &node.key.preimage().raw())
                 < node.value.data_radius()

--- a/portalnet/src/overlay/protocol.rs
+++ b/portalnet/src/overlay/protocol.rs
@@ -749,7 +749,7 @@ where
     }
 }
 
-fn validate_find_nodes_distances(distances: &Vec<u16>) -> Result<(), OverlayRequestError> {
+fn validate_find_nodes_distances(distances: &[u16]) -> Result<(), OverlayRequestError> {
     if distances.is_empty() {
         return Err(OverlayRequestError::InvalidRequest(
             "Invalid distances: Empty list".to_string(),

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -2630,7 +2630,7 @@ where
 }
 
 fn decode_and_validate_content_payload<TContentKey>(
-    accepted_keys: &Vec<TContentKey>,
+    accepted_keys: &[TContentKey],
     payload: Vec<u8>,
 ) -> anyhow::Result<Vec<Vec<u8>>> {
     let content_values = portal_wire::decode_content_payload(payload)?;


### PR DESCRIPTION
| open-ethereum/rlp version  | reth's alloy/rlp version  |
|---|---|
| ![image](https://github.com/ethereum/trin/assets/31669092/c288d6bc-fad8-47f7-b6af-0d9c87af5def) Runtime 220.35s : peak ram usage 3.9GB | ![image](https://github.com/ethereum/trin/assets/31669092/fb641d5f-702f-4c4b-91a7-c45db08fd44d) Runtime 60.52s : peak ram usage 3.2GB |

open-ethereum/rlp is 220.35s/60.52s = 3.64 times lower then reth's alloy/rlp
It also uses much more ram.

I don't think it makes sense to use this when `reth's alloy/rlp version` is already implemented and switching to alloy provides many more advantages.

The work is done already, it just doesn't make sense to keep using open-ethereum rlp. It being dog slow just displays this even more.

`reth's alloy/rlp` is based off fast-rlp developed by the now defunct Rust Ethereum Execution Client named Akula. It is indeed fast.