### PR TITLE
chore: depend on public ethereum_ssz and ethereum_serde_utils crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "const-hex",
  "derive_more",
- "ethereum_ssz 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum_ssz",
  "getrandom 0.2.12",
  "hex-literal",
  "itoa",
@@ -2268,9 +2268,10 @@ dependencies = [
 [[package]]
 name = "ethereum_serde_utils"
 version = "0.5.2"
-source = "git+https://github.com/KolbyML/ethereum_serde_utils.git?rev=b0f9fcf3ed6a983561925f1b520a725cfe2191f2#b0f9fcf3ed6a983561925f1b520a725cfe2191f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de4d5951468846963c24e8744c133d44f39dff2cd3a233f6be22b370d08a524f"
 dependencies = [
- "alloy-primitives",
+ "ethereum-types",
  "hex",
  "serde",
  "serde_derive",
@@ -2289,19 +2290,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethereum_ssz"
-version = "0.5.3"
-source = "git+https://github.com/KolbyML/ethereum_ssz.git?rev=364a2d93229e638b72c99186cbc2a56590585151#364a2d93229e638b72c99186cbc2a56590585151"
-dependencies = [
- "alloy-primitives",
- "itertools 0.10.5",
- "smallvec 1.13.2",
-]
-
-[[package]]
 name = "ethereum_ssz_derive"
 version = "0.5.3"
-source = "git+https://github.com/KolbyML/ethereum_ssz.git?rev=364a2d93229e638b72c99186cbc2a56590585151#364a2d93229e638b72c99186cbc2a56590585151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6085d7fd3cf84bd2b8fec150d54c8467fb491d8db9c460607c5534f653a0ee38"
 dependencies = [
  "darling 0.13.4",
  "proc-macro2",
@@ -2579,7 +2571,7 @@ dependencies = [
  "env_logger 0.9.3",
  "eth_trie",
  "ethereum_serde_utils",
- "ethereum_ssz 0.5.3 (git+https://github.com/KolbyML/ethereum_ssz.git?rev=364a2d93229e638b72c99186cbc2a56590585151)",
+ "ethereum_ssz",
  "ethereum_ssz_derive",
  "ethnum",
  "hex",
@@ -2621,7 +2613,7 @@ dependencies = [
  "alloy-primitives",
  "anyhow",
  "discv5",
- "ethereum_ssz 0.5.3 (git+https://github.com/KolbyML/ethereum_ssz.git?rev=364a2d93229e638b72c99186cbc2a56590585151)",
+ "ethereum_ssz",
  "ethportal-api",
  "futures 0.3.30",
  "hex",
@@ -4931,7 +4923,7 @@ dependencies = [
  "clap",
  "discv5",
  "env_logger 0.9.3",
- "ethereum_ssz 0.5.3 (git+https://github.com/KolbyML/ethereum_ssz.git?rev=364a2d93229e638b72c99186cbc2a56590585151)",
+ "ethereum_ssz",
  "ethereum_ssz_derive",
  "ethportal-api",
  "futures 0.3.30",
@@ -4972,7 +4964,7 @@ dependencies = [
  "directories",
  "discv5",
  "env_logger 0.9.3",
- "ethereum_ssz 0.5.3 (git+https://github.com/KolbyML/ethereum_ssz.git?rev=364a2d93229e638b72c99186cbc2a56590585151)",
+ "ethereum_ssz",
  "ethereum_ssz_derive",
  "ethportal-api",
  "fnv",
@@ -5771,7 +5763,7 @@ dependencies = [
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "bytes 1.6.0",
- "ethereum_ssz 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum_ssz",
  "fastrlp",
  "num-bigint",
  "num-traits",
@@ -6714,11 +6706,11 @@ dependencies = [
 [[package]]
 name = "ssz_types"
 version = "0.6.0"
-source = "git+https://github.com/KolbyML/ssz_types.git?rev=e2af01ba6b9b255880fe2a0def6a6bb81bc66c9a#e2af01ba6b9b255880fe2a0def6a6bb81bc66c9a"
+source = "git+https://github.com/morph-dev/kolby_ssz_types.git?rev=e6129bf860cea549a510281222a13154f3370ac1#e6129bf860cea549a510281222a13154f3370ac1"
 dependencies = [
  "derivative",
  "ethereum_serde_utils",
- "ethereum_ssz 0.5.3 (git+https://github.com/KolbyML/ethereum_ssz.git?rev=364a2d93229e638b72c99186cbc2a56590585151)",
+ "ethereum_ssz",
  "itertools 0.10.5",
  "serde",
  "serde_derive",
@@ -7649,7 +7641,7 @@ dependencies = [
  "clap",
  "dirs",
  "discv5",
- "ethereum_ssz 0.5.3 (git+https://github.com/KolbyML/ethereum_ssz.git?rev=364a2d93229e638b72c99186cbc2a56590585151)",
+ "ethereum_ssz",
  "ethers",
  "ethers-core",
  "ethers-providers",
@@ -7693,7 +7685,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "discv5",
- "ethereum_ssz 0.5.3 (git+https://github.com/KolbyML/ethereum_ssz.git?rev=364a2d93229e638b72c99186cbc2a56590585151)",
+ "ethereum_ssz",
  "ethportal-api",
  "light-client",
  "parking_lot 0.11.2",
@@ -7720,8 +7712,7 @@ dependencies = [
  "anyhow",
  "discv5",
  "env_logger 0.9.3",
- "ethereum_serde_utils",
- "ethereum_ssz 0.5.3 (git+https://github.com/KolbyML/ethereum_ssz.git?rev=364a2d93229e638b72c99186cbc2a56590585151)",
+ "ethereum_ssz",
  "ethportal-api",
  "parking_lot 0.11.2",
  "portalnet",
@@ -7825,8 +7816,7 @@ dependencies = [
  "alloy-rlp",
  "anyhow",
  "eth2_hashing",
- "ethereum_serde_utils",
- "ethereum_ssz 0.5.3 (git+https://github.com/KolbyML/ethereum_ssz.git?rev=364a2d93229e638b72c99186cbc2a56590585151)",
+ "ethereum_ssz",
  "ethereum_ssz_derive",
  "ethportal-api",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6706,7 +6706,7 @@ dependencies = [
 [[package]]
 name = "ssz_types"
 version = "0.6.0"
-source = "git+https://github.com/morph-dev/kolby_ssz_types.git?rev=e6129bf860cea549a510281222a13154f3370ac1#e6129bf860cea549a510281222a13154f3370ac1"
+source = "git+https://github.com/KolbyML/ssz_types.git?rev=2a5922de75f00746890bf4ea9ad663c9d5d58efe#2a5922de75f00746890bf4ea9ad663c9d5d58efe"
 dependencies = [
  "derivative",
  "ethereum_serde_utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0.68"
 clap = { version = "4.2.1", features = ["derive"] }
 dirs = "5.0.1"
 discv5 = { version = "0.4.1", features = ["serde"] }
-ethereum_ssz = { git = "https://github.com/KolbyML/ethereum_ssz.git", rev = "364a2d93229e638b72c99186cbc2a56590585151" }
+ethereum_ssz = "0.5.3"
 ethers = { version = "2.0"}
 ethers-providers = { version = "2.0", features = ["ws"] }
 ethportal-api = { path = "ethportal-api" }

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -41,7 +41,7 @@ sha2 = "0.10.1"
 sha3 = "0.9.1"
 snap = "1.1.0"
 superstruct = "0.7.0"
-ssz_types = { git = "https://github.com/morph-dev/kolby_ssz_types.git", rev = "e6129bf860cea549a510281222a13154f3370ac1" }
+ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "2a5922de75f00746890bf4ea9ad663c9d5d58efe" }
 thiserror = "1.0.57"
 tree_hash = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }
 tree_hash_derive = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography::cryptocurrencies"]
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-primitives = "0.7.0"
+alloy-primitives = { version = "0.7.0", features = ["ssz"] }
 alloy-rlp = "0.3.4"
 anyhow = "1.0.68"
 base64 = "0.13.0"
@@ -19,9 +19,9 @@ bytes = "1.3.0"
 clap = { version = "4.2.1", features = ["derive"] }
 discv5 = { version = "0.4.1", features = ["serde"] }
 eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "11ec003e3276e1413f06328ab746af5d99f112bb" }
-ethereum_serde_utils = { git = "https://github.com/KolbyML/ethereum_serde_utils.git", rev = "b0f9fcf3ed6a983561925f1b520a725cfe2191f2" }
-ethereum_ssz = { git = "https://github.com/KolbyML/ethereum_ssz.git", rev = "364a2d93229e638b72c99186cbc2a56590585151" }
-ethereum_ssz_derive = { git = "https://github.com/KolbyML/ethereum_ssz.git", rev = "364a2d93229e638b72c99186cbc2a56590585151" }
+ethereum_serde_utils = "0.5.2"
+ethereum_ssz = "0.5.3"
+ethereum_ssz_derive = "0.5.3"
 ethnum = "1.3.2"
 hex = "0.4.3"
 jsonrpsee = {version="0.20.0", features = ["async-client", "client", "macros", "server"]}
@@ -41,7 +41,7 @@ sha2 = "0.10.1"
 sha3 = "0.9.1"
 snap = "1.1.0"
 superstruct = "0.7.0"
-ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "e2af01ba6b9b255880fe2a0def6a6bb81bc66c9a" }
+ssz_types = { git = "https://github.com/morph-dev/kolby_ssz_types.git", rev = "e6129bf860cea549a510281222a13154f3370ac1" }
 thiserror = "1.0.57"
 tree_hash = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }
 tree_hash_derive = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }

--- a/ethportal-api/src/types/consensus/serde.rs
+++ b/ethportal-api/src/types/consensus/serde.rs
@@ -1,7 +1,6 @@
 use alloy_primitives::U256;
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serializer};
 use serde_json::Value;
-use serde_utils::u256_from_dec_str::u256_from_dec_str;
 use ssz_types::VariableList;
 
 use super::body::{Transaction, Transactions};
@@ -34,7 +33,7 @@ where
         Some(val) => val,
         None => return Err(serde::de::Error::custom("Unable to deserialize u256")),
     };
-    let result = u256_from_dec_str(result).map_err(serde::de::Error::custom)?;
+    let result = U256::from_str_radix(result, 10).map_err(serde::de::Error::custom)?;
     Ok(result)
 }
 

--- a/ethportal-api/src/types/execution/receipts.rs
+++ b/ethportal-api/src/types/execution/receipts.rs
@@ -516,7 +516,6 @@ mod tests {
 
     use alloy_primitives::U256;
     use serde_json::json;
-    use serde_utils::u256_from_dec_str::u256_from_dec_str;
     use ssz::{Decode, Encode};
 
     use crate::utils::bytes::hex_encode;
@@ -772,7 +771,7 @@ mod tests {
         };
         assert_eq!(
             receipt.cumulative_gas_used,
-            u256_from_dec_str("579367").unwrap()
+            U256::from_str_radix("579367", 10).unwrap()
         );
     }
 
@@ -783,7 +782,7 @@ mod tests {
         let receipt: Receipt = serde_json::from_value(response).unwrap();
         assert_eq!(
             receipt.cumulative_gas_used,
-            u256_from_dec_str("189807").unwrap()
+            U256::from_str_radix("189807", 10).unwrap()
         );
     }
 

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 alloy-primitives = "0.7.0"
 anyhow = "1.0.68"
 discv5 = { version = "0.4.1", features = ["serde"] }
-ethereum_ssz = { git = "https://github.com/KolbyML/ethereum_ssz.git", rev = "364a2d93229e638b72c99186cbc2a56590585151" }
+ethereum_ssz = "0.5.3"
 ethportal-api = { path="../ethportal-api"}
 futures = "0.3.21"
 hex = "0.4.3"

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0.85"
 serde_yaml = "0.9"
 serde-this-or-that = "0.4.2"
 ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "d09f55b4f8554491e3431e01af1c32347a8781cd" }
-ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "e2af01ba6b9b255880fe2a0def6a6bb81bc66c9a" }
+ssz_types = { git = "https://github.com/morph-dev/kolby_ssz_types.git", rev = "e6129bf860cea549a510281222a13154f3370ac1" }
 strum = { version = "0.26.1", features = ["derive"] }
 thiserror = "1.0.57"
 tokio = { version = "1", features = ["full"] }

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0.85"
 serde_yaml = "0.9"
 serde-this-or-that = "0.4.2"
 ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "d09f55b4f8554491e3431e01af1c32347a8781cd" }
-ssz_types = { git = "https://github.com/morph-dev/kolby_ssz_types.git", rev = "e6129bf860cea549a510281222a13154f3370ac1" }
+ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "2a5922de75f00746890bf4ea9ad663c9d5d58efe" }
 strum = { version = "0.26.1", features = ["derive"] }
 thiserror = "1.0.57"
 tokio = { version = "1", features = ["full"] }

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0.150", features = ["derive", "rc"] }
 serde_json = "1.0.89"
 serde_yaml = "0.9"
 snap = "1.1.1"
-ssz_types = { git = "https://github.com/morph-dev/kolby_ssz_types.git", rev = "e6129bf860cea549a510281222a13154f3370ac1" }
+ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "2a5922de75f00746890bf4ea9ad663c9d5d58efe" }
 surf = { version = "2.3.2", default-features = false, features = ["h1-client-rustls", "middleware-logger", "encoding"] } # we use rustils because OpenSSL cause issues compiling on aarch64
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -20,8 +20,8 @@ chrono = "0.4.26"
 clap = { version = "4.2.1", features = ["derive"] }
 discv5 = { version = "0.4.1", features = ["serde"] }
 ethportal-api = { path = "../ethportal-api" }
-ethereum_ssz = { git = "https://github.com/KolbyML/ethereum_ssz.git", rev = "364a2d93229e638b72c99186cbc2a56590585151" }
-ethereum_ssz_derive = { git = "https://github.com/KolbyML/ethereum_ssz.git", rev = "364a2d93229e638b72c99186cbc2a56590585151" }
+ethereum_ssz = "0.5.3"
+ethereum_ssz_derive = "0.5.3"
 futures = "0.3.21"
 jsonrpsee = { version = "0.20.0", features = [
   "async-client",
@@ -38,7 +38,7 @@ serde = { version = "1.0.150", features = ["derive", "rc"] }
 serde_json = "1.0.89"
 serde_yaml = "0.9"
 snap = "1.1.1"
-ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "e2af01ba6b9b255880fe2a0def6a6bb81bc66c9a" }
+ssz_types = { git = "https://github.com/morph-dev/kolby_ssz_types.git", rev = "e6129bf860cea549a510281222a13154f3370ac1" }
 surf = { version = "2.3.2", default-features = false, features = ["h1-client-rustls", "middleware-logger", "encoding"] } # we use rustils because OpenSSL cause issues compiling on aarch64
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -37,7 +37,7 @@ rand = "0.8.4"
 serde = { version = "1.0.150", features = ["derive"] }
 serde_json = "1.0.89"
 smallvec = "1.8.0"
-ssz_types = { git = "https://github.com/morph-dev/kolby_ssz_types.git", rev = "e6129bf860cea549a510281222a13154f3370ac1" }
+ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "2a5922de75f00746890bf4ea9ad663c9d5d58efe" }
 stunclient = "0.1.2"
 tempfile = "3.3.0"
 thiserror = "1.0.57"

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -20,8 +20,8 @@ bytes = "1.3.0"
 delay_map = "0.3.0"
 directories = "3.0"
 discv5 = { version = "0.4.1", features = ["serde"] }
-ethereum_ssz = { git = "https://github.com/KolbyML/ethereum_ssz.git", rev = "364a2d93229e638b72c99186cbc2a56590585151" }
-ethereum_ssz_derive = { git = "https://github.com/KolbyML/ethereum_ssz.git", rev = "364a2d93229e638b72c99186cbc2a56590585151" }
+ethereum_ssz = "0.5.3"
+ethereum_ssz_derive = "0.5.3"
 ethportal-api = { path = "../ethportal-api" }
 fnv = "1.0.7"
 futures = "0.3.21"
@@ -37,7 +37,7 @@ rand = "0.8.4"
 serde = { version = "1.0.150", features = ["derive"] }
 serde_json = "1.0.89"
 smallvec = "1.8.0"
-ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "e2af01ba6b9b255880fe2a0def6a6bb81bc66c9a" }
+ssz_types = { git = "https://github.com/morph-dev/kolby_ssz_types.git", rev = "e6129bf860cea549a510281222a13154f3370ac1" }
 stunclient = "0.1.2"
 tempfile = "3.3.0"
 thiserror = "1.0.57"

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -22,7 +22,7 @@ r2d2_sqlite = "0.24.0"
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 light-client = { path = "../light-client" }
 serde_json = "1.0.89"
-ssz_types = { git = "https://github.com/morph-dev/kolby_ssz_types.git", rev = "e6129bf860cea549a510281222a13154f3370ac1" }
+ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "2a5922de75f00746890bf4ea9ad663c9d5d58efe" }
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
 trin-metrics = { path = "../trin-metrics" }

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 anyhow = "1.0.68"
 discv5 = { version = "0.4.1", features = ["serde"] }
-ethereum_ssz = { git = "https://github.com/KolbyML/ethereum_ssz.git", rev = "364a2d93229e638b72c99186cbc2a56590585151" }
+ethereum_ssz = "0.5.3"
 ethportal-api = { path = "../ethportal-api" }
 parking_lot = "0.11.2"
 portalnet = { path = "../portalnet" }
@@ -22,7 +22,7 @@ r2d2_sqlite = "0.24.0"
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 light-client = { path = "../light-client" }
 serde_json = "1.0.89"
-ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "e2af01ba6b9b255880fe2a0def6a6bb81bc66c9a" }
+ssz_types = { git = "https://github.com/morph-dev/kolby_ssz_types.git", rev = "e6129bf860cea549a510281222a13154f3370ac1" }
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
 trin-metrics = { path = "../trin-metrics" }

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -36,7 +36,7 @@ quickcheck = "1.0.3"
 rand = "0.8.4"
 rstest = "0.18.2"
 serial_test = "0.5.1"
-ssz_types = { git = "https://github.com/morph-dev/kolby_ssz_types.git", rev = "e6129bf860cea549a510281222a13154f3370ac1" }
+ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "2a5922de75f00746890bf4ea9ad663c9d5d58efe" }
 test-log = { version = "0.2.11", features = ["trace"] }
 tokio-test = "0.4.2"
 tracing-subscriber = "0.3.15"

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 alloy-primitives = "0.7.0"
 anyhow = "1.0.68"
 discv5 = { version = "0.4.1", features = ["serde"] }
-ethereum_ssz = { git = "https://github.com/KolbyML/ethereum_ssz.git", rev = "364a2d93229e638b72c99186cbc2a56590585151" }
+ethereum_ssz = "0.5.3"
 ethportal-api = {path = "../ethportal-api"}
 parking_lot = "0.11.2"
 portalnet = { path = "../portalnet" }
@@ -36,8 +36,7 @@ quickcheck = "1.0.3"
 rand = "0.8.4"
 rstest = "0.18.2"
 serial_test = "0.5.1"
-ethereum_serde_utils = { git = "https://github.com/KolbyML/ethereum_serde_utils.git", rev = "b0f9fcf3ed6a983561925f1b520a725cfe2191f2" }
-ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "e2af01ba6b9b255880fe2a0def6a6bb81bc66c9a" }
+ssz_types = { git = "https://github.com/morph-dev/kolby_ssz_types.git", rev = "e6129bf860cea549a510281222a13154f3370ac1" }
 test-log = { version = "0.2.11", features = ["trace"] }
 tokio-test = "0.4.2"
 tracing-subscriber = "0.3.15"

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -135,7 +135,6 @@ mod tests {
 
     use alloy_primitives::U256;
     use serde_json::Value;
-    use serde_utils::u256_from_dec_str::u256_from_dec_str;
     use ssz::Encode;
 
     use ethportal_api::{
@@ -245,7 +244,7 @@ mod tests {
 
         epoch_acc[0] = HeaderRecord {
             block_hash: B256::random(),
-            total_difficulty: u256_from_dec_str("0").unwrap(),
+            total_difficulty: U256::ZERO,
         };
         let invalid_content = epoch_acc.as_ssz_bytes();
 
@@ -266,7 +265,7 @@ mod tests {
 
         epoch_acc[0] = HeaderRecord {
             block_hash: B256::random(),
-            total_difficulty: u256_from_dec_str("0").unwrap(),
+            total_difficulty: U256::ZERO,
         };
         let content_key = HistoryContentKey::EpochAccumulator(EpochAccumulatorKey {
             epoch_hash: epoch_acc.tree_hash_root(),

--- a/trin-validation/Cargo.toml
+++ b/trin-validation/Cargo.toml
@@ -21,7 +21,7 @@ lazy_static = "1.4.0"
 rust-embed = "6.6.1"
 serde = { version = "1.0.150", features = ["derive"] }
 serde_json = "1.0.89"
-ssz_types = { git = "https://github.com/morph-dev/kolby_ssz_types.git", rev = "e6129bf860cea549a510281222a13154f3370ac1" }
+ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "2a5922de75f00746890bf4ea9ad663c9d5d58efe" }
 tokio = { version = "1.14.0", features = ["full"] }
 tree_hash = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }
 tree_hash_derive = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }

--- a/trin-validation/Cargo.toml
+++ b/trin-validation/Cargo.toml
@@ -11,18 +11,17 @@ description = "Validation layer for the Portal Network data."
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-primitives = "0.7.0"
+alloy-primitives = { version = "0.7.0", features = ["ssz"] }
 anyhow = "1.0.68"
 eth2_hashing = "0.2.0"
-ethereum_serde_utils = { git = "https://github.com/KolbyML/ethereum_serde_utils.git", rev = "b0f9fcf3ed6a983561925f1b520a725cfe2191f2" }
-ethereum_ssz = { git = "https://github.com/KolbyML/ethereum_ssz.git", rev = "364a2d93229e638b72c99186cbc2a56590585151" }
-ethereum_ssz_derive = { git = "https://github.com/KolbyML/ethereum_ssz.git", rev = "364a2d93229e638b72c99186cbc2a56590585151" }
+ethereum_ssz = "0.5.3"
+ethereum_ssz_derive = "0.5.3"
 ethportal-api = { path = "../ethportal-api" }
 lazy_static = "1.4.0"
 rust-embed = "6.6.1"
 serde = { version = "1.0.150", features = ["derive"] }
 serde_json = "1.0.89"
-ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "e2af01ba6b9b255880fe2a0def6a6bb81bc66c9a" }
+ssz_types = { git = "https://github.com/morph-dev/kolby_ssz_types.git", rev = "e6129bf860cea549a510281222a13154f3370ac1" }
 tokio = { version = "1.14.0", features = ["full"] }
 tree_hash = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }
 tree_hash_derive = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }

--- a/trin-validation/src/accumulator.rs
+++ b/trin-validation/src/accumulator.rs
@@ -244,11 +244,10 @@ mod test {
     use super::*;
     use std::{fs, str::FromStr};
 
-    use alloy_primitives::{Address, Bloom};
+    use alloy_primitives::{Address, Bloom, U256};
     use alloy_rlp::Decodable;
     use rstest::*;
     use serde_json::json;
-    use serde_utils::u256_from_dec_str::u256_from_dec_str;
     use ssz::Decode;
 
     use crate::constants::DEFAULT_MASTER_ACC_HASH;
@@ -396,10 +395,10 @@ mod test {
             transactions_root: B256::random(),
             receipts_root: B256::random(),
             logs_bloom: Bloom::ZERO,
-            difficulty: u256_from_dec_str("1").unwrap(),
+            difficulty: U256::from(1),
             number: *height,
-            gas_limit: u256_from_dec_str("1").unwrap(),
-            gas_used: u256_from_dec_str("1").unwrap(),
+            gas_limit: U256::from(1),
+            gas_used: U256::from(1),
             timestamp: 1,
             extra_data: vec![],
             mix_hash: None,


### PR DESCRIPTION
### What was wrong?

We had dependency on private fork of `ethereum_ssz` and `ethereum_serde_utils`.

### How was it fixed?

1. Adding `ssz` feature to `alloy-primitives` eliminated need for custom version of `ethereum_ssz`.

2. The custom function `u256_from_dec_str` from `ethereum_serde_utils` that Kolby added wasn't really needed because `alloy-primitives` has `U256::from_str_radix(...)`.

3. In order for everything to work, I also needed to fork @KolbyML 's `ssz_types` repo and make it depend on public `ethereum_ssz` and `ethereum_serde_utils` as well (commit [link](https://github.com/morph-dev/kolby_ssz_types/commit/e6129bf860cea549a510281222a13154f3370ac1)).
    - Going forward, we can merge my changes into his repo, as he is more likely to keep maintaining it long term.

This leaves us with only 3 non-public repos:
- [morph-dev/kolby_ssz_types](https://github.com/morph-dev/kolby_ssz_types/tree/alloy) - only trivial changes, we can merge them into @KolbyML 's repo
- [KolbyML/tree_hash](https://github.com/KolbyML/tree_hash/tree/alloy) - relatively simple changes
- [KolbyML/eth-trie.rs](https://github.com/KolbyML/eth-trie.rs/tree/trin2-alloy) - we can leave it for now as it is and evaluate as we progress with more work on state network

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
