### PR TITLE
fix: use correct column name in "on update" usage stats trigger

### DIFF
--- a/trin-storage/src/versioned/sql.rs
+++ b/trin-storage/src/versioned/sql.rs
@@ -67,7 +67,7 @@ pub fn create_usage_stats_triggers(
         FOR EACH ROW
         BEGIN
             UPDATE usage_stats
-            SET size = size - OLD.size + NEW.size
+            SET size = size - OLD.{entry_size_column} + NEW.{entry_size_column}
             WHERE content_type = '{content_type}';
         END;
 

--- a/trin-storage/src/versioned/usage_stats.rs
+++ b/trin-storage/src/versioned/usage_stats.rs
@@ -85,10 +85,11 @@ mod tests {
     use super::*;
 
     const TABLE_NAME: &str = "test";
-    const ENTRY_SIZE_COLUMN_NAME: &str = "size";
-    const TEST_TABLE_CREATE: &str = "CREATE TABLE test (id TEXT NOT NULL, size INTEGER NOT NULL)";
-    const TEST_TABLE_INSERT: &str = "INSERT INTO test (id, size) VALUES (?1, ?2)";
-    const TEST_TABLE_UPDATE: &str = "UPDATE test SET size = (?2) WHERE id = (?1)";
+    const ENTRY_SIZE_COLUMN_NAME: &str = "content_size";
+    const TEST_TABLE_CREATE: &str =
+        "CREATE TABLE test (id TEXT NOT NULL, content_size INTEGER NOT NULL)";
+    const TEST_TABLE_INSERT: &str = "INSERT INTO test (id, content_size) VALUES (?1, ?2)";
+    const TEST_TABLE_UPDATE: &str = "UPDATE test SET content_size = (?2) WHERE id = (?1)";
     const TEST_TABLE_DELETE: &str = "DELETE FROM test WHERE id = (?1)";
 
     fn setup_for_tests(temp_dir: &TempDir) -> Pool<SqliteConnectionManager> {


### PR DESCRIPTION
### What was wrong?

While looking into issue regarding #1235, I discovered the bug regarding usage stats "on update" trigger.
There was a test that was supposed to test this functionality but it was passing by chance.

### How was it fixed?

Updated the test (verified that it fails), fixed the code and verified that test passes.

The more correct approach would be to drop the trigger if it exists, and create new one with different name.
I think that this is overkill as this code is not yet used in public. The only exception are 5 machines that @KolbyML 's used while testing the #1235 (this [comment](https://github.com/ethereum/trin/pull/1235#issuecomment-2040483220) for context), which can he can fix by manually executing following query:

```sql
DROP TRIGGER ii1_history_on_update_update_usage_stats_trigger;
```

This PR should be merged before: #1235.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
