### PR TITLE
Add the block size and withdrawal fields to eth_getBlockByHash

### DIFF
--- a/ethportal-api/src/types/consensus/withdrawal.rs
+++ b/ethportal-api/src/types/consensus/withdrawal.rs
@@ -14,6 +14,17 @@ pub struct Withdrawal {
     pub amount: u64,
 }
 
+impl From<Withdrawal> for reth_rpc_types::Withdrawal {
+    fn from(val: Withdrawal) -> reth_rpc_types::Withdrawal {
+        reth_rpc_types::Withdrawal {
+            index: val.index,
+            validator_index: val.validator_index,
+            address: val.address,
+            amount: val.amount,
+        }
+    }
+}
+
 fn string_to_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
     D: Deserializer<'de>,

--- a/ethportal-api/src/types/execution/header.rs
+++ b/ethportal-api/src/types/execution/header.rs
@@ -146,6 +146,53 @@ impl Encodable for Header {
         header.encode(out);
         out.put_slice(list.as_slice());
     }
+
+    fn length(&self) -> usize {
+        let mut length = 0;
+        length += self.parent_hash.length();
+        length += self.uncles_hash.length();
+        length += self.author.length();
+        length += self.state_root.length();
+        length += self.transactions_root.length();
+        length += self.receipts_root.length();
+        length += self.logs_bloom.length();
+        length += self.difficulty.length();
+        length += U256::from(self.number).length();
+        length += U256::from(self.gas_limit).length();
+        length += U256::from(self.gas_used).length();
+        length += self.timestamp.length();
+        length += self.extra_data.length();
+
+        if let Some(mix_hash) = self.mix_hash {
+            length += mix_hash.length();
+        }
+
+        if let Some(nonce) = self.nonce {
+            length += B64::new(nonce.0).length();
+        }
+
+        if let Some(base_fee) = self.base_fee_per_gas {
+            length += base_fee.length();
+        }
+
+        if let Some(root) = self.withdrawals_root {
+            length += root.length();
+        }
+
+        if let Some(blob_gas_used) = self.blob_gas_used {
+            length += U256::from(blob_gas_used).length();
+        }
+
+        if let Some(excess_blob_gas) = self.excess_blob_gas {
+            length += U256::from(excess_blob_gas).length();
+        }
+
+        if let Some(parent_beacon_block_root) = self.parent_beacon_block_root {
+            length += parent_beacon_block_root.length();
+        }
+
+        alloy_rlp::length_of_length(length) + length
+    }
 }
 
 impl Decodable for Header {

--- a/tests/rpc_server.rs
+++ b/tests/rpc_server.rs
@@ -164,8 +164,15 @@ async fn test_eth_get_block_by_hash() {
     assert_eq!(block.gas_limit, gas_limit);
     assert_eq!(block.difficulty, difficulty);
     assert_eq!(block.timestamp, timestamp);
-    assert_eq!(block.size, None);
     assert_eq!(block.transactions.len(), shanghai_body.txs.len());
+    assert_eq!(
+        block
+            .withdrawals
+            .expect("withdrawals must be present")
+            .len(),
+        shanghai_body.withdrawals.len()
+    );
+    assert_eq!(block.size, Some(U256::from(37890)));
 
     // Spot check a few transaction hashes:
     // First tx


### PR DESCRIPTION
### What was wrong?

Resolves: [#960](https://github.com/ethereum/trin/issues/960)

### How was it fixed?

I have added length implementations for a couple of structs.
I added the `withdrawals` and `size` fields to eth_getBlockHash

I noticed that the implementation of transaction size wasn't evaluated correctly. As per default implementation, the length is calculated from encode().len(). 
Is it possible that transaction encoding is implemented incorrectly?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [X] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
