### PR TITLE
feat(bridge): make gossip limit a cli option

### DIFF
--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -7,6 +7,7 @@ use portal_bridge::{
     api::{consensus::ConsensusApi, execution::ExecutionApi},
     bridge::{beacon::BeaconBridge, history::HistoryBridge},
     cli::Provider,
+    constants::DEFAULT_GOSSIP_LIMIT,
     types::mode::BridgeMode,
 };
 use serde_json::Value;
@@ -31,6 +32,7 @@ pub async fn test_history_bridge(peertest: &Peertest, target: &HttpClient) {
         portal_clients,
         header_oracle,
         epoch_acc_path,
+        DEFAULT_GOSSIP_LIMIT,
     );
     bridge.launch().await;
     let (content_key, content_value) = fixture_header_with_proof_1000010();

--- a/portal-bridge/src/bridge/history.rs
+++ b/portal-bridge/src/bridge/history.rs
@@ -34,7 +34,6 @@ use trin_validation::{
 const HEADER_SATURATION_DELAY: u64 = 10; // seconds
 const LATEST_BLOCK_POLL_RATE: u64 = 5; // seconds
 pub const EPOCH_SIZE: u64 = EPOCH_SIZE_USIZE as u64;
-pub const GOSSIP_LIMIT: usize = 32;
 pub const SERVE_BLOCK_TIMEOUT: Duration = Duration::from_secs(120);
 
 pub struct HistoryBridge {
@@ -44,6 +43,7 @@ pub struct HistoryBridge {
     pub header_oracle: HeaderOracle,
     pub epoch_acc_path: PathBuf,
     pub metrics: BridgeMetricsReporter,
+    pub gossip_limit: usize,
 }
 
 impl HistoryBridge {
@@ -53,6 +53,7 @@ impl HistoryBridge {
         portal_clients: Vec<HttpClient>,
         header_oracle: HeaderOracle,
         epoch_acc_path: PathBuf,
+        gossip_limit: usize,
     ) -> Self {
         let metrics = BridgeMetricsReporter::new("history".to_string(), &format!("{mode:?}"));
         Self {
@@ -62,6 +63,7 @@ impl HistoryBridge {
             header_oracle,
             epoch_acc_path,
             metrics,
+            gossip_limit,
         }
     }
 }
@@ -175,7 +177,7 @@ impl HistoryBridge {
 
         // We are using a semaphore to limit the amount of active gossip transfers to make sure we
         // don't overwhelm the trin client
-        let gossip_send_semaphore = Arc::new(Semaphore::new(GOSSIP_LIMIT));
+        let gossip_send_semaphore = Arc::new(Semaphore::new(self.gossip_limit));
 
         info!("fetching headers in range: {gossip_range:?}");
         let mut epoch_acc = None;

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -7,6 +7,7 @@ use url::Url;
 
 use crate::{
     client_handles::{fluffy_handle, trin_handle},
+    constants::DEFAULT_GOSSIP_LIMIT,
     types::{mode::BridgeMode, network::NetworkKind},
 };
 use ethportal_api::types::cli::{
@@ -117,6 +118,13 @@ pub struct BridgeConfig {
         help = "The base jsonrpc port to listen on. If more than one node is launched, the additional ports will be incremented by 1."
     )]
     pub base_rpc_port: u16,
+
+    #[arg(
+        default_value_t = DEFAULT_GOSSIP_LIMIT,
+        long = "gossip-limit",
+        help = "The maximum number of active blocks being gossiped."
+    )]
+    pub gossip_limit: usize,
 }
 
 fn check_node_count(val: &str) -> Result<u8, String> {

--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -17,3 +17,6 @@ pub const BEACON_GENESIS_TIME: u64 = 1606824023;
 // This is a very conservative timeout if a provider takes longer than even 1 second it is probably
 // overloaded and not performing well
 pub const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+
+// This is the maximum number of active blocks being gossiped
+pub const DEFAULT_GOSSIP_LIMIT: usize = 32;

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -89,6 +89,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     portal_clients.expect("Failed to create history JSON-RPC clients"),
                     header_oracle,
                     bridge_config.epoch_acc_path,
+                    bridge_config.gossip_limit,
                 )
                 .await?;
                 let bridge_handle = tokio::spawn(async move {
@@ -113,6 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         portal_clients.expect("Failed to create history JSON-RPC clients"),
                         header_oracle,
                         bridge_config.epoch_acc_path,
+                        bridge_config.gossip_limit,
                     );
 
                     bridge


### PR DESCRIPTION
### What was wrong?
we have headroom on our era1 bridges which we can use to gossip more blocks simultaneously

### How was it fixed?
by adding a cli option to configure the constant