### PR TITLE
fix: add sleep to allow for header saturation in era1 gossip

### DIFF
--- a/portal-bridge/src/bridge/history.rs
+++ b/portal-bridge/src/bridge/history.rs
@@ -31,7 +31,7 @@ use trin_validation::{
 };
 
 // todo: calculate / test optimal saturation delay
-const HEADER_SATURATION_DELAY: u64 = 10; // seconds
+pub const HEADER_SATURATION_DELAY: u64 = 10; // seconds
 const LATEST_BLOCK_POLL_RATE: u64 = 5; // seconds
 pub const EPOCH_SIZE: u64 = EPOCH_SIZE_USIZE as u64;
 pub const SERVE_BLOCK_TIMEOUT: Duration = Duration::from_secs(120);


### PR DESCRIPTION
### What was wrong?
In our `history` gossip, we have a 10 second sleep after gossiping the header to allow for network saturation, since this header is necessary to validate the following receipts & body values. We are missing this sleep in `era1` gossip. Now, the effectiveness of this sleep & it's value are up for debate, but it seems to me like it's worthwhile to match this behavior inside `era1` gossip, at least until it's proven unnecessary.

### How was it fixed?
added sleep to `era1` gossip

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
