### PR TITLE
fix: latest bridge waiting for 2 new blocks before gossiping

### DIFF
--- a/portal-bridge/src/bridge/history.rs
+++ b/portal-bridge/src/bridge/history.rs
@@ -140,6 +140,12 @@ impl HistoryBridge {
                 last_seen_block_counter = 0;
                 info!("Discovered new blocks to gossip: {block_index}-{latest_block}");
             }
+            // `..=` is the inclusive range operator, it includes the right side of the range.
+            // Example: 1..=3 is equivalent to 1, 2, 3
+            // Where as: 1..3 is equivalent to 1, 2
+            // block_index will always contain the next block to be gossiped, so when we get a new
+            // latest_block from `get_latest_block_number()` it will gossip all blocks
+            // from block_index to latest_block.
             for height in block_index..=latest_block {
                 Self::spawn_serve_full_block(
                     height,

--- a/portal-bridge/src/bridge/history.rs
+++ b/portal-bridge/src/bridge/history.rs
@@ -1,5 +1,4 @@
 use std::{
-    ops::Range,
     path::PathBuf,
     sync::{Arc, Mutex},
 };
@@ -137,25 +136,21 @@ impl HistoryBridge {
                 }
             };
             last_seen_block_counter += 1;
-            if latest_block > block_index {
+            if latest_block >= block_index {
                 last_seen_block_counter = 0;
-                let gossip_range = Range {
-                    start: block_index,
-                    end: latest_block + 1,
-                };
-                info!("Discovered new blocks to gossip: {gossip_range:?}");
-                for height in gossip_range.clone() {
-                    Self::spawn_serve_full_block(
-                        height,
-                        None,
-                        self.portal_clients.clone(),
-                        self.execution_api.clone(),
-                        None,
-                        self.metrics.clone(),
-                    );
-                }
-                block_index = gossip_range.end;
+                info!("Discovered new blocks to gossip: {block_index}-{latest_block}");
             }
+            for height in block_index..=latest_block {
+                Self::spawn_serve_full_block(
+                    height,
+                    None,
+                    self.portal_clients.clone(),
+                    self.execution_api.clone(),
+                    None,
+                    self.metrics.clone(),
+                );
+            }
+            block_index = latest_block + 1;
             // Ethereum mainnet creates a new block every 15 seconds, if we don't get a new block
             // within 1 minute. There is a problem with the provider so throw an error.
             if last_seen_block_counter > 60 / LATEST_BLOCK_POLL_RATE {


### PR DESCRIPTION
### What was wrong?
![image](https://github.com/ethereum/trin/assets/31669092/7b0d4dd0-8085-4c62-9cd4-1947644ab09d)
The latest bridge was waiting for 2 new blocks before it started gossiping them. If you notice in the picture groups of 2 form due to this bug
### How was it fixed?
I choose to just use a loop because it was easier for me to read and understand, a Range was a little overkill so this simplification helped me fix the issue.

I tested it by copy pasting it into a test and replacing any function call with logs, then fixing it till I got the expected log output I was looking for.

It no longer has a delay in gossiping latest blocks.

### Before this is how our current code works
![image](https://github.com/ethereum/trin/assets/31669092/1a28be5a-745a-4096-a79c-3cd45dcbeb2d)


### After
![image](https://github.com/ethereum/trin/assets/31669092/3c0ce636-181e-4483-bf38-98568a19ec04)


I also tested in interops of 2,3 new blocks per loop {} and it is working as expected