### PR TITLE
feat(bridge): add metric for current block number

### DIFF
--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -190,6 +190,7 @@ impl Era1Bridge {
                 .acquire_owned()
                 .await
                 .expect("to be able to acquire semaphore");
+            self.metrics.report_current_block(block_number as i64);
             let serve_block_tuple_handle = Self::spawn_serve_block_tuple(
                 self.portal_clients.clone(),
                 block_tuple,

--- a/portal-bridge/src/bridge/history.rs
+++ b/portal-bridge/src/bridge/history.rs
@@ -147,6 +147,7 @@ impl HistoryBridge {
             // latest_block from `get_latest_block_number()` it will gossip all blocks
             // from block_index to latest_block.
             for height in block_index..=latest_block {
+                self.metrics.report_current_block(height as i64);
                 Self::spawn_serve_full_block(
                     height,
                     None,
@@ -206,6 +207,7 @@ impl HistoryBridge {
             let permit = gossip_send_semaphore.clone().acquire_owned().await.expect(
                 "acquire_owned() can only error on semaphore close, this should be impossible",
             );
+            self.metrics.report_current_block(height as i64);
             serve_full_block_handles.push(Self::spawn_serve_full_block(
                 height,
                 epoch_acc.clone(),

--- a/trin-metrics/src/bridge.rs
+++ b/trin-metrics/src/bridge.rs
@@ -15,6 +15,7 @@ pub struct BridgeMetrics {
     pub process_timer: HistogramVec,
     pub bridge_info: IntGaugeVec,
     pub gossip_total: IntCounterVec,
+    pub current_block: IntGaugeVec,
 }
 
 impl BridgeMetrics {
@@ -40,10 +41,19 @@ impl BridgeMetrics {
             &["bridge", "success", "type"],
             registry
         )?;
+        let current_block = register_int_gauge_vec_with_registry!(
+            opts!(
+                "bridge_current_block",
+                "the current block number the bridge is on"
+            ),
+            &["bridge"],
+            registry
+        )?;
         Ok(Self {
             process_timer,
             bridge_info,
             gossip_total,
+            current_block,
         })
     }
 }
@@ -90,5 +100,13 @@ impl BridgeMetricsReporter {
             .bridge_info
             .with_label_values(&labels)
             .inc();
+    }
+
+    pub fn report_current_block(&self, block_number: i64) {
+        let labels: [&str; 1] = [&self.bridge];
+        self.bridge_metrics
+            .current_block
+            .with_label_values(&labels)
+            .set(block_number);
     }
 }


### PR DESCRIPTION
### What was wrong?
we don't have enough bridge metrics

what block are we even on?
### How was it fixed?
by adding a current_bridge metric for the history bridge