### PR TITLE
refactor: rename master accumulator and accumulator proof

### DIFF
--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 use crate::types::bootnodes::Bootnodes;
 
-pub const DEFAULT_MASTER_ACC_PATH: &str = "validation_assets/merge_macc.bin";
+pub const DEFAULT_PRE_MERGE_ACC_PATH: &str = "validation_assets/merge_macc.bin";
 pub const DEFAULT_WEB3_IPC_PATH: &str = "/tmp/trin-jsonrpc.ipc";
 pub const DEFAULT_WEB3_HTTP_ADDRESS: &str = "http://127.0.0.1:8545/";
 pub const DEFAULT_WEB3_HTTP_PORT: u16 = 8545;
@@ -187,11 +187,11 @@ pub struct TrinConfig {
     pub ephemeral: bool,
 
     #[arg(
-        long = "master-accumulator-path",
-        help = "Path to master accumulator for validation",
-        default_value(DEFAULT_MASTER_ACC_PATH)
+        long = "pre-merge-accumulator-path",
+        help = "Path to pre-merge accumulator for validation",
+        default_value(DEFAULT_PRE_MERGE_ACC_PATH)
     )]
-    pub master_acc_path: PathBuf,
+    pub pre_merge_acc_path: PathBuf,
 
     #[arg(
         long = "disable-poke",
@@ -245,7 +245,7 @@ impl Default for TrinConfig {
                 .expect("Parsing static DEFAULT_STORAGE_CAPACITY_MB to work"),
             enable_metrics_with_url: None,
             ephemeral: false,
-            master_acc_path: PathBuf::from(DEFAULT_MASTER_ACC_PATH.to_string()),
+            pre_merge_acc_path: PathBuf::from(DEFAULT_PRE_MERGE_ACC_PATH.to_string()),
             disable_poke: false,
             ws: false,
             ws_port: DEFAULT_WEB3_WS_PORT,

--- a/ethportal-api/src/types/execution/header_with_proof.rs
+++ b/ethportal-api/src/types/execution/header_with_proof.rs
@@ -25,7 +25,7 @@ impl ssz::Encode for HeaderWithProof {
         let header = alloy_rlp::encode(&self.header);
         let header = ByteList2048::from(header);
         let offset = <ByteList2048 as Encode>::ssz_fixed_len()
-            + <AccumulatorProof as Encode>::ssz_fixed_len();
+            + <PreMergeAccumulatorProof as Encode>::ssz_fixed_len();
         let mut encoder = SszEncoder::container(buf, offset);
         encoder.append(&header);
         encoder.append(&self.proof);
@@ -45,13 +45,13 @@ impl ssz::Encode for HeaderWithProof {
 #[allow(clippy::large_enum_variant)]
 pub enum BlockHeaderProof {
     None(SszNone),
-    AccumulatorProof(AccumulatorProof),
+    PreMergeAccumulatorProof(PreMergeAccumulatorProof),
     HistoricalRootsBlockProof(HistoricalRootsBlockProof),
     HistoricalSummariesBlockProof(HistoricalSummariesBlockProof),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AccumulatorProof {
+pub struct PreMergeAccumulatorProof {
     pub proof: [B256; 15],
 }
 
@@ -78,7 +78,7 @@ impl ssz::Decode for HeaderWithProof {
     }
 }
 
-impl ssz::Decode for AccumulatorProof {
+impl ssz::Decode for PreMergeAccumulatorProof {
     fn is_ssz_fixed_len() -> bool {
         true
     }
@@ -96,7 +96,7 @@ impl ssz::Decode for AccumulatorProof {
     }
 }
 
-impl ssz::Encode for AccumulatorProof {
+impl ssz::Encode for PreMergeAccumulatorProof {
     fn is_ssz_fixed_len() -> bool {
         true
     }

--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -13,12 +13,12 @@ use serde_json::Value;
 use std::sync::Arc;
 use surf::{Client, Config};
 use tokio::time::{sleep, Duration};
-use trin_validation::{accumulator::MasterAccumulator, oracle::HeaderOracle};
+use trin_validation::{accumulator::PreMergeAccumulator, oracle::HeaderOracle};
 use url::Url;
 
 pub async fn test_history_bridge(peertest: &Peertest, target: &HttpClient) {
-    let master_acc = MasterAccumulator::default();
-    let header_oracle = HeaderOracle::new(master_acc);
+    let pre_merge_acc = PreMergeAccumulator::default();
+    let header_oracle = HeaderOracle::new(pre_merge_acc);
     let portal_clients = vec![target.clone()];
     let epoch_acc_path = "validation_assets/epoch_acc.bin".into();
     let mode = BridgeMode::Test("./test_assets/portalnet/bridge_data.json".into());

--- a/portal-bridge/src/api/execution.rs
+++ b/portal-bridge/src/api/execution.rs
@@ -17,7 +17,9 @@ use ethportal_api::{
                 BlockBody, BlockBodyLegacy, BlockBodyMerge, BlockBodyShanghai, MERGE_TIMESTAMP,
                 SHANGHAI_TIMESTAMP,
             },
-            header_with_proof::{AccumulatorProof, BlockHeaderProof, HeaderWithProof, SszNone},
+            header_with_proof::{
+                BlockHeaderProof, HeaderWithProof, PreMergeAccumulatorProof, SszNone,
+            },
         },
         jsonrpc::{params::Params, request::JsonRequest},
     },
@@ -346,7 +348,7 @@ pub async fn construct_proof(
     epoch_acc: &EpochAccumulator,
 ) -> anyhow::Result<HeaderWithProof> {
     let proof = PreMergeAccumulator::construct_proof(&header, epoch_acc)?;
-    let proof = BlockHeaderProof::AccumulatorProof(AccumulatorProof { proof });
+    let proof = BlockHeaderProof::PreMergeAccumulatorProof(PreMergeAccumulatorProof { proof });
     Ok(HeaderWithProof { header, proof })
 }
 

--- a/portal-bridge/src/bridge/history.rs
+++ b/portal-bridge/src/bridge/history.rs
@@ -347,7 +347,7 @@ impl HistoryBridge {
     ) -> anyhow::Result<Arc<EpochAccumulator>> {
         let (epoch_hash, epoch_acc) = lookup_epoch_acc(
             epoch_index,
-            &self.header_oracle.master_acc,
+            &self.header_oracle.pre_merge_acc,
             &self.epoch_acc_path,
         )
         .await?;

--- a/portal-bridge/src/bridge/utils.rs
+++ b/portal-bridge/src/bridge/utils.rs
@@ -3,15 +3,15 @@ use anyhow::anyhow;
 use ethportal_api::{types::execution::accumulator::EpochAccumulator, utils::bytes::hex_encode};
 use ssz::Decode;
 use std::{fs, path::Path};
-use trin_validation::accumulator::MasterAccumulator;
+use trin_validation::accumulator::PreMergeAccumulator;
 
 /// Lookup the epoch accumulator & epoch hash for the given epoch index.
 pub async fn lookup_epoch_acc(
     epoch_index: u64,
-    master_acc: &MasterAccumulator,
+    pre_merge_acc: &PreMergeAccumulator,
     epoch_acc_path: &Path,
 ) -> anyhow::Result<(B256, EpochAccumulator)> {
-    let epoch_hash = master_acc.historical_epochs[epoch_index as usize];
+    let epoch_hash = pre_merge_acc.historical_epochs[epoch_index as usize];
     let epoch_hash_pretty = hex_encode(epoch_hash);
     let epoch_hash_pretty = epoch_hash_pretty.trim_start_matches("0x");
     let epoch_acc_path = format!(

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -13,7 +13,7 @@ use portal_bridge::{
     utils::generate_spaced_private_keys,
 };
 use trin_utils::log::init_tracing_logger;
-use trin_validation::{accumulator::MasterAccumulator, oracle::HeaderOracle};
+use trin_validation::{accumulator::PreMergeAccumulator, oracle::HeaderOracle};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -86,8 +86,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if bridge_config.network.contains(&NetworkKind::History) {
         match bridge_config.mode {
             BridgeMode::FourFours(_) => {
-                let master_acc = MasterAccumulator::default();
-                let header_oracle = HeaderOracle::new(master_acc);
+                let pre_merge_acc = PreMergeAccumulator::default();
+                let header_oracle = HeaderOracle::new(pre_merge_acc);
                 let era1_bridge = Era1Bridge::new(
                     bridge_config.mode,
                     portal_clients.expect("Failed to create history JSON-RPC clients"),
@@ -111,8 +111,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 )
                 .await?;
                 let bridge_handle = tokio::spawn(async move {
-                    let master_acc = MasterAccumulator::default();
-                    let header_oracle = HeaderOracle::new(master_acc);
+                    let pre_merge_acc = PreMergeAccumulator::default();
+                    let header_oracle = HeaderOracle::new(pre_merge_acc);
 
                     let bridge = HistoryBridge::new(
                         bridge_config.mode,

--- a/src/bin/test_providers.rs
+++ b/src/bin/test_providers.rs
@@ -23,7 +23,7 @@ use ethportal_api::{
 use portal_bridge::{api::execution::ExecutionApi, bridge::history::EPOCH_SIZE};
 use trin_utils::log::init_tracing_logger;
 use trin_validation::{
-    accumulator::MasterAccumulator,
+    accumulator::PreMergeAccumulator,
     constants::{
         BERLIN_BLOCK_NUMBER, BYZANTIUM_BLOCK_NUMBER, CONSTANTINOPLE_BLOCK_NUMBER,
         HOMESTEAD_BLOCK_NUMBER, ISTANBUL_BLOCK_NUMBER, LONDON_BLOCK_NUMBER, MERGE_BLOCK_NUMBER,
@@ -64,7 +64,7 @@ pub async fn main() -> Result<()> {
         let api = ExecutionApi {
             fallback_client: client.clone(),
             client,
-            master_acc: MasterAccumulator::default(),
+            pre_merge_acc: PreMergeAccumulator::default(),
         };
         for gossip_range in all_ranges.iter_mut() {
             debug!("Testing range: {gossip_range:?}");
@@ -130,8 +130,8 @@ fn lookup_epoch_acc(block: u64) -> Result<Option<Arc<EpochAccumulator>>> {
         return Ok(None);
     }
     let epoch_index = block / EPOCH_SIZE;
-    let master_acc = MasterAccumulator::default();
-    let epoch_hash = master_acc.historical_epochs[epoch_index as usize];
+    let pre_merge_acc = PreMergeAccumulator::default();
+    let epoch_hash = pre_merge_acc.historical_epochs[epoch_index as usize];
     let epoch_hash_pretty = hex_encode(epoch_hash);
     let epoch_hash_pretty = epoch_hash_pretty.trim_start_matches("0x");
     let epoch_acc_path =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use trin_history::initialize_history_network;
 use trin_state::initialize_state_network;
 use trin_storage::PortalStorageConfig;
 use trin_utils::version::get_trin_version;
-use trin_validation::{accumulator::MasterAccumulator, oracle::HeaderOracle};
+use trin_validation::{accumulator::PreMergeAccumulator, oracle::HeaderOracle};
 
 pub async fn run_trin(
     trin_config: TrinConfig,
@@ -77,12 +77,13 @@ pub async fn run_trin(
     )?;
 
     // Initialize validation oracle
-    let master_accumulator = MasterAccumulator::try_from_file(trin_config.master_acc_path.clone())?;
+    let pre_merge_accumulator =
+        PreMergeAccumulator::try_from_file(trin_config.pre_merge_acc_path.clone())?;
     info!(
-        "Loaded master accumulator from: {:?}",
-        trin_config.master_acc_path
+        "Loaded pre-merge accumulator from: {:?}",
+        trin_config.pre_merge_acc_path
     );
-    let header_oracle = HeaderOracle::new(master_accumulator);
+    let header_oracle = HeaderOracle::new(pre_merge_accumulator);
     let header_oracle = Arc::new(RwLock::new(header_oracle));
 
     // Initialize state sub-network service and event handlers, if selected

--- a/trin-state/src/validation/validator.rs
+++ b/trin-state/src/validation/validator.rs
@@ -229,15 +229,15 @@ mod tests {
     use serde::Deserialize;
     use serde_yaml::Value;
     use trin_utils::submodules::read_portal_spec_tests_file;
-    use trin_validation::accumulator::MasterAccumulator;
+    use trin_validation::accumulator::PreMergeAccumulator;
 
     use super::*;
 
     const TEST_DIRECTORY: &str = "tests/mainnet/state/validation";
 
     fn create_validator() -> StateValidator {
-        let master_acc = MasterAccumulator::default();
-        let header_oracle = Arc::new(RwLock::new(HeaderOracle::new(master_acc)));
+        let pre_merge_acc = PreMergeAccumulator::default();
+        let header_oracle = Arc::new(RwLock::new(HeaderOracle::new(pre_merge_acc)));
         StateValidator { header_oracle }
     }
 

--- a/trin-validation/src/accumulator.rs
+++ b/trin-validation/src/accumulator.rs
@@ -94,7 +94,7 @@ impl PreMergeAccumulator {
 
     pub fn validate_header_with_proof(&self, hwp: &HeaderWithProof) -> anyhow::Result<()> {
         match &hwp.proof {
-            BlockHeaderProof::AccumulatorProof(proof) => {
+            BlockHeaderProof::PreMergeAccumulatorProof(proof) => {
                 if hwp.header.number > MERGE_BLOCK_NUMBER {
                     return Err(anyhow!("Invalid proof type found for post-merge header."));
                 }
@@ -260,7 +260,7 @@ mod test {
     use crate::constants::DEFAULT_PRE_MERGE_ACC_HASH;
     use ethportal_api::{
         types::execution::header_with_proof::{
-            AccumulatorProof, BlockHeaderProof, HeaderWithProof, SszNone,
+            BlockHeaderProof, HeaderWithProof, PreMergeAccumulatorProof, SszNone,
         },
         utils::bytes::hex_encode,
     };
@@ -304,13 +304,15 @@ mod test {
         let header = get_header(block_number);
         let trin_proof = trin_macc.generate_proof(&header, tx).await.unwrap();
         let fluffy_proof = match fluffy_hwp.proof {
-            BlockHeaderProof::AccumulatorProof(val) => val,
+            BlockHeaderProof::PreMergeAccumulatorProof(val) => val,
             _ => panic!("test reached invalid state"),
         };
         assert_eq!(trin_proof, fluffy_proof.proof);
         let hwp = HeaderWithProof {
             header,
-            proof: BlockHeaderProof::AccumulatorProof(AccumulatorProof { proof: trin_proof }),
+            proof: BlockHeaderProof::PreMergeAccumulatorProof(PreMergeAccumulatorProof {
+                proof: trin_proof,
+            }),
         };
         trin_macc.validate_header_with_proof(&hwp).unwrap();
     }
@@ -327,7 +329,7 @@ mod test {
         proof.swap(0, 1);
         let hwp = HeaderWithProof {
             header,
-            proof: BlockHeaderProof::AccumulatorProof(AccumulatorProof { proof }),
+            proof: BlockHeaderProof::PreMergeAccumulatorProof(PreMergeAccumulatorProof { proof }),
         };
         assert!(trin_macc
             .validate_header_with_proof(&hwp)
@@ -370,7 +372,7 @@ mod test {
         let future_header = generate_random_header(&future_height);
         let future_hwp = HeaderWithProof {
             header: future_header,
-            proof: BlockHeaderProof::AccumulatorProof(AccumulatorProof {
+            proof: BlockHeaderProof::PreMergeAccumulatorProof(PreMergeAccumulatorProof {
                 proof: [B256::ZERO; 15],
             }),
         };

--- a/trin-validation/src/constants.rs
+++ b/trin-validation/src/constants.rs
@@ -8,8 +8,8 @@ pub const CONSTANTINOPLE_BLOCK_NUMBER: u64 = 7_280_000;
 pub const BYZANTIUM_BLOCK_NUMBER: u64 = 4_370_000;
 pub const HOMESTEAD_BLOCK_NUMBER: u64 = 1_150_000;
 
-// todo docstring
-pub const DEFAULT_MASTER_ACC_HASH: &str =
+/// The default hash of the pre-merge accumulator at the time of the merge block.
+pub const DEFAULT_PRE_MERGE_ACC_HASH: &str =
     "0x8eac399e24480dce3cfe06f4bdecba51c6e5d0c46200e3e8611a0b44a3a69ff9";
 
 /// Max number of blocks / epoch = 2 ** 13


### PR DESCRIPTION
### What was wrong?
We will introduce two more accumulators for verifying pre-capella and post-capella headers and using "master" for the pre-merge accumulator is confusing and doesn't make sense anymore.

### How was it fixed?
- Rename `master accumulator ` to `pre-merge accumulator`.
- Rename `AccumulatorProof` to `PreMergeAccumulatorProof`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
