### PR TITLE
fix: revert history storage to use LegacyHistoryStore

### DIFF
--- a/trin-history/src/storage.rs
+++ b/trin-history/src/storage.rs
@@ -1,22 +1,26 @@
 use ethportal_api::{
-    types::{distance::Distance, history::PaginateLocalContentInfo, portal_wire::ProtocolId},
+    types::{distance::Distance, history::PaginateLocalContentInfo},
     OverlayContentKey,
 };
 use trin_storage::{
     error::ContentStoreError,
-    versioned::{create_store, ContentType, IdIndexedV1Store, IdIndexedV1StoreConfig},
-    ContentId, ContentStore, PortalStorageConfig, ShouldWeStoreContent,
+    versioned::{create_store, ContentType, LegacyHistoryStore},
+    ContentStore, PortalStorageConfig, ShouldWeStoreContent,
 };
 
 /// Storage layer for the history network. Encapsulates history network specific data and logic.
 #[derive(Debug)]
 pub struct HistoryStorage {
-    store: IdIndexedV1Store,
+    store: LegacyHistoryStore,
 }
 
 impl ContentStore for HistoryStorage {
     fn get<K: OverlayContentKey>(&self, key: &K) -> Result<Option<Vec<u8>>, ContentStoreError> {
-        self.store.lookup_content_value(&key.content_id().into())
+        self.store
+            .lookup_content_value(key.content_id())
+            .map_err(|err| {
+                ContentStoreError::Database(format!("Error looking up content value: {err:?}"))
+            })
     }
 
     fn put<K: OverlayContentKey, V: AsRef<[u8]>>(
@@ -24,20 +28,23 @@ impl ContentStore for HistoryStorage {
         key: K,
         value: V,
     ) -> Result<(), ContentStoreError> {
-        self.store.insert(&key, value.as_ref().to_vec())
+        self.store.store(&key, &value.as_ref().to_vec())
     }
 
     fn is_key_within_radius_and_unavailable<K: OverlayContentKey>(
         &self,
         key: &K,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
-        let content_id = ContentId::from(key.content_id());
+        let content_id = key.content_id();
         if self.store.distance_to_content_id(&content_id) > self.store.radius() {
-            Ok(ShouldWeStoreContent::NotWithinRadius)
-        } else if self.store.has_content(&content_id)? {
-            Ok(ShouldWeStoreContent::AlreadyStored)
-        } else {
-            Ok(ShouldWeStoreContent::Store)
+            return Ok(ShouldWeStoreContent::NotWithinRadius);
+        }
+
+        match self.store.lookup_content_key(content_id).map_err(|err| {
+            ContentStoreError::Database(format!("Error looking up content key: {err:?}"))
+        })? {
+            Some(_) => Ok(ShouldWeStoreContent::AlreadyStored),
+            None => Ok(ShouldWeStoreContent::Store),
         }
     }
 
@@ -49,7 +56,6 @@ impl ContentStore for HistoryStorage {
 impl HistoryStorage {
     pub fn new(config: PortalStorageConfig) -> Result<Self, ContentStoreError> {
         let sql_connection_pool = config.sql_connection_pool.clone();
-        let config = IdIndexedV1StoreConfig::new(ContentType::History, ProtocolId::History, config);
         Ok(Self {
             store: create_store(ContentType::History, config, sql_connection_pool)?,
         })
@@ -67,12 +73,7 @@ impl HistoryStorage {
         offset: u64,
         limit: u64,
     ) -> Result<PaginateLocalContentInfo, ContentStoreError> {
-        self.store
-            .paginate(offset, limit)
-            .map(|paginate_result| PaginateLocalContentInfo {
-                content_keys: paginate_result.content_keys,
-                total_entries: paginate_result.entry_count,
-            })
+        self.store.paginate(&offset, &limit)
     }
 }
 


### PR DESCRIPTION
### What was wrong?

Pruning 5-10% of the database can take too much time that, which also blocks other tasks.

### How was it fixed?

Revert code to use `LegacyHistoryStore` again (partial revert of #1235 ).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
