### PR TITLE
fix: check for pruning more frequently

### DIFF
--- a/trin-metrics/src/storage.rs
+++ b/trin-metrics/src/storage.rs
@@ -19,6 +19,7 @@ pub struct StorageMetrics {
     pub storage_capacity_bytes: GaugeVec,
     pub radius_ratio: GaugeVec,
     pub entry_count: IntGaugeVec,
+    pub to_insert_until_pruning: IntGaugeVec,
 }
 
 const BYTES_IN_MB_F64: f64 = 1000.0 * 1000.0;
@@ -70,6 +71,14 @@ impl StorageMetrics {
             &["protocol"],
             registry
         )?;
+        let to_insert_until_pruning = register_int_gauge_vec_with_registry!(
+            opts!(
+                "trin_to_insert_until_pruning",
+                "number of entries to be inserted before we check whether we should prune"
+            ),
+            &["protocol"],
+            registry
+        )?;
         Ok(Self {
             process_timer,
             content_storage_usage_bytes,
@@ -77,6 +86,7 @@ impl StorageMetrics {
             storage_capacity_bytes,
             radius_ratio,
             entry_count,
+            to_insert_until_pruning,
         })
     }
 }
@@ -166,6 +176,13 @@ impl StorageMetricsReporter {
             .entry_count
             .with_label_values(&[&self.protocol])
             .dec();
+    }
+
+    pub fn report_to_insert_until_pruning(&self, value: u64) {
+        self.storage_metrics
+            .to_insert_until_pruning
+            .with_label_values(&[&self.protocol])
+            .set(value as i64);
     }
 
     pub fn get_summary(&self) -> String {


### PR DESCRIPTION
### What was wrong?

The `IdIndexedV1Store` store was checking for pruning only once it estimated the it reached full capacity.
In practice, this could lead to using way more storage than desired.

### How was it fixed?

I added `PRUNING_CHECKING_FREQUENCY` that forces us to check for pruning more frequently.
Checking for pruning is no longer as expensive as it was originally (because we are now using triggers to update usage stats), so this shouldn't have big performance impact.

I also removed one test that was hard to test with new logic. It's worth pointing out that most parts of the tests were already covered by other tests.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
