### PR TITLE
feat(bridge): add fallback providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2651,6 +2651,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "surf",
  "tempfile",
  "tokio",
  "tracing",
@@ -2663,6 +2664,7 @@ dependencies = [
  "trin-validation",
  "uds_windows",
  "ureq",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ reth-ipc = { tag = "v0.2.0-beta.5", git = "https://github.com/paradigmxyz/reth.g
 rpc = { path = "rpc"}
 serde_json = {version = "1.0.89", features = ["preserve_order"]}
 sha3 = "0.9.1"
-surf = { version = "2.3.2", default-features = false, features = ["h1-client-rustls", "middleware-logger", "encoding"] } # we use rustils because OpenSSL cause issues compiling on aarch64
+surf = { version = "2.3.2", default-features = false, features = ["h1-client-rustls", "middleware-logger", "encoding"] } # we use rustls because OpenSSL cause issues compiling on aarch64
 tempfile = "3.3.0"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -26,6 +26,7 @@ rpc = { path = "../rpc" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.89"
 serde_yaml = "0.9"
+surf = { version = "2.3.2", default-features = false, features = ["h1-client-rustls", "middleware-logger", "encoding"] } # we use rustls because OpenSSL cause issues compiling on aarch64
 tempfile = "3.3.0"
 tokio = {version = "1.14.0", features = ["full"]}
 tracing = "0.1.36"
@@ -38,6 +39,7 @@ trin-state = { path = "../trin-state" }
 trin-utils = { path = "../trin-utils" }
 trin-validation = { path = "../trin-validation" }
 ureq = { version = "2.5.0", features = ["json"] }
+url = "2.3.1"
 
 [target.'cfg(windows)'.dependencies]
 uds_windows = "1.0.1"

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = "1.0.89"
 serde_yaml = "0.9"
 snap = "1.1.1"
 ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "2a5922de75f00746890bf4ea9ad663c9d5d58efe" }
-surf = { version = "2.3.2", default-features = false, features = ["h1-client-rustls", "middleware-logger", "encoding"] } # we use rustils because OpenSSL cause issues compiling on aarch64
+surf = { version = "2.3.2", default-features = false, features = ["h1-client-rustls", "middleware-logger", "encoding"] } # we use rustls because OpenSSL cause issues compiling on aarch64
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"

--- a/portal-bridge/src/lib.rs
+++ b/portal-bridge/src/lib.rs
@@ -11,9 +11,6 @@ pub mod stats;
 pub mod types;
 pub mod utils;
 
-use lazy_static::lazy_static;
-use std::env;
-
 // PANDAOPS refers to the group of clients provisioned by the EF devops team.
 // These are only intended to be used by core team members who have access to the nodes.
 //
@@ -22,23 +19,9 @@ use std::env;
 // format), shackle is known to be somewhat buggy has caused some invalid responses.
 // Reth's archive node, has also exhibited some problems with the concurrent requests rate we
 // currently use.
-const DEFAULT_BASE_EL_ENDPOINT: &str = "https://geth-lighthouse.mainnet.eu1.ethpandaops.io/";
-// The `erigon` endpoint appears to perform much better for backfill requests.
-const DEFAULT_BASE_EL_ARCHIVE_ENDPOINT: &str =
-    "https://erigon-lighthouse.mainnet.eu1.ethpandaops.io/";
+pub const DEFAULT_BASE_EL_ENDPOINT: &str = "https://geth-lighthouse.mainnet.eu1.ethpandaops.io/";
+pub const FALLBACK_BASE_EL_ENDPOINT: &str = "https://geth-lighthouse.mainnet.eu1.ethpandaops.io/";
 /// Consensus layer PandaOps endpoint
 /// We use Nimbus as the CL client, because it supports light client data by default.
-const DEFAULT_BASE_CL_ENDPOINT: &str = "https://nimbus.mainnet.eu1.ethpandaops.io/";
-
-lazy_static! {
-    pub static ref PANDAOPS_CLIENT_ID: String =
-        env::var("PANDAOPS_CLIENT_ID").expect("PANDAOPS_CLIENT_ID env var not set.");
-    pub static ref PANDAOPS_CLIENT_SECRET: String =
-        env::var("PANDAOPS_CLIENT_SECRET").expect("PANDAOPS_CLIENT_SECRET env var not set.");
-    static ref BASE_EL_ENDPOINT: String =
-        env::var("BASE_EL_ENDPOINT").unwrap_or_else(|_| DEFAULT_BASE_EL_ENDPOINT.to_string());
-    static ref BASE_EL_ARCHIVE_ENDPOINT: String = env::var("BASE_EL_ARCHIVE_ENDPOINT")
-        .unwrap_or_else(|_| DEFAULT_BASE_EL_ARCHIVE_ENDPOINT.to_string());
-    static ref BASE_CL_ENDPOINT: String =
-        env::var("BASE_CL_ENDPOINT").unwrap_or_else(|_| DEFAULT_BASE_CL_ENDPOINT.to_string());
-}
+pub const DEFAULT_BASE_CL_ENDPOINT: &str = "https://nimbus.mainnet.eu1.ethpandaops.io/";
+pub const FALLBACK_BASE_CL_ENDPOINT: &str = "https://nimbus.mainnet.eu1.ethpandaops.io/";

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -64,7 +64,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let portal_clients = portal_clients
             .clone()
             .expect("Failed to create beacon JSON-RPC clients");
-        let consensus_api = ConsensusApi::new(bridge_config.cl_provider).await?;
+        let consensus_api = ConsensusApi::new(
+            bridge_config.cl_provider,
+            bridge_config.cl_provider_fallback,
+        )
+        .await?;
         let bridge_handle = tokio::spawn(async move {
             let beacon_bridge =
                 BeaconBridge::new(consensus_api, bridge_mode, Arc::new(portal_clients));
@@ -101,9 +105,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 bridge_tasks.push(bridge_handle);
             }
             _ => {
-                let execution_api =
-                    ExecutionApi::new(bridge_config.el_provider, bridge_config.mode.clone())
-                        .await?;
+                let execution_api = ExecutionApi::new(
+                    bridge_config.el_provider,
+                    bridge_config.el_provider_fallback,
+                )
+                .await?;
                 let bridge_handle = tokio::spawn(async move {
                     let master_acc = MasterAccumulator::default();
                     let header_oracle = HeaderOracle::new(master_acc);


### PR DESCRIPTION
### What was wrong?
Added the ability to set a fallback provider, in case a request to the primary provider fails.

### How was it fixed?
- Removed `Retry` middleware
- Added fallback & primary providers for both el & cl bridge apis
- Removed ability to set provider urls via env variable, since these can now just be set via cli flag

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
