### PR TITLE
feat: implement `id_indexed_v1` -> `legacy_history` store migration

### DIFF
--- a/trin-storage/src/versioned/id_indexed_v1/mod.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/mod.rs
@@ -1,6 +1,6 @@
 mod config;
 mod migration;
-mod sql;
+pub(super) mod sql;
 mod store;
 
 pub use config::IdIndexedV1StoreConfig;

--- a/trin-storage/src/versioned/legacy_history/migration.rs
+++ b/trin-storage/src/versioned/legacy_history/migration.rs
@@ -1,0 +1,96 @@
+use r2d2::Pool;
+use r2d2_sqlite::SqliteConnectionManager;
+use tracing::{debug, info};
+
+use crate::{
+    error::ContentStoreError,
+    versioned::{id_indexed_v1, sql::delete_usage_stats_triggers, ContentType},
+};
+
+pub fn migrate_id_indexed_store(
+    sql_connection_pool: &Pool<SqliteConnectionManager>,
+) -> Result<(), ContentStoreError> {
+    info!("Migration started");
+    let old_table_name = id_indexed_v1::sql::table_name(&ContentType::History);
+
+    // Rename table
+    debug!("Renaming table: {old_table_name} -> history");
+    sql_connection_pool.get()?.execute_batch(&format!(
+        "ALTER TABLE {} RENAME TO history;",
+        old_table_name
+    ))?;
+
+    // Drop old indicies (they can't be renamed)
+    debug!("Dropping old indices");
+    sql_connection_pool.get()?.execute_batch(&format!(
+        "DROP INDEX {old_table_name}_distance_short_idx;
+        DROP INDEX {old_table_name}_content_size_idx;"
+    ))?;
+
+    // Delete usage stats
+    debug!("Deleting usage stats");
+    sql_connection_pool
+        .get()?
+        .execute_batch(&delete_usage_stats_triggers(
+            &ContentType::History,
+            &old_table_name,
+        ))?;
+
+    info!("Migration finished");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use anyhow::Result;
+    use ethportal_api::{types::portal_wire::ProtocolId, IdentityContentKey, OverlayContentKey};
+    use rand::Rng;
+
+    use crate::{
+        test_utils::{create_test_portal_storage_config_with_capacity, generate_random_bytes},
+        versioned::{create_store, IdIndexedV1StoreConfig, LegacyHistoryStore},
+    };
+
+    use self::id_indexed_v1::IdIndexedV1Store;
+
+    use super::*;
+
+    #[test]
+    fn legacy_history_using_create_store() -> Result<()> {
+        let (_temp_dir, config) =
+            create_test_portal_storage_config_with_capacity(/* capacity_mb= */ 10)?;
+
+        let mut key_value_map = HashMap::new();
+
+        // initialize IdIndexedV1Store
+        let mut id_indexed_v1_store: IdIndexedV1Store = create_store(
+            ContentType::History,
+            IdIndexedV1StoreConfig::new(ContentType::History, ProtocolId::History, config.clone()),
+            config.sql_connection_pool.clone(),
+        )?;
+        for _ in 0..10 {
+            let key = IdentityContentKey::random();
+            let value = generate_random_bytes(rand::thread_rng().gen_range(100..200));
+            id_indexed_v1_store.insert(&key, value.clone())?;
+            key_value_map.insert(key, value);
+        }
+        drop(id_indexed_v1_store);
+
+        // create legacy store and verify content
+        let legacy_history_store: LegacyHistoryStore = create_store(
+            ContentType::History,
+            config.clone(),
+            config.sql_connection_pool.clone(),
+        )?;
+        for (key, value) in key_value_map.into_iter() {
+            assert_eq!(
+                legacy_history_store.lookup_content_value(key.content_id())?,
+                Some(value),
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/trin-storage/src/versioned/legacy_history/mod.rs
+++ b/trin-storage/src/versioned/legacy_history/mod.rs
@@ -1,3 +1,4 @@
+mod migration;
 mod sql;
 mod store;
 

--- a/trin-storage/src/versioned/sql.rs
+++ b/trin-storage/src/versioned/sql.rs
@@ -77,6 +77,17 @@ pub fn create_usage_stats_triggers(
     )
 }
 
+pub fn delete_usage_stats_triggers(content_type: &ContentType, table_name: &str) -> String {
+    format!(
+        "
+        DROP TRIGGER {table_name}_on_insert_update_usage_stats_trigger;
+        DROP TRIGGER {table_name}_on_delete_update_usage_stats_trigger;
+        DROP TRIGGER {table_name}_on_update_update_usage_stats_trigger;
+        DELETE FROM usage_stats WHERE content_type = '{content_type}';
+        "
+    )
+}
+
 // The table management queries
 
 pub const TABLE_EXISTS: &str = "


### PR DESCRIPTION
### What was wrong?

It is currently not possible to migrate from `id_indexed_v1` back to `legacy_history` store.
This makes development and testing the migration hard.

### How was it fixed?

Implemented the migration.
One can now easily switch to any desired implementation.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
