### PR TITLE
chore: update github release template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,14 +180,6 @@ jobs:
           - [ ] Write the summary.
           - [ ] Ensure all binaries have been added.
 
-          ## Summary
-
-          Add a summary, including:
-
-          - Critical bug fixes
-          - New features
-          - Any breaking changes (and what to expect)
-
           ## All Changes
 
           ${{ steps.changelog.outputs.CHANGELOG }}


### PR DESCRIPTION
### What was wrong?
We don't update the `Summary` section in the release template when we release a new version.

### How was it fixed?
Removes the `Summary` section from the release template for now.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
