### PR TITLE
feat: add post-merge proof variants to block header with proof type

### DIFF
--- a/ethportal-api/src/types/content_value/history.rs
+++ b/ethportal-api/src/types/content_value/history.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ssz::{Decode, Encode};
 
 /// A Portal History content value.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum HistoryContentValue {
     BlockHeaderWithProof(HeaderWithProof),

--- a/ethportal-api/src/types/history.rs
+++ b/ethportal-api/src/types/history.rs
@@ -3,7 +3,7 @@ use crate::{types::enr::Enr, HistoryContentKey, HistoryContentValue};
 use serde::{Deserialize, Serialize};
 
 /// Response for FindContent & RecursiveFindContent endpoints
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ContentInfo {
     #[serde(rename_all = "camelCase")]
@@ -21,7 +21,7 @@ pub enum ContentInfo {
 ///
 /// This struct represents the content info, and is only used
 /// when the content is found locally or on the network.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TraceContentInfo {
     pub content: HistoryContentValue,

--- a/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -53,7 +53,7 @@ pub enum StateEndpoint {
 }
 
 /// History network JSON-RPC endpoints. Start with "portal_history" prefix
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum HistoryEndpoint {
     /// params: [enr]
     AddEnr(Enr),


### PR DESCRIPTION
### What was wrong?
The `BlockHeaderProof` enum must contain proofs for post-merge headers.

### How was it fixed?
Add post-merge proof types to block header proof.

The logic for verification of the post-merge proofs will be added later because additional refactoring of the validation modules will be introduced in the following PRs.

We will add tests for SSZ encode/decode for the post-merge header with proof when the test vectors are available.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
