### PR TITLE
fix(bridge): add sleep before request retry to fallback

### DIFF
--- a/portal-bridge/src/api/consensus.rs
+++ b/portal-bridge/src/api/consensus.rs
@@ -2,7 +2,10 @@ use std::fmt::Display;
 
 use anyhow::anyhow;
 use surf::Client;
+use tokio::time::sleep;
 use tracing::{debug, warn};
+
+use crate::constants::FALLBACK_RETRY_AFTER;
 
 /// Implements endpoints from the Beacon API to access data from the consensus layer.
 #[derive(Clone, Debug, Default)]
@@ -86,6 +89,7 @@ impl ConsensusApi {
             Ok(response) => Ok(response),
             Err(err) => {
                 warn!("Error requesting consensus data from provider, retrying with fallback provider: {err:?}");
+                sleep(FALLBACK_RETRY_AFTER).await;
                 self.fallback_client
                     .get(endpoint)
                     .recv_string()

--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -20,3 +20,6 @@ pub const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 
 // This is the maximum number of active blocks being gossiped
 pub const DEFAULT_GOSSIP_LIMIT: usize = 32;
+
+// Number of seconds to wait before retrying a provider request
+pub const FALLBACK_RETRY_AFTER: Duration = Duration::from_secs(5);


### PR DESCRIPTION
### What was wrong?
When we removed the `Retry` middleware, we lost a built-in sleep mechanism. Some of the current bridge errors seems to be a result of "DOS protection". Re-introducing a manual sleep "should" help prevent this error from happening.

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
