### PR TITLE
fix: flaky test: pruning_with_one_large_item

### DIFF
--- a/trin-storage/src/versioned/id_indexed_v1/store.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/store.rs
@@ -787,7 +787,7 @@ mod tests {
         );
         store.insert(&big_value_key, value)?;
 
-        // Add another 48 small items (1% each) and check that:
+        // Add another 48 small-ish items (1% each) and check that:
         // - we didn't prune
         // - we are at 148% total capacity
         for _ in 0..48 {
@@ -807,7 +807,6 @@ mod tests {
         // Add one more and check that:
         // - we pruned enough to be under pruning capacity
         // - the big_value_key is still stored
-        // - to_insert_until_pruning is set to correct value
         let (key, value) = generate_key_value(&config, 1);
         store.insert(&key, value).unwrap();
         assert!(
@@ -815,7 +814,6 @@ mod tests {
                 <= config.pruning_capacity_threshold()
         );
         assert!(store.has_content(&big_value_key.content_id().into())?);
-        assert_eq!(store.to_insert_until_pruning, 1);
 
         Ok(())
     }


### PR DESCRIPTION
### What was wrong?

The `id_indexed_v1::store::tests::pruning_with_one_large_item` test was flaky.
Some elements are created with different sizes, so test wasn't deterministic.

fix: #1268

### How was it fixed?

Removed the failing check, as it wasn't really needed for this test.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
