### PR TITLE
refactor(bridge): remove multiple client functionality

### DIFF
--- a/portal-bridge/README.md
+++ b/portal-bridge/README.md
@@ -4,7 +4,7 @@ Process to feed the portal network by gossiping data retrieved from a trusted pr
 ex.
 ```sh
 git clone https://github.com/ethereum/portal-accumulators.git
-cargo run -p portal-bridge -- --node-count 1 --executable-path ./target/debug/trin --epoch-accumulator-path ./portal-accumulators trin
+cargo run -p portal-bridge -- --executable-path ./target/debug/trin --epoch-accumulator-path ./portal-accumulators trin
 ```
 
 ## Providers

--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -44,7 +44,7 @@ const ERA1_FILE_COUNT: usize = 1897;
 
 pub struct Era1Bridge {
     pub mode: BridgeMode,
-    pub portal_clients: Vec<HttpClient>,
+    pub portal_client: HttpClient,
     pub header_oracle: HeaderOracle,
     pub epoch_acc_path: PathBuf,
     pub era1_files: Vec<String>,
@@ -57,7 +57,7 @@ pub struct Era1Bridge {
 impl Era1Bridge {
     pub async fn new(
         mode: BridgeMode,
-        portal_clients: Vec<HttpClient>,
+        portal_client: HttpClient,
         header_oracle: HeaderOracle,
         epoch_acc_path: PathBuf,
         gossip_limit: usize,
@@ -70,7 +70,7 @@ impl Era1Bridge {
         let metrics = BridgeMetricsReporter::new("era1".to_string(), &format!("{mode:?}"));
         Ok(Self {
             mode,
-            portal_clients,
+            portal_client,
             header_oracle,
             epoch_acc_path,
             era1_files,
@@ -192,7 +192,7 @@ impl Era1Bridge {
                 .expect("to be able to acquire semaphore");
             self.metrics.report_current_block(block_number as i64);
             let serve_block_tuple_handle = Self::spawn_serve_block_tuple(
-                self.portal_clients.clone(),
+                self.portal_client.clone(),
                 block_tuple,
                 epoch_acc.clone(),
                 pre_merge_acc.clone(),
@@ -222,11 +222,10 @@ impl Era1Bridge {
         )));
         debug!("Built EpochAccumulator for Epoch #{epoch_index:?}: now gossiping.");
         // spawn gossip in new thread to avoid blocking
-        let portal_clients = self.portal_clients.clone();
+        let portal_client = self.portal_client.clone();
         tokio::spawn(async move {
             if let Err(msg) =
-                gossip_history_content(&portal_clients, content_key, content_value, block_stats)
-                    .await
+                gossip_history_content(portal_client, content_key, content_value, block_stats).await
             {
                 warn!("Failed to gossip epoch accumulator: {msg}");
             }
@@ -235,7 +234,7 @@ impl Era1Bridge {
     }
 
     fn spawn_serve_block_tuple(
-        portal_clients: Vec<HttpClient>,
+        portal_client: HttpClient,
         block_tuple: BlockTuple,
         epoch_acc: Arc<EpochAccumulator>,
         pre_merge_acc: Arc<PreMergeAccumulator>,
@@ -250,7 +249,7 @@ impl Era1Bridge {
             match timeout(
                 SERVE_BLOCK_TIMEOUT,
                 Self::serve_block_tuple(
-                    portal_clients,
+                    portal_client,
                     block_tuple,
                     epoch_acc,
                     pre_merge_acc,
@@ -275,7 +274,7 @@ impl Era1Bridge {
     }
 
     async fn serve_block_tuple(
-        portal_clients: Vec<HttpClient>,
+        portal_client: HttpClient,
         block_tuple: BlockTuple,
         epoch_acc: Arc<EpochAccumulator>,
         pre_merge_acc: Arc<PreMergeAccumulator>,
@@ -288,7 +287,7 @@ impl Era1Bridge {
         );
         let timer = metrics.start_process_timer("construct_and_gossip_header");
         match Self::construct_and_gossip_header(
-            portal_clients.clone(),
+            portal_client.clone(),
             block_tuple.clone(),
             epoch_acc,
             pre_merge_acc,
@@ -323,7 +322,7 @@ impl Era1Bridge {
         sleep(Duration::from_secs(HEADER_SATURATION_DELAY)).await;
         let timer = metrics.start_process_timer("construct_and_gossip_block_body");
         match Self::construct_and_gossip_block_body(
-            portal_clients.clone(),
+            portal_client.clone(),
             block_tuple.clone(),
             block_stats.clone(),
         )
@@ -347,7 +346,7 @@ impl Era1Bridge {
         metrics.stop_process_timer(timer);
         let timer = metrics.start_process_timer("construct_and_gossip_receipts");
         match Self::construct_and_gossip_receipts(
-            portal_clients.clone(),
+            portal_client.clone(),
             block_tuple.clone(),
             block_stats.clone(),
         )
@@ -373,7 +372,7 @@ impl Era1Bridge {
     }
 
     async fn construct_and_gossip_header(
-        portal_clients: Vec<HttpClient>,
+        portal_client: HttpClient,
         block_tuple: BlockTuple,
         epoch_acc: Arc<EpochAccumulator>,
         pre_merge_acc: Arc<PreMergeAccumulator>,
@@ -409,18 +408,11 @@ impl Era1Bridge {
         // Construct HistoryContentValue
         let content_value = HistoryContentValue::BlockHeaderWithProof(header_with_proof);
 
-        gossip_history_content(
-            // remove borrow
-            &portal_clients,
-            content_key,
-            content_value,
-            block_stats,
-        )
-        .await
+        gossip_history_content(portal_client, content_key, content_value, block_stats).await
     }
 
     async fn construct_and_gossip_block_body(
-        portal_clients: Vec<HttpClient>,
+        portal_client: HttpClient,
         block_tuple: BlockTuple,
         block_stats: Arc<Mutex<HistoryBlockStats>>,
     ) -> anyhow::Result<()> {
@@ -435,11 +427,11 @@ impl Era1Bridge {
         });
         // Construct HistoryContentValue
         let content_value = HistoryContentValue::BlockBody(block_tuple.body.body);
-        gossip_history_content(&portal_clients, content_key, content_value, block_stats).await
+        gossip_history_content(portal_client, content_key, content_value, block_stats).await
     }
 
     async fn construct_and_gossip_receipts(
-        portal_clients: Vec<HttpClient>,
+        portal_client: HttpClient,
         block_tuple: BlockTuple,
         block_stats: Arc<Mutex<HistoryBlockStats>>,
     ) -> anyhow::Result<()> {
@@ -454,7 +446,7 @@ impl Era1Bridge {
         });
         // Construct HistoryContentValue
         let content_value = HistoryContentValue::Receipts(block_tuple.receipts.receipts);
-        gossip_history_content(&portal_clients, content_key, content_value, block_stats).await
+        gossip_history_content(portal_client, content_key, content_value, block_stats).await
     }
 }
 

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use clap::Parser;
 use tokio::time::{sleep, Duration};
 use tracing::Instrument;
@@ -10,7 +8,6 @@ use portal_bridge::{
     bridge::{beacon::BeaconBridge, era1::Era1Bridge, history::HistoryBridge},
     cli::BridgeConfig,
     types::{mode::BridgeMode, network::NetworkKind},
-    utils::generate_spaced_private_keys,
 };
 use trin_utils::log::init_tracing_logger;
 use trin_validation::{accumulator::PreMergeAccumulator, oracle::HeaderOracle};
@@ -25,53 +22,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         prometheus_exporter::start(addr)?;
     }
 
-    let private_keys =
-        generate_spaced_private_keys(bridge_config.node_count, bridge_config.root_private_key);
-    let mut handles = vec![];
-    let mut http_addresses = vec![];
-    for (i, key) in private_keys.into_iter().enumerate() {
-        let web3_http_port = bridge_config.base_rpc_port + i as u16;
-        let discovery_port = bridge_config.base_discovery_port + i as u16;
-        let handle = bridge_config.client_type.build_handle(
-            key,
-            web3_http_port,
-            discovery_port,
-            bridge_config.clone(),
-        );
-        let web3_http_address = format!("http://127.0.0.1:{}", web3_http_port);
-        http_addresses.push(web3_http_address);
-        handles.push(handle);
+    // start the bridge client
+    if let Err(err) = bridge_config.client_type.build_handle(&bridge_config) {
+        return Err(format!("Failed to start bridge client: {err}").into());
     }
+
+    let web3_http_address = format!("http://127.0.0.1:{}", bridge_config.base_rpc_port);
     sleep(Duration::from_secs(5)).await;
 
-    let portal_clients: Result<Vec<HttpClient>, String> = http_addresses
-        .iter()
-        .map(|address| {
-            HttpClientBuilder::default()
-                // increase default timeout to allow for trace_gossip requests that can take a long
-                // time
-                .request_timeout(Duration::from_secs(120))
-                .build(address)
-                .map_err(|e| e.to_string())
-        })
-        .collect();
+    let portal_client: HttpClient = HttpClientBuilder::default()
+        // increase default timeout to allow for trace_gossip requests that can take a long
+        // time
+        .request_timeout(Duration::from_secs(120))
+        .build(web3_http_address.clone())
+        .map_err(|e| e.to_string())?;
 
     let mut bridge_tasks = Vec::new();
 
     // Launch Beacon Network portal bridge
     if bridge_config.network.contains(&NetworkKind::Beacon) {
         let bridge_mode = bridge_config.mode.clone();
-        let portal_clients = portal_clients
-            .clone()
-            .expect("Failed to create beacon JSON-RPC clients");
         let consensus_api = ConsensusApi::new(
             bridge_config.cl_provider,
             bridge_config.cl_provider_fallback,
         )
         .await?;
+        let portal_client_clone = portal_client.clone();
         let bridge_handle = tokio::spawn(async move {
-            let beacon_bridge =
-                BeaconBridge::new(consensus_api, bridge_mode, Arc::new(portal_clients));
+            let beacon_bridge = BeaconBridge::new(consensus_api, bridge_mode, portal_client_clone);
 
             beacon_bridge
                 .launch()
@@ -90,7 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let header_oracle = HeaderOracle::new(pre_merge_acc);
                 let era1_bridge = Era1Bridge::new(
                     bridge_config.mode,
-                    portal_clients.expect("Failed to create history JSON-RPC clients"),
+                    portal_client,
                     header_oracle,
                     bridge_config.epoch_acc_path,
                     bridge_config.gossip_limit,
@@ -117,7 +95,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let bridge = HistoryBridge::new(
                         bridge_config.mode,
                         execution_api,
-                        portal_clients.expect("Failed to create history JSON-RPC clients"),
+                        portal_client,
                         header_oracle,
                         bridge_config.epoch_acc_path,
                         bridge_config.gossip_limit,

--- a/portal-bridge/src/stats.rs
+++ b/portal-bridge/src/stats.rs
@@ -184,36 +184,34 @@ impl std::fmt::Display for ContentStats {
     }
 }
 
-impl From<Vec<Result<GossipReport, Error>>> for ContentStats {
-    fn from(results: Vec<Result<GossipReport, Error>>) -> Self {
+impl From<Result<GossipReport, Error>> for ContentStats {
+    fn from(result: Result<GossipReport, Error>) -> Self {
         let mut content_stats = ContentStats::default();
-        for trace_gossip_info in results.iter() {
-            match trace_gossip_info {
-                Ok(gossip_report) => {
-                    content_stats.retries += gossip_report.retries;
-                    content_stats.found = gossip_report.found;
-                    for trace in &gossip_report.traces {
-                        for enr in trace.offered.iter() {
-                            let enr = Enr::from_str(enr)
-                                .expect("ENR from trace gossip response to successfully decode.");
-                            content_stats.offered.insert(enr);
-                        }
+        match result {
+            Ok(gossip_report) => {
+                content_stats.retries += gossip_report.retries;
+                content_stats.found = gossip_report.found;
+                for trace in &gossip_report.traces {
+                    for enr in trace.offered.iter() {
+                        let enr = Enr::from_str(enr)
+                            .expect("ENR from trace gossip response to successfully decode.");
+                        content_stats.offered.insert(enr);
+                    }
 
-                        for enr in trace.accepted.iter() {
-                            let enr = Enr::from_str(enr)
-                                .expect("ENR from trace gossip response to successfully decode.");
-                            content_stats.accepted.insert(enr);
-                        }
+                    for enr in trace.accepted.iter() {
+                        let enr = Enr::from_str(enr)
+                            .expect("ENR from trace gossip response to successfully decode.");
+                        content_stats.accepted.insert(enr);
+                    }
 
-                        for enr in trace.transferred.iter() {
-                            let enr = Enr::from_str(enr)
-                                .expect("ENR from trace gossip response to successfully decode.");
-                            content_stats.transferred.insert(enr);
-                        }
+                    for enr in trace.transferred.iter() {
+                        let enr = Enr::from_str(enr)
+                            .expect("ENR from trace gossip response to successfully decode.");
+                        content_stats.transferred.insert(enr);
                     }
                 }
-                Err(_) => content_stats.failures += 1,
             }
+            Err(_) => content_stats.failures += 1,
         }
         content_stats
     }


### PR DESCRIPTION
### What was wrong?
The bridge was initially architected to support gossip via multiple clients at once. This introduced some edge cases and unwieldy code which resulted in a feature that's not actually used / nor properly supported & tested. 

Taking into account that this general structure is not suitable for state network gossip (since a bridge should only gossip content that it's "near" to), I think it's a good idea to go ahead and remove this feature. 

Furthermore, it's likely that we'll introduce an alternative approach to "covering the keyspace" with multiple clients. via #1228 

### How was it fixed?
Removed support for `--node-count` argument

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Update cluster scripts to accommodate this change
