### PR TITLE
refactor: disable loading pre-merge accumulator from custom path

### DIFF
--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -10,7 +10,6 @@ use url::Url;
 
 use crate::types::bootnodes::Bootnodes;
 
-pub const DEFAULT_PRE_MERGE_ACC_PATH: &str = "validation_assets/merge_macc.bin";
 pub const DEFAULT_WEB3_IPC_PATH: &str = "/tmp/trin-jsonrpc.ipc";
 pub const DEFAULT_WEB3_HTTP_ADDRESS: &str = "http://127.0.0.1:8545/";
 pub const DEFAULT_WEB3_HTTP_PORT: u16 = 8545;
@@ -187,13 +186,6 @@ pub struct TrinConfig {
     pub ephemeral: bool,
 
     #[arg(
-        long = "pre-merge-accumulator-path",
-        help = "Path to pre-merge accumulator for validation",
-        default_value(DEFAULT_PRE_MERGE_ACC_PATH)
-    )]
-    pub pre_merge_acc_path: PathBuf,
-
-    #[arg(
         long = "disable-poke",
         help = "Disables the poke mechanism, which propagates content at the end of a successful content query. Disabling is useful for network analysis purposes."
     )]
@@ -245,7 +237,6 @@ impl Default for TrinConfig {
                 .expect("Parsing static DEFAULT_STORAGE_CAPACITY_MB to work"),
             enable_metrics_with_url: None,
             ephemeral: false,
-            pre_merge_acc_path: PathBuf::from(DEFAULT_PRE_MERGE_ACC_PATH.to_string()),
             disable_poke: false,
             ws: false,
             ws_port: DEFAULT_WEB3_WS_PORT,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,12 +77,8 @@ pub async fn run_trin(
     )?;
 
     // Initialize validation oracle
-    let pre_merge_accumulator =
-        PreMergeAccumulator::try_from_file(trin_config.pre_merge_acc_path.clone())?;
-    info!(
-        "Loaded pre-merge accumulator from: {:?}",
-        trin_config.pre_merge_acc_path
-    );
+    let pre_merge_accumulator = PreMergeAccumulator::default();
+    info!("Loaded pre-merge accumulator.",);
     let header_oracle = HeaderOracle::new(pre_merge_accumulator);
     let header_oracle = Arc::new(RwLock::new(header_oracle));
 

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -134,16 +134,15 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use std::{fs, path::PathBuf};
+    use std::fs;
 
     use alloy_primitives::U256;
     use serde_json::Value;
     use ssz::Encode;
 
     use ethportal_api::{
-        types::{cli::DEFAULT_PRE_MERGE_ACC_PATH, execution::accumulator::HeaderRecord},
-        utils::bytes::hex_decode,
-        BlockHeaderKey, EpochAccumulatorKey,
+        types::execution::accumulator::HeaderRecord, utils::bytes::hex_decode, BlockHeaderKey,
+        EpochAccumulatorKey,
     };
     use trin_validation::accumulator::PreMergeAccumulator;
 
@@ -282,10 +281,7 @@ mod tests {
     }
 
     fn default_header_oracle() -> Arc<RwLock<HeaderOracle>> {
-        let pre_merge_acc = PreMergeAccumulator::try_from_file(PathBuf::from(
-            DEFAULT_PRE_MERGE_ACC_PATH.to_string(),
-        ))
-        .unwrap();
+        let pre_merge_acc = PreMergeAccumulator::default();
         Arc::new(RwLock::new(HeaderOracle::new(pre_merge_acc)))
     }
 }

--- a/trin-validation/src/accumulator.rs
+++ b/trin-validation/src/accumulator.rs
@@ -1,5 +1,4 @@
 use alloy_primitives::B256;
-use rust_embed::RustEmbed;
 use std::path::PathBuf;
 
 use anyhow::anyhow;
@@ -15,6 +14,7 @@ use tree_hash_derive::TreeHash;
 use crate::{
     constants::{EPOCH_SIZE, MERGE_BLOCK_NUMBER},
     merkle::proof::MerkleTree,
+    TrinValidationAssets,
 };
 use ethportal_api::{
     types::{
@@ -28,11 +28,6 @@ use ethportal_api::{
 /// SSZ List[Hash256, max_length = MAX_HISTORICAL_EPOCHS]
 /// List of historical epoch accumulator merkle roots preceding current epoch.
 pub type HistoricalEpochRoots = VariableList<tree_hash::Hash256, typenum::U131072>;
-
-#[derive(RustEmbed)]
-#[folder = "src/assets/"]
-#[prefix = "validation_assets/"]
-struct TrinValidationAssets;
 
 /// SSZ Container
 /// Primary datatype used to maintain record of historical and current epoch.

--- a/trin-validation/src/lib.rs
+++ b/trin-validation/src/lib.rs
@@ -7,3 +7,10 @@ pub mod header_validfator;
 pub mod merkle;
 pub mod oracle;
 pub mod validator;
+
+use rust_embed::RustEmbed;
+
+#[derive(RustEmbed)]
+#[folder = "src/assets/"]
+#[prefix = "validation_assets/"]
+struct TrinValidationAssets;

--- a/trin-validation/src/oracle.rs
+++ b/trin-validation/src/oracle.rs
@@ -108,13 +108,10 @@ mod test {
     use tree_hash::TreeHash;
 
     use crate::constants::DEFAULT_PRE_MERGE_ACC_HASH;
-    use ethportal_api::types::cli::TrinConfig;
 
     #[tokio::test]
     async fn header_oracle_bootstraps_with_default_pre_merge_acc() {
-        let trin_config = TrinConfig::default();
-        let pre_merge_acc =
-            PreMergeAccumulator::try_from_file(trin_config.pre_merge_acc_path).unwrap();
+        let pre_merge_acc = PreMergeAccumulator::default();
         let header_oracle = HeaderOracle::new(pre_merge_acc);
         assert_eq!(
             header_oracle


### PR DESCRIPTION
### What was wrong?
There is no real use case for loading a pre-merge accumulator from a user-provided path, because we embed the accumulator in Trin binary.

### How was it fixed?
Remove the `pre_merge_acc_path` argument from Trin CLI.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
