### PR TITLE
fix(bridge): use client object per request in bridge

### DIFF
--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -10,7 +10,6 @@ use portal_bridge::{
     types::mode::BridgeMode,
 };
 use serde_json::Value;
-use surf::{Client, Config};
 use tokio::time::{sleep, Duration};
 use trin_validation::{accumulator::PreMergeAccumulator, oracle::HeaderOracle};
 use url::Url;
@@ -20,12 +19,11 @@ pub async fn test_history_bridge(peertest: &Peertest, portal_client: &HttpClient
     let header_oracle = HeaderOracle::new(pre_merge_acc);
     let epoch_acc_path = "validation_assets/epoch_acc.bin".into();
     let mode = BridgeMode::Test("./test_assets/portalnet/bridge_data.json".into());
-    let client: Client = Config::new()
-        // url doesn't matter, we're not making any requests
-        .set_base_url(Url::parse("http://www.null.com").unwrap())
-        .try_into()
+    // url doesn't matter, we're not making any requests
+    let client_url = Url::parse("http://www.null.com").unwrap();
+    let execution_api = ExecutionApi::new(client_url.clone(), client_url)
+        .await
         .unwrap();
-    let execution_api = ExecutionApi::new(client.clone(), client).await.unwrap();
     // Wait for bootnode to start
     sleep(Duration::from_secs(1)).await;
     let bridge = HistoryBridge::new(
@@ -51,7 +49,11 @@ pub async fn test_beacon_bridge(peertest: &Peertest, portal_client: &HttpClient)
     let mode = BridgeMode::Test("./test_assets/portalnet/beacon_bridge_data.yaml".into());
     // Wait for bootnode to start
     sleep(Duration::from_secs(1)).await;
-    let consensus_api = ConsensusApi::default();
+    // url doesn't matter, we're not making any requests
+    let client_url = Url::parse("http://www.null.com").unwrap();
+    let consensus_api = ConsensusApi::new(client_url.clone(), client_url)
+        .await
+        .unwrap();
     let bridge = BeaconBridge::new(consensus_api, mode, portal_client.clone());
     bridge.launch().await;
 

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -96,33 +96,29 @@ pub struct BridgeConfig {
         long = "el-provider",
         default_value = DEFAULT_BASE_EL_ENDPOINT,
         help = "Data provider for execution layer data. (pandaops url / infura url with api key / local node url)",
-        value_parser = url_to_client
     )]
-    pub el_provider: Client,
+    pub el_provider: Url,
 
     #[arg(
         long = "el-provider-fallback",
         default_value = FALLBACK_BASE_EL_ENDPOINT,
         help = "Data provider for execution layer data. (pandaops url / infura url with api key / local node url)",
-        value_parser = url_to_client
     )]
-    pub el_provider_fallback: Client,
+    pub el_provider_fallback: Url,
 
     #[arg(
         long = "cl-provider",
         default_value = DEFAULT_BASE_CL_ENDPOINT,
         help = "Data provider for consensus layer data. (pandaops url / local node url)",
-        value_parser = url_to_client
     )]
-    pub cl_provider: Client,
+    pub cl_provider: Url,
 
     #[arg(
         long = "cl-provider-fallback",
         default_value = FALLBACK_BASE_CL_ENDPOINT,
         help = "Data provider for consensus layer data. (pandaops url / local node url)",
-        value_parser = url_to_client
     )]
-    pub cl_provider_fallback: Client,
+    pub cl_provider_fallback: Url,
 
     #[arg(
         default_value_t = DEFAULT_DISCOVERY_PORT,
@@ -146,12 +142,11 @@ pub struct BridgeConfig {
     pub gossip_limit: usize,
 }
 
-fn url_to_client(url: &str) -> Result<Client, String> {
+pub fn url_to_client(url: Url) -> Result<Client, String> {
     let mut config = Config::new()
         .add_header("Content-Type", "application/json")
         .expect("to be able to add content type header")
         .set_timeout(Some(HTTP_REQUEST_TIMEOUT));
-    let url = Url::parse(url).map_err(|_| "Invalid provider url".to_string())?;
     if url
         .host_str()
         .expect("to find host string")
@@ -284,38 +279,22 @@ mod test {
         );
         assert_eq!(bridge_config.mode, BridgeMode::Latest);
         assert_eq!(bridge_config.epoch_acc_path, PathBuf::from(EPOCH_ACC_PATH));
-        assert!(bridge_config
-            .el_provider
-            .config()
-            .base_url
-            .as_ref()
-            .unwrap()
-            .as_str()
-            .contains(DEFAULT_BASE_EL_ENDPOINT));
-        assert!(bridge_config
-            .el_provider_fallback
-            .config()
-            .base_url
-            .as_ref()
-            .unwrap()
-            .as_str()
-            .contains(FALLBACK_BASE_EL_ENDPOINT));
-        assert!(bridge_config
-            .cl_provider
-            .config()
-            .base_url
-            .as_ref()
-            .unwrap()
-            .as_str()
-            .contains(DEFAULT_BASE_CL_ENDPOINT));
-        assert!(bridge_config
-            .cl_provider_fallback
-            .config()
-            .base_url
-            .as_ref()
-            .unwrap()
-            .as_str()
-            .contains(FALLBACK_BASE_CL_ENDPOINT));
+        assert_eq!(
+            bridge_config.el_provider.to_string(),
+            DEFAULT_BASE_EL_ENDPOINT
+        );
+        assert_eq!(
+            bridge_config.el_provider_fallback.to_string(),
+            FALLBACK_BASE_EL_ENDPOINT
+        );
+        assert_eq!(
+            bridge_config.cl_provider.to_string(),
+            DEFAULT_BASE_CL_ENDPOINT
+        );
+        assert_eq!(
+            bridge_config.cl_provider_fallback.to_string(),
+            FALLBACK_BASE_CL_ENDPOINT
+        );
         assert_eq!(
             bridge_config.network,
             vec![NetworkKind::History, NetworkKind::Beacon]


### PR DESCRIPTION
### What was wrong?
This is a bit of an experimental pr. The "latest" bridge issues we're experiencing only occur after a significant time of bridge operation. It's possible that there's an error with our request construction / response handling for long-running `Client` objects, handling many requests. Imo, it's worth trying out this change to see if constructing a `Client` object for each request at least resolves the issue, then we can see about changing this back / fixing the long-running `Client` object if we feel like it's worthwhile.

### How was it fixed?
- replaced a single-use `Client` object for a per-request `Client` object

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
