### PR TITLE
feat(bridge): throw error if invalid executable path was provided

### DIFF
--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -252,6 +252,11 @@ impl FromStr for ClientType {
 
 impl ClientType {
     pub fn build_handle(&self, bridge_config: &BridgeConfig) -> anyhow::Result<Child> {
+        if !bridge_config.executable_path.is_file() {
+            return Err(anyhow::anyhow!(
+                "Invalid executable path: exectuable doesn't exist"
+            ));
+        }
         match self {
             ClientType::Fluffy => fluffy_handle(bridge_config),
             ClientType::Trin => trin_handle(bridge_config),

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -1,6 +1,7 @@
 use std::{env, net::SocketAddr, path::PathBuf, str::FromStr};
 
 use alloy_primitives::B256;
+use anyhow::anyhow;
 use clap::{Parser, Subcommand};
 use surf::{
     middleware::{Middleware, Next},
@@ -253,8 +254,9 @@ impl FromStr for ClientType {
 impl ClientType {
     pub fn build_handle(&self, bridge_config: &BridgeConfig) -> anyhow::Result<Child> {
         if !bridge_config.executable_path.is_file() {
-            return Err(anyhow::anyhow!(
-                "Invalid executable path: exectuable doesn't exist"
+            return Err(anyhow!(
+                "Invalid path executable doesn't exist: {:?}",
+                bridge_config.executable_path
             ));
         }
         match self {


### PR DESCRIPTION
### What was wrong?
When I was working on the state bridge. An incorrect executable-path took a lot of my time, cause their was no error, but the bridge kept trying to gossip content anyways
### How was it fixed?

throw an error if the executable path doesn't lead to a file. This is a naive solution which doesn't handle all cases, but it handles most which would save people time if they entered the incorrect path.
