### PR TITLE
feat(trin-validation): add validation logic for post-merge/pre-Capella headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7985,6 +7985,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
+ "serde_yaml",
  "ssz_types",
  "tokio",
  "tree_hash",

--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -11,12 +11,11 @@ use portal_bridge::{
 };
 use serde_json::Value;
 use tokio::time::{sleep, Duration};
-use trin_validation::{accumulator::PreMergeAccumulator, oracle::HeaderOracle};
+use trin_validation::oracle::HeaderOracle;
 use url::Url;
 
 pub async fn test_history_bridge(peertest: &Peertest, portal_client: &HttpClient) {
-    let pre_merge_acc = PreMergeAccumulator::default();
-    let header_oracle = HeaderOracle::new(pre_merge_acc);
+    let header_oracle = HeaderOracle::default();
     let epoch_acc_path = "validation_assets/epoch_acc.bin".into();
     let mode = BridgeMode::Test("./test_assets/portalnet/bridge_data.json".into());
     // url doesn't matter, we're not making any requests

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -10,7 +10,7 @@ use portal_bridge::{
     types::{mode::BridgeMode, network::NetworkKind},
 };
 use trin_utils::log::init_tracing_logger;
-use trin_validation::{accumulator::PreMergeAccumulator, oracle::HeaderOracle};
+use trin_validation::oracle::HeaderOracle;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -67,8 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let bridge_mode = bridge_config.mode.clone();
         let portal_client_clone = portal_client.clone();
         let epoch_acc_path = bridge_config.epoch_acc_path.clone();
-        let master_acc = PreMergeAccumulator::default();
-        let header_oracle = HeaderOracle::new(master_acc);
+        let header_oracle = HeaderOracle::default();
         let state_bridge = StateBridge::new(
             bridge_mode,
             portal_client_clone,
@@ -90,8 +89,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if bridge_config.network.contains(&NetworkKind::History) {
         match bridge_config.mode {
             BridgeMode::FourFours(_) => {
-                let pre_merge_acc = PreMergeAccumulator::default();
-                let header_oracle = HeaderOracle::new(pre_merge_acc);
+                let header_oracle = HeaderOracle::default();
                 let era1_bridge = Era1Bridge::new(
                     bridge_config.mode,
                     portal_client,
@@ -115,8 +113,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 )
                 .await?;
                 let bridge_handle = tokio::spawn(async move {
-                    let pre_merge_acc = PreMergeAccumulator::default();
-                    let header_oracle = HeaderOracle::new(pre_merge_acc);
+                    let header_oracle = HeaderOracle::default();
 
                     let bridge = HistoryBridge::new(
                         bridge_config.mode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use trin_history::initialize_history_network;
 use trin_state::initialize_state_network;
 use trin_storage::PortalStorageConfig;
 use trin_utils::version::get_trin_version;
-use trin_validation::{accumulator::PreMergeAccumulator, oracle::HeaderOracle};
+use trin_validation::oracle::HeaderOracle;
 
 pub async fn run_trin(
     trin_config: TrinConfig,
@@ -81,9 +81,9 @@ pub async fn run_trin(
     )?;
 
     // Initialize validation oracle
-    let pre_merge_accumulator = PreMergeAccumulator::default();
-    info!(hash_tree_root = %hex_encode(pre_merge_accumulator.tree_hash_root().0),"Loaded pre-merge accumulator.",);
-    let header_oracle = HeaderOracle::new(pre_merge_accumulator);
+    let header_oracle = HeaderOracle::default();
+    info!(hash_tree_root = %hex_encode(header_oracle.header_validator.pre_merge_acc.tree_hash_root().0),"Loaded
+        pre-merge accumulator.");
     let header_oracle = Arc::new(RwLock::new(header_oracle));
 
     // Initialize state sub-network service and event handlers, if selected

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -144,7 +144,6 @@ mod tests {
         types::execution::accumulator::HeaderRecord, utils::bytes::hex_decode, BlockHeaderKey,
         EpochAccumulatorKey,
     };
-    use trin_validation::accumulator::PreMergeAccumulator;
 
     fn get_hwp_ssz() -> Vec<u8> {
         let file =
@@ -281,7 +280,6 @@ mod tests {
     }
 
     fn default_header_oracle() -> Arc<RwLock<HeaderOracle>> {
-        let pre_merge_acc = PreMergeAccumulator::default();
-        Arc::new(RwLock::new(HeaderOracle::new(pre_merge_acc)))
+        Arc::new(RwLock::new(HeaderOracle::default()))
     }
 }

--- a/trin-state/src/validation/validator.rs
+++ b/trin-state/src/validation/validator.rs
@@ -229,15 +229,13 @@ mod tests {
     use serde::Deserialize;
     use serde_yaml::Value;
     use trin_utils::submodules::read_portal_spec_tests_file;
-    use trin_validation::accumulator::PreMergeAccumulator;
 
     use super::*;
 
     const TEST_DIRECTORY: &str = "tests/mainnet/state/validation";
 
     fn create_validator() -> StateValidator {
-        let pre_merge_acc = PreMergeAccumulator::default();
-        let header_oracle = Arc::new(RwLock::new(HeaderOracle::new(pre_merge_acc)));
+        let header_oracle = Arc::new(RwLock::new(HeaderOracle::default()));
         StateValidator { header_oracle }
     }
 

--- a/trin-validation/Cargo.toml
+++ b/trin-validation/Cargo.toml
@@ -21,6 +21,7 @@ lazy_static = "1.4.0"
 rust-embed = "6.6.1"
 serde = { version = "1.0.150", features = ["derive"] }
 serde_json = "1.0.89"
+serde_yaml = "0.9.33"
 ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "2a5922de75f00746890bf4ea9ad663c9d5d58efe" }
 tokio = { version = "1.14.0", features = ["full"] }
 tree_hash = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }

--- a/trin-validation/src/header_validator.rs
+++ b/trin-validation/src/header_validator.rs
@@ -21,8 +21,10 @@ pub struct HeaderValidator {
 }
 
 impl HeaderValidator {
-    pub fn new(pre_merge_acc: PreMergeAccumulator) -> Self {
+    pub fn new() -> Self {
+        let pre_merge_acc = PreMergeAccumulator::default();
         let historical_roots_acc = HistoricalRootsAccumulator::default();
+
         Self {
             pre_merge_acc,
             historical_roots_acc,

--- a/trin-validation/src/oracle.rs
+++ b/trin-validation/src/oracle.rs
@@ -3,7 +3,7 @@ use anyhow::anyhow;
 use serde_json::Value;
 use tokio::sync::mpsc;
 
-use crate::{accumulator::PreMergeAccumulator, header_validator::HeaderValidator};
+use crate::header_validator::HeaderValidator;
 use ethportal_api::{
     types::{
         execution::header_with_proof::HeaderWithProof,
@@ -28,9 +28,15 @@ pub struct HeaderOracle {
     pub header_validator: HeaderValidator,
 }
 
+impl Default for HeaderOracle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HeaderOracle {
-    pub fn new(pre_merge_acc: PreMergeAccumulator) -> Self {
-        let header_validator = HeaderValidator::new(pre_merge_acc);
+    pub fn new() -> Self {
+        let header_validator = HeaderValidator::new();
         Self {
             history_jsonrpc_tx: None,
             beacon_jsonrpc_tx: None,
@@ -111,8 +117,7 @@ mod test {
 
     #[tokio::test]
     async fn header_oracle_bootstraps_with_default_pre_merge_acc() {
-        let pre_merge_acc = PreMergeAccumulator::default();
-        let header_oracle = HeaderOracle::new(pre_merge_acc);
+        let header_oracle = HeaderOracle::default();
         assert_eq!(
             header_oracle
                 .header_validator


### PR DESCRIPTION
### What was wrong?
No logic was implemented for validating post-merge/pre-Capella execution headers.

### How was it fixed?
- Implement the chain of proofs validation using the historical roots accumulator.
- move the build of the pre-merge accumulator inside `HeaderValidator`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
