### PR TITLE
feat(bridge): add four fours hunter mode

### DIFF
--- a/portal-bridge/README.md
+++ b/portal-bridge/README.md
@@ -37,6 +37,9 @@ Current options include `"trin"` / `"fluffy"`.
 - `"--mode fourfours:random_epoch:100"`: will randomly select a single era1 file from `era1.ethportal.net` that represents an epoch number greater than the floor provided and then gossip it
 - `"--mode fourfours:e600`: will select era1 file 600 from `era1.ethportal.net` and gossip it
 - `"--mode fourfours:r100-200`: will gossip a block range from an era1 file, range must be from the same epoch
+- `"--mode fourfours:hunter:10:50`: sample size = 10, threshold = 50
+    - will randomly select era1 files from `era1.ethportal.net` and gossip them after performing rfc lookups given the sample size. if the threshold is **not** met, the era1 file will be gossiped.
+    - before gossiping a individual piece of content, the bridge will perform a lookup to see if the content is already in the portal network. If it is, the content will not be gossiped.
 
 ### Network
 You can specify the `--network` flag for which network to run the bridge for

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -88,6 +88,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Launch History Network portal bridge
     if bridge_config.network.contains(&NetworkKind::History) {
+        let execution_api = ExecutionApi::new(
+            bridge_config.el_provider,
+            bridge_config.el_provider_fallback,
+        )
+        .await?;
         match bridge_config.mode {
             BridgeMode::FourFours(_) => {
                 let pre_merge_acc = PreMergeAccumulator::default();
@@ -98,6 +103,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     header_oracle,
                     bridge_config.epoch_acc_path,
                     bridge_config.gossip_limit,
+                    execution_api,
                 )
                 .await?;
                 let bridge_handle = tokio::spawn(async move {
@@ -109,11 +115,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 bridge_tasks.push(bridge_handle);
             }
             _ => {
-                let execution_api = ExecutionApi::new(
-                    bridge_config.el_provider,
-                    bridge_config.el_provider_fallback,
-                )
-                .await?;
                 let bridge_handle = tokio::spawn(async move {
                     let pre_merge_acc = PreMergeAccumulator::default();
                     let header_oracle = HeaderOracle::new(pre_merge_acc);

--- a/portal-bridge/src/types/mode.rs
+++ b/portal-bridge/src/types/mode.rs
@@ -175,6 +175,9 @@ pub enum FourFoursMode {
     Single(u64),
     // Gossips a block range from within a single epoch
     Range(u64, u64),
+    // Hunter mode tries to efficiently find missing data, by sampling a given number of blocks
+    // (sample_size, threshold)
+    Hunter(u64, u64),
 }
 
 const RANDOM_SINGLE_MODE: &str = "random_epoch";
@@ -184,6 +187,21 @@ impl FromStr for FourFoursMode {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty() {
             return Err("Invalid bridge fourfours mode arg: empty string".to_string());
+        }
+        if s.starts_with("hunter") {
+            let mut split = s.split(':');
+            let _ = split.next();
+            let sample_size = split
+                .next()
+                .expect("Invalid 4444s bridge hunter mode arg: missing sample size")
+                .parse()
+                .expect("Invalid 4444s bridge hunter mode arg: invalid sample size");
+            let threshold = split
+                .next()
+                .expect("Invalid 4444s bridge hunter mode arg: missing threshold")
+                .parse()
+                .expect("Invalid 4444s bridge hunter mode arg: invalid threshold");
+            return Ok(FourFoursMode::Hunter(sample_size, threshold));
         }
         if s.starts_with(RANDOM_SINGLE_MODE) {
             match s.split(':').nth(1) {


### PR DESCRIPTION
### What was wrong?
Added a four fours mode that accepts a sample size & threshold, will iter through all the epochs until it finds an epoch that's insufficiently available on the network according to the provided levels. Then it will gossip this epoch. For each individual piece of content within the epoch, it will perform an RFC lookup and will only gossip that piece of content if the RFC lookup fails.

### How was it fixed?
added "hunter" mode to 4444s bridge

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
