### PR TITLE
feat(trin-validation): add validation logic for post-Capella headers

### DIFF
--- a/ethportal-api/src/types/consensus/beacon_state.rs
+++ b/ethportal-api/src/types/consensus/beacon_state.rs
@@ -5,7 +5,7 @@ use crate::consensus::{
     },
     fork::ForkName,
     header::BeaconBlockHeader,
-    historical_summaries::HistoricalSummary,
+    historical_summaries::HistoricalSummaries,
     participation_flags::ParticipationFlags,
     pubkey::PubKey,
     sync_committee::SyncCommittee,
@@ -143,7 +143,7 @@ pub struct BeaconState {
     pub next_withdrawal_validator_index: u64,
     // Deep history valid from Capella onwards.
     #[superstruct(only(Capella, Deneb))]
-    pub historical_summaries: VariableList<HistoricalSummary, HistoricalRootsLimit>,
+    pub historical_summaries: HistoricalSummaries,
 }
 
 impl BeaconState {

--- a/ethportal-api/src/types/consensus/historical_summaries.rs
+++ b/ethportal-api/src/types/consensus/historical_summaries.rs
@@ -12,11 +12,11 @@ use tree_hash_derive::TreeHash;
 /// https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#historicalsummary
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Decode, Encode, TreeHash)]
 pub struct HistoricalSummary {
-    block_summary_root: B256,
-    state_summary_root: B256,
+    pub block_summary_root: B256,
+    pub state_summary_root: B256,
 }
 
-type HistoricalSummaries = VariableList<HistoricalSummary, typenum::U16777216>;
+pub type HistoricalSummaries = VariableList<HistoricalSummary, typenum::U16777216>;
 
 /// Proof against the beacon state root hash
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -121,7 +121,7 @@ impl Era1Bridge {
         for era1_path in era1_files {
             let epoch = get_epoch_from_era1_path(&era1_path)?;
             info!("Hunting for missing content inside epoch: {epoch}");
-            let block_range = (epoch * EPOCH_SIZE as u64)..((epoch + 1) * EPOCH_SIZE as u64);
+            let block_range = (epoch * EPOCH_SIZE)..((epoch + 1) * EPOCH_SIZE);
             let blocks_to_sample = block_range.clone().collect::<Vec<u64>>();
             let blocks_to_sample =
                 blocks_to_sample.choose_multiple(&mut thread_rng(), sample_size as usize);
@@ -203,7 +203,7 @@ impl Era1Bridge {
     }
 
     async fn launch_range(&self, start: u64, end: u64) {
-        let epoch = start / EPOCH_SIZE as u64;
+        let epoch = start / EPOCH_SIZE;
         let era1_path =
             self.era1_files.clone().into_iter().find(|file| {
                 file.contains(&format!("mainnet-{epoch:05}-")) && file.contains(".era1")
@@ -283,9 +283,7 @@ impl Era1Bridge {
         let content_key = HistoryContentKey::EpochAccumulator(EpochAccumulatorKey { epoch_hash });
         let content_value = HistoryContentValue::EpochAccumulator(epoch_acc.clone());
         // create unique stats for epoch accumulator, since it's rarely gossiped
-        let block_stats = Arc::new(Mutex::new(HistoryBlockStats::new(
-            epoch_index * EPOCH_SIZE as u64,
-        )));
+        let block_stats = Arc::new(Mutex::new(HistoryBlockStats::new(epoch_index * EPOCH_SIZE)));
         debug!("Built EpochAccumulator for Epoch #{epoch_index:?}: now gossiping.");
         // spawn gossip in new thread to avoid blocking
         let portal_client = self.portal_client.clone();
@@ -514,7 +512,7 @@ impl Era1Bridge {
         );
         let header = block_tuple.header.header;
         // Fetch HeaderRecord from EpochAccumulator for validation
-        let header_index = header.number % EPOCH_SIZE as u64;
+        let header_index = header.number % EPOCH_SIZE;
         let header_record = &epoch_acc[header_index as usize];
 
         // Validate Header

--- a/portal-bridge/src/bridge/history.rs
+++ b/portal-bridge/src/bridge/history.rs
@@ -25,14 +25,13 @@ use ethportal_api::{
     EpochAccumulatorKey, HistoryContentKey, HistoryContentValue,
 };
 use trin_validation::{
-    constants::{EPOCH_SIZE as EPOCH_SIZE_USIZE, MERGE_BLOCK_NUMBER},
+    constants::{EPOCH_SIZE, MERGE_BLOCK_NUMBER},
     oracle::HeaderOracle,
 };
 
 // todo: calculate / test optimal saturation delay
 pub const HEADER_SATURATION_DELAY: u64 = 10; // seconds
 const LATEST_BLOCK_POLL_RATE: u64 = 5; // seconds
-pub const EPOCH_SIZE: u64 = EPOCH_SIZE_USIZE as u64;
 pub const SERVE_BLOCK_TIMEOUT: Duration = Duration::from_secs(120);
 pub const SERVE_CONTENT_TIMEOUT: Duration = Duration::from_secs(30);
 

--- a/portal-bridge/src/bridge/state.rs
+++ b/portal-bridge/src/bridge/state.rs
@@ -11,10 +11,10 @@ use tokio::{
 };
 use tracing::{debug, error, info, warn};
 use trin_metrics::bridge::BridgeMetricsReporter;
-use trin_validation::oracle::HeaderOracle;
+use trin_validation::{constants::EPOCH_SIZE, oracle::HeaderOracle};
 
 use crate::{
-    bridge::history::{EPOCH_SIZE, SERVE_BLOCK_TIMEOUT},
+    bridge::history::SERVE_BLOCK_TIMEOUT,
     gossip::gossip_state_content,
     types::{
         era1::Era1,

--- a/portal-bridge/src/types/full_header.rs
+++ b/portal-bridge/src/types/full_header.rs
@@ -5,7 +5,6 @@ use anyhow::{anyhow, ensure};
 use serde::{Deserialize, Deserializer};
 use serde_json::Value;
 
-use crate::bridge::history::EPOCH_SIZE;
 use ethportal_api::types::{
     consensus::withdrawal::Withdrawal,
     execution::{
@@ -14,7 +13,7 @@ use ethportal_api::types::{
         transaction::Transaction,
     },
 };
-use trin_validation::constants::MERGE_BLOCK_NUMBER;
+use trin_validation::constants::{EPOCH_SIZE, MERGE_BLOCK_NUMBER};
 
 /// Helper type to deserialize a response from a batched Header request.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/portal-bridge/src/types/mode.rs
+++ b/portal-bridge/src/types/mode.rs
@@ -46,10 +46,10 @@ impl BridgeMode {
         let (start, end) = match mode_type.clone() {
             ModeType::Epoch(epoch_number) => {
                 let end_block = match is_single_mode {
-                    true => (epoch_number + 1) * EPOCH_SIZE as u64,
+                    true => (epoch_number + 1) * EPOCH_SIZE,
                     false => latest_block + 1,
                 };
-                (epoch_number * EPOCH_SIZE as u64, end_block)
+                (epoch_number * EPOCH_SIZE, end_block)
             }
             ModeType::Block(block) => {
                 let end_block = match is_single_mode {
@@ -250,8 +250,8 @@ impl FromStr for FourFoursMode {
                             .to_string(),
                     );
                 }
-                let start_epoch = start_block / EPOCH_SIZE as u64;
-                let end_epoch = end_block / EPOCH_SIZE as u64;
+                let start_epoch = start_block / EPOCH_SIZE;
+                let end_epoch = end_block / EPOCH_SIZE;
                 if start_epoch != end_epoch {
                     return Err(
                         "Invalid 4444s bridge mode arg: start_block and end_block are not in the same epoch"

--- a/src/bin/test_providers.rs
+++ b/src/bin/test_providers.rs
@@ -20,12 +20,12 @@ use ethportal_api::{
     utils::bytes::hex_encode,
     Header,
 };
-use portal_bridge::{api::execution::ExecutionApi, bridge::history::EPOCH_SIZE};
+use portal_bridge::api::execution::ExecutionApi;
 use trin_utils::log::init_tracing_logger;
 use trin_validation::{
     accumulator::PreMergeAccumulator,
     constants::{
-        BERLIN_BLOCK_NUMBER, BYZANTIUM_BLOCK_NUMBER, CONSTANTINOPLE_BLOCK_NUMBER,
+        BERLIN_BLOCK_NUMBER, BYZANTIUM_BLOCK_NUMBER, CONSTANTINOPLE_BLOCK_NUMBER, EPOCH_SIZE,
         HOMESTEAD_BLOCK_NUMBER, ISTANBUL_BLOCK_NUMBER, LONDON_BLOCK_NUMBER, MERGE_BLOCK_NUMBER,
         SHANGHAI_BLOCK_NUMBER,
     },

--- a/trin-validation/src/accumulator.rs
+++ b/trin-validation/src/accumulator.rs
@@ -63,7 +63,7 @@ impl PreMergeAccumulator {
     }
 
     pub(crate) fn get_epoch_index_of_header(&self, header: &Header) -> u64 {
-        header.number / EPOCH_SIZE as u64
+        header.number / EPOCH_SIZE
     }
 
     pub async fn lookup_premerge_hash_by_number(
@@ -74,8 +74,8 @@ impl PreMergeAccumulator {
         if block_number > MERGE_BLOCK_NUMBER {
             return Err(anyhow!("Post-merge blocks are not supported."));
         }
-        let rel_index = block_number % EPOCH_SIZE as u64;
-        let epoch_index = block_number / EPOCH_SIZE as u64;
+        let rel_index = block_number % EPOCH_SIZE;
+        let epoch_index = block_number / EPOCH_SIZE;
         let epoch_hash = self.historical_epochs[epoch_index as usize];
         let epoch_acc = self
             .lookup_epoch_acc(epoch_hash, history_jsonrpc_tx)
@@ -146,7 +146,7 @@ impl PreMergeAccumulator {
         epoch_acc: &EpochAccumulator,
     ) -> anyhow::Result<[B256; 15]> {
         // Validate header hash matches historical hash from epoch accumulator
-        let hr_index = (header.number % EPOCH_SIZE as u64) as usize;
+        let hr_index = (header.number % EPOCH_SIZE) as usize;
         let header_record = epoch_acc[hr_index];
         if header_record.block_hash != header.hash() {
             return Err(anyhow!(

--- a/trin-validation/src/constants.rs
+++ b/trin-validation/src/constants.rs
@@ -15,7 +15,7 @@ pub const DEFAULT_PRE_MERGE_ACC_HASH: &str =
     "0x8eac399e24480dce3cfe06f4bdecba51c6e5d0c46200e3e8611a0b44a3a69ff9";
 
 /// Max number of blocks / epoch = 2 ** 13
-pub const EPOCH_SIZE: usize = 8192;
+pub const EPOCH_SIZE: u64 = 8192;
 
 // Max number of epochs = 2 ** 17
 // const MAX_HISTORICAL_EPOCHS: usize = 131072;

--- a/trin-validation/src/constants.rs
+++ b/trin-validation/src/constants.rs
@@ -7,6 +7,8 @@ pub const ISTANBUL_BLOCK_NUMBER: u64 = 9_069_000;
 pub const CONSTANTINOPLE_BLOCK_NUMBER: u64 = 7_280_000;
 pub const BYZANTIUM_BLOCK_NUMBER: u64 = 4_370_000;
 pub const HOMESTEAD_BLOCK_NUMBER: u64 = 1_150_000;
+pub const CAPELLA_FORK_EPOCH: u64 = 194_048;
+pub const SLOTS_PER_EPOCH: u64 = 32;
 
 /// The default hash of the pre-merge accumulator at the time of the merge block.
 pub const DEFAULT_PRE_MERGE_ACC_HASH: &str =

--- a/trin-validation/src/header_validator.rs
+++ b/trin-validation/src/header_validator.rs
@@ -1,14 +1,18 @@
 use crate::{
     accumulator::PreMergeAccumulator,
-    constants::{EPOCH_SIZE, MERGE_BLOCK_NUMBER, SHANGHAI_BLOCK_NUMBER},
+    constants::{
+        CAPELLA_FORK_EPOCH, EPOCH_SIZE, MERGE_BLOCK_NUMBER, SHANGHAI_BLOCK_NUMBER, SLOTS_PER_EPOCH,
+    },
     historical_roots_acc::HistoricalRootsAccumulator,
     merkle::proof::verify_merkle_proof,
 };
 use alloy_primitives::B256;
 use anyhow::anyhow;
 use ethportal_api::{
+    consensus::historical_summaries::HistoricalSummaries,
     types::execution::header_with_proof::{
-        BlockHeaderProof, HeaderWithProof, HistoricalRootsBlockProof,
+        BeaconBlockBodyProof, BeaconBlockHeaderProof, BlockHeaderProof, HeaderWithProof,
+        HistoricalRootsBlockProof, HistoricalSummariesBlockProof,
     },
     Header,
 };
@@ -70,7 +74,7 @@ impl HeaderValidator {
             BlockHeaderProof::HistoricalRootsBlockProof(proof) => self
                 .verify_post_merge_pre_capella_header(hwp.header.number, hwp.header.hash(), proof),
             BlockHeaderProof::HistoricalSummariesBlockProof(_) => {
-                if hwp.header.number <= SHANGHAI_BLOCK_NUMBER {
+                if hwp.header.number < SHANGHAI_BLOCK_NUMBER {
                     return Err(anyhow!(
                         "Invalid HistoricalSummariesBlockProof found for pre-Shanghai header."
                     ));
@@ -100,29 +104,16 @@ impl HeaderValidator {
         }
 
         // Verify the chain of proofs for post-merge/pre-capella block header
-        if !verify_merkle_proof(
+        Self::verify_beacon_block_body_proof(
             header_hash,
             &proof.beacon_block_body_proof,
-            8,
-            412,
             proof.beacon_block_body_root,
-        ) {
-            return Err(anyhow!(
-                "Merkle proof validation failed for BeaconBlockBodyProof"
-            ));
-        }
-
-        if !verify_merkle_proof(
+        )?;
+        Self::verify_beacon_block_header_proof(
             proof.beacon_block_body_root,
             &proof.beacon_block_header_proof,
-            3,
-            12,
             proof.beacon_block_header_root,
-        ) {
-            return Err(anyhow!(
-                "Merkle proof validation failed for BeaconBlockHeaderProof"
-            ));
-        }
+        )?;
 
         let block_root_index = proof.slot % 8192;
         let gen_index = 2 * 8192 + block_root_index;
@@ -142,6 +133,88 @@ impl HeaderValidator {
             ));
         }
 
+        Ok(())
+    }
+
+    /// A method to verify the chain of proofs for post-Capella execution headers.
+    #[allow(dead_code)] // TODO: Remove this when used
+    fn verify_post_capella_header(
+        &self,
+        block_number: u64,
+        header_hash: B256,
+        proof: &HistoricalSummariesBlockProof,
+        historical_summaries: HistoricalSummaries,
+    ) -> anyhow::Result<()> {
+        if block_number < SHANGHAI_BLOCK_NUMBER {
+            return Err(anyhow!(
+                "Invalid HistoricalSummariesBlockProof found for pre-Shanghai header."
+            ));
+        }
+
+        // Verify the chain of proofs for post-merge/pre-capella block header
+        Self::verify_beacon_block_body_proof(
+            header_hash,
+            &proof.beacon_block_body_proof,
+            proof.beacon_block_body_root,
+        )?;
+        Self::verify_beacon_block_header_proof(
+            proof.beacon_block_body_root,
+            &proof.beacon_block_header_proof,
+            proof.beacon_block_header_root,
+        )?;
+
+        let block_root_index = proof.slot % 8192;
+        let gen_index = 8192 + block_root_index;
+        let historical_summary_index = (proof.slot - CAPELLA_FORK_EPOCH * SLOTS_PER_EPOCH) / 8192;
+        let historical_summary =
+            historical_summaries[historical_summary_index as usize].block_summary_root;
+
+        if !verify_merkle_proof(
+            proof.beacon_block_header_root,
+            &proof.historical_summaries_proof,
+            13,
+            gen_index as usize,
+            historical_summary,
+        ) {
+            return Err(anyhow!(
+                "Merkle proof validation failed for HistoricalSummariesProof"
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Verify that the beacon block body root is included in the beacon header
+    fn verify_beacon_block_header_proof(
+        block_body_root: B256,
+        block_header_proof: &BeaconBlockHeaderProof,
+        block_header_root: B256,
+    ) -> anyhow::Result<()> {
+        if !verify_merkle_proof(
+            block_body_root,
+            block_header_proof,
+            3,
+            12,
+            block_header_root,
+        ) {
+            return Err(anyhow!(
+                "Merkle proof validation failed for BeaconBlockHeaderProof"
+            ));
+        }
+        Ok(())
+    }
+
+    /// Verify that the execution block header is included in the beacon block body
+    fn verify_beacon_block_body_proof(
+        header_hash: B256,
+        block_body_proof: &BeaconBlockBodyProof,
+        block_body_root: B256,
+    ) -> anyhow::Result<()> {
+        if !verify_merkle_proof(header_hash, block_body_proof, 8, 412, block_body_root) {
+            return Err(anyhow!(
+                "Merkle proof validation failed for BeaconBlockBodyProof"
+            ));
+        }
         Ok(())
     }
 }
@@ -352,6 +425,64 @@ mod test {
             MERGE_BLOCK_NUMBER,
             header_hash,
             &historical_roots_block_proof,
+        );
+        assert!(validator_result.is_err());
+    }
+
+    #[rstest]
+    #[case(17034870)]
+    #[case(17042287)]
+    #[case(17062257)]
+    #[tokio::test]
+    async fn header_validator_validate_post_capella_header(#[case] block_number: u64) {
+        let header_validator = get_mainnet_header_validator();
+
+        // Read the historical roots block proof from a test file
+        let file = fs::read_to_string(format!("./../portal-spec-tests/tests/mainnet/history/headers_with_proof/block_proofs_capella/beacon_block_proof-{block_number}.yaml")).unwrap();
+        let mut value: serde_yaml::Value = serde_yaml::from_str(&file).unwrap();
+        let header_hash = value
+            .get("execution_block_header")
+            .unwrap()
+            .as_str()
+            .unwrap();
+        let header_hash = B256::from_str(header_hash).unwrap();
+
+        // Change the first value of beacon_block_header_proof from Number to String.
+        // This is required because yaml Value deserialize 0x0000.. as Number(0) instead of String
+        let inner_value = value
+            .get_mut("beacon_block_header_proof")
+            .unwrap()
+            .get_mut(0)
+            .unwrap();
+        *inner_value = serde_yaml::Value::String(
+            "0x0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+        );
+
+        let historical_summaries_block_proof: HistoricalSummariesBlockProof =
+            serde_yaml::from_value(value).unwrap();
+
+        // Load historical summaries from ssz file
+        let historical_summaries_bytes = std::fs::read("./../portal-spec-tests/tests/mainnet/history/headers_with_proof/block_proofs_capella/historical_summaries_at_slot_8953856.ssz"
+        ).expect("cannot load HistoricalSummaries bytes from test file");
+
+        let historical_summaries = HistoricalSummaries::from_ssz_bytes(&historical_summaries_bytes)
+            .expect("cannot decode HistoricalSummaries bytes");
+
+        header_validator
+            .verify_post_capella_header(
+                block_number,
+                header_hash,
+                &historical_summaries_block_proof,
+                historical_summaries.clone(),
+            )
+            .unwrap();
+
+        // Test for invalid block numbers
+        let validator_result = header_validator.verify_post_capella_header(
+            SHANGHAI_BLOCK_NUMBER - 1,
+            header_hash,
+            &historical_summaries_block_proof,
+            historical_summaries,
         );
         assert!(validator_result.is_err());
     }

--- a/trin-validation/src/header_validator.rs
+++ b/trin-validation/src/header_validator.rs
@@ -54,7 +54,7 @@ impl HeaderValidator {
                     hwp.header.hash(),
                     &proof.proof,
                     15,
-                    gen_index,
+                    gen_index as usize,
                     epoch_hash,
                 ) {
                     true => Ok(()),
@@ -115,9 +115,9 @@ impl HeaderValidator {
             proof.beacon_block_header_root,
         )?;
 
-        let block_root_index = proof.slot % 8192;
-        let gen_index = 2 * 8192 + block_root_index;
-        let historical_root_index = proof.slot / 8192;
+        let block_root_index = proof.slot % EPOCH_SIZE;
+        let gen_index = 2 * EPOCH_SIZE + block_root_index;
+        let historical_root_index = proof.slot / EPOCH_SIZE;
         let historical_root =
             self.historical_roots_acc.historical_roots[historical_root_index as usize];
 
@@ -163,9 +163,10 @@ impl HeaderValidator {
             proof.beacon_block_header_root,
         )?;
 
-        let block_root_index = proof.slot % 8192;
-        let gen_index = 8192 + block_root_index;
-        let historical_summary_index = (proof.slot - CAPELLA_FORK_EPOCH * SLOTS_PER_EPOCH) / 8192;
+        let block_root_index = proof.slot % EPOCH_SIZE;
+        let gen_index = EPOCH_SIZE + block_root_index;
+        let historical_summary_index =
+            (proof.slot - CAPELLA_FORK_EPOCH * SLOTS_PER_EPOCH) / EPOCH_SIZE;
         let historical_summary =
             historical_summaries[historical_summary_index as usize].block_summary_root;
 
@@ -219,10 +220,10 @@ impl HeaderValidator {
     }
 }
 
-fn calculate_generalized_index(header: &Header) -> usize {
+fn calculate_generalized_index(header: &Header) -> u64 {
     // Calculate generalized index for header
     // https://github.com/ethereum/consensus-specs/blob/v0.11.1/ssz/merkle-proofs.md#generalized-merkle-tree-index
-    let hr_index = header.number as usize % EPOCH_SIZE;
+    let hr_index = header.number % EPOCH_SIZE;
     (EPOCH_SIZE * 2 * 2) + (hr_index * 2)
 }
 


### PR DESCRIPTION
### What was wrong?
Validation logic for post-Capella headers was missing.

### How was it fixed?
- add validation logic for post-Capella headers.
- add tests using the test vectors [here](https://github.com/ethereum/portal-spec-tests/pull/12#pullrequestreview-2044988449).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Rebase when test vectors get merged: https://github.com/ethereum/portal-spec-tests/pull/12#pullrequestreview-2044988449
