### PR TITLE
feat(beacon-storage): store `HistoricalSummariesWithProof` content and add beacon storage tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8251,6 +8251,8 @@ dependencies = [
  "r2d2_sqlite",
  "rusqlite",
  "serde_json",
+ "serde_yaml",
+ "snap",
  "ssz_types",
  "tokio",
  "tracing",

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -30,3 +30,7 @@ trin-storage = { path = "../trin-storage" }
 trin-validation = { path = "../trin-validation" }
 trin-utils = { path = "../trin-utils" }
 utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.12" }
+
+[dev-dependencies]
+serde_yaml = "0.9.33"
+snap = "1.1.1"


### PR DESCRIPTION
### What was wrong?

We don't store `HistoricalSummariesWithProof` in db.

### How was it fixed?
- store the latest "HistoricalSummariesWithProof" version in the beacon cache storage
- add tests for beacon storage

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
