### PR TITLE
fix(storage): skip error log if storage config is 0

### DIFF
--- a/trin-storage/src/versioned/id_indexed_v1/store.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/store.rs
@@ -436,6 +436,12 @@ impl IdIndexedV1Store {
             return Ok(());
         }
 
+        if self.config.storage_capacity_bytes == 0 {
+            warn!(Db = %self.config.content_type,
+                "Pruning requested but storage capacity is 0. Skipping");
+            return Ok(());
+        }
+
         let timer = self.metrics.start_process_timer("prune");
         debug!(Db = %self.config.content_type,
             "Pruning start: count={} capacity={}",


### PR DESCRIPTION
### What was wrong?
If storage capacity is set to 0, you get a whole lot of these `ERROR` warnings, which also sets the `data_radius` to `MAX` incorrectly.

### How was it fixed?
Skip pruning if storage config is set to 0

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
