### PR TITLE
fix(bridge): add floor to hunter mode

### DIFF
--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -120,6 +120,10 @@ impl Era1Bridge {
         let era1_files = self.era1_files.clone().into_iter();
         for era1_path in era1_files {
             let epoch = get_epoch_from_era1_path(&era1_path)?;
+            if epoch < 512 {
+                info!("Skipping epoch {epoch} since it's from before block #4,200,000 and this range is already very well saturated.");
+                continue;
+            }
             info!("Hunting for missing content inside epoch: {epoch}");
             let block_range = (epoch * EPOCH_SIZE)..((epoch + 1) * EPOCH_SIZE);
             let blocks_to_sample = block_range.clone().collect::<Vec<u64>>();


### PR DESCRIPTION
### What was wrong?
Block range prior to `4.200.000` is very well saturated already. I've noticed on my personal "hunter" nodes that they still spend a significant amount of time trying to find un-saturated epochs from this range, so to expedite the hunting process it seems worthwhile to implement a floor to the hunter. This can easily be reversed / undone down the road once 4444s is thoroughly saturated.

### How was it fixed?
Skip epochs < 512 in hunter mode.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
