### PR TITLE
refactor: make `stop_process_timer` return duration

### DIFF
--- a/trin-metrics/src/storage.rs
+++ b/trin-metrics/src/storage.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use ethportal_api::types::{distance::Distance, portal_wire::ProtocolId};
 use prometheus_exporter::{
     self,
@@ -104,8 +106,8 @@ impl StorageMetricsReporter {
         )
     }
 
-    pub fn stop_process_timer(&self, timer: DiscardOnDropHistogramTimer) {
-        timer.observe_duration()
+    pub fn stop_process_timer(&self, timer: DiscardOnDropHistogramTimer) -> Duration {
+        Duration::from_secs_f64(timer.stop_and_record())
     }
 
     pub fn report_content_data_storage_bytes(&self, bytes: f64) {


### PR DESCRIPTION
### What was wrong?

The `StorageMetricsReporter` doesn't return elapsed duration when `stop_process_timer` is called, which can be useful in some situations.

This is a followup from #1295.

### How was it fixed?

Make `stop_process_timer` return elapsed duration and use it to simplify the logic for updating pruning strategy.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
