### PR TITLE
fix: remove newspace from log message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8041,6 +8041,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "anyhow",
+ "enr",
  "eth2_hashing",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -8304,6 +8305,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
  "trin-utils",
+ "trin-validation",
  "utp-rs",
 ]
 

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -6,7 +6,7 @@ use std::{
 use discv5::TalkRequest;
 use parking_lot::RwLock;
 use tokio::{
-    sync::{mpsc, mpsc::unbounded_channel},
+    sync::{mpsc, mpsc::unbounded_channel, RwLock as TokioRwLock},
     time::{self, Duration},
 };
 use utp_rs::socket::UtpSocket;
@@ -27,7 +27,7 @@ use portalnet::{
     utils::db::setup_temp_dir,
 };
 use trin_storage::{ContentStore, DistanceFunction, MemoryContentStore};
-use trin_validation::validator::MockValidator;
+use trin_validation::{oracle::HeaderOracle, validator::MockValidator};
 
 async fn init_overlay(
     discovery: Arc<Discovery>,
@@ -39,8 +39,11 @@ async fn init_overlay(
     let store = MemoryContentStore::new(node_id, DistanceFunction::Xor);
     let store = Arc::new(RwLock::new(store));
 
+    let header_oracle = HeaderOracle::default();
+    let header_oracle = Arc::new(TokioRwLock::new(header_oracle));
     let (_utp_talk_req_tx, utp_talk_req_rx) = unbounded_channel();
-    let discv5_utp = Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx);
+    let discv5_utp =
+        Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx, header_oracle, 50);
     let utp_socket = Arc::new(UtpSocket::with_socket(discv5_utp));
 
     let validator = Arc::new(MockValidator {});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,6 @@
 
 use std::sync::Arc;
 
-use rpc::{launch_jsonrpc_server, RpcServerHandle};
-use tokio::sync::{mpsc, RwLock};
-use tracing::info;
-use tree_hash::TreeHash;
-use utp_rs::socket::UtpSocket;
-
 #[cfg(windows)]
 use ethportal_api::types::cli::Web3TransportType;
 use ethportal_api::{
@@ -21,12 +15,17 @@ use portalnet::{
     events::PortalnetEvents,
     utils::db::{configure_node_data_dir, configure_trin_data_dir},
 };
+use rpc::{launch_jsonrpc_server, RpcServerHandle};
+use tokio::sync::{mpsc, RwLock};
+use tracing::info;
+use tree_hash::TreeHash;
 use trin_beacon::initialize_beacon_network;
 use trin_history::initialize_history_network;
 use trin_state::initialize_state_network;
 use trin_storage::PortalStorageConfig;
 use trin_utils::version::get_trin_version;
 use trin_validation::oracle::HeaderOracle;
+use utp_rs::socket::UtpSocket;
 
 pub async fn run_trin(
     trin_config: TrinConfig,
@@ -68,9 +67,26 @@ pub async fn run_trin(
         prometheus_exporter::start(addr)?;
     }
 
+    // Initialize validation oracle
+    let header_oracle = HeaderOracle::default();
+    info!(hash_tree_root = %hex_encode(header_oracle.header_validator.pre_merge_acc.tree_hash_root().0),"Loaded pre-merge accumulator.");
+    let header_oracle = Arc::new(RwLock::new(header_oracle));
+
     // Initialize and spawn uTP socket
     let (utp_talk_reqs_tx, utp_talk_reqs_rx) = mpsc::unbounded_channel();
-    let discv5_utp_socket = Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_reqs_rx);
+
+    // Set the enr_cache_capacity to the maximum uTP limit between all active networks. This is
+    // a trade off between memory usage and increased searches from the networks for each Enr.
+    // utp_transfer_limit is 2x as it would be utp_transfer_limit for incoming and
+    // utp_transfer_limit for outgoing
+    let enr_cache_capacity =
+        portalnet_config.utp_transfer_limit * 2 * trin_config.portal_subnetworks.len();
+    let discv5_utp_socket = Discv5UdpSocket::new(
+        Arc::clone(&discovery),
+        utp_talk_reqs_rx,
+        header_oracle.clone(),
+        enr_cache_capacity,
+    );
     let utp_socket = UtpSocket::with_socket(discv5_utp_socket);
     let utp_socket = Arc::new(utp_socket);
 
@@ -79,12 +95,6 @@ pub async fn run_trin(
         node_data_dir,
         discovery.local_enr().node_id(),
     )?;
-
-    // Initialize validation oracle
-    let header_oracle = HeaderOracle::default();
-    info!(hash_tree_root = %hex_encode(header_oracle.header_validator.pre_merge_acc.tree_hash_root().0),"Loaded
-        pre-merge accumulator.");
-    let header_oracle = Arc::new(RwLock::new(header_oracle));
 
     // Initialize state sub-network service and event handlers, if selected
     let (state_handler, state_network_task, state_event_tx, state_jsonrpc_tx, state_event_stream) =

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -48,6 +48,7 @@ pub async fn initialize_state_network(
     StateEventStream,
 )> {
     let (state_jsonrpc_tx, state_jsonrpc_rx) = mpsc::unbounded_channel::<StateJsonRpcRequest>();
+    header_oracle.write().await.state_jsonrpc_tx = Some(state_jsonrpc_tx.clone());
     let (state_event_tx, state_event_rx) = mpsc::unbounded_channel::<OverlayRequest>();
 
     let state_network = StateNetwork::new(

--- a/trin-validation/Cargo.toml
+++ b/trin-validation/Cargo.toml
@@ -13,6 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 alloy-primitives = { version = "0.7.0", features = ["ssz"] }
 anyhow = "1.0.68"
+enr = "0.10.0"
 eth2_hashing = "0.2.0"
 ethereum_ssz = "0.5.3"
 ethereum_ssz_derive = "0.5.3"

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -21,6 +21,7 @@ rand = "0.8.4"
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 trin-utils = { path = "../trin-utils" }
+trin-validation = { path="../trin-validation" }
 tokio = {version = "1.14.0", features = ["full"]}
 utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.12" }
 

--- a/utp-testing/src/lib.rs
+++ b/utp-testing/src/lib.rs
@@ -29,6 +29,7 @@ use tokio::sync::{
     mpsc::{self, Receiver},
     RwLock,
 };
+use trin_validation::oracle::HeaderOracle;
 use utp_rs::{conn::ConnectionConfig, socket::UtpSocket};
 
 /// uTP test app
@@ -175,9 +176,15 @@ pub async fn run_test_app(
     let enr = discovery.local_enr();
     let discovery = Arc::new(discovery);
 
+    let header_oracle = HeaderOracle::default();
+    let header_oracle = Arc::new(RwLock::new(header_oracle));
     let (utp_talk_req_tx, utp_talk_req_rx) = mpsc::unbounded_channel();
-    let discv5_utp_socket =
-        portalnet::discovery::Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx);
+    let discv5_utp_socket = portalnet::discovery::Discv5UdpSocket::new(
+        Arc::clone(&discovery),
+        utp_talk_req_rx,
+        header_oracle,
+        50,
+    );
     let utp_socket = utp_rs::socket::UtpSocket::with_socket(discv5_utp_socket);
     let utp_socket = Arc::new(utp_socket);
 


### PR DESCRIPTION
### What was wrong?
There's a newline in a log message that looks weird when booting up a trin node.

### How was it fixed?
Removed newline character

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
