### PR TITLE
chore: add trin docker compose file

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,14 +1,13 @@
 version: '3'
 services:
   trin:
+    container_name: trin
     hostname: trin
     image: portalnetwork/trin:latest
     environment:
-      RUST_LOG: info
+      - RUST_LOG: info
     command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/"
     network_mode: "host"
     volumes: 
-      - $HOME/.local/share:$HOME/.local/share
-    ports:
-      - "8545:8545"
+      - ${HOME}/.local/share:${HOME}/.local/share
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  trin:
+    hostname: trin
+    image: portalnetwork/trin:latest
+    environment:
+      RUST_LOG: info
+    command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/"
+    network_mode: "host"
+    volumes: 
+      - $HOME/.local/share:$HOME/.local/share
+    ports:
+      - "8545:8545"
+    restart: always


### PR DESCRIPTION
### What was wrong?
People want to run trin in docker images, but doing it with raw docker is complex for someone new to Trin
### How was it fixed?
By making a good starter docker compose file which people can expand easily with what they want
