### PR TITLE
feat: add an environment variable to specify private key location

### DIFF
--- a/book/src/users/startup.md
+++ b/book/src/users/startup.md
@@ -43,10 +43,15 @@ See the `--mb` flag.
 Trin requires a private key to configure a node's identity. Upon startup,
 Trin will automatically generate a random private key that will be re-used
 every time Trin is restarted. The only exceptions are if...
+- User supplies a private key via the environment variable `TRIN_PRIVATE_KEY_PATH`, in which
+  case that private key will be used to create the node's identity. If `TRIN_PRIVATE_KEY_PATH` is specified it will override `--unsafe-private-key`
 - User supplies a private key via the `--unsafe-private-key` flag, in which
   case that private key will be used to create the node's identity.
 - User deletes the `TRIN_DATA_DIR` or changes the `TRIN_DATA_DIR`. In which 
   case a new private key will be randomly generated and used.
+
+#### What does a private key file look like?
+A private key file is hex encode private key in a text file. Trin currently uses `ECDSA/secp256k1` as it's private key format which is 256 bits.
 
 ### Sub-Protocols
 


### PR DESCRIPTION
### What was wrong?
<img width="501" alt="image" src="https://github.com/ethereum/trin/assets/31669092/2e345471-8c31-4553-92c4-a433b1864479">
<img width="509" alt="image" src="https://github.com/ethereum/trin/assets/31669092/e70ea5bf-9d0c-4eb5-aeb5-437cd2c6500a">
<img width="480" alt="image" src="https://github.com/ethereum/trin/assets/31669092/95d2c323-96cb-4e78-a061-c4809f40929f">

### How was it fixed?

By adding an environment variable ``TRIN_PRIVATE_KEY_PATH`` which overrides the default trin directory if provided
