### PR TITLE
fix: gossip state from trie diff and gossip every intermediate node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,7 +2374,7 @@ dependencies = [
 [[package]]
 name = "eth_trie"
 version = "0.4.0"
-source = "git+https://github.com/kolbyml/eth-trie.rs.git?rev=11ec003e3276e1413f06328ab746af5d99f112bb#11ec003e3276e1413f06328ab746af5d99f112bb"
+source = "git+https://github.com/kolbyml/eth-trie.rs.git?rev=a69f99cdee5ea37edddd1147058f1990a5d943eb#a69f99cdee5ea37edddd1147058f1990a5d943eb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5247,6 +5247,7 @@ dependencies = [
  "ethereum_ssz_derive",
  "ethportal-api",
  "futures 0.3.30",
+ "hashbrown 0.14.5",
  "jsonrpsee",
  "lazy_static",
  "parking_lot 0.11.2",

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -22,7 +22,7 @@ const_format = {version = "0.2.0", features = ["rust_1_64"]}
 c-kzg = "1.0.0"
 discv5 = { version = "0.4.1", features = ["serde"] }
 ethereum_hashing = "0.6.0"
-eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "11ec003e3276e1413f06328ab746af5d99f112bb" }
+eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "a69f99cdee5ea37edddd1147058f1990a5d943eb" }
 ethereum_serde_utils = "0.5.2"
 ethereum_ssz = "0.5.3"
 ethereum_ssz_derive = "0.5.3"

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -23,8 +23,9 @@ discv5 = { version = "0.4.1", features = ["serde"] }
 ethereum_ssz = "0.5.3"
 ethereum_ssz_derive = "0.5.3"
 ethportal-api = { path = "../ethportal-api" }
-eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "11ec003e3276e1413f06328ab746af5d99f112bb" }
+eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "a69f99cdee5ea37edddd1147058f1990a5d943eb" }
 futures = "0.3.21"
+hashbrown = "0.14.0"
 jsonrpsee = { version = "0.20.0", features = [
   "async-client",
   "client",

--- a/portal-bridge/src/types/state/content.rs
+++ b/portal-bridge/src/types/state/content.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{keccak256, B256};
-use anyhow::{anyhow, bail};
+use anyhow::anyhow;
 use ethportal_api::{
     types::{
         content_key::state::AccountTrieNodeKey,
@@ -9,7 +9,7 @@ use ethportal_api::{
     StateContentKey, StateContentValue,
 };
 
-use super::execution::AccountProof;
+use super::trie_walker::AccountProof;
 
 pub fn create_content_key(account_proof: &AccountProof) -> anyhow::Result<StateContentKey> {
     let last_node = account_proof
@@ -18,29 +18,8 @@ pub fn create_content_key(account_proof: &AccountProof) -> anyhow::Result<StateC
         .ok_or(anyhow!("Missing proof!"))?;
     let last_node_hash = keccak256(last_node);
 
-    let eth_trie::node::Node::Leaf(last_node) = eth_trie::decode_node(&mut last_node.as_ref())?
-    else {
-        bail!("Last node in the proof should be leaf!")
-    };
-    let mut last_node_nibbles = last_node.key.clone();
-    if last_node_nibbles.is_leaf() {
-        last_node_nibbles.pop();
-    } else {
-        bail!("Nibbles of the last node should have LEAF Marker")
-    }
-
-    let mut path: Vec<u8> = keccak256(account_proof.address)
-        .into_iter()
-        .flat_map(|b| [b >> 4, b & 0xF])
-        .collect();
-    if path.ends_with(last_node_nibbles.get_data()) {
-        path.truncate(path.len() - last_node_nibbles.len());
-    } else {
-        bail!("Path should have a suffix of last node's nibbles")
-    }
-
     Ok(StateContentKey::AccountTrieNode(AccountTrieNodeKey {
-        path: Nibbles::try_from_unpacked_nibbles(&path)?,
+        path: Nibbles::try_from_unpacked_nibbles(&account_proof.path)?,
         node_hash: last_node_hash,
     }))
 }

--- a/portal-bridge/src/types/state/execution.rs
+++ b/portal-bridge/src/types/state/execution.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
 use alloy_rlp::EMPTY_STRING_CODE;
-use anyhow::{ensure, Error};
-use eth_trie::Trie;
+use anyhow::{anyhow, bail, ensure, Error};
+use eth_trie::{RootWithTrieDiff, Trie};
 use ethportal_api::types::{
     execution::transaction::Transaction,
     state_trie::account_state::AccountState as AccountStateInfo,
@@ -9,7 +9,7 @@ use ethportal_api::types::{
 use revm::{
     db::EmptyDB, inspector_handle_register, inspectors::NoOpInspector, DatabaseCommit, Evm,
 };
-use revm_primitives::{Env, ResultAndState, SpecId};
+use revm_primitives::{Env, SpecId};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeSet, HashMap},
@@ -28,6 +28,8 @@ use crate::types::{
     },
 };
 
+use super::trie_walker::AccountProof;
+
 #[derive(Debug, Serialize, Deserialize)]
 struct AllocBalance {
     balance: U256,
@@ -40,13 +42,6 @@ struct GenesisConfig {
     state_root: B256,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AccountProof {
-    pub address: Address,
-    pub state: AccountStateInfo,
-    pub proof: Vec<Bytes>,
-}
-
 pub struct State {
     pub database: CacheDB<EmptyDB>,
     next_block_number: u64,
@@ -54,21 +49,36 @@ pub struct State {
 
 const GENESIS_STATE_FILE: &str = "resources/genesis/mainnet.json";
 
+impl Default for State {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl State {
-    pub fn new() -> anyhow::Result<Self> {
-        let mut cache_db = CacheDB::new(EmptyDB::default());
-        let mut accounts = BTreeSet::new();
+    pub fn new() -> Self {
+        State {
+            next_block_number: 0,
+            database: CacheDB::new(EmptyDB::default()),
+        }
+    }
+
+    pub fn initialize_genesis(&mut self) -> anyhow::Result<RootWithTrieDiff> {
+        ensure!(
+            self.next_block_number == 0,
+            "Trying to initialize genesis but received block {}",
+            self.next_block_number,
+        );
 
         let genesis_file = File::open(GENESIS_STATE_FILE)?;
         let genesis: GenesisConfig = serde_json::from_reader(BufReader::new(genesis_file))?;
 
         for (address, alloc_balance) in genesis.alloc {
-            accounts.insert(address);
             let mut account = DbAccount::default();
             account.info.balance += alloc_balance.balance;
             let account_info = account.info.clone();
-            cache_db.accounts.insert(address, account);
-            cache_db.trie.lock().insert(
+            self.database.accounts.insert(address, account);
+            self.database.trie.lock().insert(
                 keccak256(address).as_ref(),
                 &alloy_rlp::encode(AccountStateInfo {
                     nonce: account_info.nonce,
@@ -79,18 +89,18 @@ impl State {
             )?;
         }
 
-        let root = B256::from_slice(cache_db.trie.lock().root_hash()?.as_slice());
+        let root_with_trie_diff = self.get_root_with_trie_diff()?;
         ensure!(
-            root == genesis.state_root,
+            root_with_trie_diff.root == genesis.state_root,
             "Root doesn't match state root from genesis file"
         );
-        Ok(State {
-            next_block_number: 1,
-            database: cache_db,
-        })
+
+        self.next_block_number += 1;
+
+        Ok(root_with_trie_diff)
     }
 
-    pub fn process_block(&mut self, block_tuple: &BlockTuple) -> anyhow::Result<BTreeSet<Address>> {
+    pub fn process_block(&mut self, block_tuple: &BlockTuple) -> anyhow::Result<RootWithTrieDiff> {
         info!(
             "State EVM processing block {}",
             block_tuple.header.header.number
@@ -102,9 +112,7 @@ impl State {
             block_tuple.header.header.number
         );
 
-        let mut updated_accounts: BTreeSet<Address> = BTreeSet::new();
-
-        // initalize evm environment
+        // initialize evm environment
         let mut env = Env::default();
         env.block.number = U256::from(block_tuple.header.header.number);
         env.block.coinbase = block_tuple.header.header.author;
@@ -142,7 +150,7 @@ impl State {
             .transactions()
             .map_err(|err| Error::msg(format!("Error getting transactions: {err:?}")))?;
         for transaction in transactions {
-            updated_accounts.extend(self.execute_transaction(transaction, &env)?);
+            self.execute_transaction(transaction, &env)?;
         }
 
         // update beneficiary
@@ -164,10 +172,13 @@ impl State {
                     self.database.accounts.insert(beneficiary, account);
                 }
             }
-            updated_accounts.insert(beneficiary);
         }
 
-        if self.get_root()? != block_tuple.header.header.state_root {
+        let RootWithTrieDiff {
+            root,
+            trie_diff: changed_nodes,
+        } = self.get_root_with_trie_diff()?;
+        if root != block_tuple.header.header.state_root {
             panic!(
                 "State root doesn't match! Irreversible! Block number: {}",
                 self.next_block_number
@@ -176,47 +187,49 @@ impl State {
 
         self.next_block_number += 1;
 
-        Ok(updated_accounts)
+        Ok(RootWithTrieDiff {
+            root,
+            trie_diff: changed_nodes,
+        })
     }
 
     fn execute_transaction(
         &mut self,
         tx: Transaction,
         evm_evnironment: &Env,
-    ) -> anyhow::Result<BTreeSet<Address>> {
+    ) -> anyhow::Result<()> {
         let block_number = evm_evnironment.block.number.to::<u64>();
-        let ResultAndState { state: changes, .. } = {
-            let mut evm = Evm::builder()
-                .with_ref_db(&self.database)
-                .with_env(Box::new(evm_evnironment.clone()))
-                .with_spec_id(get_spec_id(block_number))
-                .modify_tx_env(|tx_env| {
-                    tx_env.caller = tx
-                        .get_transaction_sender_address(
-                            get_spec_id(block_number).is_enabled_in(SpecId::SPURIOUS_DRAGON),
-                        )
-                        .expect(
-                            "We should always be able to get the sender address of a transaction",
-                        );
-                    match tx {
-                        Transaction::Legacy(tx) => tx.modify(block_number, tx_env),
-                        Transaction::EIP1559(tx) => tx.modify(block_number, tx_env),
-                        Transaction::AccessList(tx) => tx.modify(block_number, tx_env),
-                        Transaction::Blob(tx) => tx.modify(block_number, tx_env),
-                    }
-                })
-                .with_external_context(NoOpInspector)
-                .append_handler_register(inspector_handle_register)
-                .build();
-            evm.transact()?
-        };
-        let updated_accounts: BTreeSet<Address> = changes.keys().cloned().collect();
-        self.database.commit(changes);
-        Ok(updated_accounts)
+        let evm_result = Evm::builder()
+            .with_ref_db(&self.database)
+            .with_env(Box::new(evm_evnironment.clone()))
+            .with_spec_id(get_spec_id(block_number))
+            .modify_tx_env(|tx_env| {
+                tx_env.caller = tx
+                    .get_transaction_sender_address(
+                        get_spec_id(block_number).is_enabled_in(SpecId::SPURIOUS_DRAGON),
+                    )
+                    .expect("We should always be able to get the sender address of a transaction");
+                match tx {
+                    Transaction::Legacy(tx) => tx.modify(block_number, tx_env),
+                    Transaction::EIP1559(tx) => tx.modify(block_number, tx_env),
+                    Transaction::AccessList(tx) => tx.modify(block_number, tx_env),
+                    Transaction::Blob(tx) => tx.modify(block_number, tx_env),
+                }
+            })
+            .with_external_context(NoOpInspector)
+            .append_handler_register(inspector_handle_register)
+            .build()
+            .transact()?;
+        self.database.commit(evm_result.state);
+        Ok(())
     }
 
     pub fn get_root(&mut self) -> anyhow::Result<B256> {
         Ok(self.database.trie.lock().root_hash()?)
+    }
+
+    pub fn get_root_with_trie_diff(&mut self) -> anyhow::Result<RootWithTrieDiff> {
+        Ok(self.database.trie.lock().root_hash_with_changed_nodes()?)
     }
 
     pub fn get_account_state(&self, account: &Address) -> anyhow::Result<AccountStateInfo> {
@@ -233,18 +246,38 @@ impl State {
     }
 
     pub fn get_proof(&mut self, account: &Address) -> anyhow::Result<AccountProof> {
-        Ok(AccountProof {
-            address: *account,
-            state: self.get_account_state(account)?,
-            proof: self
-                .database
-                .trie
-                .lock()
-                .get_proof(keccak256(account).as_slice())?
-                .into_iter()
-                .map(Bytes::from)
-                .collect(),
-        })
+        let proof: Vec<Bytes> = self
+            .database
+            .trie
+            .lock()
+            .get_proof(keccak256(account).as_slice())?
+            .into_iter()
+            .map(Bytes::from)
+            .collect();
+        let last_node = proof.last().ok_or(anyhow!("Missing proof!"))?;
+
+        let eth_trie::node::Node::Leaf(last_node) = eth_trie::decode_node(&mut last_node.as_ref())?
+        else {
+            bail!("Last node in the proof should be leaf!")
+        };
+        let mut last_node_nibbles = last_node.key.clone();
+        if last_node_nibbles.is_leaf() {
+            last_node_nibbles.pop();
+        } else {
+            bail!("Nibbles of the last node should have LEAF Marker")
+        }
+
+        let mut path: Vec<u8> = keccak256(*account)
+            .into_iter()
+            .flat_map(|b| [b >> 4, b & 0xF])
+            .collect();
+        if path.ends_with(last_node_nibbles.get_data()) {
+            path.truncate(path.len() - last_node_nibbles.len());
+        } else {
+            bail!("Path should have a suffix of last node's nibbles")
+        }
+
+        Ok(AccountProof { path, proof })
     }
 
     pub fn get_proofs(
@@ -265,10 +298,13 @@ mod tests {
     use crate::types::era1::Era1;
 
     use super::State;
+    use alloy_primitives::Address;
+    use revm_primitives::hex::FromHex;
 
     #[test_log::test]
     fn test_we_generate_the_correct_state_root_for_the_first_8192_blocks() {
-        let mut state = State::new().unwrap();
+        let mut state = State::new();
+        let _ = state.initialize_genesis();
         let raw_era1 = fs::read("../test_assets/era1/mainnet-00000-5ec1ffb8.era1").unwrap();
         for block_tuple in Era1::iter_tuples(raw_era1) {
             if block_tuple.header.header.number == 0 {
@@ -280,5 +316,16 @@ mod tests {
                 block_tuple.header.header.state_root
             );
         }
+    }
+
+    #[test_log::test]
+    fn test_get_proof() {
+        let mut state = State::new();
+        let _ = state.initialize_genesis().unwrap();
+        let valid_proof = state
+            .get_proof(&Address::from_hex("0x001d14804b399c6ef80e64576f657660804fec0b").unwrap())
+            .unwrap();
+        assert_eq!(valid_proof.path, [5, 9, 2, 13]);
+        // the proof is already tested by eth-trie.rs
     }
 }

--- a/portal-bridge/src/types/state/mod.rs
+++ b/portal-bridge/src/types/state/mod.rs
@@ -4,3 +4,4 @@ pub mod database;
 pub mod execution;
 pub mod spec_id;
 pub mod transaction;
+pub mod trie_walker;

--- a/portal-bridge/src/types/state/trie_walker.rs
+++ b/portal-bridge/src/types/state/trie_walker.rs
@@ -1,0 +1,190 @@
+use alloy_primitives::{Bytes, B256};
+use anyhow::ensure;
+use eth_trie::{decode_node, node::Node};
+use hashbrown::HashMap as BrownHashMap;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AccountProof {
+    pub path: Vec<u8>,
+    pub proof: Vec<Bytes>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrieWalkerNode {
+    /// The encoded version of the trie node.
+    pub encoded_node: Vec<u8>,
+    /// The hash of the parent node. It is `None` only for root of the trie.
+    pub parent_hash: Option<B256>,
+    /// Path from parent node to this node.
+    pub path_nibbles: Vec<u8>,
+}
+
+impl TrieWalkerNode {
+    pub fn new(encoded_node: Vec<u8>, parent_hash: Option<B256>, path_nibbles: Vec<u8>) -> Self {
+        Self {
+            encoded_node,
+            parent_hash,
+            path_nibbles,
+        }
+    }
+}
+
+/// This struct takes in a root hash and a hashmap of changed nodes, then you can call an iterator
+/// which will return every proof to gossip
+pub struct TrieWalker {
+    pub nodes: BrownHashMap<B256, TrieWalkerNode>,
+}
+
+impl TrieWalker {
+    pub fn new(root_hash: B256, nodes: BrownHashMap<B256, Vec<u8>>) -> Self {
+        let processed_nodes = Self::process_trie(root_hash, &nodes)
+            .expect("This shouldn't fail as we only pass valid tries");
+        Self {
+            nodes: processed_nodes,
+        }
+    }
+
+    fn process_trie(
+        root_hash: B256,
+        nodes: &BrownHashMap<B256, Vec<u8>>,
+    ) -> anyhow::Result<BrownHashMap<B256, TrieWalkerNode>> {
+        let mut trie_walker_nodes: BrownHashMap<B256, TrieWalkerNode> = BrownHashMap::new();
+        let mut stack = vec![root_hash];
+
+        trie_walker_nodes.insert(
+            root_hash,
+            TrieWalkerNode::new(
+                nodes
+                    .get(&root_hash)
+                    .expect("Failed to get encoded node for root node. This should never happen.")
+                    .clone(),
+                None,
+                vec![],
+            ),
+        );
+        while let Some(node_key) = stack.pop() {
+            let encoded_node = nodes
+                .get(&node_key)
+                .expect("The stack should only contain nodes that are in the changed nodes");
+
+            let decoded_node = decode_node(&mut encoded_node.as_slice())
+                .expect("Should should only be passing valid encoded nodes");
+
+            match decoded_node {
+                Node::Extension(extension) => {
+                    let extension = extension.read().expect("Reading an extension should work");
+                    // We look for hash nodes in order to connect them to the root. If this node is
+                    // not a hash node, then neither is any of its children.
+                    // We know this because any node that has a hash node as it's descendant would
+                    // also become hash node, because its encoding would be longer than 32 bytes.
+                    if let Node::Hash(hash_node) = &extension.node {
+                        // Only process provided nodes (they belong to the partial trie that we care
+                        // about)
+                        if nodes.contains_key(&hash_node.hash) {
+                            stack.push(hash_node.hash);
+                            trie_walker_nodes.insert(
+                                hash_node.hash,
+                                TrieWalkerNode::new(
+                                    nodes
+                                    .get(&hash_node.hash)
+                                    .expect("The stack should only contain nodes that are in the changed nodes")
+                                    .clone(),
+                                    Some(node_key),
+                                    extension.prefix.get_data().to_vec(),
+                                ),
+                            );
+                        }
+                    }
+                }
+                Node::Branch(branch) => {
+                    let branch = branch.read().expect("Reading a branch should work");
+                    for (i, child) in branch.children.iter().enumerate() {
+                        // We look for hash nodes in order to connect them to the root. If this node
+                        // is not a hash node, then neither is any of its children.
+                        // We know this because any node that has a hash node as it's descendant
+                        // would also become hash node, because its encoding would be longer than 32
+                        // bytes.
+                        if let Node::Hash(hash_node) = child {
+                            //Only process provided nodes (they belong to the partial trie that we
+                            // care about)
+                            if nodes.contains_key(&hash_node.hash) {
+                                stack.push(hash_node.hash);
+                                trie_walker_nodes.insert(
+                                    hash_node.hash,
+                                    TrieWalkerNode::new(
+                                        nodes
+                                    .get(&hash_node.hash)
+                                    .expect("The stack should only contain nodes that are in the changed nodes")
+                                    .clone(),
+                                        Some(node_key),
+                                        vec![i as u8],
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // Ensure we discovered all nodes (root is not present in the trie_walker_nodes)
+        ensure!(nodes.len() == trie_walker_nodes.len(), "We expect the node length and trie_walker_nodes length to be the same, as we should have discovered all nodes in the trie. If this fails it implies an invalid trie was provided with an unnavigable path.");
+
+        Ok(trie_walker_nodes)
+    }
+
+    pub fn get_proof(&self, node_hash: B256) -> AccountProof {
+        // Build path and proof from the node to the root and reverse it at the end.
+        let mut reverse_path = vec![];
+        let mut reverse_proof = vec![];
+        let mut next_node: Option<B256> = Some(node_hash);
+        while let Some(current_node) = next_node {
+            let Some(parent) = self.nodes.get(&current_node) else {
+                break;
+            };
+            for nibble in parent.path_nibbles.iter().rev() {
+                reverse_path.push(*nibble);
+            }
+            reverse_proof.push(Bytes(parent.encoded_node.clone().into()));
+            next_node = parent.parent_hash;
+        }
+
+        reverse_path.reverse();
+        reverse_proof.reverse();
+        AccountProof {
+            path: reverse_path,
+            proof: reverse_proof,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::state::{execution::State, trie_walker::TrieWalker};
+
+    use alloy_primitives::{keccak256, Address};
+    use anyhow::anyhow;
+    use eth_trie::RootWithTrieDiff;
+    use revm_primitives::hex::FromHex;
+
+    #[test_log::test]
+    fn test_trie_walker_builds_valid_proof() {
+        let mut state = State::new();
+        let RootWithTrieDiff { trie_diff, .. } = state.initialize_genesis().unwrap();
+        let valid_proof = state
+            .get_proof(&Address::from_hex("0x001d14804b399c6ef80e64576f657660804fec0b").unwrap())
+            .unwrap();
+        let root_hash = state.get_root().unwrap();
+        let walk_diff = TrieWalker::new(root_hash, trie_diff);
+
+        let last_node = valid_proof
+            .proof
+            .last()
+            .ok_or(anyhow!("Missing proof!"))
+            .unwrap();
+        let account_proof = walk_diff.get_proof(keccak256(last_node));
+        assert_eq!(valid_proof, account_proof);
+    }
+}

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -15,7 +15,7 @@ alloy-primitives = { version = "0.7.0", features = ["getrandom"] }
 alloy-rlp = "0.3.4"
 anyhow = "1.0.68"
 discv5 = { version = "0.4.1", features = ["serde"] }
-eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "11ec003e3276e1413f06328ab746af5d99f112bb" }
+eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "a69f99cdee5ea37edddd1147058f1990a5d943eb" }
 ethportal-api = { path = "../ethportal-api" }
 keccak-hash = "0.10.0"
 parking_lot = "0.11.2"


### PR DESCRIPTION
### What was wrong?
fixes https://github.com/ethereum/trin/issues/1292

Calling get proof on all changed accounts missing changed intermediate trie nodes

recursive gossip doesn't work so we have to gossip proofs for every intermediate try node

### How was it fixed?

This PR gossips every intermediate node (as from the summit we discussed recursive gossip doesn't work)

This PR also makes it so we don't miss a changed node, by utilizing a Trie Diff

By getting the Trie diff from eth-trie.rs

Then by walking the diff building back traces then iterating over all the intermediate trie keys and building proofs to gossip

