### PR TITLE
feat(state bridge): gossip contract bytecode and storage

### DIFF
--- a/ethportal-api/src/types/content_value/state.rs
+++ b/ethportal-api/src/types/content_value/state.rs
@@ -12,13 +12,13 @@ use crate::{
 /// A Portal State content value.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum StateContentValue {
-    /// A content value type for retriving a trie node.
+    /// A content value type for retrieving a trie node.
     TrieNode(TrieNode),
     /// A content value type for offering a trie node from the account trie.
     AccountTrieNodeWithProof(AccountTrieNodeWithProof),
     /// A content value type for offering a trie node from the contract storage trie.
     ContractStorageTrieNodeWithProof(ContractStorageTrieNodeWithProof),
-    /// A content value type for retriving contract's bytecode.
+    /// A content value type for retrieving contract's bytecode.
     ContractBytecode(ContractBytecode),
     /// A content value type for offering contract's bytecode.
     ContractBytecodeWithProof(ContractBytecodeWithProof),

--- a/portal-bridge/src/bridge/state.rs
+++ b/portal-bridge/src/bridge/state.rs
@@ -1,10 +1,16 @@
 use std::{path::PathBuf, sync::Arc};
 
 use super::era1::get_shuffled_era1_files;
+use alloy_rlp::Decodable;
 use anyhow::anyhow;
-use eth_trie::RootWithTrieDiff;
-use ethportal_api::{jsonrpsee::http_client::HttpClient, StateContentKey, StateContentValue};
-use revm_primitives::SpecId;
+use eth_trie::{decode_node, node::Node, RootWithTrieDiff};
+use ethportal_api::{
+    jsonrpsee::http_client::HttpClient,
+    types::state_trie::account_state::AccountState as AccountStateInfo, StateContentKey,
+    StateContentValue,
+};
+use revm::DatabaseRef;
+use revm_primitives::{keccak256, Address, Bytecode, SpecId, B256};
 use surf::{Client, Config};
 use tokio::{
     sync::{OwnedSemaphorePermit, Semaphore},
@@ -22,11 +28,18 @@ use crate::{
         era1::Era1,
         mode::{BridgeMode, ModeType},
         state::{
-            content::{create_content_key, create_content_value},
+            config::StateConfig,
+            content::{
+                create_account_content_key, create_account_content_value,
+                create_contract_content_key, create_contract_content_value,
+                create_storage_content_key, create_storage_content_value,
+            },
             execution::State,
             spec_id::get_spec_block_number,
             storage::utils::setup_temp_dir,
             trie_walker::TrieWalker,
+            types::trie_proof::TrieProof,
+            utils::full_nibble_path_to_address_hash,
         },
     },
 };
@@ -39,7 +52,7 @@ pub struct StateBridge {
     pub era1_files: Vec<String>,
     pub http_client: Client,
     pub metrics: BridgeMetricsReporter,
-    pub gossip_limit: usize,
+    pub gossip_limit_semaphore: Arc<Semaphore>,
 }
 
 impl StateBridge {
@@ -56,6 +69,10 @@ impl StateBridge {
             .try_into()?;
         let era1_files = get_shuffled_era1_files(&http_client).await?;
         let metrics = BridgeMetricsReporter::new("state".to_string(), &format!("{mode:?}"));
+
+        // We are using a semaphore to limit the amount of active gossip transfers to make sure
+        // we don't overwhelm the trin client
+        let gossip_limit_semaphore = Arc::new(Semaphore::new(gossip_limit));
         Ok(Self {
             mode,
             portal_client,
@@ -64,7 +81,7 @@ impl StateBridge {
             era1_files,
             http_client,
             metrics,
-            gossip_limit,
+            gossip_limit_semaphore,
         })
     }
 
@@ -89,13 +106,15 @@ impl StateBridge {
 
     async fn launch_state(&self, last_block: u64) -> anyhow::Result<()> {
         info!("Gossiping state data from block 0 to {last_block}");
-        // We are using a semaphore to limit the amount of active gossip transfers to make sure
-        // we don't overwhelm the trin client
-        let gossip_send_semaphore = Arc::new(Semaphore::new(self.gossip_limit));
         let mut current_epoch_index = u64::MAX;
         let mut current_raw_era1 = vec![];
         let temp_directory = setup_temp_dir()?;
-        let mut state = State::new(Some(temp_directory.path().to_path_buf()));
+
+        // Enable contract storage changes caching required for gossiping the storage trie
+        let state_config = StateConfig {
+            cache_contract_storage_changes: true,
+        };
+        let mut state = State::new(Some(temp_directory.path().to_path_buf()), state_config);
         for block_index in 0..=last_block {
             info!("Gossipping state for block at height: {block_index}");
             let epoch_index = block_index / EPOCH_SIZE;
@@ -134,24 +153,148 @@ impl StateBridge {
 
             // gossip block's new state transitions
             for node in walk_diff.nodes.keys() {
-                let permit = gossip_send_semaphore
-                    .clone()
-                    .acquire_owned()
-                    .await
-                    .expect("to be able to acquire semaphore");
                 let account_proof = walk_diff.get_proof(*node);
-                let content_key = create_content_key(&account_proof)?;
-                let content_value =
-                    create_content_value(block_tuple.header.header.hash(), &account_proof)?;
-                Self::spawn_serve_state_proof(
-                    self.portal_client.clone(),
-                    content_key,
-                    content_value,
-                    permit,
-                    self.metrics.clone(),
-                );
+
+                // gossip the account
+                self.gossip_account(&account_proof, block_tuple.header.header.hash())
+                    .await?;
+
+                let Some(encoded_last_node) = account_proof.proof.last() else {
+                    error!("Account proof is empty. This should never happen maybe there is a bug in trie_walker?");
+                    continue;
+                };
+
+                let decoded_node = decode_node(&mut encoded_last_node.as_ref())
+                    .expect("Should should only be passing valid encoded nodes");
+                let Node::Leaf(leaf) = decoded_node else {
+                    continue;
+                };
+                let account: AccountStateInfo = Decodable::decode(&mut leaf.value.as_slice())?;
+
+                // if the code_hash is empty then it isn't a contract so we can skip it
+                if account.code_hash == keccak256([]) {
+                    continue;
+                }
+
+                // reconstruct the address hash from the path so that we can fetch the
+                // address from the database
+                let mut partial_key_path = leaf.key.get_data().to_vec();
+                partial_key_path.pop();
+                let full_key_path =
+                    [&account_proof.path.clone(), partial_key_path.as_slice()].concat();
+                let address_hash = full_nibble_path_to_address_hash(&full_key_path);
+                let address = state
+                    .database
+                    .get_address_from_hash(address_hash)
+                    .expect("Contracts should always have an address in the database");
+
+                // gossip contract bytecode
+                let code = state.database.code_by_hash_ref(account.code_hash)?;
+                self.gossip_contract_bytecode(
+                    address,
+                    &account_proof,
+                    block_tuple.header.header.hash(),
+                    account.code_hash,
+                    code,
+                )
+                .await?;
+
+                // gossip contract storage
+                let storage_changed_nodes = state.database.get_storage_trie_diff(address);
+
+                let storage_walk_diff =
+                    TrieWalker::new(account.storage_root, storage_changed_nodes);
+
+                for storage_node in storage_walk_diff.nodes.keys() {
+                    let storage_proof = storage_walk_diff.get_proof(*storage_node);
+                    self.gossip_storage(
+                        &account_proof,
+                        &storage_proof,
+                        address,
+                        block_tuple.header.header.hash(),
+                    )
+                    .await?;
+                }
             }
+            // flush the database cache
+            // This is used for gossiping storage trie diffs
+            state.database.storage_cache.clear();
         }
+        Ok(())
+    }
+
+    async fn gossip_account(
+        &self,
+        account_proof: &TrieProof,
+        block_hash: B256,
+    ) -> anyhow::Result<()> {
+        let permit = self
+            .gossip_limit_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("to be able to acquire semaphore");
+        let content_key = create_account_content_key(account_proof)?;
+        let content_value = create_account_content_value(block_hash, account_proof)?;
+        Self::spawn_serve_state_proof(
+            self.portal_client.clone(),
+            content_key,
+            content_value,
+            permit,
+            self.metrics.clone(),
+        );
+        Ok(())
+    }
+
+    async fn gossip_contract_bytecode(
+        &self,
+        address: Address,
+        account_proof: &TrieProof,
+        block_hash: B256,
+        code_hash: B256,
+        code: Bytecode,
+    ) -> anyhow::Result<()> {
+        let permit = self
+            .gossip_limit_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("to be able to acquire semaphore");
+        let code_content_key = create_contract_content_key(address, code_hash)?;
+        let code_content_value = create_contract_content_value(block_hash, account_proof, code)?;
+        Self::spawn_serve_state_proof(
+            self.portal_client.clone(),
+            code_content_key,
+            code_content_value,
+            permit,
+            self.metrics.clone(),
+        );
+        Ok(())
+    }
+
+    async fn gossip_storage(
+        &self,
+        account_proof: &TrieProof,
+        storage_proof: &TrieProof,
+        address: Address,
+        block_hash: B256,
+    ) -> anyhow::Result<()> {
+        let permit = self
+            .gossip_limit_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("to be able to acquire semaphore");
+        let storage_content_key = create_storage_content_key(storage_proof, address)?;
+        let storage_content_value =
+            create_storage_content_value(block_hash, account_proof, storage_proof)?;
+        Self::spawn_serve_state_proof(
+            self.portal_client.clone(),
+            storage_content_key,
+            storage_content_value,
+            permit,
+            self.metrics.clone(),
+        );
         Ok(())
     }
 

--- a/portal-bridge/src/types/state/config.rs
+++ b/portal-bridge/src/types/state/config.rs
@@ -1,0 +1,15 @@
+#[derive(Debug, Clone)]
+pub struct StateConfig {
+    /// This flag when enabled will storage all the trie keys from block execution in a cache, this
+    /// is needed for gossiping the storage trie's changes.
+    pub cache_contract_storage_changes: bool,
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for StateConfig {
+    fn default() -> Self {
+        Self {
+            cache_contract_storage_changes: false,
+        }
+    }
+}

--- a/portal-bridge/src/types/state/content.rs
+++ b/portal-bridge/src/types/state/content.rs
@@ -2,43 +2,94 @@ use alloy_primitives::{keccak256, B256};
 use anyhow::anyhow;
 use ethportal_api::{
     types::{
-        content_key::state::AccountTrieNodeKey,
-        content_value::state::AccountTrieNodeWithProof,
-        state_trie::{nibbles::Nibbles, EncodedTrieNode, TrieProof},
+        content_key::state::{AccountTrieNodeKey, ContractBytecodeKey, ContractStorageTrieNodeKey},
+        content_value::state::{
+            AccountTrieNodeWithProof, ContractBytecodeWithProof, ContractStorageTrieNodeWithProof,
+        },
+        state_trie::nibbles::Nibbles,
     },
     StateContentKey, StateContentValue,
 };
+use revm_primitives::{Address, Bytecode};
 
-use super::trie_walker::AccountProof;
+use super::types::trie_proof::TrieProof;
 
-pub fn create_content_key(account_proof: &AccountProof) -> anyhow::Result<StateContentKey> {
+pub fn create_account_content_key(account_proof: &TrieProof) -> anyhow::Result<StateContentKey> {
     let last_node = account_proof
         .proof
         .last()
         .ok_or(anyhow!("Missing proof!"))?;
-    let last_node_hash = keccak256(last_node);
 
     Ok(StateContentKey::AccountTrieNode(AccountTrieNodeKey {
         path: Nibbles::try_from_unpacked_nibbles(&account_proof.path)?,
-        node_hash: last_node_hash,
+        node_hash: keccak256(last_node),
     }))
 }
 
-pub fn create_content_value(
+pub fn create_account_content_value(
     block_hash: B256,
-    account_proof: &AccountProof,
+    account_proof: &TrieProof,
 ) -> anyhow::Result<StateContentValue> {
-    let trie_proof = TrieProof::from(
-        account_proof
-            .proof
-            .iter()
-            .map(|bytes| EncodedTrieNode::from(bytes.to_vec()))
-            .collect::<Vec<EncodedTrieNode>>(),
-    );
     Ok(StateContentValue::AccountTrieNodeWithProof(
         AccountTrieNodeWithProof {
-            proof: trie_proof,
+            proof: account_proof.into(),
             block_hash,
+        },
+    ))
+}
+
+pub fn create_contract_content_key(
+    address: Address,
+    code_hash: B256,
+) -> anyhow::Result<StateContentKey> {
+    Ok(StateContentKey::ContractBytecode(ContractBytecodeKey {
+        address,
+        code_hash,
+    }))
+}
+
+pub fn create_contract_content_value(
+    block_hash: B256,
+    account_proof: &TrieProof,
+    code: Bytecode,
+) -> anyhow::Result<StateContentValue> {
+    Ok(StateContentValue::ContractBytecodeWithProof(
+        ContractBytecodeWithProof {
+            block_hash,
+            code: code.bytecode.to_vec().into(),
+            account_proof: account_proof.into(),
+        },
+    ))
+}
+
+pub fn create_storage_content_key(
+    storage_proof: &TrieProof,
+    address: Address,
+) -> anyhow::Result<StateContentKey> {
+    let last_node = storage_proof
+        .proof
+        .last()
+        .ok_or(anyhow!("Missing proof!"))?;
+
+    Ok(StateContentKey::ContractStorageTrieNode(
+        ContractStorageTrieNodeKey {
+            path: Nibbles::try_from_unpacked_nibbles(&storage_proof.path)?,
+            node_hash: keccak256(last_node),
+            address,
+        },
+    ))
+}
+
+pub fn create_storage_content_value(
+    block_hash: B256,
+    account_proof: &TrieProof,
+    storage_proof: &TrieProof,
+) -> anyhow::Result<StateContentValue> {
+    Ok(StateContentValue::ContractStorageTrieNodeWithProof(
+        ContractStorageTrieNodeWithProof {
+            block_hash,
+            storage_proof: storage_proof.into(),
+            account_proof: account_proof.into(),
         },
     ))
 }

--- a/portal-bridge/src/types/state/mod.rs
+++ b/portal-bridge/src/types/state/mod.rs
@@ -1,7 +1,10 @@
 pub mod block_reward;
+pub mod config;
 pub mod content;
 pub mod execution;
 pub mod spec_id;
 pub mod storage;
 pub mod transaction;
 pub mod trie_walker;
+pub mod types;
+pub mod utils;

--- a/portal-bridge/src/types/state/storage/evm_db.rs
+++ b/portal-bridge/src/types/state/storage/evm_db.rs
@@ -1,11 +1,12 @@
 use std::{path::PathBuf, sync::Arc};
 
-use crate::types::state::storage::error::EVMError;
+use crate::types::state::{config::StateConfig, storage::error::EVMError};
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_primitives::{Address, B256, U256};
 use alloy_rlp::{Decodable, EMPTY_STRING_CODE};
-use eth_trie::{EthTrie, Trie};
+use eth_trie::{EthTrie, RootWithTrieDiff, Trie};
 use ethportal_api::types::state_trie::account_state::AccountState as AccountStateInfo;
+use hashbrown::{HashMap as BrownHashMap, HashSet};
 use parking_lot::Mutex;
 use revm::{DatabaseCommit, DatabaseRef};
 use revm_primitives::{keccak256, Account, AccountInfo, Bytecode, HashMap};
@@ -18,9 +19,15 @@ use super::{
     utils::setup_rocksdb,
 };
 
+const REVERSE_HASH_LOOKUP_PREFIX: &[u8] = b"reverse hash lookup";
+
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EvmDB {
+    /// State config
+    pub config: StateConfig,
+    /// Storage cache for the accounts used optionally for gossiping.
+    pub storage_cache: HashMap<Address, HashSet<B256>>,
     /// The underlying database.
     pub db: Arc<RocksDB>,
     /// To get proofs and to verify trie state.
@@ -28,7 +35,7 @@ pub struct EvmDB {
 }
 
 impl EvmDB {
-    pub fn new(path: Option<PathBuf>) -> anyhow::Result<Self> {
+    pub fn new(path: Option<PathBuf>, config: StateConfig) -> anyhow::Result<Self> {
         let db = Arc::new(setup_rocksdb(path)?);
         db.put(KECCAK_EMPTY, Bytecode::new().bytes().as_ref())?;
         db.put(B256::ZERO, Bytecode::new().bytes().as_ref())?;
@@ -36,7 +43,14 @@ impl EvmDB {
             false,
             db.clone(),
         )))));
-        Ok(Self { db, trie })
+
+        let storage_cache = HashMap::new();
+        Ok(Self {
+            config,
+            storage_cache,
+            db,
+            trie,
+        })
     }
 
     /// Inserts the account's code into the cache.
@@ -45,13 +59,25 @@ impl EvmDB {
     /// the account and instead map it to the code hash.
     ///
     /// Note: This will not insert into the underlying external database.
-    pub fn insert_contract(&mut self, account: &mut AccountInfo) {
+    pub fn insert_contract(&mut self, address: Address, account: &mut AccountInfo) {
         if let Some(code) = &account.code {
             if !code.is_empty() {
                 if account.code_hash == KECCAK_EMPTY {
                     account.code_hash = code.hash_slow();
                 }
 
+                // Insert address lookup into the database so that we can look up the address for
+                // smart contracts
+                if self.config.cache_contract_storage_changes {
+                    self.db
+                        .put(
+                            [REVERSE_HASH_LOOKUP_PREFIX, keccak256(address).as_slice()].concat(),
+                            address.as_slice(),
+                        )
+                        .expect("Inserting address should never fail");
+                }
+
+                // Insert contract code into the database
                 self.db
                     .put(account.code_hash, code.bytes().as_ref())
                     .expect("Inserting contract shouldn't fail");
@@ -60,6 +86,29 @@ impl EvmDB {
         if account.code_hash == B256::ZERO {
             account.code_hash = KECCAK_EMPTY;
         }
+    }
+
+    pub fn get_address_from_hash(&self, address_hash: B256) -> Option<Address> {
+        self.db
+            .get([REVERSE_HASH_LOOKUP_PREFIX, address_hash.as_slice()].concat())
+            .expect("Getting address from the database should never fail")
+            .map(|raw_address| Address::from_slice(&raw_address))
+    }
+
+    pub fn get_storage_trie_diff(&self, address: Address) -> BrownHashMap<B256, Vec<u8>> {
+        let mut trie_diff = BrownHashMap::new();
+
+        for key in self.storage_cache.get(&address).unwrap_or(&HashSet::new()) {
+            let value = self
+                .db
+                .get(key)
+                .expect("Getting storage value should never fail");
+
+            if let Some(raw_value) = value {
+                trie_diff.insert(*key, raw_value);
+            }
+        }
+        trie_diff
     }
 }
 
@@ -101,7 +150,7 @@ impl DatabaseCommit for EvmDB {
                 continue;
             }
             let is_newly_created = account.is_created();
-            self.insert_contract(&mut account.info);
+            self.insert_contract(address, &mut account.info);
 
             let mut rocks_account: RocksAccount = match self
                 .db
@@ -156,9 +205,19 @@ impl DatabaseCommit for EvmDB {
             }
 
             // update trie
-            let storage_root = trie
-                .root_hash()
+            let RootWithTrieDiff {
+                root: storage_root,
+                trie_diff,
+            } = trie
+                .root_hash_with_changed_nodes()
                 .expect("Getting the root hash should never fail");
+
+            if self.config.cache_contract_storage_changes {
+                let account_storage_cache = self.storage_cache.entry(address).or_default();
+                for key in trie_diff.keys() {
+                    account_storage_cache.insert(*key);
+                }
+            }
 
             let _ = self.trie.lock().insert(
                 address_hash.as_ref(),

--- a/portal-bridge/src/types/state/types/mod.rs
+++ b/portal-bridge/src/types/state/types/mod.rs
@@ -1,0 +1,1 @@
+pub mod trie_proof;

--- a/portal-bridge/src/types/state/types/trie_proof.rs
+++ b/portal-bridge/src/types/state/types/trie_proof.rs
@@ -1,0 +1,21 @@
+use ethportal_api::types::state_trie::{EncodedTrieNode, TrieProof as EncodedTrieProof};
+use revm_primitives::Bytes;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrieProof {
+    pub path: Vec<u8>,
+    pub proof: Vec<Bytes>,
+}
+
+impl From<&TrieProof> for EncodedTrieProof {
+    fn from(trie_proof: &TrieProof) -> Self {
+        EncodedTrieProof::from(
+            trie_proof
+                .proof
+                .iter()
+                .map(|bytes| EncodedTrieNode::from(bytes.to_vec()))
+                .collect::<Vec<EncodedTrieNode>>(),
+        )
+    }
+}

--- a/portal-bridge/src/types/state/utils.rs
+++ b/portal-bridge/src/types/state/utils.rs
@@ -1,0 +1,52 @@
+use alloy_primitives::{keccak256, Address, B256};
+
+pub fn full_nibble_path_to_address_hash(key_path: &[u8]) -> B256 {
+    if key_path.len() != 64 {
+        panic!("Key path should always be 64 bytes long.")
+    }
+
+    let mut raw_address_hash = vec![];
+    for i in 0..key_path.len() {
+        if i % 2 == 0 {
+            raw_address_hash.push(key_path[i] << 4);
+        } else {
+            raw_address_hash[i / 2] |= key_path[i];
+        }
+    }
+    B256::from_slice(&raw_address_hash)
+}
+
+pub fn address_to_nibble_path(address: Address) -> Vec<u8> {
+    keccak256(address)
+        .into_iter()
+        .flat_map(|b| [b >> 4, b & 0xF])
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use eth_trie::nibbles::Nibbles as EthNibbles;
+    use revm_primitives::{keccak256, Address};
+
+    use crate::types::state::utils::{address_to_nibble_path, full_nibble_path_to_address_hash};
+
+    #[test]
+    fn test_eth_trie_and_ethportalapi_nibbles() {
+        let address = Address::random();
+        let address_hash = keccak256(address);
+
+        let mut eth_trie_nibbles = EthNibbles::from_raw(address_hash.as_slice(), true);
+        eth_trie_nibbles.pop();
+        let path: Vec<u8> = address_to_nibble_path(address);
+        assert_eq!(eth_trie_nibbles.get_data(), &path);
+    }
+
+    #[test]
+    fn test_key_path_to_address_hash() {
+        let address = Address::random();
+        let address_hash = keccak256(address);
+        let path: Vec<u8> = address_to_nibble_path(address);
+        let generated_address_hash = full_nibble_path_to_address_hash(&path);
+        assert_eq!(address_hash, generated_address_hash);
+    }
+}

--- a/portal-bridge/tests/state.rs
+++ b/portal-bridge/tests/state.rs
@@ -5,7 +5,7 @@ mod tests {
         bridge::era1::get_shuffled_era1_files,
         types::{
             era1::Era1,
-            state::{execution::State, storage::utils::setup_temp_dir},
+            state::{config::StateConfig, execution::State, storage::utils::setup_temp_dir},
         },
     };
     use surf::{Client, Config};
@@ -28,7 +28,10 @@ mod tests {
             .unwrap();
         let era1_files = get_shuffled_era1_files(&http_client).await.unwrap();
         let temp_directory = setup_temp_dir().unwrap();
-        let mut state = State::new(Some(temp_directory.path().to_path_buf()));
+        let mut state = State::new(
+            Some(temp_directory.path().to_path_buf()),
+            StateConfig::default(),
+        );
         state.initialize_genesis().unwrap();
         for epoch_index in 0..=last_epoch {
             println!("Gossipping state for epoch: {epoch_index}");


### PR DESCRIPTION
### What was wrong?

We weren't gossiping contract bytecode and storage, Milos really wanted me to do this before working on being able to execute to the front of the chain. It isn't really that big of a deal, so I am getting this done quick

### How was it fixed?

By adding code to gossip the contract bytecode

For storage because the storage root is updated multiple times per a block, we maintain a cache of updated storage keys per an account.

This implementation is meant to be simple and work, I am aware of optimizations, but those are yet to be seen as needed so we will wait till be run into walls and go from there.