### PR TITLE
docs: Rectify typographical inaccuracies

### DIFF
--- a/book/src/developers/architecture/README.md
+++ b/book/src/developers/architecture/README.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Trin can be understood a from different perspectives.
+Trin can be understood from different perspectives.
 
 - How is code organised?
 - How does data flow through trin?

--- a/book/src/developers/contributing/build_instructions/linux.md
+++ b/book/src/developers/contributing/build_instructions/linux.md
@@ -65,7 +65,7 @@ Some selected flags are described below.
 
 `--no-stun`. A third party server connection is configured by default to assist in testing.
 This is a Session Traversal Utilities for NAT (STUN) server and may be disabled
-a flag. The docs state: "Do not use STUN to determine an external IP. Leaves
+as a flag. The docs state: "Do not use STUN to determine an external IP. Leaves
 ENR entry for IP blank. Some users report better connections over VPN."
 
 #### Optional flags for conflicting nodes

--- a/book/src/developers/contributing/git/code_review.md
+++ b/book/src/developers/contributing/git/code_review.md
@@ -4,7 +4,7 @@
 
 Every team member is responsible for reviewing code. The designations :speech_balloon:, :heavy_check_mark:, and :x: **should** be left by a reviewer as follows:
 
-- :speech_balloon: (Comment) should be used when there is not yet an opinion on overall validity of complete PR, for example:
+- :speech_balloon: (Comment) should be used when there is not yet an opinion on the overall validity of complete PR, for example:
   - comments from a partial review
   - comments from a complete review on a Work in Progress PR
   - questions or non-specific concerns, where the answer might trigger an expected change before merging

--- a/book/src/developers/contributing/git/pull_requests.md
+++ b/book/src/developers/contributing/git/pull_requests.md
@@ -15,7 +15,7 @@ through github via pull requests.
   prior to being merged.
     * Obvious exceptions include very small pull requests.
     * Less obvious examples include things like time-sensitive fixes.
-* You should not expect feedback on a pull request which is not passing CI.
+* You should not expect feedback on a pull request that is not passing CI.
     * Obvious exceptions include soliciting high-level feedback on your approach.
 
 

--- a/book/src/developers/contributing/git/submodules.md
+++ b/book/src/developers/contributing/git/submodules.md
@@ -7,7 +7,7 @@ just cloned the project, be sure to run:
 $ git submodule update --init
 ```
 
-This page provides short overview of most common use cases.
+This page provides a short overview of the most common use cases.
 
 ## Pulling in Upstream Changes from the Submodule Remote
 

--- a/book/src/developers/contributing/releases/deployment.md
+++ b/book/src/developers/contributing/releases/deployment.md
@@ -51,7 +51,7 @@ This step directs Ansible to use the current master version of trin. Read [about
     - [Grafana](https://trin-bench.ethdevops.io/d/e23mBdEVk/trin-metrics?orgId=1)
 - Activate the virtual environment in the cluster repo: `. venv/bin/activate`
 - Make sure you've pulled the latest master branch of the deployment scripts, to include any recent changes: `git pull origin master`
-- Go into Portal section of Ansible: `cd portal-network/trin/ansible/`
+- Go into the Portal section of Ansible: `cd portal-network/trin/ansible/`
 - Run the deployment: `ansible-playbook playbook.yml --tags trin`
 - Run Glados deployment: updates glados + portal client (currently configured as trin, but this could change)
   - `cd ../../glados/ansible`


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.
