### PR TITLE
feat(ethportal-api): adds within-radius boolean to NodeInfo within QueryTrace

### DIFF
--- a/ethportal-api/src/types/query_trace.rs
+++ b/ethportal-api/src/types/query_trace.rs
@@ -125,6 +125,7 @@ impl QueryTrace {
         NodeInfo {
             enr: enr.clone(),
             distance,
+            radius: None,
         }
     }
 }
@@ -145,6 +146,7 @@ pub struct QueryResponse {
 pub struct NodeInfo {
     pub enr: Enr,
     pub distance: B256,
+    pub radius: Option<B256>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### What was wrong?
Including query-time radius information in any query trace analysis requires a property within `ethportal-api`'s `query_trace::NodeInfo` struct so that a node's radius data can be optionally recorded.

### How was it fixed?

Adds the `radius: Option<B256>` to the `ethportal_api::query_trace::NodeInfo` for recording the radius. It's an `Option` because radius of most nodes won't be known by trin at query time, most will be filled in after the fact by Glados before displaying the trace.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
