### PR TITLE
refactor: make storage generic over content key trait

### DIFF
--- a/portalnet/src/find/query_pool.rs
+++ b/portalnet/src/find/query_pool.rs
@@ -44,7 +44,7 @@ pub struct QueryPool<TNodeId, TQuery, TContentKey> {
     next_id: QueryId,
     query_timeout: Duration,
     queries: FnvHashMap<QueryId, (QueryInfo<TContentKey>, TQuery)>,
-    marker: PhantomData<TNodeId>,
+    _marker: PhantomData<TNodeId>,
 }
 
 /// The observable states emitted by [`QueryPool::poll`].
@@ -80,7 +80,7 @@ where
             next_id: QueryId(0),
             query_timeout,
             queries: Default::default(),
-            marker: PhantomData,
+            _marker: PhantomData,
         }
     }
 

--- a/portalnet/src/overlay/protocol.rs
+++ b/portalnet/src/overlay/protocol.rs
@@ -78,9 +78,9 @@ pub struct OverlayProtocol<TContentKey, TMetric, TValidator, TStore> {
     /// Declare the allowed content key types for a given overlay network.
     /// Use a phantom, because we don't store any keys in this struct.
     /// For example, this type is used when decoding a content key received over the network.
-    phantom_content_key: PhantomData<TContentKey>,
+    _phantom_content_key: PhantomData<TContentKey>,
     /// Associate a distance metric with the overlay network.
-    phantom_metric: PhantomData<TMetric>,
+    _phantom_metric: PhantomData<TMetric>,
     /// Accepted content validator that makes requests to this/other overlay networks
     validator: Arc<TValidator>,
     /// Runtime telemetry metrics for the overlay network.
@@ -147,8 +147,8 @@ where
             protocol,
             command_tx,
             utp_controller,
-            phantom_content_key: PhantomData,
-            phantom_metric: PhantomData,
+            _phantom_content_key: PhantomData,
+            _phantom_metric: PhantomData,
             validator,
             metrics,
         }

--- a/portalnet/src/overlay/protocol.rs
+++ b/portalnet/src/overlay/protocol.rs
@@ -91,7 +91,7 @@ impl<
         TContentKey: 'static + OverlayContentKey + Send + Sync,
         TMetric: Metric + Send + Sync,
         TValidator: 'static + Validator<TContentKey> + Send + Sync,
-        TStore: 'static + ContentStore + Send + Sync,
+        TStore: 'static + ContentStore<TContentKey> + Send + Sync,
     > OverlayProtocol<TContentKey, TMetric, TValidator, TStore>
 where
     <TContentKey as TryFrom<Vec<u8>>>::Error: Debug + Display + Send,

--- a/portalnet/src/overlay/protocol.rs
+++ b/portalnet/src/overlay/protocol.rs
@@ -91,7 +91,7 @@ impl<
         TContentKey: 'static + OverlayContentKey + Send + Sync,
         TMetric: Metric + Send + Sync,
         TValidator: 'static + Validator<TContentKey> + Send + Sync,
-        TStore: 'static + ContentStore<TContentKey> + Send + Sync,
+        TStore: 'static + ContentStore<Key = TContentKey> + Send + Sync,
     > OverlayProtocol<TContentKey, TMetric, TValidator, TStore>
 where
     <TContentKey as TryFrom<Vec<u8>>>::Error: Debug + Display + Send,

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -161,7 +161,7 @@ impl<
         TContentKey: 'static + OverlayContentKey + Send + Sync,
         TMetric: Metric + Send + Sync,
         TValidator: 'static + Validator<TContentKey> + Send + Sync,
-        TStore: 'static + ContentStore + Send + Sync,
+        TStore: 'static + ContentStore<TContentKey> + Send + Sync,
     > OverlayService<TContentKey, TMetric, TValidator, TStore>
 where
     <TContentKey as TryFrom<Vec<u8>>>::Error: Debug,
@@ -2574,7 +2574,7 @@ struct UtpProcessing<TValidator, TStore, TContentKey>
 where
     TContentKey: OverlayContentKey + Send + Sync,
     TValidator: Validator<TContentKey>,
-    TStore: ContentStore,
+    TStore: ContentStore<TContentKey>,
 {
     validator: Arc<TValidator>,
     store: Arc<RwLock<TStore>>,
@@ -2592,7 +2592,7 @@ impl<TContentKey, TMetric, TValidator, TStore>
 where
     TContentKey: OverlayContentKey + Send + Sync,
     TValidator: Validator<TContentKey>,
-    TStore: ContentStore,
+    TStore: ContentStore<TContentKey>,
 {
     fn from(service: &OverlayService<TContentKey, TMetric, TValidator, TStore>) -> Self {
         Self {
@@ -2612,7 +2612,7 @@ impl<TValidator, TStore, TContentKey> Clone for UtpProcessing<TValidator, TStore
 where
     TContentKey: OverlayContentKey + Send + Sync,
     TValidator: Validator<TContentKey>,
-    TStore: ContentStore,
+    TStore: ContentStore<TContentKey>,
 {
     fn clone(&self) -> Self {
         Self {

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -161,7 +161,7 @@ impl<
         TContentKey: 'static + OverlayContentKey + Send + Sync,
         TMetric: Metric + Send + Sync,
         TValidator: 'static + Validator<TContentKey> + Send + Sync,
-        TStore: 'static + ContentStore<TContentKey> + Send + Sync,
+        TStore: 'static + ContentStore<Key = TContentKey> + Send + Sync,
     > OverlayService<TContentKey, TMetric, TValidator, TStore>
 where
     <TContentKey as TryFrom<Vec<u8>>>::Error: Debug,
@@ -2574,7 +2574,7 @@ struct UtpProcessing<TValidator, TStore, TContentKey>
 where
     TContentKey: OverlayContentKey + Send + Sync,
     TValidator: Validator<TContentKey>,
-    TStore: ContentStore<TContentKey>,
+    TStore: ContentStore<Key = TContentKey>,
 {
     validator: Arc<TValidator>,
     store: Arc<RwLock<TStore>>,
@@ -2592,7 +2592,7 @@ impl<TContentKey, TMetric, TValidator, TStore>
 where
     TContentKey: OverlayContentKey + Send + Sync,
     TValidator: Validator<TContentKey>,
-    TStore: ContentStore<TContentKey>,
+    TStore: ContentStore<Key = TContentKey>,
 {
     fn from(service: &OverlayService<TContentKey, TMetric, TValidator, TStore>) -> Self {
         Self {
@@ -2612,7 +2612,7 @@ impl<TValidator, TStore, TContentKey> Clone for UtpProcessing<TValidator, TStore
 where
     TContentKey: OverlayContentKey + Send + Sync,
     TValidator: Validator<TContentKey>,
-    TStore: ContentStore<TContentKey>,
+    TStore: ContentStore<Key = TContentKey>,
 {
     fn clone(&self) -> Self {
         Self {

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -142,9 +142,9 @@ where
     /// uTP controller.
     utp_controller: Arc<UtpController>,
     /// Phantom content key.
-    phantom_content_key: PhantomData<TContentKey>,
+    _phantom_content_key: PhantomData<TContentKey>,
     /// Phantom metric (distance function).
-    phantom_metric: PhantomData<TMetric>,
+    _phantom_metric: PhantomData<TMetric>,
     /// Metrics reporting component
     metrics: OverlayMetricsReporter,
     /// Validator for overlay network content.
@@ -223,8 +223,8 @@ where
                 response_rx,
                 response_tx,
                 utp_controller,
-                phantom_content_key: PhantomData,
-                phantom_metric: PhantomData,
+                _phantom_content_key: PhantomData,
+                _phantom_metric: PhantomData,
                 metrics,
                 validator,
                 event_stream,
@@ -2750,8 +2750,8 @@ mod tests {
             findnodes_query_distances_per_peer: overlay_config.findnodes_query_distances_per_peer,
             response_tx,
             response_rx,
-            phantom_content_key: PhantomData,
-            phantom_metric: PhantomData,
+            _phantom_content_key: PhantomData,
+            _phantom_metric: PhantomData,
             metrics,
             validator,
             event_stream: broadcast::channel(EVENT_STREAM_CHANNEL_CAPACITY).0,

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -224,7 +224,7 @@ async fn store(
         .overlay
         .store
         .write()
-        .put::<BeaconContentKey, Vec<u8>>(content_key, data)
+        .put::<Vec<u8>>(content_key, data)
     {
         Ok(_) => Ok(Value::Bool(true)),
         Err(msg) => Ok(Value::String(msg.to_string())),

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -142,8 +142,8 @@ pub struct BeaconStorage {
     cache: BeaconStorageCache,
 }
 
-impl ContentStore for BeaconStorage {
-    fn get<K: OverlayContentKey>(&self, key: &K) -> Result<Option<Vec<u8>>, ContentStoreError> {
+impl<TContentKey: OverlayContentKey> ContentStore<TContentKey> for BeaconStorage {
+    fn get(&self, key: &TContentKey) -> Result<Option<Vec<u8>>, ContentStoreError> {
         let content_key: Vec<u8> = key.clone().into();
         let beacon_content_key = BeaconContentKey::try_from(content_key).map_err(|err| {
             ContentStoreError::InvalidData {
@@ -221,18 +221,14 @@ impl ContentStore for BeaconStorage {
         }
     }
 
-    fn put<K: OverlayContentKey, V: AsRef<[u8]>>(
-        &mut self,
-        key: K,
-        value: V,
-    ) -> Result<(), ContentStoreError> {
+    fn put<V: AsRef<[u8]>>(&mut self, key: TContentKey, value: V) -> Result<(), ContentStoreError> {
         self.store(&key, &value.as_ref().to_vec())
     }
 
     /// The "radius" concept is not applicable for Beacon network
-    fn is_key_within_radius_and_unavailable<K: OverlayContentKey>(
+    fn is_key_within_radius_and_unavailable(
         &self,
-        key: &K,
+        key: &TContentKey,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
         let content_key: Vec<u8> = key.clone().into();
         let beacon_content_key = BeaconContentKey::try_from(content_key).map_err(|err| {

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -142,8 +142,10 @@ pub struct BeaconStorage {
     cache: BeaconStorageCache,
 }
 
-impl<TContentKey: OverlayContentKey> ContentStore<TContentKey> for BeaconStorage {
-    fn get(&self, key: &TContentKey) -> Result<Option<Vec<u8>>, ContentStoreError> {
+impl ContentStore for BeaconStorage {
+    type Key = BeaconContentKey;
+
+    fn get(&self, key: &Self::Key) -> Result<Option<Vec<u8>>, ContentStoreError> {
         let content_key: Vec<u8> = key.clone().into();
         let beacon_content_key = BeaconContentKey::try_from(content_key).map_err(|err| {
             ContentStoreError::InvalidData {
@@ -221,14 +223,14 @@ impl<TContentKey: OverlayContentKey> ContentStore<TContentKey> for BeaconStorage
         }
     }
 
-    fn put<V: AsRef<[u8]>>(&mut self, key: TContentKey, value: V) -> Result<(), ContentStoreError> {
+    fn put<V: AsRef<[u8]>>(&mut self, key: Self::Key, value: V) -> Result<(), ContentStoreError> {
         self.store(&key, &value.as_ref().to_vec())
     }
 
     /// The "radius" concept is not applicable for Beacon network
     fn is_key_within_radius_and_unavailable(
         &self,
-        key: &TContentKey,
+        key: &Self::Key,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
         let content_key: Vec<u8> = key.clone().into();
         let beacon_content_key = BeaconContentKey::try_from(content_key).map_err(|err| {

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -217,7 +217,7 @@ async fn store(
         .overlay
         .store
         .write()
-        .put::<HistoryContentKey, Vec<u8>>(content_key, data)
+        .put::<Vec<u8>>(content_key, data)
     {
         Ok(_) => Ok(Value::Bool(true)),
         Err(err) => Ok(Value::String(err.to_string())),

--- a/trin-history/src/storage.rs
+++ b/trin-history/src/storage.rs
@@ -78,10 +78,10 @@ pub mod test {
     use std::path::PathBuf;
 
     use discv5::enr::{CombinedKey, Enr as Discv5Enr, NodeId};
-    use ethportal_api::{BlockHeaderKey, HistoryContentKey, IdentityContentKey};
+    use ethportal_api::{BlockHeaderKey, HistoryContentKey};
     use portalnet::utils::db::{configure_node_data_dir, setup_temp_dir};
     use quickcheck::{QuickCheck, TestResult};
-    use rand::{seq::SliceRandom, RngCore};
+    use rand::RngCore;
     use serial_test::serial;
 
     use super::*;
@@ -104,10 +104,7 @@ pub mod test {
                 PortalStorageConfig::new(CAPACITY_MB, temp_dir.path().to_path_buf(), node_id)
                     .unwrap();
             let mut storage = HistoryStorage::new(storage_config).unwrap();
-            let prefixes = [0u8, 1u8, 2u8, 3u8];
-            let mut raw_content_key: Vec<u8> = IdentityContentKey::random().to_bytes();
-            raw_content_key.insert(0, *prefixes.choose(&mut rand::thread_rng()).unwrap());
-            let content_key = HistoryContentKey::try_from(raw_content_key).unwrap();
+            let content_key = HistoryContentKey::random().unwrap();
             let mut value = [0u8; 32];
             rand::thread_rng().fill_bytes(&mut value);
             storage.put(content_key, value).unwrap();

--- a/trin-history/src/storage.rs
+++ b/trin-history/src/storage.rs
@@ -14,19 +14,20 @@ pub struct HistoryStorage {
     store: IdIndexedV1Store<HistoryContentKey>,
 }
 
-impl<TContentKey: OverlayContentKey> ContentStore<TContentKey> for HistoryStorage {
-    fn get(&self, key: &TContentKey) -> Result<Option<Vec<u8>>, ContentStoreError> {
+impl ContentStore for HistoryStorage {
+    type Key = HistoryContentKey;
+
+    fn get(&self, key: &Self::Key) -> Result<Option<Vec<u8>>, ContentStoreError> {
         self.store.lookup_content_value(&key.content_id().into())
     }
 
-    fn put<V: AsRef<[u8]>>(&mut self, key: TContentKey, value: V) -> Result<(), ContentStoreError> {
-        let key = HistoryContentKey::try_from(key.to_bytes())?;
+    fn put<V: AsRef<[u8]>>(&mut self, key: Self::Key, value: V) -> Result<(), ContentStoreError> {
         self.store.insert(&key, value.as_ref().to_vec())
     }
 
     fn is_key_within_radius_and_unavailable(
         &self,
-        key: &TContentKey,
+        key: &Self::Key,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
         let content_id = ContentId::from(key.content_id());
         if self.store.distance_to_content_id(&content_id) > self.store.radius() {

--- a/trin-state/src/storage.rs
+++ b/trin-state/src/storage.rs
@@ -21,12 +21,14 @@ pub struct StateStorage {
     store: IdIndexedV1Store<StateContentKey>,
 }
 
-impl<TContentKey: OverlayContentKey> ContentStore<TContentKey> for StateStorage {
-    fn get(&self, key: &TContentKey) -> Result<Option<Vec<u8>>, ContentStoreError> {
+impl ContentStore for StateStorage {
+    type Key = StateContentKey;
+
+    fn get(&self, key: &Self::Key) -> Result<Option<Vec<u8>>, ContentStoreError> {
         self.store.lookup_content_value(&key.content_id().into())
     }
 
-    fn put<V: AsRef<[u8]>>(&mut self, key: TContentKey, value: V) -> Result<(), ContentStoreError> {
+    fn put<V: AsRef<[u8]>>(&mut self, key: Self::Key, value: V) -> Result<(), ContentStoreError> {
         let key = StateContentKey::try_from(key.to_bytes())?;
         let value = StateContentValue::decode(value.as_ref())?;
 
@@ -45,7 +47,7 @@ impl<TContentKey: OverlayContentKey> ContentStore<TContentKey> for StateStorage 
 
     fn is_key_within_radius_and_unavailable(
         &self,
-        key: &TContentKey,
+        key: &Self::Key,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
         let content_id = ContentId::from(key.content_id());
         if self.store.distance_to_content_id(&content_id) > self.store.radius() {

--- a/trin-storage/src/versioned/id_indexed_v1/migration.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/migration.rs
@@ -138,7 +138,8 @@ mod tests {
         migrate_legacy_history_store(&config)?;
 
         // make sure we can initialize new store and that it's empty
-        let store = IdIndexedV1Store::create(ContentType::History, config.clone())?;
+        let store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::History, config.clone())?;
         assert_eq!(store.usage_stats(), UsageStats::default(),);
 
         Ok(())
@@ -164,7 +165,8 @@ mod tests {
         migrate_legacy_history_store(&config)?;
 
         // create IdIndexedV1Store and verify content
-        let store = IdIndexedV1Store::create(ContentType::History, config)?;
+        let store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::History, config)?;
         for (key, value) in key_value_map.into_iter() {
             assert_eq!(
                 store.lookup_content_value(&key.content_id().into())?,

--- a/trin-storage/src/versioned/id_indexed_v1/store.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/store.rs
@@ -52,7 +52,7 @@ pub struct IdIndexedV1Store<TContentKey: OverlayContentKey> {
     /// The Metrics for tracking performance.
     metrics: StorageMetricsReporter,
     /// Phantom Content Key
-    phantom_content_key: PhantomData<TContentKey>,
+    _phantom_content_key: PhantomData<TContentKey>,
 }
 
 impl<TContentKey: OverlayContentKey> VersionedContentStore for IdIndexedV1Store<TContentKey> {
@@ -89,7 +89,7 @@ impl<TContentKey: OverlayContentKey> VersionedContentStore for IdIndexedV1Store<
             pruning_strategy,
             usage_stats: UsageStats::default(),
             metrics: StorageMetricsReporter::new(protocol_id),
-            phantom_content_key: PhantomData,
+            _phantom_content_key: PhantomData,
         };
         store.init()?;
         Ok(store)
@@ -603,8 +603,8 @@ mod tests {
     fn create_empty() -> Result<()> {
         let temp_dir = TempDir::new()?;
         let config = create_config(&temp_dir, STORAGE_CAPACITY_100_ITEMS);
-        let store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config)?;
+        let store =
+            IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config.clone())?;
         assert_eq!(store.usage_stats.entry_count, 0);
         assert_eq!(store.usage_stats.total_entry_size_bytes, 0);
         assert_eq!(store.radius(), Distance::MAX);
@@ -619,8 +619,8 @@ mod tests {
         let item_count = 20; // 20%
         create_and_populate_table(&config, item_count)?;
 
-        let store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config)?;
+        let store =
+            IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config.clone())?;
 
         assert_eq!(store.usage_stats.entry_count, item_count);
         assert_eq!(
@@ -639,8 +639,8 @@ mod tests {
         let item_count = 50; // 50%
         create_and_populate_table(&config, item_count)?;
 
-        let store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config)?;
+        let store =
+            IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config.clone())?;
 
         assert_eq!(store.usage_stats.entry_count, item_count);
         assert_eq!(
@@ -660,8 +660,8 @@ mod tests {
         let target_capacity_count = target_capacity_bytes / CONTENT_DEFAULT_SIZE_BYTES;
         create_and_populate_table(&config, target_capacity_count)?;
 
-        let store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config)?;
+        let store =
+            IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config.clone())?;
         assert_eq!(store.usage_stats.entry_count, target_capacity_count);
         assert_eq!(
             store.usage_stats.total_entry_size_bytes,
@@ -681,8 +681,8 @@ mod tests {
 
         create_and_populate_table(&config, above_target_capacity_count)?;
 
-        let store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config)?;
+        let store =
+            IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config.clone())?;
 
         // Should not prune
         assert_eq!(store.usage_stats.entry_count, above_target_capacity_count);
@@ -705,8 +705,8 @@ mod tests {
 
         create_and_populate_table(&config, full_capacity_count)?;
 
-        let store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let store =
+            IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config.clone())?;
 
         // Should not prune
         assert_eq!(store.usage_stats.entry_count, full_capacity_count);
@@ -730,8 +730,8 @@ mod tests {
 
         create_and_populate_table(&config, above_full_capacity_count)?;
 
-        let store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let store =
+            IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config.clone())?;
 
         // should prune until target capacity
         assert_eq!(
@@ -751,8 +751,7 @@ mod tests {
         let temp_dir = TempDir::new()?;
         let config = create_config(&temp_dir, /* storage_capacity_bytes= */ 0);
 
-        let store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config)?;
+        let store = IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config)?;
 
         assert_eq!(store.usage_stats, UsageStats::default());
         assert_eq!(store.radius(), Distance::ZERO);
@@ -766,8 +765,7 @@ mod tests {
 
         // Add 1K entries, more than we would normally prune.
         create_and_populate_table(&config, 1_000)?;
-        let store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config)?;
+        let store = IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config)?;
 
         // Check that db is empty and distance is ZERO.
         assert_eq!(store.usage_stats, UsageStats::default());
@@ -782,8 +780,8 @@ mod tests {
 
         // fill 50% of storage with 50 items, 1% each
         create_and_populate_table(&config, 50)?;
-        let mut store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store =
+            IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config.clone())?;
 
         let (key, value) = generate_key_value(&config, 0);
         let id = ContentId::from(key.content_id());
@@ -813,8 +811,8 @@ mod tests {
 
         // fill 50% of storage with 50 items, 1% each
         create_and_populate_table(&config, 50)?;
-        let mut store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store =
+            IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config.clone())?;
 
         let (key, value) = generate_key_value(&config, 0);
         let id = ContentId::from(key.content_id());
@@ -841,8 +839,8 @@ mod tests {
     fn prune_simple() -> Result<()> {
         let temp_dir = TempDir::new()?;
         let config = create_config(&temp_dir, STORAGE_CAPACITY_100_ITEMS);
-        let mut store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store =
+            IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config.clone())?;
 
         assert_eq!(store.radius(), Distance::MAX);
 
@@ -907,8 +905,8 @@ mod tests {
 
         // fill 50% of storage with 50 items, 1% each
         create_and_populate_table(&config, 50)?;
-        let mut store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store =
+            IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config.clone())?;
 
         let mut rng = rand::thread_rng();
 
@@ -960,8 +958,8 @@ mod tests {
 
         // fill 50% of storage with 50 items, 1% each
         create_and_populate_table(&config, 50)?;
-        let mut store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store =
+            IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config.clone())?;
         assert_eq!(store.usage_stats.entry_count, 50);
 
         // Insert key/value such that:
@@ -1005,8 +1003,8 @@ mod tests {
         let temp_dir = TempDir::new()?;
         let config = create_config(&temp_dir, STORAGE_CAPACITY_10000_ITEMS);
 
-        let mut store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store =
+            IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config.clone())?;
 
         // insert 10_000 entries, each 0x01% of storage size -> storage fully used
         for _ in 0..10_000 {
@@ -1045,8 +1043,8 @@ mod tests {
         let temp_dir = TempDir::new()?;
         let config = create_config(&temp_dir, STORAGE_CAPACITY_10000_ITEMS);
 
-        let mut store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store =
+            IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config.clone())?;
 
         // insert 10_000 entries, each 0x01% of storage size -> storage fully used
         for _ in 0..10_000 {
@@ -1092,8 +1090,7 @@ mod tests {
     fn pagination_empty() -> Result<()> {
         let temp_dir = TempDir::new()?;
         let config = create_config(&temp_dir, STORAGE_CAPACITY_100_ITEMS);
-        let store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config)?;
+        let store = IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config)?;
 
         assert_eq!(
             store.paginate(/* offset= */ 0, /* limit= */ 10)?,
@@ -1109,8 +1106,8 @@ mod tests {
     fn pagination() -> Result<()> {
         let temp_dir = TempDir::new()?;
         let config = create_config(&temp_dir, STORAGE_CAPACITY_100_ITEMS);
-        let mut store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store =
+            IdIndexedV1Store::<IdentityContentKey>::create(ContentType::State, config.clone())?;
 
         let entry_count = 12;
 

--- a/trin-storage/src/versioned/id_indexed_v1/store.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/store.rs
@@ -1,9 +1,9 @@
-use ethportal_api::types::distance::Distance;
+use std::marker::PhantomData;
+
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::{named_params, types::Type, OptionalExtension};
 use tracing::{debug, error, warn};
-use trin_metrics::storage::StorageMetricsReporter;
 
 use super::{
     migration::migrate_legacy_history_store, pruning_strategy::PruningStrategy, sql,
@@ -15,6 +15,8 @@ use crate::{
     versioned::{usage_stats::UsageStats, ContentType, StoreVersion, VersionedContentStore},
     ContentId,
 };
+use ethportal_api::{types::distance::Distance, OverlayContentKey};
+use trin_metrics::storage::StorageMetricsReporter;
 
 /// The result of looking for the farthest content.
 struct FarthestQueryResult {
@@ -24,9 +26,9 @@ struct FarthestQueryResult {
 
 /// The result of the pagination lookup.
 #[derive(Debug, PartialEq, Eq)]
-pub struct PaginateResult<K> {
+pub struct PaginateResult<TContentKey> {
     /// The content keys of the queried page
-    pub content_keys: Vec<K>,
+    pub content_keys: Vec<TContentKey>,
     /// The total count of entries in the database
     pub entry_count: u64,
 }
@@ -37,7 +39,7 @@ pub struct PaginateResult<K> {
 /// It has a configurable capacity and it will prune data that is farthest from the `NodeId` once
 /// it uses more than storage capacity.
 #[derive(Debug)]
-pub struct IdIndexedV1Store {
+pub struct IdIndexedV1Store<TContentKey: OverlayContentKey> {
     /// The configuration.
     config: IdIndexedV1StoreConfig,
     /// The maximum distance between `NodeId` and content id that store should keep. Updated
@@ -49,9 +51,11 @@ pub struct IdIndexedV1Store {
     usage_stats: UsageStats,
     /// The Metrics for tracking performance.
     metrics: StorageMetricsReporter,
+    /// Phantom Content Key
+    phantom_content_key: PhantomData<TContentKey>,
 }
 
-impl VersionedContentStore for IdIndexedV1Store {
+impl<TContentKey: OverlayContentKey> VersionedContentStore for IdIndexedV1Store<TContentKey> {
     type Config = IdIndexedV1StoreConfig;
 
     fn version() -> StoreVersion {
@@ -85,13 +89,14 @@ impl VersionedContentStore for IdIndexedV1Store {
             pruning_strategy,
             usage_stats: UsageStats::default(),
             metrics: StorageMetricsReporter::new(protocol_id),
+            phantom_content_key: PhantomData,
         };
         store.init()?;
         Ok(store)
     }
 }
 
-impl IdIndexedV1Store {
+impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
     /// Initializes variables and metrics, and runs necessary checks.
     fn init(&mut self) -> Result<(), ContentStoreError> {
         self.metrics
@@ -181,10 +186,10 @@ impl IdIndexedV1Store {
     }
 
     /// Returns content key data is stored.
-    pub fn lookup_content_key<K: ethportal_api::OverlayContentKey>(
+    pub fn lookup_content_key(
         &self,
         content_id: &ContentId,
-    ) -> Result<Option<K>, ContentStoreError> {
+    ) -> Result<Option<TContentKey>, ContentStoreError> {
         let timer = self.metrics.start_process_timer("lookup_content_key");
 
         let key = self
@@ -196,7 +201,7 @@ impl IdIndexedV1Store {
                 named_params! { ":content_id": content_id.to_vec() },
                 |row| {
                     let bytes: Vec<u8> = row.get("content_key")?;
-                    K::try_from(bytes).map_err(|e| {
+                    TContentKey::try_from(bytes).map_err(|e| {
                         rusqlite::Error::FromSqlConversionFailure(0, Type::Blob, e.into())
                     })
                 },
@@ -232,9 +237,9 @@ impl IdIndexedV1Store {
     /// Inserts content key/value pair into storage and prunes the db if necessary.
     ///
     /// It returns `InsufficientRadius` error if content is outside radius.
-    pub fn insert<K: ethportal_api::OverlayContentKey>(
+    pub fn insert(
         &mut self,
-        content_key: &K,
+        content_key: &TContentKey,
         content_value: Vec<u8>,
     ) -> Result<(), ContentStoreError> {
         let insert_with_pruning_timer = self.metrics.start_process_timer("insert_with_pruning");
@@ -312,11 +317,11 @@ impl IdIndexedV1Store {
 
     /// Returns a paginated list of all locally available content keys, according to the provided
     /// offset and limit.
-    pub fn paginate<K: ethportal_api::OverlayContentKey>(
+    pub fn paginate(
         &self,
         offset: u64,
         limit: u64,
-    ) -> Result<PaginateResult<K>, ContentStoreError> {
+    ) -> Result<PaginateResult<TContentKey>, ContentStoreError> {
         let timer = self.metrics.start_process_timer("paginate");
 
         let conn = self.config.sql_connection_pool.get()?;
@@ -329,12 +334,12 @@ impl IdIndexedV1Store {
                 },
                 |row| {
                     let bytes = row.get::<&str, Vec<u8>>("content_key")?;
-                    K::try_from(bytes).map_err(|e| {
+                    TContentKey::try_from(bytes).map_err(|e| {
                         rusqlite::Error::FromSqlConversionFailure(0, Type::Blob, e.into())
                     })
                 },
             )?
-            .collect::<Result<Vec<K>, rusqlite::Error>>()?;
+            .collect::<Result<Vec<TContentKey>, rusqlite::Error>>()?;
 
         self.metrics.stop_process_timer(timer);
         Ok(PaginateResult {
@@ -517,7 +522,7 @@ fn maybe_create_table_and_indexes(
 mod tests {
     use anyhow::Result;
     use discv5::enr::NodeId;
-    use ethportal_api::{types::portal_wire::ProtocolId, IdentityContentKey, OverlayContentKey};
+    use ethportal_api::{types::portal_wire::ProtocolId, IdentityContentKey};
     use rand::Rng;
     use tempfile::TempDir;
 
@@ -598,7 +603,8 @@ mod tests {
     fn create_empty() -> Result<()> {
         let temp_dir = TempDir::new()?;
         let config = create_config(&temp_dir, STORAGE_CAPACITY_100_ITEMS);
-        let store = IdIndexedV1Store::create(ContentType::State, config)?;
+        let store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config)?;
         assert_eq!(store.usage_stats.entry_count, 0);
         assert_eq!(store.usage_stats.total_entry_size_bytes, 0);
         assert_eq!(store.radius(), Distance::MAX);
@@ -613,7 +619,8 @@ mod tests {
         let item_count = 20; // 20%
         create_and_populate_table(&config, item_count)?;
 
-        let store = IdIndexedV1Store::create(ContentType::State, config)?;
+        let store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config)?;
 
         assert_eq!(store.usage_stats.entry_count, item_count);
         assert_eq!(
@@ -632,7 +639,8 @@ mod tests {
         let item_count = 50; // 50%
         create_and_populate_table(&config, item_count)?;
 
-        let store = IdIndexedV1Store::create(ContentType::State, config)?;
+        let store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config)?;
 
         assert_eq!(store.usage_stats.entry_count, item_count);
         assert_eq!(
@@ -652,7 +660,8 @@ mod tests {
         let target_capacity_count = target_capacity_bytes / CONTENT_DEFAULT_SIZE_BYTES;
         create_and_populate_table(&config, target_capacity_count)?;
 
-        let store = IdIndexedV1Store::create(ContentType::State, config)?;
+        let store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config)?;
         assert_eq!(store.usage_stats.entry_count, target_capacity_count);
         assert_eq!(
             store.usage_stats.total_entry_size_bytes,
@@ -672,7 +681,8 @@ mod tests {
 
         create_and_populate_table(&config, above_target_capacity_count)?;
 
-        let store = IdIndexedV1Store::create(ContentType::State, config)?;
+        let store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config)?;
 
         // Should not prune
         assert_eq!(store.usage_stats.entry_count, above_target_capacity_count);
@@ -695,7 +705,8 @@ mod tests {
 
         create_and_populate_table(&config, full_capacity_count)?;
 
-        let store = IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config.clone())?;
 
         // Should not prune
         assert_eq!(store.usage_stats.entry_count, full_capacity_count);
@@ -719,7 +730,8 @@ mod tests {
 
         create_and_populate_table(&config, above_full_capacity_count)?;
 
-        let store = IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config.clone())?;
 
         // should prune until target capacity
         assert_eq!(
@@ -739,7 +751,8 @@ mod tests {
         let temp_dir = TempDir::new()?;
         let config = create_config(&temp_dir, /* storage_capacity_bytes= */ 0);
 
-        let store = IdIndexedV1Store::create(ContentType::State, config)?;
+        let store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config)?;
 
         assert_eq!(store.usage_stats, UsageStats::default());
         assert_eq!(store.radius(), Distance::ZERO);
@@ -753,7 +766,8 @@ mod tests {
 
         // Add 1K entries, more than we would normally prune.
         create_and_populate_table(&config, 1_000)?;
-        let store = IdIndexedV1Store::create(ContentType::State, config)?;
+        let store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config)?;
 
         // Check that db is empty and distance is ZERO.
         assert_eq!(store.usage_stats, UsageStats::default());
@@ -768,7 +782,8 @@ mod tests {
 
         // fill 50% of storage with 50 items, 1% each
         create_and_populate_table(&config, 50)?;
-        let mut store = IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config.clone())?;
 
         let (key, value) = generate_key_value(&config, 0);
         let id = ContentId::from(key.content_id());
@@ -798,7 +813,8 @@ mod tests {
 
         // fill 50% of storage with 50 items, 1% each
         create_and_populate_table(&config, 50)?;
-        let mut store = IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config.clone())?;
 
         let (key, value) = generate_key_value(&config, 0);
         let id = ContentId::from(key.content_id());
@@ -825,7 +841,8 @@ mod tests {
     fn prune_simple() -> Result<()> {
         let temp_dir = TempDir::new()?;
         let config = create_config(&temp_dir, STORAGE_CAPACITY_100_ITEMS);
-        let mut store = IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config.clone())?;
 
         assert_eq!(store.radius(), Distance::MAX);
 
@@ -890,7 +907,8 @@ mod tests {
 
         // fill 50% of storage with 50 items, 1% each
         create_and_populate_table(&config, 50)?;
-        let mut store = IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config.clone())?;
 
         let mut rng = rand::thread_rng();
 
@@ -942,7 +960,8 @@ mod tests {
 
         // fill 50% of storage with 50 items, 1% each
         create_and_populate_table(&config, 50)?;
-        let mut store = IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config.clone())?;
         assert_eq!(store.usage_stats.entry_count, 50);
 
         // Insert key/value such that:
@@ -986,7 +1005,8 @@ mod tests {
         let temp_dir = TempDir::new()?;
         let config = create_config(&temp_dir, STORAGE_CAPACITY_10000_ITEMS);
 
-        let mut store = IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config.clone())?;
 
         // insert 10_000 entries, each 0x01% of storage size -> storage fully used
         for _ in 0..10_000 {
@@ -1025,7 +1045,8 @@ mod tests {
         let temp_dir = TempDir::new()?;
         let config = create_config(&temp_dir, STORAGE_CAPACITY_10000_ITEMS);
 
-        let mut store = IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config.clone())?;
 
         // insert 10_000 entries, each 0x01% of storage size -> storage fully used
         for _ in 0..10_000 {
@@ -1071,10 +1092,11 @@ mod tests {
     fn pagination_empty() -> Result<()> {
         let temp_dir = TempDir::new()?;
         let config = create_config(&temp_dir, STORAGE_CAPACITY_100_ITEMS);
-        let store = IdIndexedV1Store::create(ContentType::State, config)?;
+        let store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config)?;
 
         assert_eq!(
-            store.paginate::<IdentityContentKey>(/* offset= */ 0, /* limit= */ 10)?,
+            store.paginate(/* offset= */ 0, /* limit= */ 10)?,
             PaginateResult {
                 content_keys: vec![],
                 entry_count: 0,
@@ -1087,7 +1109,8 @@ mod tests {
     fn pagination() -> Result<()> {
         let temp_dir = TempDir::new()?;
         let config = create_config(&temp_dir, STORAGE_CAPACITY_100_ITEMS);
-        let mut store = IdIndexedV1Store::create(ContentType::State, config.clone())?;
+        let mut store: IdIndexedV1Store<IdentityContentKey> =
+            IdIndexedV1Store::create(ContentType::State, config.clone())?;
 
         let entry_count = 12;
 
@@ -1101,28 +1124,28 @@ mod tests {
 
         // Paginate in steps of 4, there should be exactly 3 pages
         assert_eq!(
-            store.paginate::<IdentityContentKey>(/* offset= */ 0, /* limit= */ 4)?,
+            store.paginate(/* offset= */ 0, /* limit= */ 4)?,
             PaginateResult {
                 content_keys: content_keys[0..4].into(),
                 entry_count,
             }
         );
         assert_eq!(
-            store.paginate::<IdentityContentKey>(/* offset= */ 4, /* limit= */ 4)?,
+            store.paginate(/* offset= */ 4, /* limit= */ 4)?,
             PaginateResult {
                 content_keys: content_keys[4..8].into(),
                 entry_count,
             }
         );
         assert_eq!(
-            store.paginate::<IdentityContentKey>(/* offset= */ 8, /* limit= */ 4)?,
+            store.paginate(/* offset= */ 8, /* limit= */ 4)?,
             PaginateResult {
                 content_keys: content_keys[8..].into(),
                 entry_count,
             }
         );
         assert_eq!(
-            store.paginate::<IdentityContentKey>(/* offset= */ 12, /* limit= */ 4)?,
+            store.paginate(/* offset= */ 12, /* limit= */ 4)?,
             PaginateResult {
                 content_keys: vec![],
                 entry_count,
@@ -1131,21 +1154,21 @@ mod tests {
 
         // Paginate in steps of 5, last page should have only 2
         assert_eq!(
-            store.paginate::<IdentityContentKey>(/* offset= */ 0, /* limit= */ 5)?,
+            store.paginate(/* offset= */ 0, /* limit= */ 5)?,
             PaginateResult {
                 content_keys: content_keys[0..5].into(),
                 entry_count,
             }
         );
         assert_eq!(
-            store.paginate::<IdentityContentKey>(/* offset= */ 5, /* limit= */ 5)?,
+            store.paginate(/* offset= */ 5, /* limit= */ 5)?,
             PaginateResult {
                 content_keys: content_keys[5..10].into(),
                 entry_count,
             }
         );
         assert_eq!(
-            store.paginate::<IdentityContentKey>(/* offset= */ 10, /* limit= */ 5)?,
+            store.paginate(/* offset= */ 10, /* limit= */ 5)?,
             PaginateResult {
                 content_keys: content_keys[10..].into(),
                 entry_count,


### PR DESCRIPTION
### What was wrong?
Preliminary work for gossiping dropped content. Spoke with @morph-dev offline and decided this was a good step, since I will soon update `prune()` to return content keys. Rather than having 4 separate fns on `IdIndexedStoreV1` using custom generics, better to make the entire struct generic over `OverlayContentKey`. This also helps simplify the upcoming implementation of `prune()` returning dropped content.

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
