### PR TITLE
feat(trin-execution): execute multiple blocks in memory + able to execute to merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2858,6 +2858,7 @@ dependencies = [
 name = "ethportal-api"
 version = "0.2.2"
 dependencies = [
+ "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "anyhow",

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["cryptography::cryptocurrencies"]
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
+alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 anyhow.workspace = true

--- a/ethportal-api/src/types/state_trie/account_state.rs
+++ b/ethportal-api/src/types/state_trie/account_state.rs
@@ -1,5 +1,6 @@
-use alloy_primitives::{keccak256, B256, U256};
-use alloy_rlp::{RlpDecodable, RlpEncodable, EMPTY_STRING_CODE};
+use alloy_consensus::{constants::KECCAK_EMPTY, EMPTY_ROOT_HASH};
+use alloy_primitives::{B256, U256};
+use alloy_rlp::{RlpDecodable, RlpEncodable};
 use serde::{Deserialize, Serialize};
 
 /// The Account State stored in the state trie.
@@ -16,8 +17,8 @@ impl Default for AccountState {
         Self {
             nonce: 0,
             balance: U256::ZERO,
-            storage_root: keccak256([EMPTY_STRING_CODE]),
-            code_hash: keccak256([]),
+            storage_root: EMPTY_ROOT_HASH,
+            code_hash: KECCAK_EMPTY,
         }
     }
 }

--- a/portal-bridge/src/bridge/state.rs
+++ b/portal-bridge/src/bridge/state.rs
@@ -9,7 +9,7 @@ use ethportal_api::{
     types::state_trie::account_state::AccountState as AccountStateInfo, StateContentKey,
     StateContentValue,
 };
-use revm::DatabaseRef;
+use revm::Database;
 use revm_primitives::{keccak256, Bytecode, SpecId, B256};
 use surf::{Client, Config};
 use tokio::{
@@ -24,7 +24,6 @@ use trin_execution::{
         create_account_content_key, create_account_content_value, create_contract_content_key,
         create_contract_content_value, create_storage_content_key, create_storage_content_value,
     },
-    era::manager::EraManager,
     execution::State,
     spec_id::get_spec_block_number,
     storage::utils::setup_temp_dir,
@@ -86,10 +85,10 @@ impl StateBridge {
         info!("Launching state bridge: {:?}", self.mode);
         match self.mode.clone() {
             BridgeMode::Single(ModeType::Block(last_block)) => {
-                if last_block > get_spec_block_number(SpecId::DAO_FORK) {
+                if last_block > get_spec_block_number(SpecId::MERGE) {
                     panic!(
                         "State bridge only supports blocks up to {} for the time being.",
-                        get_spec_block_number(SpecId::DAO_FORK)
+                        get_spec_block_number(SpecId::MERGE)
                     );
                 }
                 self.launch_state(last_block)
@@ -110,13 +109,9 @@ impl StateBridge {
             cache_contract_storage_changes: true,
             block_to_trace: BlockToTrace::None,
         };
-        let mut state = State::new(Some(temp_directory.path().to_path_buf()), state_config)?;
-        let starting_block = 0;
-        let mut era_manager = EraManager::new(starting_block).await?;
-        for block_number in starting_block..=last_block {
+        let mut state = State::new(Some(temp_directory.path().to_path_buf()), state_config).await?;
+        for block_number in 0..=last_block {
             info!("Gossipping state for block at height: {block_number}");
-
-            let block = era_manager.get_next_block().await?;
 
             // process block
             let RootWithTrieDiff {
@@ -126,8 +121,15 @@ impl StateBridge {
                 true => state
                     .initialize_genesis()
                     .map_err(|e| anyhow!("unable to create genesis state: {e}"))?,
-                false => state.process_block(block)?,
+                false => state.process_block(block_number).await?,
             };
+            let block = state
+                .era_manager
+                .lock()
+                .await
+                .last_fetched_block()
+                .await?
+                .clone();
 
             let walk_diff = TrieWalker::new(root_hash, changed_nodes);
 
@@ -162,7 +164,7 @@ impl StateBridge {
                 // if the code_hash is empty then then don't try to gossip the contract bytecode
                 if account.code_hash != keccak256([]) {
                     // gossip contract bytecode
-                    let code = state.database.code_by_hash_ref(account.code_hash)?;
+                    let code = state.database.code_by_hash(account.code_hash)?;
                     self.gossip_contract_bytecode(
                         address_hash,
                         &account_proof,

--- a/trin-execution/metrics/grafana/dashboards/trin-execution-main.json
+++ b/trin-execution/metrics/grafana/dashboards/trin-execution-main.json
@@ -1097,4 +1097,4 @@
     "uid": "fdqcqby1pyvb4d",
     "version": 1,
     "weekStart": ""
-  }
+}

--- a/trin-execution/metrics/prometheus/prometheus.yml
+++ b/trin-execution/metrics/prometheus/prometheus.yml
@@ -17,3 +17,4 @@ scrape_configs:
         - localhost:9091
         labels:
           instance: local_node
+

--- a/trin-execution/src/dao_fork.rs
+++ b/trin-execution/src/dao_fork.rs
@@ -1,10 +1,7 @@
 //! DAO Fork related constants from [EIP-779](https://eips.ethereum.org/EIPS/eip-779).
 //! It happened on Ethereum block 1_920_000
 
-use revm::{db::State as RevmState, Evm};
 use revm_primitives::{address, Address};
-
-use crate::storage::evm_db::EvmDB;
 
 /// Dao hardfork beneficiary that received ether from accounts from DAO and DAO creator children.
 pub static DAO_HARDFORK_BENEFICIARY: Address = address!("bf4ed7b27f1d666546e30d74d50d173d20bca754");
@@ -128,16 +125,3 @@ pub static DAO_HARDKFORK_ACCOUNTS: [Address; 116] = [
     address!("bb9bc244d798123fde783fcc1c72d3bb8c189413"),
     address!("807640a13483f8ac783c557fcdf27be11ea4ac7a"),
 ];
-
-pub fn process_dao_fork(database: &mut Evm<(), RevmState<EvmDB>>) -> anyhow::Result<()> {
-    // drain balances from DAO hardfork accounts
-    let drained_balances = database.db_mut().drain_balances(DAO_HARDKFORK_ACCOUNTS)?;
-    let drained_balance_sum: u128 = drained_balances.iter().sum();
-
-    // transfer drained balance to beneficiary
-    database
-        .db_mut()
-        .increment_balances([(DAO_HARDFORK_BENEFICIARY, drained_balance_sum)].into_iter())?;
-
-    Ok(())
-}

--- a/trin-execution/src/era/manager.rs
+++ b/trin-execution/src/era/manager.rs
@@ -64,6 +64,17 @@ impl EraManager {
         self.next_block_number
     }
 
+    pub async fn last_fetched_block(&self) -> anyhow::Result<&ProcessedBlock> {
+        let Some(current_era) = &self.current_era else {
+            panic!("current_era should be initialized in EraManager::new");
+        };
+        ensure!(
+            self.next_block_number > 0,
+            "next_block_number should be greater than 0"
+        );
+        Ok(current_era.get_block(self.next_block_number - 1))
+    }
+
     pub async fn get_next_block(&mut self) -> anyhow::Result<&ProcessedBlock> {
         let processed_era = match &self.current_era {
             Some(processed_era) if processed_era.contains_block(self.next_block_number) => {

--- a/trin-execution/src/evm/blocking.rs
+++ b/trin-execution/src/evm/blocking.rs
@@ -1,0 +1,24 @@
+use revm::{inspector_handle_register, Database, Evm, GetInspector};
+use revm_primitives::{EVMResult, Env};
+
+use crate::spec_id::get_spec_id;
+
+/// Executes the transaction with external context in the blocking manner.
+pub fn execute_transaction_with_external_context<
+    DB: Database,
+    EXT: revm::Inspector<DB> + for<'a> GetInspector<&'a mut DB>,
+>(
+    evm_environment: Env,
+    external_context: EXT,
+    database: &mut DB,
+) -> EVMResult<DB::Error> {
+    let block_number = evm_environment.block.number.to::<u64>();
+    Evm::builder()
+        .with_env(Box::new(evm_environment))
+        .with_spec_id(get_spec_id(block_number))
+        .with_db(database)
+        .with_external_context(external_context)
+        .append_handler_register(inspector_handle_register)
+        .build()
+        .transact()
+}

--- a/trin-execution/src/evm/execution_context.rs
+++ b/trin-execution/src/evm/execution_context.rs
@@ -1,0 +1,291 @@
+use std::{
+    collections::HashMap,
+    fs::{self, File},
+    path::PathBuf,
+};
+
+use anyhow::ensure;
+use eth_trie::{RootWithTrieDiff, Trie};
+use ethportal_api::types::execution::transaction::Transaction;
+use revm::{
+    db::{states::bundle_state::BundleRetention, State},
+    inspectors::TracerEip3155,
+    DatabaseCommit, Evm,
+};
+use revm_primitives::{keccak256, Account, Address, Env, ResultAndState, SpecId, B256, U256};
+use tracing::info;
+
+use crate::{
+    block_reward::get_block_reward,
+    dao_fork::{DAO_HARDFORK_BENEFICIARY, DAO_HARDKFORK_ACCOUNTS},
+    era::types::{ProcessedBlock, TransactionsWithSender},
+    metrics::{
+        set_int_gauge_vec, start_timer_vec, stop_timer, BLOCK_HEIGHT, BLOCK_PROCESSING_TIMES,
+        TRANSACTION_PROCESSING_TIMES,
+    },
+    spec_id::{get_spec_block_number, get_spec_id},
+    storage::evm_db::EvmDB,
+    transaction::TxEnvModifier,
+    types::block_to_trace::BlockToTrace,
+};
+
+use super::blocking::execute_transaction_with_external_context;
+
+const BLOCKHASH_SERVE_WINDOW: u64 = 256;
+
+pub struct ExecutionContext<'a> {
+    pub evm: Evm<'a, (), State<EvmDB>>,
+    cumulative_gas_used: u64,
+    cumulative_gas_expected: u64,
+    block_to_trace: BlockToTrace,
+    node_data_directory: PathBuf,
+}
+
+impl<'a> ExecutionContext<'a> {
+    pub fn new(
+        database: EvmDB,
+        block_to_trace: BlockToTrace,
+        node_data_directory: PathBuf,
+    ) -> Self {
+        let state_database = State::builder()
+            .with_database(database)
+            .with_bundle_update()
+            .build();
+        let evm: Evm<(), State<EvmDB>> = Evm::builder().with_db(state_database).build();
+
+        Self {
+            evm,
+            cumulative_gas_used: 0,
+            cumulative_gas_expected: 0,
+            block_to_trace,
+            node_data_directory,
+        }
+    }
+
+    pub fn set_evm_environment_from_block(&mut self, block: &ProcessedBlock) {
+        let timer: prometheus_exporter::prometheus::HistogramTimer =
+            start_timer_vec(&BLOCK_PROCESSING_TIMES, &["initialize_evm"]);
+        if get_spec_id(block.header.number).is_enabled_in(SpecId::SPURIOUS_DRAGON) {
+            self.evm.db_mut().set_state_clear_flag(true);
+        } else {
+            self.evm.db_mut().set_state_clear_flag(false);
+        };
+
+        // initialize evm environment
+        let mut env = Env::default();
+        env.block.number = U256::from(block.header.number);
+        env.block.coinbase = block.header.author;
+        env.block.timestamp = U256::from(block.header.timestamp);
+        if get_spec_id(block.header.number).is_enabled_in(SpecId::MERGE) {
+            env.block.difficulty = U256::ZERO;
+            env.block.prevrandao = block.header.mix_hash;
+        } else {
+            env.block.difficulty = block.header.difficulty;
+            env.block.prevrandao = None;
+        }
+        env.block.basefee = block.header.base_fee_per_gas.unwrap_or_default();
+        env.block.gas_limit = block.header.gas_limit;
+
+        // EIP-4844 excess blob gas of this block, introduced in Cancun
+        if let Some(excess_blob_gas) = block.header.excess_blob_gas {
+            env.block
+                .set_blob_excess_gas_and_price(u64::from_be_bytes(excess_blob_gas.to_be_bytes()));
+        }
+
+        self.evm.context.evm.env = Box::new(env);
+        self.evm
+            .handler
+            .modify_spec_id(get_spec_id(block.header.number));
+        stop_timer(timer);
+    }
+
+    pub fn set_transaction_evm_context(&mut self, tx: &TransactionsWithSender) {
+        let block_number = self.block_number();
+
+        let timer = start_timer_vec(&TRANSACTION_PROCESSING_TIMES, &["modify_tx"]);
+        self.evm.context.evm.env.tx.caller = tx.sender_address;
+        match &tx.transaction {
+            Transaction::Legacy(tx) => tx.modify(block_number, &mut self.evm.context.evm.env.tx),
+            Transaction::EIP1559(tx) => tx.modify(block_number, &mut self.evm.context.evm.env.tx),
+            Transaction::AccessList(tx) => {
+                tx.modify(block_number, &mut self.evm.context.evm.env.tx)
+            }
+            Transaction::Blob(tx) => tx.modify(block_number, &mut self.evm.context.evm.env.tx),
+        }
+        stop_timer(timer);
+    }
+
+    pub fn commit(&mut self, evm_state: HashMap<Address, Account>) {
+        let timer = start_timer_vec(&BLOCK_PROCESSING_TIMES, &["commit_state"]);
+        self.evm.db_mut().commit(evm_state);
+        stop_timer(timer);
+    }
+
+    pub fn transact(&mut self) -> anyhow::Result<ResultAndState> {
+        Ok(self.evm.transact()?)
+    }
+
+    pub fn increment_balances(
+        &mut self,
+        balances: impl IntoIterator<Item = (Address, u128)>,
+    ) -> anyhow::Result<()> {
+        Ok(self.evm.db_mut().increment_balances(balances)?)
+    }
+
+    pub fn process_dao_fork(&mut self) -> anyhow::Result<()> {
+        // drain balances from DAO hardfork accounts
+        let drained_balances = self.evm.db_mut().drain_balances(DAO_HARDKFORK_ACCOUNTS)?;
+        let drained_balance_sum: u128 = drained_balances.iter().sum();
+
+        // transfer drained balance to beneficiary
+        self.evm
+            .db_mut()
+            .increment_balances([(DAO_HARDFORK_BENEFICIARY, drained_balance_sum)].into_iter())?;
+
+        Ok(())
+    }
+
+    pub fn commit_bundle(&mut self, expected_state_root: B256) -> anyhow::Result<RootWithTrieDiff> {
+        ensure!(
+            self.cumulative_gas_used == self.cumulative_gas_expected,
+            "Cumulative gas used doesn't match gas expected! Irreversible! Block number: {}",
+            self.block_number()
+        );
+
+        let timer = start_timer_vec(&BLOCK_PROCESSING_TIMES, &["commit_bundle"]);
+        self.evm
+            .db_mut()
+            .merge_transitions(BundleRetention::PlainState);
+        let state_bundle = self.evm.db_mut().take_bundle();
+        self.evm.db_mut().database.commit_bundle(state_bundle)?;
+        stop_timer(timer);
+
+        let timer = start_timer_vec(&BLOCK_PROCESSING_TIMES, &["get_root_with_trie_diff"]);
+        let RootWithTrieDiff {
+            root,
+            trie_diff: changed_nodes,
+        } = self
+            .evm
+            .db_mut()
+            .database
+            .trie
+            .lock()
+            .root_hash_with_changed_nodes()?;
+        if root != expected_state_root {
+            panic!(
+                "State root doesn't match! Irreversible! Block number: {}",
+                self.block_number()
+            )
+        }
+        stop_timer(timer);
+
+        Ok(RootWithTrieDiff {
+            root,
+            trie_diff: changed_nodes,
+        })
+    }
+
+    pub fn execute_block(&mut self, block: &ProcessedBlock) -> anyhow::Result<()> {
+        info!("State EVM processing block {}", block.header.number);
+
+        self.manage_block_hash_serve_window(block)?;
+
+        let execute_block_timer = start_timer_vec(&BLOCK_PROCESSING_TIMES, &["execute_block"]);
+
+        self.set_evm_environment_from_block(block);
+
+        // execute transactions
+        let cumulative_transaction_timer =
+            start_timer_vec(&BLOCK_PROCESSING_TIMES, &["cumulative_transaction"]);
+        for transaction in block.transactions.iter() {
+            let transaction_timer = start_timer_vec(&BLOCK_PROCESSING_TIMES, &["transaction"]);
+            let evm_result = self.execute_transaction(transaction)?;
+            self.cumulative_gas_used += evm_result.result.gas_used();
+            self.commit(evm_result.state);
+            stop_timer(transaction_timer);
+        }
+        stop_timer(cumulative_transaction_timer);
+
+        // update beneficiary
+        let timer = start_timer_vec(&BLOCK_PROCESSING_TIMES, &["update_beneficiary"]);
+        let _ = self.increment_balances(get_block_reward(block));
+
+        // check if dao fork, if it is drain accounts and transfer it to beneficiary
+        if block.header.number == get_spec_block_number(SpecId::DAO_FORK) {
+            self.process_dao_fork()?;
+        }
+        self.cumulative_gas_expected += block.header.gas_used.to::<u64>();
+        stop_timer(timer);
+        stop_timer(execute_block_timer);
+        set_int_gauge_vec(&BLOCK_HEIGHT, block.header.number as i64, &[]);
+        Ok(())
+    }
+
+    fn execute_transaction(
+        &mut self,
+        tx: &TransactionsWithSender,
+    ) -> anyhow::Result<ResultAndState> {
+        self.set_transaction_evm_context(tx);
+        let block_number = self.block_number();
+
+        let timer = start_timer_vec(&TRANSACTION_PROCESSING_TIMES, &["transact"]);
+
+        let result = if self.block_to_trace.should_trace(block_number) {
+            let output_path = self
+                .node_data_directory
+                .as_path()
+                .join("evm_traces")
+                .join(format!("block_{block_number}"));
+            fs::create_dir_all(&output_path)?;
+            let output_file =
+                File::create(output_path.join(format!("tx_{}.json", tx.transaction.hash())))?;
+            let tracer = TracerEip3155::new(Box::new(output_file));
+            execute_transaction_with_external_context(
+                *self.evm.context.evm.inner.env.clone(),
+                tracer,
+                &mut self.evm.context.evm.inner.db,
+            )?
+        } else {
+            self.transact()?
+        };
+        stop_timer(timer);
+
+        Ok(result)
+    }
+
+    /// insert block hash into database and remove old one
+    fn manage_block_hash_serve_window(&self, block: &ProcessedBlock) -> anyhow::Result<()> {
+        let timer = start_timer_vec(&BLOCK_PROCESSING_TIMES, &["insert_blockhash"]);
+        self.evm.db().database.db.put(
+            keccak256(B256::from(U256::from(block.header.number))),
+            block.header.hash(),
+        )?;
+        if block.header.number >= BLOCKHASH_SERVE_WINDOW {
+            self.evm
+                .db()
+                .database
+                .db
+                .delete(keccak256(B256::from(U256::from(
+                    block.header.number - BLOCKHASH_SERVE_WINDOW,
+                ))))?;
+        }
+        stop_timer(timer);
+        Ok(())
+    }
+
+    pub fn cumulative_gas_used(&self) -> u64 {
+        self.cumulative_gas_used
+    }
+
+    pub fn cumulative_gas_expected(&self) -> u64 {
+        self.cumulative_gas_expected
+    }
+
+    pub fn bundle_size_hint(&self) -> usize {
+        self.evm.db().bundle_size_hint()
+    }
+
+    pub fn block_number(&self) -> u64 {
+        self.evm.context.evm.env.block.number.to::<u64>()
+    }
+}

--- a/trin-execution/src/evm/mod.rs
+++ b/trin-execution/src/evm/mod.rs
@@ -1,0 +1,2 @@
+pub mod blocking;
+pub mod execution_context;

--- a/trin-execution/src/evm/mod.rs
+++ b/trin-execution/src/evm/mod.rs
@@ -1,2 +1,2 @@
+pub mod block_executor;
 pub mod blocking;
-pub mod execution_context;

--- a/trin-execution/src/execution.rs
+++ b/trin-execution/src/execution.rs
@@ -70,6 +70,7 @@ pub struct State {
 
 const GENESIS_STATE_FILE: &str = "trin-execution/resources/genesis/mainnet.json";
 const TEST_GENESIS_STATE_FILE: &str = "resources/genesis/mainnet.json";
+const BLOCKHASH_SERVE_WINDOW: u64 = 256;
 
 impl State {
     pub async fn new(path: Option<PathBuf>, config: StateConfig) -> anyhow::Result<Self> {
@@ -180,9 +181,9 @@ impl State {
                 keccak256(B256::from(U256::from(block.header.number))),
                 block.header.hash(),
             )?;
-            if block.header.number >= 8192 {
+            if block.header.number >= BLOCKHASH_SERVE_WINDOW {
                 self.database.db.delete(keccak256(B256::from(U256::from(
-                    block.header.number - 8192,
+                    block.header.number - BLOCKHASH_SERVE_WINDOW,
                 ))))?;
             }
             stop_timer(timer);

--- a/trin-execution/src/execution.rs
+++ b/trin-execution/src/execution.rs
@@ -440,12 +440,12 @@ impl State {
 ///   but are based on the current state of the network and what we have seen so far
 pub fn should_we_commit_block_execution_early(
     blocks_processed: u64,
-    pending_cache_size_mb: u64,
+    pending_state_changes: u64,
     cumulative_gas_used: u64,
     elapsed: Duration,
 ) -> bool {
     blocks_processed >= 500_000
-        || pending_cache_size_mb >= 5_000_000
+        || pending_state_changes >= 5_000_000
         || cumulative_gas_used >= 30_000_000 * 50_000
         || elapsed >= Duration::from_secs(30 * 60)
 }

--- a/trin-execution/src/lib.rs
+++ b/trin-execution/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod content;
 pub mod dao_fork;
 pub mod era;
+pub mod evm;
 pub mod execution;
 pub mod metrics;
 pub mod spec_id;

--- a/trin-execution/src/main.rs
+++ b/trin-execution/src/main.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
 
-use e2store::era1::BLOCK_TUPLE_COUNT;
 use revm_primitives::SpecId;
 use tracing::info;
 use trin_execution::{

--- a/trin-execution/src/main.rs
+++ b/trin-execution/src/main.rs
@@ -53,10 +53,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             break;
         }
 
-        let end =
-            ((block_number / (BLOCK_TUPLE_COUNT as u64)) + 86) * (BLOCK_TUPLE_COUNT as u64) - 1;
-        let end = std::cmp::min(end, end_block);
-
         if block_number == 0 {
             // initialize genesis state processes this block so we skip it
             state.era_manager.lock().await.get_next_block().await?;
@@ -64,7 +60,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             block_number = 1;
             continue;
         }
-        state.process_range_of_blocks(block_number, end).await?;
+        state
+            .process_range_of_blocks(block_number, end_block)
+            .await?;
         block_number = state.next_block_number();
     }
 

--- a/trin-execution/src/storage/account.rs
+++ b/trin-execution/src/storage/account.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{keccak256, B256, U256};
-use alloy_rlp::{Buf, Decodable, Encodable, RlpDecodable, RlpEncodable, EMPTY_STRING_CODE};
+use alloy_rlp::{RlpDecodable, RlpEncodable, EMPTY_STRING_CODE};
 use ethportal_api::types::state_trie::account_state::AccountState as AccountStateInfo;
-use revm_primitives::KECCAK_EMPTY;
+use revm_primitives::{AccountInfo, KECCAK_EMPTY};
 
 /// The Account State stored in the state trie.
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
@@ -10,8 +10,6 @@ pub struct Account {
     pub balance: U256,
     pub storage_root: B256,
     pub code_hash: B256,
-    /// If account is self destructed or newly created, storage will be cleared.
-    pub account_state: AccountState,
 }
 
 impl Default for Account {
@@ -21,7 +19,6 @@ impl Default for Account {
             balance: U256::ZERO,
             storage_root: keccak256([EMPTY_STRING_CODE]),
             code_hash: KECCAK_EMPTY,
-            account_state: AccountState::default(),
         }
     }
 }
@@ -37,59 +34,13 @@ impl From<&Account> for AccountStateInfo {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
-pub enum AccountState {
-    /// Before Spurious Dragon hardfork there was a difference between empty and not existing.
-    /// And we are flagging it here.
-    NotExisting,
-    /// EVM touched this account. For newer hardfork this means it can be cleared/removed from
-    /// state.
-    Touched,
-    /// EVM cleared storage of this account, mostly by selfdestruct, we don't ask database for
-    /// storage slots and assume they are U256::ZERO
-    StorageCleared,
-    /// EVM didn't interacted with this account
-    #[default]
-    None,
-}
-
-impl Encodable for AccountState {
-    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
-        match self {
-            AccountState::NotExisting => out.put_u8(0),
-            AccountState::Touched => out.put_u8(1),
-            AccountState::StorageCleared => out.put_u8(2),
-            AccountState::None => out.put_u8(3),
+impl From<AccountInfo> for Account {
+    fn from(account_info: AccountInfo) -> Self {
+        Self {
+            nonce: account_info.nonce,
+            balance: account_info.balance,
+            storage_root: keccak256([EMPTY_STRING_CODE]),
+            code_hash: account_info.code_hash,
         }
-    }
-}
-
-impl Decodable for AccountState {
-    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let account_state = AccountState::try_from(buf[0])
-            .map_err(|_| alloy_rlp::Error::Custom("Unknown transaction id"))?;
-        buf.advance(1);
-        Ok(account_state)
-    }
-}
-
-impl TryFrom<u8> for AccountState {
-    type Error = alloy_rlp::Error;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(AccountState::NotExisting),
-            1 => Ok(AccountState::Touched),
-            2 => Ok(AccountState::StorageCleared),
-            3 => Ok(AccountState::None),
-            _ => Err(alloy_rlp::Error::Custom("Invalid AccountState byte")),
-        }
-    }
-}
-
-impl AccountState {
-    /// Returns `true` if EVM cleared storage of this account
-    pub fn is_storage_cleared(&self) -> bool {
-        matches!(self, AccountState::StorageCleared)
     }
 }

--- a/trin-execution/src/storage/account.rs
+++ b/trin-execution/src/storage/account.rs
@@ -1,5 +1,6 @@
-use alloy_primitives::{keccak256, B256, U256};
-use alloy_rlp::{RlpDecodable, RlpEncodable, EMPTY_STRING_CODE};
+use alloy_consensus::EMPTY_ROOT_HASH;
+use alloy_primitives::{B256, U256};
+use alloy_rlp::{RlpDecodable, RlpEncodable};
 use ethportal_api::types::state_trie::account_state::AccountState as AccountStateInfo;
 use revm_primitives::{AccountInfo, KECCAK_EMPTY};
 
@@ -17,7 +18,7 @@ impl Default for Account {
         Self {
             nonce: 0,
             balance: U256::ZERO,
-            storage_root: keccak256([EMPTY_STRING_CODE]),
+            storage_root: EMPTY_ROOT_HASH,
             code_hash: KECCAK_EMPTY,
         }
     }
@@ -34,13 +35,13 @@ impl From<&Account> for AccountStateInfo {
     }
 }
 
-impl From<AccountInfo> for Account {
-    fn from(account_info: AccountInfo) -> Self {
+impl Account {
+    pub fn from_account_info(account: AccountInfo, storage_root: B256) -> Self {
         Self {
-            nonce: account_info.nonce,
-            balance: account_info.balance,
-            storage_root: keccak256([EMPTY_STRING_CODE]),
-            code_hash: account_info.code_hash,
+            nonce: account.nonce,
+            balance: account.balance,
+            storage_root,
+            code_hash: account.code_hash,
         }
     }
 }

--- a/trin-execution/src/storage/error.rs
+++ b/trin-execution/src/storage/error.rs
@@ -11,8 +11,8 @@ pub enum EVMError {
     #[error("rocksdb error {0}")]
     DB(#[from] rocksdb::Error),
 
-    #[error("not found")]
-    NotFound,
+    #[error("not found database error {0}")]
+    NotFound(String),
 
     #[error("balance error")]
     BalanceError,

--- a/trin-execution/src/storage/error.rs
+++ b/trin-execution/src/storage/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-#[derive(Debug, PartialEq, Eq, Error)]
+#[derive(Debug, Error)]
 pub enum EVMError {
     #[error("trie error {0}")]
     Trie(#[from] eth_trie::TrieError),
@@ -10,6 +10,9 @@ pub enum EVMError {
 
     #[error("rocksdb error {0}")]
     DB(#[from] rocksdb::Error),
+
+    #[error("ethportal error {0}")]
+    ANYHOW(#[from] anyhow::Error),
 
     #[error("not found database error {0}")]
     NotFound(String),

--- a/trin-execution/src/storage/evm_db.rs
+++ b/trin-execution/src/storage/evm_db.rs
@@ -1,22 +1,28 @@
 use std::sync::Arc;
 
-use crate::{config::StateConfig, storage::error::EVMError};
+use crate::{
+    config::StateConfig,
+    metrics::{
+        start_timer_vec, stop_timer, BUNDLE_COMMIT_PROCESSING_TIMES, TRANSACTION_PROCESSING_TIMES,
+    },
+    storage::error::EVMError,
+};
 use alloy_primitives::{Address, B256, U256};
 use alloy_rlp::{Decodable, EMPTY_STRING_CODE};
 use eth_trie::{EthTrie, RootWithTrieDiff, Trie};
-use ethportal_api::{
-    types::state_trie::account_state::AccountState as AccountStateInfo, utils::bytes::hex_encode,
-};
+use ethportal_api::types::state_trie::account_state::AccountState as AccountStateInfo;
 use hashbrown::{HashMap as BrownHashMap, HashSet};
 use parking_lot::Mutex;
-use revm::{DatabaseCommit, DatabaseRef};
-use revm_primitives::{keccak256, Account, AccountInfo, Bytecode, HashMap, KECCAK_EMPTY};
+use revm::{
+    db::{states::PlainStorageChangeset, BundleState, OriginalValuesKnown},
+    Database, DatabaseRef,
+};
+use revm_primitives::{keccak256, AccountInfo, Bytecode, HashMap, KECCAK_EMPTY};
 use rocksdb::DB as RocksDB;
+use tracing::info;
 
 use super::{
-    account::{Account as RocksAccount, AccountState as RocksAccountState},
-    account_db::AccountDB,
-    execution_position::ExecutionPosition,
+    account::Account as RocksAccount, account_db::AccountDB, execution_position::ExecutionPosition,
     trie_db::TrieRocksDB,
 };
 
@@ -61,30 +67,6 @@ impl EvmDB {
         })
     }
 
-    /// Inserts the account's code into the cache.
-    ///
-    /// Accounts objects and code are stored separately in the cache, this will take the code from
-    /// the account and instead map it to the code hash.
-    ///
-    /// Note: This will not insert into the underlying external database.
-    pub fn insert_contract(&mut self, account: &mut AccountInfo) {
-        if let Some(code) = &account.code {
-            if !code.is_empty() {
-                if account.code_hash == KECCAK_EMPTY {
-                    account.code_hash = code.hash_slow();
-                }
-
-                // Insert contract code into the database
-                self.db
-                    .put(account.code_hash, code.original_bytes().as_ref())
-                    .expect("Inserting contract shouldn't fail");
-            }
-        }
-        if account.code_hash == B256::ZERO {
-            account.code_hash = KECCAK_EMPTY;
-        }
-    }
-
     pub fn get_storage_trie_diff(&self, address_hash: B256) -> BrownHashMap<B256, Vec<u8>> {
         let mut trie_diff = BrownHashMap::new();
 
@@ -109,149 +91,267 @@ impl EvmDB {
         }
         trie_diff
     }
-}
 
-impl DatabaseCommit for EvmDB {
-    fn commit(&mut self, changes: HashMap<Address, Account>) {
-        for (address, mut account) in changes {
-            if !account.is_touched() {
-                continue;
-            }
+    fn commit_accounts(
+        &mut self,
+        plain_account: Vec<(Address, Option<AccountInfo>)>,
+    ) -> anyhow::Result<()> {
+        for (address, account) in plain_account {
             let address_hash = keccak256(address);
-            if account.is_selfdestructed() {
-                let mut rocks_account: RocksAccount = match self
-                    .db
-                    .get(address_hash)
-                    .expect("Committing account to database should never fail")
-                {
-                    Some(raw_account) => Decodable::decode(&mut raw_account.as_slice())
-                        .expect("Decoding account should never fail"),
+            if let Some(account_info) = account {
+                let plain_state_some_account_timer = start_timer_vec(
+                    &BUNDLE_COMMIT_PROCESSING_TIMES,
+                    &["account:plain_state_some_account"],
+                );
+
+                let mut rocks_account: RocksAccount = account_info.into();
+
+                let timer = start_timer_vec(
+                    &BUNDLE_COMMIT_PROCESSING_TIMES,
+                    &["account:fetch_account_from_db"],
+                );
+                let raw_account = self.db.get(address_hash)?.unwrap_or_default();
+                stop_timer(timer);
+
+                if !raw_account.is_empty() {
+                    let decoded_account: RocksAccount =
+                        Decodable::decode(&mut raw_account.as_slice())?;
+                    rocks_account.storage_root = decoded_account.storage_root;
+                }
+
+                let timer = start_timer_vec(
+                    &BUNDLE_COMMIT_PROCESSING_TIMES,
+                    &["account:insert_into_trie"],
+                );
+                let _ = self.trie.lock().insert(
+                    address_hash.as_ref(),
+                    &alloy_rlp::encode(AccountStateInfo::from(&rocks_account)),
+                );
+                stop_timer(timer);
+
+                let timer = start_timer_vec(
+                    &BUNDLE_COMMIT_PROCESSING_TIMES,
+                    &["account:put_account_into_db"],
+                );
+                self.db
+                    .put(address_hash, alloy_rlp::encode(rocks_account))?;
+                stop_timer(timer);
+
+                stop_timer(plain_state_some_account_timer);
+            } else if self.db.get(address_hash)?.is_some() {
+                let timer =
+                    start_timer_vec(&BUNDLE_COMMIT_PROCESSING_TIMES, &["account:delete_account"]);
+                let rocks_account: RocksAccount = match self.db.get(address_hash)? {
+                    Some(raw_account) => Decodable::decode(&mut raw_account.as_slice())?,
                     None => RocksAccount::default(),
                 };
                 if rocks_account.storage_root != keccak256([EMPTY_STRING_CODE]) {
                     let account_db = AccountDB::new(address_hash, self.db.clone());
-                    let mut trie = EthTrie::from(Arc::new(account_db), rocks_account.storage_root)
-                        .expect("Creating trie should never fail");
-                    trie.clear_trie_from_db()
-                        .expect("Clearing trie should never fail");
+                    let mut trie = EthTrie::from(Arc::new(account_db), rocks_account.storage_root)?;
+                    trie.clear_trie_from_db()?;
                 }
-                rocks_account = RocksAccount::default();
-                rocks_account.account_state = RocksAccountState::NotExisting;
-                self.db
-                    .put(
-                        keccak256(address.as_slice()),
-                        alloy_rlp::encode(rocks_account),
-                    )
-                    .expect("Inserting account should never fail");
+                self.db.delete(address_hash)?;
 
                 // update trie
                 let _ = self.trie.lock().remove(address_hash.as_ref());
-                continue;
+                stop_timer(timer);
             }
-            let is_newly_created = account.is_created();
-            self.insert_contract(&mut account.info);
+        }
+        Ok(())
+    }
 
-            let mut rocks_account: RocksAccount = match self
-                .db
-                .get(address_hash)
-                .expect("Reading account from database should never fail")
-            {
-                Some(raw_account) => {
-                    Decodable::decode(&mut raw_account.as_slice()).unwrap_or_else(|_| {
-                        panic!(
-                            "Decoding account should never fail {}",
-                            hex_encode(&raw_account)
-                        )
-                    })
-                }
-                None => RocksAccount::default(),
-            };
-
-            rocks_account.balance = account.info.balance;
-            rocks_account.nonce = account.info.nonce;
-            rocks_account.code_hash = account.info.code_hash;
-
-            let account_db = AccountDB::new(address_hash, self.db.clone());
-
-            let mut trie = if rocks_account.storage_root == keccak256([EMPTY_STRING_CODE]) {
-                EthTrie::new(Arc::new(account_db))
-            } else {
-                EthTrie::from(Arc::new(account_db), rocks_account.storage_root)
-                    .expect("Creating trie should never fail")
-            };
-
-            rocks_account.account_state = if is_newly_created {
-                if rocks_account.storage_root != keccak256([EMPTY_STRING_CODE]) {
-                    trie.clear_trie_from_db()
-                        .expect("Clearing trie should never fail");
-                };
-
-                RocksAccountState::StorageCleared
-            } else if rocks_account.account_state.is_storage_cleared() {
-                // Preserve old account state if it already exists
-                RocksAccountState::StorageCleared
-            } else {
-                RocksAccountState::Touched
-            };
-
-            for (key, value) in account
-                .storage
-                .into_iter()
-                .filter(|(_, value)| value.is_changed())
-            {
-                if value.present_value() > U256::ZERO {
-                    let _ = trie.insert(
-                        keccak256(B256::from(key)).as_ref(),
-                        &alloy_rlp::encode(value.present_value()),
-                    );
-                } else {
-                    let _ = trie.remove(keccak256(B256::from(key)).as_ref());
-                }
-            }
-
-            // update trie
-            let RootWithTrieDiff {
-                root: storage_root,
-                trie_diff,
-            } = trie
-                .root_hash_with_changed_nodes()
-                .expect("Getting the root hash should never fail");
-
-            if self.config.cache_contract_storage_changes {
-                let account_storage_cache = self.storage_cache.entry(address_hash).or_default();
-                for key in trie_diff.keys() {
-                    account_storage_cache.insert(*key);
-                }
-            }
-
-            rocks_account.storage_root = storage_root;
-
-            let _ = self.trie.lock().insert(
-                address_hash.as_ref(),
-                &alloy_rlp::encode(AccountStateInfo::from(&rocks_account)),
+    fn commit_storage(&mut self, plain_storage: Vec<PlainStorageChangeset>) -> anyhow::Result<()> {
+        for PlainStorageChangeset {
+            address,
+            wipe_storage,
+            storage,
+        } in plain_storage
+        {
+            let plain_state_storage_timer = start_timer_vec(
+                &BUNDLE_COMMIT_PROCESSING_TIMES,
+                &["storage:plain_state_storage"],
             );
 
-            self.db
-                .put(
-                    keccak256(address.as_slice()),
-                    alloy_rlp::encode(rocks_account),
-                )
-                .expect("Inserting account should never fail");
+            let timer = start_timer_vec(
+                &BUNDLE_COMMIT_PROCESSING_TIMES,
+                &["storage:fetch_account_from_db"],
+            );
+            let address_hash = keccak256(address);
+            let rocks_account: Option<RocksAccount> =
+                self.db.get(address_hash)?.map(|raw_account| {
+                    Decodable::decode(&mut raw_account.as_slice())
+                        .expect("valid account should be decoded")
+                });
+            stop_timer(timer);
+
+            if wipe_storage && rocks_account.is_some() {
+                let timer =
+                    start_timer_vec(&BUNDLE_COMMIT_PROCESSING_TIMES, &["storage:wipe_storage"]);
+
+                let account_db = AccountDB::new(address_hash, self.db.clone());
+                let mut rocks_account = rocks_account.expect("We already checked that it is some");
+                if rocks_account.storage_root != keccak256([EMPTY_STRING_CODE]) {
+                    let mut trie = EthTrie::from(Arc::new(account_db), rocks_account.storage_root)?;
+                    trie.clear_trie_from_db()?;
+                    rocks_account.storage_root = keccak256([EMPTY_STRING_CODE]);
+                    let _ = self.trie.lock().insert(
+                        address_hash.as_ref(),
+                        &alloy_rlp::encode(AccountStateInfo::from(&rocks_account)),
+                    );
+                    self.db
+                        .put(address_hash, alloy_rlp::encode(rocks_account))
+                        .expect("Inserting account should never fail");
+                }
+                stop_timer(timer);
+            }
+
+            if !storage.is_empty() {
+                let timer =
+                    start_timer_vec(&BUNDLE_COMMIT_PROCESSING_TIMES, &["storage:apply_updates"]);
+
+                let account_db = AccountDB::new(address_hash, self.db.clone());
+                let mut rocks_account: RocksAccount = self
+                    .db
+                    .get(address_hash)?
+                    .map(|raw_account| {
+                        let rocks_account: RocksAccount =
+                            Decodable::decode(&mut raw_account.as_slice())
+                                .expect("Decoding account should never fail");
+                        rocks_account
+                    })
+                    .unwrap_or_default();
+
+                let mut trie = if rocks_account.storage_root == keccak256([EMPTY_STRING_CODE]) {
+                    EthTrie::new(Arc::new(account_db))
+                } else {
+                    EthTrie::from(Arc::new(account_db), rocks_account.storage_root)?
+                };
+
+                for (key, value) in storage {
+                    let key = B256::from(key);
+                    trie.remove(keccak256(B256::from(key)).as_ref())?;
+
+                    if value != U256::ZERO {
+                        trie.insert(
+                            keccak256(B256::from(key)).as_ref(),
+                            &alloy_rlp::encode(value),
+                        )?;
+                    }
+                }
+
+                // update trie
+                let RootWithTrieDiff {
+                    root: storage_root,
+                    trie_diff,
+                } = trie.root_hash_with_changed_nodes()?;
+
+                if self.config.cache_contract_storage_changes {
+                    let account_storage_cache = self.storage_cache.entry(address_hash).or_default();
+                    for key in trie_diff.keys() {
+                        account_storage_cache.insert(*key);
+                    }
+                }
+
+                rocks_account.storage_root = storage_root;
+
+                let _ = self.trie.lock().insert(
+                    address_hash.as_ref(),
+                    &alloy_rlp::encode(AccountStateInfo::from(&rocks_account)),
+                );
+
+                self.db
+                    .put(address_hash, alloy_rlp::encode(rocks_account))?;
+                stop_timer(timer);
+            }
+            stop_timer(plain_state_storage_timer);
         }
+        Ok(())
+    }
+
+    pub fn commit_bundle(&mut self, bundle_state: BundleState) -> anyhow::Result<()> {
+        // Currently we don't use reverts, so we can ignore them, but they are here for when we do.
+        let timer = start_timer_vec(
+            &BUNDLE_COMMIT_PROCESSING_TIMES,
+            &["generate_plain_state_and_reverts"],
+        );
+        let (plain_state, _reverts) =
+            bundle_state.into_plain_state_and_reverts(OriginalValuesKnown::Yes);
+        stop_timer(timer);
+
+        info!(
+            "Committing bundle state with {} accounts, {} contracts, {} storage changes",
+            plain_state.accounts.len(),
+            plain_state.contracts.len(),
+            plain_state.storage.len()
+        );
+
+        // Write Account State
+        let timer = start_timer_vec(
+            &BUNDLE_COMMIT_PROCESSING_TIMES,
+            &["account:committing_accounts_total"],
+        );
+        self.commit_accounts(plain_state.accounts)?;
+        stop_timer(timer);
+
+        // Write Contract Code
+        let timer = start_timer_vec(
+            &BUNDLE_COMMIT_PROCESSING_TIMES,
+            &["contract:committing_contracts_total"],
+        );
+        for (hash, bytecode) in plain_state.contracts {
+            let timer = start_timer_vec(&BUNDLE_COMMIT_PROCESSING_TIMES, &["committing_contract"]);
+            self.db
+                .put(hash, bytecode.original_bytes().as_ref())
+                .expect("Inserting contract code should never fail");
+            stop_timer(timer);
+        }
+        stop_timer(timer);
+
+        // Write Storage
+        let timer = start_timer_vec(
+            &BUNDLE_COMMIT_PROCESSING_TIMES,
+            &["storage:committing_storage_total"],
+        );
+        self.commit_storage(plain_state.storage)?;
+        stop_timer(timer);
+
+        Ok(())
+    }
+}
+
+impl Database for EvmDB {
+    type Error = EVMError;
+
+    #[doc = " Get basic account information."]
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        DatabaseRef::basic_ref(&self, address)
+    }
+
+    #[doc = " Get account code by its hash."]
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        DatabaseRef::code_by_hash_ref(&self, code_hash)
+    }
+
+    #[doc = " Get storage value of address at index."]
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        DatabaseRef::storage_ref(&self, address, index)
+    }
+
+    #[doc = " Get block hash by block number."]
+    fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
+        DatabaseRef::block_hash_ref(&self, number)
     }
 }
 
 impl DatabaseRef for EvmDB {
     type Error = EVMError;
 
+    #[doc = " Get basic account information."]
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        let _timer = start_timer_vec(&TRANSACTION_PROCESSING_TIMES, &["database_get_basic"]);
         match self.db.get(keccak256(address))? {
             Some(raw_account) => {
                 let account: RocksAccount = Decodable::decode(&mut raw_account.as_slice())?;
-
-                if account.account_state == RocksAccountState::NotExisting {
-                    return Ok(None);
-                }
 
                 Ok(Some(AccountInfo {
                     balance: account.balance,
@@ -264,18 +364,25 @@ impl DatabaseRef for EvmDB {
         }
     }
 
+    #[doc = " Get account code by its hash."]
     fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        let _timer = start_timer_vec(
+            &TRANSACTION_PROCESSING_TIMES,
+            &["database_get_code_by_hash"],
+        );
         match self.db.get(code_hash)? {
             Some(raw_code) => Ok(Bytecode::new_raw(raw_code.into())),
-            None => Err(Self::Error::NotFound),
+            None => Err(Self::Error::NotFound("code_by_hash".to_string())),
         }
     }
 
+    #[doc = " Get storage value of address at index."]
     fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        let _timer = start_timer_vec(&TRANSACTION_PROCESSING_TIMES, &["database_get_storage"]);
         let address_hash = keccak256(address);
         let account: RocksAccount = match self.db.get(address_hash)? {
             Some(raw_account) => Decodable::decode(&mut raw_account.as_slice())?,
-            None => return Err(Self::Error::NotFound),
+            None => return Err(Self::Error::NotFound("storage".to_string())),
         };
         let account_db = AccountDB::new(address_hash, self.db.clone());
         let trie = if account.storage_root == keccak256([EMPTY_STRING_CODE]) {
@@ -285,23 +392,15 @@ impl DatabaseRef for EvmDB {
         };
         match trie.get(keccak256(B256::from(index)).as_ref())? {
             Some(raw_value) => Ok(Decodable::decode(&mut raw_value.as_slice())?),
-            None => {
-                if matches!(
-                    account.account_state,
-                    RocksAccountState::StorageCleared | RocksAccountState::NotExisting
-                ) {
-                    Ok(U256::ZERO)
-                } else {
-                    Err(Self::Error::NotFound)
-                }
-            }
+            None => Ok(U256::ZERO),
         }
     }
 
     fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
+        let _timer = start_timer_vec(&TRANSACTION_PROCESSING_TIMES, &["database_get_block_hash"]);
         match self.db.get(keccak256(B256::from(U256::from(number))))? {
             Some(raw_hash) => Ok(B256::from_slice(&raw_hash)),
-            None => Err(Self::Error::NotFound),
+            None => Err(Self::Error::NotFound("block_hash".to_string())),
         }
     }
 }

--- a/trin-execution/src/storage/evm_db.rs
+++ b/trin-execution/src/storage/evm_db.rs
@@ -7,12 +7,14 @@ use crate::{
     },
     storage::error::EVMError,
 };
+use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_primitives::{Address, B256, U256};
-use alloy_rlp::{Decodable, EMPTY_STRING_CODE};
+use alloy_rlp::Decodable;
 use eth_trie::{EthTrie, RootWithTrieDiff, Trie};
 use ethportal_api::types::state_trie::account_state::AccountState as AccountStateInfo;
 use hashbrown::{HashMap as BrownHashMap, HashSet};
 use parking_lot::Mutex;
+use prometheus_exporter::prometheus::HistogramTimer;
 use revm::{
     db::{states::PlainStorageChangeset, BundleState, OriginalValuesKnown},
     Database, DatabaseRef,
@@ -25,6 +27,14 @@ use super::{
     account::Account as RocksAccount, account_db::AccountDB, execution_position::ExecutionPosition,
     trie_db::TrieRocksDB,
 };
+
+fn start_commit_timer(name: &str) -> HistogramTimer {
+    start_timer_vec(&BUNDLE_COMMIT_PROCESSING_TIMES, &[name])
+}
+
+fn start_processing_timer(name: &str) -> HistogramTimer {
+    start_timer_vec(&TRANSACTION_PROCESSING_TIMES, &[name])
+}
 
 #[derive(Debug, Clone)]
 pub struct EvmDB {
@@ -48,7 +58,7 @@ impl EvmDB {
         db.put(B256::ZERO, Bytecode::new().bytes().as_ref())?;
 
         let trie = Arc::new(Mutex::new(
-            if execution_position.state_root() == keccak256([EMPTY_STRING_CODE]) {
+            if execution_position.state_root() == EMPTY_ROOT_HASH {
                 EthTrie::new(Arc::new(TrieRocksDB::new(false, db.clone())))
             } else {
                 EthTrie::from(
@@ -97,39 +107,27 @@ impl EvmDB {
         address_hash: B256,
         account_info: AccountInfo,
     ) -> anyhow::Result<()> {
-        let plain_state_some_account_timer = start_timer_vec(
-            &BUNDLE_COMMIT_PROCESSING_TIMES,
-            &["account:plain_state_some_account"],
-        );
+        let plain_state_some_account_timer = start_commit_timer("account:plain_state_some_account");
 
-        let mut rocks_account: RocksAccount = account_info.into();
-
-        let timer = start_timer_vec(
-            &BUNDLE_COMMIT_PROCESSING_TIMES,
-            &["account:fetch_account_from_db"],
-        );
+        let timer = start_commit_timer("account:fetch_account_from_db");
         let raw_account = self.db.get(address_hash)?.unwrap_or_default();
         stop_timer(timer);
 
-        if !raw_account.is_empty() {
+        let rocks_account = if !raw_account.is_empty() {
             let decoded_account = RocksAccount::decode(&mut raw_account.as_slice())?;
-            rocks_account.storage_root = decoded_account.storage_root;
-        }
+            RocksAccount::from_account_info(account_info, decoded_account.storage_root)
+        } else {
+            RocksAccount::from_account_info(account_info, EMPTY_ROOT_HASH)
+        };
 
-        let timer = start_timer_vec(
-            &BUNDLE_COMMIT_PROCESSING_TIMES,
-            &["account:insert_into_trie"],
-        );
+        let timer = start_commit_timer("account:insert_into_trie");
         let _ = self.trie.lock().insert(
             address_hash.as_ref(),
             &alloy_rlp::encode(AccountStateInfo::from(&rocks_account)),
         );
         stop_timer(timer);
 
-        let timer = start_timer_vec(
-            &BUNDLE_COMMIT_PROCESSING_TIMES,
-            &["account:put_account_into_db"],
-        );
+        let timer = start_commit_timer("account:put_account_into_db");
         self.db
             .put(address_hash, alloy_rlp::encode(rocks_account))?;
         stop_timer(timer);
@@ -148,8 +146,8 @@ impl EvmDB {
             true => "account:delete_account",
             false => "storage:wipe_storage",
         };
-        let timer = start_timer_vec(&BUNDLE_COMMIT_PROCESSING_TIMES, &[timer_label]);
-        if rocks_account.storage_root != keccak256([EMPTY_STRING_CODE]) {
+        let timer = start_commit_timer(timer_label);
+        if rocks_account.storage_root != EMPTY_ROOT_HASH {
             let account_db = AccountDB::new(address_hash, self.db.clone());
             let mut trie = EthTrie::from(Arc::new(account_db), rocks_account.storage_root)?;
             trie.clear_trie_from_db()?;
@@ -163,13 +161,13 @@ impl EvmDB {
             None
         } else {
             let mut rocks_account = rocks_account;
-            rocks_account.storage_root = keccak256([EMPTY_STRING_CODE]);
+            rocks_account.storage_root = EMPTY_ROOT_HASH;
             let _ = self.trie.lock().insert(
                 address_hash.as_ref(),
                 &alloy_rlp::encode(AccountStateInfo::from(&rocks_account)),
             );
             self.db
-                .put(address_hash, &alloy_rlp::encode(&rocks_account))
+                .put(address_hash, alloy_rlp::encode(&rocks_account))
                 .expect("Inserting account should never fail");
 
             Some(rocks_account)
@@ -200,12 +198,12 @@ impl EvmDB {
         rocks_account: Option<RocksAccount>,
         storage: Vec<(U256, U256)>,
     ) -> anyhow::Result<()> {
-        let timer = start_timer_vec(&BUNDLE_COMMIT_PROCESSING_TIMES, &["storage:apply_updates"]);
+        let timer = start_commit_timer("storage:apply_updates");
 
         let account_db = AccountDB::new(address_hash, self.db.clone());
         let mut rocks_account = rocks_account.unwrap_or_default();
 
-        let mut trie = if rocks_account.storage_root == keccak256([EMPTY_STRING_CODE]) {
+        let mut trie = if rocks_account.storage_root == EMPTY_ROOT_HASH {
             EthTrie::new(Arc::new(account_db))
         } else {
             EthTrie::from(Arc::new(account_db), rocks_account.storage_root)?
@@ -253,15 +251,9 @@ impl EvmDB {
             storage,
         } in plain_storage
         {
-            let plain_state_storage_timer = start_timer_vec(
-                &BUNDLE_COMMIT_PROCESSING_TIMES,
-                &["storage:plain_state_storage"],
-            );
+            let plain_state_storage_timer = start_commit_timer("storage:plain_state_storage");
 
-            let timer = start_timer_vec(
-                &BUNDLE_COMMIT_PROCESSING_TIMES,
-                &["storage:fetch_account_from_db"],
-            );
+            let timer = start_commit_timer("storage:fetch_account_from_db");
             let address_hash = keccak256(address);
             let rocks_account: Option<RocksAccount> =
                 self.db.get(address_hash)?.map(|raw_account| {
@@ -287,10 +279,7 @@ impl EvmDB {
 
     pub fn commit_bundle(&mut self, bundle_state: BundleState) -> anyhow::Result<()> {
         // Currently we don't use reverts, so we can ignore them, but they are here for when we do.
-        let timer = start_timer_vec(
-            &BUNDLE_COMMIT_PROCESSING_TIMES,
-            &["generate_plain_state_and_reverts"],
-        );
+        let timer = start_commit_timer("generate_plain_state_and_reverts");
         let (plain_state, _reverts) =
             bundle_state.into_plain_state_and_reverts(OriginalValuesKnown::Yes);
         stop_timer(timer);
@@ -303,20 +292,14 @@ impl EvmDB {
         );
 
         // Write Account State
-        let timer = start_timer_vec(
-            &BUNDLE_COMMIT_PROCESSING_TIMES,
-            &["account:committing_accounts_total"],
-        );
+        let timer = start_commit_timer("account:committing_accounts_total");
         self.commit_accounts(plain_state.accounts)?;
         stop_timer(timer);
 
         // Write Contract Code
-        let timer = start_timer_vec(
-            &BUNDLE_COMMIT_PROCESSING_TIMES,
-            &["contract:committing_contracts_total"],
-        );
+        let timer = start_commit_timer("contract:committing_contracts_total");
         for (hash, bytecode) in plain_state.contracts {
-            let timer = start_timer_vec(&BUNDLE_COMMIT_PROCESSING_TIMES, &["committing_contract"]);
+            let timer = start_commit_timer("committing_contract");
             self.db
                 .put(hash, bytecode.original_bytes().as_ref())
                 .expect("Inserting contract code should never fail");
@@ -325,10 +308,7 @@ impl EvmDB {
         stop_timer(timer);
 
         // Write Storage
-        let timer = start_timer_vec(
-            &BUNDLE_COMMIT_PROCESSING_TIMES,
-            &["storage:committing_storage_total"],
-        );
+        let timer = start_commit_timer("storage:committing_storage_total");
         self.commit_storage(plain_state.storage)?;
         stop_timer(timer);
 
@@ -360,7 +340,7 @@ impl DatabaseRef for EvmDB {
     type Error = EVMError;
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-        let timer = start_timer_vec(&TRANSACTION_PROCESSING_TIMES, &["database_get_basic"]);
+        let timer = start_processing_timer("database_get_basic");
         let result = match self.db.get(keccak256(address))? {
             Some(raw_account) => {
                 let account: RocksAccount = Decodable::decode(&mut raw_account.as_slice())?;
@@ -379,10 +359,7 @@ impl DatabaseRef for EvmDB {
     }
 
     fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
-        let timer = start_timer_vec(
-            &TRANSACTION_PROCESSING_TIMES,
-            &["database_get_code_by_hash"],
-        );
+        let timer = start_processing_timer("database_get_code_by_hash");
         let result = match self.db.get(code_hash)? {
             Some(raw_code) => Ok(Bytecode::new_raw(raw_code.into())),
             None => Err(Self::Error::NotFound("code_by_hash".to_string())),
@@ -392,14 +369,14 @@ impl DatabaseRef for EvmDB {
     }
 
     fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
-        let timer = start_timer_vec(&TRANSACTION_PROCESSING_TIMES, &["database_get_storage"]);
+        let timer = start_processing_timer("database_get_storage");
         let address_hash = keccak256(address);
         let account: RocksAccount = match self.db.get(address_hash)? {
             Some(raw_account) => Decodable::decode(&mut raw_account.as_slice())?,
             None => return Err(Self::Error::NotFound("storage".to_string())),
         };
         let account_db = AccountDB::new(address_hash, self.db.clone());
-        let trie = if account.storage_root == keccak256([EMPTY_STRING_CODE]) {
+        let trie = if account.storage_root == EMPTY_ROOT_HASH {
             EthTrie::new(Arc::new(account_db))
         } else {
             EthTrie::from(Arc::new(account_db), account.storage_root)?
@@ -413,7 +390,7 @@ impl DatabaseRef for EvmDB {
     }
 
     fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
-        let timer = start_timer_vec(&TRANSACTION_PROCESSING_TIMES, &["database_get_block_hash"]);
+        let timer = start_processing_timer("database_get_block_hash");
         let result = match self.db.get(keccak256(B256::from(U256::from(number))))? {
             Some(raw_hash) => Ok(B256::from_slice(&raw_hash)),
             None => Err(Self::Error::NotFound("block_hash".to_string())),

--- a/trin-execution/src/storage/evm_db.rs
+++ b/trin-execution/src/storage/evm_db.rs
@@ -297,6 +297,14 @@ impl EvmDB {
         stop_timer(timer);
 
         // Write Contract Code
+        // TODO: Delete contract code if no accounts point to it: https://github.com/ethereum/trin/issues/1428
+        // This can happen in 1 of 2 cases
+        // - the account is deleted and the contract code is not used by any other accounts
+        // - we do a revert and the contract code is not used by any other accounts
+        // The solution would require keeping a count of how many accounts point to a contract code
+        // and deleting the contract code if the count is 0.
+        // This is very low priority due to this issue being very rare and it not taking up much
+        // storage
         let timer = start_commit_timer("contract:committing_contracts_total");
         for (hash, bytecode) in plain_state.contracts {
             let timer = start_commit_timer("committing_contract");

--- a/trin-execution/src/storage/execution_position.rs
+++ b/trin-execution/src/storage/execution_position.rs
@@ -15,11 +15,8 @@ pub struct ExecutionPosition {
 
     state_root: B256,
 
-    /// The block number we are currently executing
-    block_execution_number: u64,
-
-    /// The index of the transaction we are currently executing
-    transaction_index: u64,
+    /// The next block number to be executed.
+    next_block_number: u64,
 }
 
 impl ExecutionPosition {
@@ -30,9 +27,8 @@ impl ExecutionPosition {
             }
             None => Self {
                 version: 0,
-                block_execution_number: 0,
+                next_block_number: 0,
                 state_root: keccak256([EMPTY_STRING_CODE]),
-                transaction_index: 0,
             },
         })
     }
@@ -41,32 +37,22 @@ impl ExecutionPosition {
         self.version
     }
 
-    pub fn block_execution_number(&self) -> u64 {
-        self.block_execution_number
+    pub fn next_block_number(&self) -> u64 {
+        self.next_block_number
     }
 
     pub fn state_root(&self) -> B256 {
         self.state_root
     }
 
-    pub fn transaction_index(&self) -> u64 {
-        self.transaction_index
-    }
-
-    pub fn increase_block_execution_number(
+    pub fn set_next_block_number(
         &mut self,
         db: Arc<RocksDB>,
+        block_number: u64,
         state_root: B256,
     ) -> anyhow::Result<()> {
-        self.block_execution_number += 1;
+        self.next_block_number = block_number;
         self.state_root = state_root;
-        self.transaction_index = 0;
-        db.put(EXECUTION_POSITION_DB_KEY, alloy_rlp::encode(self))?;
-        Ok(())
-    }
-
-    pub fn increase_transaction_index(&mut self, db: Arc<RocksDB>) -> anyhow::Result<()> {
-        self.transaction_index += 1;
         db.put(EXECUTION_POSITION_DB_KEY, alloy_rlp::encode(self))?;
         Ok(())
     }

--- a/trin-execution/src/storage/execution_position.rs
+++ b/trin-execution/src/storage/execution_position.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_rlp::{Decodable, RlpDecodable, RlpEncodable};
+use ethportal_api::Header;
 use revm_primitives::B256;
 use rocksdb::DB as RocksDB;
 use serde::{Deserialize, Serialize};
@@ -46,14 +47,9 @@ impl ExecutionPosition {
         self.state_root
     }
 
-    pub fn set_next_block_number(
-        &mut self,
-        db: Arc<RocksDB>,
-        block_number: u64,
-        state_root: B256,
-    ) -> anyhow::Result<()> {
-        self.next_block_number = block_number;
-        self.state_root = state_root;
+    pub fn update_position(&mut self, db: Arc<RocksDB>, header: Header) -> anyhow::Result<()> {
+        self.next_block_number = header.number + 1;
+        self.state_root = header.state_root;
         db.put(EXECUTION_POSITION_DB_KEY, alloy_rlp::encode(self))?;
         Ok(())
     }

--- a/trin-execution/src/storage/execution_position.rs
+++ b/trin-execution/src/storage/execution_position.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
-use alloy_rlp::{Decodable, RlpDecodable, RlpEncodable, EMPTY_STRING_CODE};
-use revm_primitives::{keccak256, B256};
+use alloy_consensus::EMPTY_ROOT_HASH;
+use alloy_rlp::{Decodable, RlpDecodable, RlpEncodable};
+use revm_primitives::B256;
 use rocksdb::DB as RocksDB;
 use serde::{Deserialize, Serialize};
 
@@ -28,7 +29,7 @@ impl ExecutionPosition {
             None => Self {
                 version: 0,
                 next_block_number: 0,
-                state_root: keccak256([EMPTY_STRING_CODE]),
+                state_root: EMPTY_ROOT_HASH,
             },
         })
     }

--- a/trin-execution/src/storage/utils.rs
+++ b/trin-execution/src/storage/utils.rs
@@ -13,8 +13,14 @@ pub fn setup_rocksdb(path: PathBuf) -> anyhow::Result<RocksDB> {
     let rocksdb_path = path.join("rocksdb");
     info!(path = %rocksdb_path.display(), "Setting up RocksDB");
 
+    let cache_size = 1024 * 1024 * 1024; // 1GB
+
     let mut db_opts = Options::default();
     db_opts.create_if_missing(true);
+    db_opts.set_write_buffer_size(cache_size / 4);
+    let mut factory = rocksdb::BlockBasedOptions::default();
+    factory.set_block_cache(&rocksdb::Cache::new_lru_cache(cache_size / 2));
+    db_opts.set_block_based_table_factory(&factory);
 
     // Set the max number of open files to 150. MacOs has a default limit of 256 open files per
     // process. This limit prevents issues with the OS running out of file descriptors.

--- a/trin-execution/src/trie_walker.rs
+++ b/trin-execution/src/trie_walker.rs
@@ -178,7 +178,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let RootWithTrieDiff { trie_diff, .. } = trin_execution.process_block(0).await.unwrap();
+        let RootWithTrieDiff { trie_diff, .. } = trin_execution.process_next_block().await.unwrap();
         let valid_proof = trin_execution
             .get_proof(Address::from_hex("0x001d14804b399c6ef80e64576f657660804fec0b").unwrap())
             .unwrap();

--- a/trin-execution/src/trie_walker.rs
+++ b/trin-execution/src/trie_walker.rs
@@ -1,10 +1,9 @@
 use std::collections::VecDeque;
 
+use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_primitives::B256;
-use alloy_rlp::EMPTY_STRING_CODE;
 use eth_trie::{decode_node, node::Node};
 use hashbrown::HashMap as BrownHashMap;
-use revm_primitives::keccak256;
 use serde::{Deserialize, Serialize};
 
 use super::types::trie_proof::TrieProof;
@@ -38,7 +37,7 @@ pub struct TrieWalker {
 impl TrieWalker {
     pub fn new(root_hash: B256, nodes: BrownHashMap<B256, Vec<u8>>) -> Self {
         // if the storage root is empty then there is no storage to gossip
-        if root_hash == keccak256([EMPTY_STRING_CODE]) {
+        if root_hash == EMPTY_ROOT_HASH {
             return Self {
                 nodes: BrownHashMap::new(),
             };

--- a/trin-execution/src/trie_walker.rs
+++ b/trin-execution/src/trie_walker.rs
@@ -170,13 +170,14 @@ mod tests {
         trie_walker::TrieWalker,
     };
 
-    #[test_log::test]
-    fn test_trie_walker_builds_valid_proof() {
+    #[tokio::test]
+    async fn test_trie_walker_builds_valid_proof() {
         let temp_directory = setup_temp_dir().unwrap();
         let mut state = State::new(
             Some(temp_directory.path().to_path_buf()),
             StateConfig::default(),
         )
+        .await
         .unwrap();
         let RootWithTrieDiff { trie_diff, .. } = state.initialize_genesis().unwrap();
         let valid_proof = state

--- a/trin-execution/src/trie_walker.rs
+++ b/trin-execution/src/trie_walker.rs
@@ -165,24 +165,24 @@ mod tests {
     use revm_primitives::hex::FromHex;
 
     use crate::{
-        config::StateConfig, execution::State, storage::utils::setup_temp_dir,
+        config::StateConfig, execution::TrinExecution, storage::utils::setup_temp_dir,
         trie_walker::TrieWalker,
     };
 
     #[tokio::test]
     async fn test_trie_walker_builds_valid_proof() {
         let temp_directory = setup_temp_dir().unwrap();
-        let mut state = State::new(
+        let mut trin_execution = TrinExecution::new(
             Some(temp_directory.path().to_path_buf()),
             StateConfig::default(),
         )
         .await
         .unwrap();
-        let RootWithTrieDiff { trie_diff, .. } = state.initialize_genesis().unwrap();
-        let valid_proof = state
+        let RootWithTrieDiff { trie_diff, .. } = trin_execution.process_block(0).await.unwrap();
+        let valid_proof = trin_execution
             .get_proof(Address::from_hex("0x001d14804b399c6ef80e64576f657660804fec0b").unwrap())
             .unwrap();
-        let root_hash = state.get_root().unwrap();
+        let root_hash = trin_execution.get_root().unwrap();
         let walk_diff = TrieWalker::new(root_hash, trie_diff);
 
         let last_node = valid_proof

--- a/trin-execution/tests/content_generation.rs
+++ b/trin-execution/tests/content_generation.rs
@@ -51,7 +51,7 @@ async fn test_we_can_generate_content_key_values_up_to_x() -> Result<()> {
         let RootWithTrieDiff {
             root: root_hash,
             trie_diff: changed_nodes,
-        } = trin_execution.process_block(block_number).await?;
+        } = trin_execution.process_next_block().await?;
         let block = trin_execution
             .era_manager
             .lock()

--- a/trin-execution/tests/content_generation.rs
+++ b/trin-execution/tests/content_generation.rs
@@ -1,5 +1,5 @@
 use alloy_rlp::Decodable;
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{ensure, Result};
 use eth_trie::{decode_node, node::Node, RootWithTrieDiff};
 use ethportal_api::types::state_trie::account_state::AccountState;
 use revm::DatabaseRef;
@@ -11,7 +11,7 @@ use trin_execution::{
         create_account_content_key, create_account_content_value, create_contract_content_key,
         create_contract_content_value, create_storage_content_key, create_storage_content_value,
     },
-    execution::State,
+    execution::TrinExecution,
     storage::utils::setup_temp_dir,
     trie_walker::TrieWalker,
     types::block_to_trace::BlockToTrace,
@@ -36,7 +36,7 @@ async fn test_we_can_generate_content_key_values_up_to_x() -> Result<()> {
 
     let temp_directory = setup_temp_dir()?;
 
-    let mut state = State::new(
+    let mut trin_execution = TrinExecution::new(
         Some(temp_directory.path().to_path_buf()),
         StateConfig {
             cache_contract_storage_changes: true,
@@ -51,17 +51,8 @@ async fn test_we_can_generate_content_key_values_up_to_x() -> Result<()> {
         let RootWithTrieDiff {
             root: root_hash,
             trie_diff: changed_nodes,
-        } = match block_number == 0 {
-            true => {
-                // initialize genesis state processes this block so we skip it
-                state.era_manager.lock().await.get_next_block().await?;
-                state
-                    .initialize_genesis()
-                    .map_err(|e| anyhow!("unable to create genesis state: {e}"))?
-            }
-            false => state.process_block(block_number).await?,
-        };
-        let block = state
+        } = trin_execution.process_block(block_number).await?;
+        let block = trin_execution
             .era_manager
             .lock()
             .await
@@ -73,7 +64,7 @@ async fn test_we_can_generate_content_key_values_up_to_x() -> Result<()> {
             "Block number doesn't match!"
         );
         ensure!(
-            state.get_root()? == block.header.state_root,
+            trin_execution.get_root()? == block.header.state_root,
             "State root doesn't match"
         );
 
@@ -106,14 +97,16 @@ async fn test_we_can_generate_content_key_values_up_to_x() -> Result<()> {
 
             // check contract code content key/value
             if account.code_hash != keccak256([]) {
-                let code = state.database.code_by_hash_ref(account.code_hash)?;
+                let code = trin_execution
+                    .database
+                    .code_by_hash_ref(account.code_hash)?;
                 assert!(create_contract_content_key(address_hash, account.code_hash).is_ok());
                 assert!(create_contract_content_value(block_hash, &account_proof, code).is_ok());
                 content_pairs += 1;
             }
 
             // check contract storage content key/value
-            let storage_changed_nodes = state.database.get_storage_trie_diff(address_hash);
+            let storage_changed_nodes = trin_execution.database.get_storage_trie_diff(address_hash);
             let storage_walk_diff = TrieWalker::new(account.storage_root, storage_changed_nodes);
             for storage_node in storage_walk_diff.nodes.keys() {
                 let storage_proof = storage_walk_diff.get_proof(*storage_node);
@@ -128,7 +121,7 @@ async fn test_we_can_generate_content_key_values_up_to_x() -> Result<()> {
 
         // flush the database cache
         // This is used for gossiping storage trie diffs
-        state.database.storage_cache.clear();
+        trin_execution.database.storage_cache.clear();
         println!("Block {block_number} finished. Total content key/value pairs: {content_pairs}");
     }
     Ok(())


### PR DESCRIPTION
### What was wrong?
fixes https://github.com/ethereum/trin/issues/1333

Execution started slowing down around block 2.34 million, to resolve this issue I add ``revm::db:State`` which is a middleware between the database interface and EVM. It makes it so whole blocks can be processed in memory. Instead of as before where we would commit per every transaction. This saves a lot of reads to the database. ``revm::db::State`` also gives us reverts as well which is cool

We also lacked some metrics, this PR will add some not all proposed metrics to add like
- transaction performance
- block height
### How was it fixed?

add the ability to execute multiple blocks in memory, this makes execution a lot faster because then you don't need to call storage as much which is slow