### PR TITLE
Gossip pruned

### DIFF
--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -209,6 +209,12 @@ pub struct TrinConfig {
     )]
     pub utp_transfer_limit: usize,
 
+    #[arg(
+        long = "gossip-dropped",
+        help = "Gossip content as it gets dropped from local storage (history network only)."
+    )]
+    pub gossip_dropped: bool,
+
     #[command(subcommand)]
     pub command: Option<TrinConfigCommands>,
 }
@@ -242,6 +248,7 @@ impl Default for TrinConfig {
             ws_port: DEFAULT_WEB3_WS_PORT,
             command: None,
             utp_transfer_limit: DEFAULT_UTP_TRANSFER_LIMIT,
+            gossip_dropped: false,
             network: MAINNET.clone(),
         }
     }

--- a/portalnet/src/config.rs
+++ b/portalnet/src/config.rs
@@ -22,6 +22,8 @@ pub struct PortalnetConfig {
     pub no_upnp: bool,
     pub node_addr_cache_capacity: usize,
     pub disable_poke: bool,
+    // gossip content as it gets dropped from local storage
+    pub gossip_dropped: bool,
     pub trusted_block_root: Option<String>,
     // the max number of concurrent utp transfers
     pub utp_transfer_limit: usize,
@@ -39,6 +41,7 @@ impl Default for PortalnetConfig {
             no_upnp: false,
             node_addr_cache_capacity: NODE_ADDR_CACHE_CAPACITY,
             disable_poke: false,
+            gossip_dropped: false,
             trusted_block_root: None,
             utp_transfer_limit: DEFAULT_UTP_TRANSFER_LIMIT,
         }
@@ -55,6 +58,7 @@ impl PortalnetConfig {
             no_upnp: trin_config.no_upnp,
             bootnodes: trin_config.bootnodes.clone(),
             disable_poke: trin_config.disable_poke,
+            gossip_dropped: trin_config.gossip_dropped,
             trusted_block_root: trin_config.trusted_block_root.clone(),
             utp_transfer_limit: trin_config.utp_transfer_limit,
             ..Default::default()

--- a/portalnet/src/overlay/config.rs
+++ b/portalnet/src/overlay/config.rs
@@ -22,6 +22,7 @@ pub struct OverlayConfig {
     pub query_num_results: usize,
     pub findnodes_query_distances_per_peer: usize,
     pub disable_poke: bool,
+    pub gossip_dropped: bool,
     pub utp_transfer_limit: usize,
 }
 
@@ -40,6 +41,7 @@ impl Default for OverlayConfig {
             query_num_results: MAX_NODES_PER_BUCKET,
             findnodes_query_distances_per_peer: 3,
             disable_poke: false,
+            gossip_dropped: false,
             utp_transfer_limit: DEFAULT_UTP_TRANSFER_LIMIT,
         }
     }

--- a/portalnet/src/overlay/protocol.rs
+++ b/portalnet/src/overlay/protocol.rs
@@ -137,6 +137,7 @@ where
             config.query_num_results,
             config.findnodes_query_distances_per_peer,
             config.disable_poke,
+            config.gossip_dropped,
         )
         .await;
 

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -271,6 +271,24 @@ async fn peertest_history_offer_propagates_gossip_multiple_large_content_values(
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+async fn peertest_history_gossip_dropped_with_offer() {
+    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    peertest::scenarios::gossip::test_gossip_dropped_with_offer(&peertest, &target).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn peertest_history_gossip_dropped_with_find_content() {
+    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    peertest::scenarios::gossip::test_gossip_dropped_with_find_content(&peertest, &target).await;
+    peertest.exit_all_nodes();
+    handle.stop().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
 async fn peertest_ping_cross_discv5_protocol_id() {
     let (peertest, target, handle) = setup_peertest("angelfood").await;
     peertest::scenarios::basic::test_ping_cross_network(&target, &peertest).await;

--- a/trin-beacon/src/network.rs
+++ b/trin-beacon/src/network.rs
@@ -27,6 +27,10 @@ pub struct BeaconNetwork {
     pub beacon_client: Arc<Mutex<Option<Client<FileDB, PortalRpc>>>>,
 }
 
+/// Gossiping content as it gets dropped from local storage is disabled for the beacon network,
+/// since beacon nodes already store all the content they're interested in.
+const GOSSIP_DROPPED: bool = false;
+
 impl BeaconNetwork {
     pub async fn new(
         discovery: Arc<Discovery>,
@@ -39,6 +43,7 @@ impl BeaconNetwork {
         let config = OverlayConfig {
             bootnode_enrs,
             utp_transfer_limit: portal_config.utp_transfer_limit,
+            gossip_dropped: GOSSIP_DROPPED,
             ..Default::default()
         };
         let storage = Arc::new(PLRwLock::new(BeaconStorage::new(storage_config)?));

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -223,8 +223,16 @@ impl ContentStore for BeaconStorage {
         }
     }
 
-    fn put<V: AsRef<[u8]>>(&mut self, key: Self::Key, value: V) -> Result<(), ContentStoreError> {
-        self.store(&key, &value.as_ref().to_vec())
+    fn put<V: AsRef<[u8]>>(
+        &mut self,
+        key: Self::Key,
+        value: V,
+    ) -> Result<Vec<(Self::Key, Vec<u8>)>, ContentStoreError> {
+        match self.store(&key, &value.as_ref().to_vec()) {
+            // in the beacon network we don't return any dropped content for propagation
+            Ok(_) => Ok(vec![]),
+            Err(err) => Err(err),
+        }
     }
 
     /// The "radius" concept is not applicable for Beacon network

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -228,11 +228,8 @@ impl ContentStore for BeaconStorage {
         key: Self::Key,
         value: V,
     ) -> Result<Vec<(Self::Key, Vec<u8>)>, ContentStoreError> {
-        match self.store(&key, &value.as_ref().to_vec()) {
-            // in the beacon network we don't return any dropped content for propagation
-            Ok(_) => Ok(vec![]),
-            Err(err) => Err(err),
-        }
+        // in the beacon network we don't return any dropped content for propagation
+        self.store(&key, &value.as_ref().to_vec()).and(Ok(vec![]))
     }
 
     /// The "radius" concept is not applicable for Beacon network

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -39,6 +39,7 @@ impl HistoryNetwork {
         let config = OverlayConfig {
             bootnode_enrs,
             disable_poke: portal_config.disable_poke,
+            gossip_dropped: portal_config.gossip_dropped,
             utp_transfer_limit: portal_config.utp_transfer_limit,
             ..Default::default()
         };

--- a/trin-history/src/storage.rs
+++ b/trin-history/src/storage.rs
@@ -21,7 +21,11 @@ impl ContentStore for HistoryStorage {
         self.store.lookup_content_value(&key.content_id().into())
     }
 
-    fn put<V: AsRef<[u8]>>(&mut self, key: Self::Key, value: V) -> Result<(), ContentStoreError> {
+    fn put<V: AsRef<[u8]>>(
+        &mut self,
+        key: Self::Key,
+        value: V,
+    ) -> Result<Vec<(Self::Key, Vec<u8>)>, ContentStoreError> {
         self.store.insert(&key, value.as_ref().to_vec())
     }
 

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -29,6 +29,9 @@ pub struct StateNetwork {
 /// Poke is disabled for state network because Offer/Accept and Find/Found Content are different,
 /// and recipient of the poke wouldn't be able to verify that content is canonical.
 const DISABLE_POKE: bool = true;
+/// Gossiping content as it gets dropped from local storage is disabled for the state network,
+/// since data as it's stored locally doesn't contain the proofs needed to verify the gossiped data.
+const GOSSIP_DROPPED: bool = false;
 
 impl StateNetwork {
     pub async fn new(
@@ -44,6 +47,7 @@ impl StateNetwork {
         let config = OverlayConfig {
             bootnode_enrs: portal_config.bootnodes.into(),
             disable_poke: DISABLE_POKE,
+            gossip_dropped: GOSSIP_DROPPED,
             utp_transfer_limit: portal_config.utp_transfer_limit,
             ..Default::default()
         };

--- a/trin-storage/src/lib.rs
+++ b/trin-storage/src/lib.rs
@@ -52,7 +52,15 @@ pub trait ContentStore {
     fn get(&self, key: &Self::Key) -> Result<Option<Vec<u8>>, ContentStoreError>;
 
     /// Puts a piece of content into the store.
-    fn put<V: AsRef<[u8]>>(&mut self, key: Self::Key, value: V) -> Result<(), ContentStoreError>;
+    /// Returns a list of keys that were evicted from the store, which are gossiped into the
+    /// network. In the future this might be updated to a separate table that stores a queue
+    /// of content keys to be gossiped and gossips them in a background task.
+    #[allow(clippy::type_complexity)]
+    fn put<V: AsRef<[u8]>>(
+        &mut self,
+        key: Self::Key,
+        value: V,
+    ) -> Result<Vec<(Self::Key, Vec<u8>)>, ContentStoreError>;
 
     /// Returns whether the content denoted by `key` is within the radius of the data store and not
     /// already stored within the data store.
@@ -114,12 +122,16 @@ impl ContentStore for MemoryContentStore {
         Ok(val)
     }
 
-    fn put<V: AsRef<[u8]>>(&mut self, key: Self::Key, value: V) -> Result<(), ContentStoreError> {
+    fn put<V: AsRef<[u8]>>(
+        &mut self,
+        key: Self::Key,
+        value: V,
+    ) -> Result<Vec<(Self::Key, Vec<u8>)>, ContentStoreError> {
         let content_id = key.content_id();
         let value: &[u8] = value.as_ref();
         self.store.insert(content_id.to_vec(), value.to_vec());
 
-        Ok(())
+        Ok(vec![])
     }
 
     fn is_key_within_radius_and_unavailable(

--- a/trin-storage/src/lib.rs
+++ b/trin-storage/src/lib.rs
@@ -52,7 +52,7 @@ pub trait ContentStore {
     fn get(&self, key: &Self::Key) -> Result<Option<Vec<u8>>, ContentStoreError>;
 
     /// Puts a piece of content into the store.
-    /// Returns a list of keys that were evicted from the store, which are gossiped into the
+    /// Returns a list of keys that were evicted from the store, which should be gossiped into the
     /// network. In the future this might be updated to a separate table that stores a queue
     /// of content keys to be gossiped and gossips them in a background task.
     #[allow(clippy::type_complexity)]

--- a/trin-storage/src/versioned/id_indexed_v1/migration.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/migration.rs
@@ -138,8 +138,7 @@ mod tests {
         migrate_legacy_history_store(&config)?;
 
         // make sure we can initialize new store and that it's empty
-        let store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::History, config.clone())?;
+        let store = IdIndexedV1Store::<IdentityContentKey>::create(ContentType::History, config)?;
         assert_eq!(store.usage_stats(), UsageStats::default(),);
 
         Ok(())
@@ -165,8 +164,7 @@ mod tests {
         migrate_legacy_history_store(&config)?;
 
         // create IdIndexedV1Store and verify content
-        let store: IdIndexedV1Store<IdentityContentKey> =
-            IdIndexedV1Store::create(ContentType::History, config)?;
+        let store = IdIndexedV1Store::<IdentityContentKey>::create(ContentType::History, config)?;
         for (key, value) in key_value_map.into_iter() {
             assert_eq!(
                 store.lookup_content_value(&key.content_id().into())?,

--- a/trin-storage/src/versioned/id_indexed_v1/sql.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/sql.rs
@@ -75,7 +75,7 @@ pub fn delete_farthest(content_type: &ContentType) -> String {
             ORDER BY distance_short DESC
             LIMIT :limit
         )
-        RETURNING content_size",
+        RETURNING content_key, content_value",
         table_name(content_type)
     )
 }

--- a/trin-storage/src/versioned/id_indexed_v1/sql.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/sql.rs
@@ -75,7 +75,7 @@ pub fn delete_farthest(content_type: &ContentType) -> String {
             ORDER BY distance_short DESC
             LIMIT :limit
         )
-        RETURNING content_key, content_value",
+        RETURNING content_key, content_value, content_size",
         table_name(content_type)
     )
 }

--- a/trin-storage/src/versioned/id_indexed_v1/store.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/store.rs
@@ -110,6 +110,7 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
                 "High storage usage ({}) -> Pruning",
                 self.usage_stats.total_entry_size_bytes,
             );
+            // ignore dropped content...
             self.prune()?;
         } else if self
             .pruning_strategy
@@ -241,7 +242,7 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
         &mut self,
         content_key: &TContentKey,
         content_value: Vec<u8>,
-    ) -> Result<(), ContentStoreError> {
+    ) -> Result<Vec<(TContentKey, Vec<u8>)>, ContentStoreError> {
         let insert_with_pruning_timer = self.metrics.start_process_timer("insert_with_pruning");
 
         let content_id = content_key.content_id();
@@ -275,12 +276,13 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
         self.usage_stats.total_entry_size_bytes += content_size as u64;
         self.usage_stats.report_metrics(&self.metrics);
 
+        let mut dropped_content: Vec<(TContentKey, Vec<u8>)> = Vec::new();
         if self.pruning_strategy.should_prune(&self.usage_stats) {
-            self.prune()?;
+            dropped_content.extend(self.prune()?);
         }
 
         self.metrics.stop_process_timer(insert_with_pruning_timer);
-        Ok(())
+        Ok(dropped_content)
     }
 
     /// Deletes content with the given content id.
@@ -441,11 +443,13 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
     }
 
     /// Prunes database and updates `radius`.
-    fn prune(&mut self) -> Result<(), ContentStoreError> {
+    /// Returns any content items that were pruned.
+    fn prune(&mut self) -> Result<Vec<(TContentKey, Vec<u8>)>, ContentStoreError> {
+        let mut deleted_content: Vec<(TContentKey, Vec<u8>)> = Vec::new();
         if !self.pruning_strategy.should_prune(&self.usage_stats) {
             warn!(Db = %self.config.content_type,
                 "Pruning requested but not needed. Skipping");
-            return Ok(());
+            return Ok(deleted_content);
         }
 
         let pruning_timer = self.metrics.start_process_timer("prune");
@@ -466,30 +470,43 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
                     Db = %self.config.content_type,
                     "Entries to prune is 0. This is not supposed to happen (we should be above storage capacity)."
                 );
-                return Ok(());
+                return Ok(deleted_content);
             }
 
             let delete_timer = self.metrics.start_process_timer("prune_delete");
-            let deleted_content_sizes = delete_query
+            let deleted_content_result = delete_query
                 .query_map(named_params! { ":limit": to_delete }, |row| {
-                    row.get("content_size")
+                    let key_bytes: Vec<u8> = row.get("content_key")?;
+                    let value_bytes: Vec<u8> = row.get("content_value")?;
+                    TContentKey::try_from(key_bytes)
+                        .map(|key| (key, value_bytes))
+                        .map_err(|e| {
+                            rusqlite::Error::FromSqlConversionFailure(0, Type::Blob, e.into())
+                        })
                 })?
-                .collect::<Result<Vec<u64>, rusqlite::Error>>()?;
+                .collect::<Result<Vec<(TContentKey, Vec<u8>)>, rusqlite::Error>>()?;
             let pruning_duration = self.metrics.stop_process_timer(delete_timer);
             self.pruning_strategy
                 .observe_pruning_duration(pruning_duration);
 
-            if to_delete != deleted_content_sizes.len() as u64 {
+            let deleted_content_count = deleted_content_result.len() as u64;
+            if to_delete != deleted_content_count {
                 error!(Db = %self.config.content_type,
-                    "Attempted to delete {to_delete} but deleted {}",
-                    deleted_content_sizes.len());
+                    "Attempted to delete {to_delete} but deleted {deleted_content_count}");
                 self.init_usage_stats()?;
                 break;
             }
 
+            let deleted_content_size = deleted_content_result
+                .iter()
+                .map(|(key, value)| {
+                    key.content_id().len() as u64 + key.to_bytes().len() as u64 + value.len() as u64
+                })
+                .sum::<u64>();
             self.usage_stats.entry_count -= to_delete;
-            self.usage_stats.total_entry_size_bytes -= deleted_content_sizes.iter().sum::<u64>();
+            self.usage_stats.total_entry_size_bytes -= deleted_content_size;
             self.usage_stats.report_metrics(&self.metrics);
+            deleted_content.extend(deleted_content_result);
         }
         // Free connection.
         drop(delete_query);
@@ -504,7 +521,7 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
             self.usage_stats.total_entry_size_bytes,
         );
         self.metrics.stop_process_timer(pruning_timer);
-        Ok(())
+        Ok(deleted_content)
     }
 }
 


### PR DESCRIPTION
### What was wrong?
fixes #981 


### How was it fixed?
- add content that's dropped from local storage to propagation content vector
- limit offer message in propagation to 64 content keys (according to spec)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
