### PR TITLE
fix: add missing step to release docs

### DIFF
--- a/book/src/developers/contributing/releases/deployment.md
+++ b/book/src/developers/contributing/releases/deployment.md
@@ -9,6 +9,7 @@
     python3 -m venv venv
     . venv/bin/activate
     pip install ansible
+    pip install docker
     sudo apt install ansible-core
     ```
     On mac you can do `brew install ansible` instead of `apt`.


### PR DESCRIPTION
### What was wrong?
To successfully cut a new release, starting from a fresh virtual environment also requires to install `docker` via pip.

### How was it fixed?
- Added missing step to docs

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
