### PR TITLE
refactor: offer rpc endpoints

### DIFF
--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -99,6 +99,7 @@ pub trait BeaconNetworkApi {
     ) -> RpcResult<TraceGossipInfo>;
 
     /// Send an OFFER request with given ContentKey, to the designated peer and wait for a response.
+    /// Does not store the content locally.
     /// Returns the content keys bitlist upon successful content transmission or empty bitlist
     /// receive.
     #[method(name = "beaconOffer")]
@@ -106,7 +107,18 @@ pub trait BeaconNetworkApi {
         &self,
         enr: Enr,
         content_key: BeaconContentKey,
-        content_value: Option<BeaconContentValue>,
+        content_value: BeaconContentValue,
+    ) -> RpcResult<AcceptInfo>;
+
+    /// Send an OFFER request with given ContentKeys, to the designated peer and wait for a
+    /// response. Requires the content keys to be stored locally.
+    /// Returns the content keys bitlist upon successful content transmission or empty bitlist
+    /// receive.
+    #[method(name = "beaconWireOffer")]
+    async fn wire_offer(
+        &self,
+        enr: Enr,
+        content_keys: Vec<BeaconContentKey>,
     ) -> RpcResult<AcceptInfo>;
 
     /// Store content key with a content data to the local database.

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -99,6 +99,7 @@ pub trait HistoryNetworkApi {
     ) -> RpcResult<TraceGossipInfo>;
 
     /// Send an OFFER request with given ContentKey, to the designated peer and wait for a response.
+    /// Does not store the content locally.
     /// Returns the content keys bitlist upon successful content transmission or empty bitlist
     /// receive.
     #[method(name = "historyOffer")]
@@ -106,7 +107,18 @@ pub trait HistoryNetworkApi {
         &self,
         enr: Enr,
         content_key: HistoryContentKey,
-        content_value: Option<HistoryContentValue>,
+        content_value: HistoryContentValue,
+    ) -> RpcResult<AcceptInfo>;
+
+    /// Send an OFFER request with given ContentKeys, to the designated peer and wait for a
+    /// response. Requires the content keys to be stored locally.
+    /// Returns the content keys bitlist upon successful content transmission or empty bitlist
+    /// receive.
+    #[method(name = "historyWireOffer")]
+    async fn wire_offer(
+        &self,
+        enr: Enr,
+        content_keys: Vec<HistoryContentKey>,
     ) -> RpcResult<AcceptInfo>;
 
     /// Store content key with a content data to the local database.

--- a/ethportal-api/src/state.rs
+++ b/ethportal-api/src/state.rs
@@ -92,6 +92,7 @@ pub trait StateNetworkApi {
     ) -> RpcResult<TraceGossipInfo>;
 
     /// Send an OFFER request with given ContentKey, to the designated peer and wait for a response.
+    /// Does not store the content locally.
     /// Returns the content keys bitlist upon successful content transmission or empty bitlist
     /// receive.
     #[method(name = "stateOffer")]
@@ -99,7 +100,7 @@ pub trait StateNetworkApi {
         &self,
         enr: Enr,
         content_key: StateContentKey,
-        content_value: Option<StateContentValue>,
+        content_value: StateContentValue,
     ) -> RpcResult<AcceptInfo>;
 
     /// Store content key with a content data to the local database.

--- a/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -42,9 +42,11 @@ pub enum StateEndpoint {
     TraceRecursiveFindContent(StateContentKey),
     /// params: [content_key, content_value]
     Store(StateContentKey, StateContentValue),
-    /// params: [enr, content_key]
-    Offer(Enr, StateContentKey, Option<StateContentValue>),
-    /// params: [content_key, content_value]
+    /// params: [enr, content_key, content_value]
+    Offer(Enr, StateContentKey, StateContentValue),
+    /// WireOffer is not supported in the state network, since locally
+    /// stored values do not contain the proofs necessary for valid gossip.
+    /// params: [enr, content_key, content_value]
     Gossip(StateContentKey, StateContentValue),
     /// params: [content_key, content_value]
     TraceGossip(StateContentKey, StateContentValue),
@@ -75,8 +77,10 @@ pub enum HistoryEndpoint {
     Gossip(HistoryContentKey, HistoryContentValue),
     /// params: [content_key, content_value]
     TraceGossip(HistoryContentKey, HistoryContentValue),
-    /// params: [enr, content_key]
-    Offer(Enr, HistoryContentKey, Option<HistoryContentValue>),
+    /// params: [enr, content_key, content_value]
+    Offer(Enr, HistoryContentKey, HistoryContentValue),
+    /// params: [enr, [content_key]]
+    WireOffer(Enr, Vec<HistoryContentKey>),
     /// params: [enr]
     Ping(Enr),
     /// params: content_key
@@ -119,8 +123,10 @@ pub enum BeaconEndpoint {
     Gossip(BeaconContentKey, BeaconContentValue),
     /// params: [content_key, content_value]
     TraceGossip(BeaconContentKey, BeaconContentValue),
-    /// params: [enr, content_key]
-    Offer(Enr, BeaconContentKey, Option<BeaconContentValue>),
+    /// params: [enr, content_key, content_value]
+    Offer(Enr, BeaconContentKey, BeaconContentValue),
+    /// params: [enr, [content_key]]
+    WireOffer(Enr, Vec<BeaconContentKey>),
     /// params: enr
     Ping(Enr),
     /// params: content_key

--- a/ethportal-peertest/src/scenarios/offer_accept.rs
+++ b/ethportal-peertest/src/scenarios/offer_accept.rs
@@ -29,12 +29,11 @@ pub async fn test_unpopulated_offer(peertest: &Peertest, target: &Client) {
 
     assert!(store_result);
 
-    // Send unpopulated offer request from testnode to bootnode
+    // Send wire offer request from testnode to bootnode
     let result = target
-        .offer(
+        .wire_offer(
             Enr::from_str(&peertest.bootnode.enr.to_base64()).unwrap(),
-            content_key.clone(),
-            None,
+            vec![content_key.clone()],
         )
         .await
         .unwrap();
@@ -59,12 +58,11 @@ pub async fn test_unpopulated_offer_fails_with_missing_content(
 
     let (content_key, _content_value) = fixture_header_with_proof();
 
-    // validate that unpopulated offer fails if content not available locally
+    // validate that wire offer fails if content not available locally
     match target
-        .offer(
+        .wire_offer(
             Enr::from_str(&peertest.bootnode.enr.to_base64()).unwrap(),
-            content_key.clone(),
-            None,
+            vec![content_key.clone()],
         )
         .await
     {
@@ -85,7 +83,7 @@ pub async fn test_populated_offer(peertest: &Peertest, target: &Client) {
         .offer(
             Enr::from_str(&peertest.bootnode.enr.to_base64()).unwrap(),
             content_key.clone(),
-            Some(content_value.clone()),
+            content_value.clone(),
         )
         .await
         .unwrap();
@@ -150,7 +148,7 @@ pub async fn test_offer_propagates_gossip(peertest: &Peertest, target: &Client) 
         .offer(
             fresh_enr.clone(),
             content_key.clone(),
-            Some(content_value.clone()),
+            content_value.clone(),
         )
         .await
         .unwrap();

--- a/ethportal-peertest/src/scenarios/state.rs
+++ b/ethportal-peertest/src/scenarios/state.rs
@@ -47,7 +47,7 @@ async fn test_state_offer(fixture: &StateFixture, target: &Client, peer: &Peerte
         .offer(
             peer.enr.clone(),
             fixture.content_data.key.clone(),
-            Some(fixture.content_data.offer_value.clone()),
+            fixture.content_data.offer_value.clone(),
         )
         .await
         .unwrap();

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -872,8 +872,7 @@ where
             protocol = %self.protocol,
             request.source = %source,
             request.discv5.id = %request_id,
-            "Handling Ping message {}",
-            request
+            "Handling Ping message {request}",
         );
 
         let enr_seq = self.local_enr().seq();

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -230,18 +230,31 @@ impl BeaconNetworkApiServer for BeaconNetworkApi {
     }
 
     /// Send an OFFER request with given ContentKey, to the designated peer and wait for a response.
-    /// If the content value is provided, a "populated" offer is used, which will not store the
-    /// content locally. Otherwise a regular offer is sent, after validating that the content is
-    /// available locally.
+    /// Does not store content locally.
     /// Returns the content keys bitlist upon successful content transmission or empty bitlist
     /// receive.
     async fn offer(
         &self,
         enr: Enr,
         content_key: BeaconContentKey,
-        content_value: Option<BeaconContentValue>,
+        content_value: BeaconContentValue,
     ) -> RpcResult<AcceptInfo> {
         let endpoint = BeaconEndpoint::Offer(enr, content_key, content_value);
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: AcceptInfo = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Send an OFFER request with given ContentKeys, to the designated peer and wait for a
+    /// response. Requires the content keys to be stored locally.
+    /// Returns the content keys bitlist upon successful content transmission or empty bitlist
+    /// receive.
+    async fn wire_offer(
+        &self,
+        enr: Enr,
+        content_keys: Vec<BeaconContentKey>,
+    ) -> RpcResult<AcceptInfo> {
+        let endpoint = BeaconEndpoint::WireOffer(enr, content_keys);
         let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
         let result: AcceptInfo = from_value(result)?;
         Ok(result)

--- a/rpc/src/state_rpc.rs
+++ b/rpc/src/state_rpc.rs
@@ -190,16 +190,14 @@ impl StateNetworkApiServer for StateNetworkApi {
     }
 
     /// Send an OFFER request with given ContentKey, to the designated peer and wait for a response.
-    /// If the content value is provided, a "populated" offer is used, which will not store the
-    /// content locally. Otherwise a regular offer is sent, after validating that the content is
-    /// available locally.
+    /// Does not store content locally.
     /// Returns the content keys bitlist upon successful content transmission or empty bitlist
     /// receive.
     async fn offer(
         &self,
         enr: Enr,
         content_key: StateContentKey,
-        content_value: Option<StateContentValue>,
+        content_value: StateContentValue,
     ) -> RpcResult<AcceptInfo> {
         let endpoint = StateEndpoint::Offer(enr, content_key, content_value);
         let result = self.proxy_query_to_state_subnet(endpoint).await?;

--- a/trin-execution/src/storage/evm_db.rs
+++ b/trin-execution/src/storage/evm_db.rs
@@ -24,7 +24,6 @@ use super::{
 const REVERSE_HASH_LOOKUP_PREFIX: &[u8] = b"reverse hash lookup";
 
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EvmDB {
     /// State config
     pub config: StateConfig,

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -304,31 +304,18 @@ async fn offer(
     network: Arc<StateNetwork>,
     enr: Enr,
     content_key: StateContentKey,
-    content_value: Option<StateContentValue>,
+    content_value: StateContentValue,
 ) -> Result<Value, String> {
-    if let Some(content_value) = content_value {
-        to_json_result(
-            "Populate Offer",
-            network
-                .overlay
-                .send_populated_offer(enr, content_key.into(), content_value.encode())
-                .await
-                .map(|accept| AcceptInfo {
-                    content_keys: accept.content_keys,
-                }),
-        )
-    } else {
-        to_json_result(
-            "Offer",
-            network
-                .overlay
-                .send_offer(vec![content_key.into()], enr)
-                .await
-                .map(|accept| AcceptInfo {
-                    content_keys: accept.content_keys,
-                }),
-        )
-    }
+    to_json_result(
+        "Offer",
+        network
+            .overlay
+            .send_offer(enr, content_key.into(), content_value.encode())
+            .await
+            .map(|accept| AcceptInfo {
+                content_keys: accept.content_keys,
+            }),
+    )
 }
 
 async fn gossip(


### PR DESCRIPTION
### What was wrong?
- To debug #1345 we need a jsonrpc endpoint that allows gossiping multiple pieces of data simultaneously (aka exactly how it's specified in the wire protocol)
- our current jsonrpc api is not [spec](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/portal-network-specs/assembled-spec/jsonrpc/openrpc.json&uiSchema%5BappBar%5D%5Bui:splitView%5D=false&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false) compliant
  - spec defines: `portal_historyOffer(enr, content_key, content_value)`
  - we have `portal_historyOffer(enr, content_key, Option<content_value>)`
    - this is not a great way of handling our offer endpoint...
      - doesn't allow offering multiple content keys simultaneously
      - the `Option` is awkward and can be confusing to the user about what's actually happening (aka which offer kind is being used) 

### How was it fixed?
- Updated our `portal_historyOffer()` endpoint to be spec compliant
- Added a `portal_historyWireOffer()` endpoint that allows direct access to the offer wire message type.
  - this endpoint requires all content keys to be available locally

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
