### PR TITLE
fix: unable to find ENR for NodeId killing network perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8041,6 +8041,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "anyhow",
+ "enr",
  "eth2_hashing",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -8304,6 +8305,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
  "trin-utils",
+ "trin-validation",
  "utp-rs",
 ]
 

--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -17,8 +17,9 @@ use discv5::{
 };
 use lru::LruCache;
 use parking_lot::RwLock;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, RwLock as TokioRwLock};
 use tracing::{debug, info, warn};
+use trin_validation::oracle::HeaderOracle;
 use utp_rs::{cid::ConnectionPeer, udp::AsyncUdpSocket};
 
 use super::config::PortalnetConfig;
@@ -42,6 +43,9 @@ const ENR_PORTAL_CLIENT_KEY: &str = "c";
 
 /// ENR file name saving enr history to disk.
 const ENR_FILE_NAME: &str = "trin.enr";
+
+/// Amount of Enr to cache for Discv5UdpSocket
+const ENR_CACHE_CAPACITY: usize = 150;
 
 pub type ProtocolRequest = Vec<u8>;
 
@@ -346,13 +350,72 @@ impl Discovery {
 }
 
 pub struct Discv5UdpSocket {
-    talk_reqs: mpsc::UnboundedReceiver<TalkRequest>,
+    talk_request_receiver: mpsc::UnboundedReceiver<TalkRequest>,
     discv5: Arc<Discovery>,
+    enr_cache: Arc<TokioRwLock<LruCache<NodeId, Enr>>>,
+    header_oracle: Arc<TokioRwLock<HeaderOracle>>,
 }
 
 impl Discv5UdpSocket {
-    pub fn new(discv5: Arc<Discovery>, talk_reqs: mpsc::UnboundedReceiver<TalkRequest>) -> Self {
-        Self { discv5, talk_reqs }
+    pub fn new(
+        discv5: Arc<Discovery>,
+        talk_request_receiver: mpsc::UnboundedReceiver<TalkRequest>,
+        header_oracle: Arc<TokioRwLock<HeaderOracle>>,
+    ) -> Self {
+        let enr_cache = LruCache::new(ENR_CACHE_CAPACITY);
+        let enr_cache = Arc::new(TokioRwLock::new(enr_cache));
+        Self {
+            discv5,
+            talk_request_receiver,
+            enr_cache,
+            header_oracle,
+        }
+    }
+
+    async fn find_enr(&mut self, node_id: &NodeId) -> io::Result<UtpEnr> {
+        if let Some(cached_enr) = self.enr_cache.write().await.get(node_id).cloned() {
+            return Ok(UtpEnr(cached_enr));
+        }
+
+        if let Some(enr) = self.discv5.find_enr(node_id) {
+            self.enr_cache.write().await.put(*node_id, enr.clone());
+            return Ok(UtpEnr(enr));
+        }
+
+        if let Some(enr) = self.discv5.cached_node_addr(node_id) {
+            self.enr_cache.write().await.put(*node_id, enr.enr.clone());
+            return Ok(UtpEnr(enr.enr));
+        }
+
+        let history_jsonrpc_tx = self.header_oracle.read().await.history_jsonrpc_tx();
+        if let Ok(history_jsonrpc_tx) = history_jsonrpc_tx {
+            if let Ok(enr) = HeaderOracle::history_get_enr(node_id, history_jsonrpc_tx).await {
+                self.enr_cache.write().await.put(*node_id, enr.clone());
+                return Ok(UtpEnr(enr));
+            }
+        }
+
+        let state_jsonrpc_tx = self.header_oracle.read().await.state_jsonrpc_tx();
+        if let Ok(state_jsonrpc_tx) = state_jsonrpc_tx {
+            if let Ok(enr) = HeaderOracle::state_get_enr(node_id, state_jsonrpc_tx).await {
+                self.enr_cache.write().await.put(*node_id, enr.clone());
+                return Ok(UtpEnr(enr));
+            }
+        }
+
+        let beacon_jsonrpc_tx = self.header_oracle.read().await.beacon_jsonrpc_tx();
+        if let Ok(beacon_jsonrpc_tx) = beacon_jsonrpc_tx {
+            if let Ok(enr) = HeaderOracle::beacon_get_enr(node_id, beacon_jsonrpc_tx).await {
+                self.enr_cache.write().await.put(*node_id, enr.clone());
+                return Ok(UtpEnr(enr));
+            }
+        }
+
+        debug!(node_id = %node_id, "uTP packet from unknown source");
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            "ENR not found for talk req destination",
+        ))
     }
 }
 
@@ -418,25 +481,10 @@ impl AsyncUdpSocket<UtpEnr> for Discv5UdpSocket {
     }
 
     async fn recv_from(&mut self, buf: &mut [u8]) -> io::Result<(usize, UtpEnr)> {
-        match self.talk_reqs.recv().await {
+        match self.talk_request_receiver.recv().await {
             Some(talk_req) => {
                 let src_node_id = talk_req.node_id();
-                let enr = match self.discv5.find_enr(src_node_id) {
-                    Some(enr) => UtpEnr(enr),
-                    None => {
-                        let enr = match self.discv5.cached_node_addr(src_node_id) {
-                            Some(node_addr) => Ok(node_addr.enr),
-                            None => {
-                                debug!(node_id = %src_node_id, "uTP packet from unknown source");
-                                Err(io::Error::new(
-                                    io::ErrorKind::Other,
-                                    "ENR not found for talk req destination",
-                                ))
-                            }
-                        }?;
-                        UtpEnr(enr)
-                    }
-                };
+                let enr = self.find_enr(src_node_id).await?;
                 let packet = talk_req.body();
                 let n = std::cmp::min(buf.len(), packet.len());
                 buf[..n].copy_from_slice(&packet[..n]);

--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -44,9 +44,6 @@ const ENR_PORTAL_CLIENT_KEY: &str = "c";
 /// ENR file name saving enr history to disk.
 const ENR_FILE_NAME: &str = "trin.enr";
 
-/// Amount of Enr to cache for Discv5UdpSocket
-const ENR_CACHE_CAPACITY: usize = 150;
-
 pub type ProtocolRequest = Vec<u8>;
 
 /// The contact info for a remote node.
@@ -361,8 +358,9 @@ impl Discv5UdpSocket {
         discv5: Arc<Discovery>,
         talk_request_receiver: mpsc::UnboundedReceiver<TalkRequest>,
         header_oracle: Arc<TokioRwLock<HeaderOracle>>,
+        enr_cache_capacity: usize,
     ) -> Self {
-        let enr_cache = LruCache::new(ENR_CACHE_CAPACITY);
+        let enr_cache = LruCache::new(enr_cache_capacity);
         let enr_cache = Arc::new(TokioRwLock::new(enr_cache));
         Self {
             discv5,

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -2695,6 +2695,7 @@ mod tests {
             Arc::clone(&discovery),
             utp_talk_req_rx,
             header_oracle,
+            50,
         );
         let utp_socket = utp_rs::socket::UtpSocket::with_socket(discv5_utp);
         let metrics = OverlayMetricsReporter {

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -42,7 +42,8 @@ async fn init_overlay(
     let header_oracle = HeaderOracle::default();
     let header_oracle = Arc::new(TokioRwLock::new(header_oracle));
     let (_utp_talk_req_tx, utp_talk_req_rx) = unbounded_channel();
-    let discv5_utp = Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx, header_oracle);
+    let discv5_utp =
+        Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx, header_oracle, 50);
     let utp_socket = Arc::new(UtpSocket::with_socket(discv5_utp));
 
     let validator = Arc::new(MockValidator {});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,10 +75,16 @@ pub async fn run_trin(
 
     // Initialize and spawn uTP socket
     let (utp_talk_reqs_tx, utp_talk_reqs_rx) = mpsc::unbounded_channel();
+
+    // Set the enr_cache_capacity to half the maximum uTP limit between all active networks. This is
+    // a trade off between memory usage and increased searches from the networks for each Enr.
+    let enr_cache_capacity =
+        portalnet_config.utp_transfer_limit * 2 * trin_config.portal_subnetworks.len() / 2;
     let discv5_utp_socket = Discv5UdpSocket::new(
         Arc::clone(&discovery),
         utp_talk_reqs_rx,
         header_oracle.clone(),
+        enr_cache_capacity,
     );
     let utp_socket = UtpSocket::with_socket(discv5_utp_socket);
     let utp_socket = Arc::new(utp_socket);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,10 +76,12 @@ pub async fn run_trin(
     // Initialize and spawn uTP socket
     let (utp_talk_reqs_tx, utp_talk_reqs_rx) = mpsc::unbounded_channel();
 
-    // Set the enr_cache_capacity to half the maximum uTP limit between all active networks. This is
+    // Set the enr_cache_capacity to the maximum uTP limit between all active networks. This is
     // a trade off between memory usage and increased searches from the networks for each Enr.
+    // utp_transfer_limit is 2x as it would be utp_transfer_limit for incoming and
+    // utp_transfer_limit for outgoing
     let enr_cache_capacity =
-        portalnet_config.utp_transfer_limit * 2 * trin_config.portal_subnetworks.len() / 2;
+        portalnet_config.utp_transfer_limit * 2 * trin_config.portal_subnetworks.len();
     let discv5_utp_socket = Discv5UdpSocket::new(
         Arc::clone(&discovery),
         utp_talk_reqs_rx,

--- a/trin-execution/src/storage/evm_db.rs
+++ b/trin-execution/src/storage/evm_db.rs
@@ -24,7 +24,6 @@ use super::{
 const REVERSE_HASH_LOOKUP_PREFIX: &[u8] = b"reverse hash lookup";
 
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EvmDB {
     /// State config
     pub config: StateConfig,

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -48,6 +48,7 @@ pub async fn initialize_state_network(
     StateEventStream,
 )> {
     let (state_jsonrpc_tx, state_jsonrpc_rx) = mpsc::unbounded_channel::<StateJsonRpcRequest>();
+    header_oracle.write().await.state_jsonrpc_tx = Some(state_jsonrpc_tx.clone());
     let (state_event_tx, state_event_rx) = mpsc::unbounded_channel::<OverlayRequest>();
 
     let state_network = StateNetwork::new(

--- a/trin-validation/Cargo.toml
+++ b/trin-validation/Cargo.toml
@@ -13,6 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 alloy-primitives = { version = "0.7.0", features = ["ssz"] }
 anyhow = "1.0.68"
+enr = "0.10.0"
 eth2_hashing = "0.2.0"
 ethereum_ssz = "0.5.3"
 ethereum_ssz_derive = "0.5.3"

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -21,6 +21,7 @@ rand = "0.8.4"
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 trin-utils = { path = "../trin-utils" }
+trin-validation = { path="../trin-validation" }
 tokio = {version = "1.14.0", features = ["full"]}
 utp-rs = { git = "https://github.com/ethereum/utp", tag = "v0.1.0-alpha.12" }
 

--- a/utp-testing/src/lib.rs
+++ b/utp-testing/src/lib.rs
@@ -183,6 +183,7 @@ pub async fn run_test_app(
         Arc::clone(&discovery),
         utp_talk_req_rx,
         header_oracle,
+        50,
     );
     let utp_socket = utp_rs::socket::UtpSocket::with_socket(discv5_utp_socket);
     let utp_socket = Arc::new(utp_socket);

--- a/utp-testing/src/lib.rs
+++ b/utp-testing/src/lib.rs
@@ -29,6 +29,7 @@ use tokio::sync::{
     mpsc::{self, Receiver},
     RwLock,
 };
+use trin_validation::oracle::HeaderOracle;
 use utp_rs::{conn::ConnectionConfig, socket::UtpSocket};
 
 /// uTP test app
@@ -175,9 +176,14 @@ pub async fn run_test_app(
     let enr = discovery.local_enr();
     let discovery = Arc::new(discovery);
 
+    let header_oracle = HeaderOracle::default();
+    let header_oracle = Arc::new(RwLock::new(header_oracle));
     let (utp_talk_req_tx, utp_talk_req_rx) = mpsc::unbounded_channel();
-    let discv5_utp_socket =
-        portalnet::discovery::Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx);
+    let discv5_utp_socket = portalnet::discovery::Discv5UdpSocket::new(
+        Arc::clone(&discovery),
+        utp_talk_req_rx,
+        header_oracle,
+    );
     let utp_socket = utp_rs::socket::UtpSocket::with_socket(discv5_utp_socket);
     let utp_socket = Arc::new(utp_socket);
 


### PR DESCRIPTION
### What was wrong?
![image](https://github.com/user-attachments/assets/93fbf8b6-2bea-4958-9b3c-4ee34472e040)

![image](https://github.com/user-attachments/assets/5c7fd4bf-4279-49fa-bda4-9d4a26d6101b)


### How was it fixed?

![image](https://github.com/user-attachments/assets/5c236926-533f-43b6-be16-8fb7ac7c5ca7)
![image](https://github.com/user-attachments/assets/b1024ef2-ca5d-4e10-a0fd-c067d47040a8)
![image](https://github.com/user-attachments/assets/220e8fe1-5ce6-49dd-a1cf-dbc70042d1ed)
![image](https://github.com/user-attachments/assets/414c9475-2255-42e0-add3-6b8b85f44152)
![image](https://github.com/user-attachments/assets/77bbda42-5a31-429b-9f22-e1851a5c567c)
![image](https://github.com/user-attachments/assets/40b99b00-408d-4d41-a0fc-95f04205c79d)

In short this bug was caused by us only checking for `Enr`'s from our `node_addr_cache` which only contains new temporary connections. The fix was to also check our `kbuckets` and pending query caches

## Other issue
![image](https://github.com/user-attachments/assets/9fa41032-ff70-4c71-a9a0-7d0f074210b1)

^ So I did implement a solution for this which checks each active sub-network as a as a fallback method.

GetEnr() json-rpc checks the kbuckets of the sub-network, but it doesn't check

![image](https://github.com/user-attachments/assets/db5de630-23f9-483c-bf5e-fdb8ffbace20)
This is only available in the OverlayService, not Overlay, so if in the future we still find a issue we can add it to the json-rpc GetEnr, but for now I think the solution is good enough.

I wish we wouldn't need to query every active sub-network as a backup option, but without a much bigger code change I think this is the best solution.

`enr_cache` should help reduce any locks on discv5 kbuckets or doing Json-rpc requests, uTP recv_from is called a lot and needing to lock kbucket or do a json-rpc request isn't the viable.