### PR TITLE
refactor: fix comments and redundant newline in logs

### DIFF
--- a/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -42,10 +42,10 @@ pub enum StateEndpoint {
     TraceRecursiveFindContent(StateContentKey),
     /// params: [content_key, content_value]
     Store(StateContentKey, StateContentValue),
-    /// params: [enr, content_key, content_value]
-    Offer(Enr, StateContentKey, StateContentValue),
     /// WireOffer is not supported in the state network, since locally
     /// stored values do not contain the proofs necessary for valid gossip.
+    /// params: [enr, content_key, content_value]
+    Offer(Enr, StateContentKey, StateContentValue),
     /// params: [enr, content_key, content_value]
     Gossip(StateContentKey, StateContentValue),
     /// params: [content_key, content_value]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,10 @@ pub async fn run_trin(
 
     // Initialize validation oracle
     let header_oracle = HeaderOracle::default();
-    info!(hash_tree_root = %hex_encode(header_oracle.header_validator.pre_merge_acc.tree_hash_root().0),"Loaded
-        pre-merge accumulator.");
+    info!(
+        hash_tree_root = %hex_encode(header_oracle.header_validator.pre_merge_acc.tree_hash_root().0),
+        "Loaded pre-merge accumulator."
+    );
     let header_oracle = Arc::new(RwLock::new(header_oracle));
 
     // Initialize and spawn uTP socket


### PR DESCRIPTION
### What was wrong?
- unnecessary newline in startup logs
- https://github.com/ethereum/trin/pull/1347#discussion_r1695388667

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
