### PR TITLE
fix: sender_recovery getting wrong address for typed tx's

### DIFF
--- a/trin-execution/src/execution.rs
+++ b/trin-execution/src/execution.rs
@@ -279,9 +279,7 @@ impl State {
             .with_spec_id(get_spec_id(block_number))
             .modify_tx_env(|tx_env| {
                 tx_env.caller = tx
-                    .get_transaction_sender_address(
-                        get_spec_id(block_number).is_enabled_in(SpecId::SPURIOUS_DRAGON),
-                    )
+                    .get_transaction_sender_address()
                     .expect("We should always be able to get the sender address of a transaction");
                 match tx {
                     Transaction::Legacy(tx) => tx.modify(block_number, tx_env),


### PR DESCRIPTION
### What was wrong?
- `get_transaction_sender_address` was returning the wrong address for typed transaction
- we were also detecting non-chain-id tx's wrong
### How was it fixed?
- detect if chain id is present based off v size
- generate correct rlp for sender recovery

