### PR TITLE
feat: allow e2store/era to decode all forks not just bellatrix

### DIFF
--- a/e2store/src/era.rs
+++ b/e2store/src/era.rs
@@ -54,11 +54,7 @@ impl Era {
             let entry: Entry = file.entries[idx].clone();
             let fork = get_beacon_fork(next_slot);
             let beacon_block = CompressedSignedBeaconBlock::try_from(&entry, fork)?;
-            next_slot = match &beacon_block.block {
-                SignedBeaconBlock::Bellatrix(block) => block.message.slot,
-                SignedBeaconBlock::Capella(block) => block.message.slot,
-                SignedBeaconBlock::Deneb(block) => block.message.slot,
-            } + 1;
+            next_slot = beacon_block.block.slot() + 1;
             blocks.push(beacon_block);
         }
         let fork = get_beacon_fork(slot_index_state.slot_index.starting_slot);

--- a/ethportal-api/src/types/consensus/beacon_block.rs
+++ b/ethportal-api/src/types/consensus/beacon_block.rs
@@ -165,6 +165,15 @@ impl SignedBeaconBlock {
             }
         }
     }
+
+    /// Returns slot of the beacon block.
+    pub fn slot(&self) -> u64 {
+        match self {
+            SignedBeaconBlock::Bellatrix(block) => block.message.slot,
+            SignedBeaconBlock::Capella(block) => block.message.slot,
+            SignedBeaconBlock::Deneb(block) => block.message.slot,
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### What was wrong?
`e2store/era` was hardcoded to only decode bellatrix, when I need to be able to decode all forks since execution payload was added
### How was it fixed?

by doing a if else decode pattern like we do for decoding transactions