### PR TITLE
feat(beacon-network): add json-rpc method to get the latest finalized state root

### DIFF
--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -42,6 +42,10 @@ pub trait BeaconNetworkApi {
     #[method(name = "beaconPing")]
     async fn ping(&self, enr: Enr) -> RpcResult<PongInfo>;
 
+    /// Get the finalized state root of the finalized beacon header.
+    #[method(name = "beaconFinalizedStateRoot")]
+    async fn finalized_state_root(&self) -> RpcResult<B256>;
+
     /// Send a FINDNODES request for nodes that fall within the given set of distances, to the
     /// designated peer and wait for a response
     #[method(name = "beaconFindNodes")]

--- a/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -113,6 +113,8 @@ pub enum BeaconEndpoint {
     FindContent(Enr, BeaconContentKey),
     /// params: [enr, distances]
     FindNodes(Enr, Vec<u16>),
+    /// params: None
+    FinalizedStateRoot,
     /// params: node_id
     GetEnr(NodeId),
     /// params: content_key

--- a/light-client/src/client.rs
+++ b/light-client/src/client.rs
@@ -459,4 +459,8 @@ impl<DB: Database, R: ConsensusRpc + 'static> Client<DB, R> {
     pub async fn get_header(&self) -> Result<BeaconBlockHeader> {
         self.node.read().await.get_header()
     }
+
+    pub async fn get_finalized_header(&self) -> Result<BeaconBlockHeader> {
+        self.node.read().await.get_finalized_header()
+    }
 }

--- a/light-client/src/node.rs
+++ b/light-client/src/node.rs
@@ -77,6 +77,10 @@ impl<R: ConsensusRpc> Node<R> {
         self.config.chain.chain_id
     }
 
+    pub fn get_finalized_header(&self) -> Result<BeaconBlockHeader> {
+        Ok(self.consensus.get_finalized_header().clone())
+    }
+
     pub fn get_header(&self) -> Result<BeaconBlockHeader> {
         self.check_head_age()?;
         Ok(self.consensus.get_header().clone())

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -151,6 +151,7 @@ impl BeaconNetworkApiServer for BeaconNetworkApi {
         Ok(result)
     }
 
+    /// Get the optimistic state root of the optimistic beacon header.
     async fn optimistic_state_root(&self) -> RpcResult<B256> {
         let endpoint = BeaconEndpoint::OptimisticStateRoot;
         let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
@@ -167,6 +168,14 @@ impl BeaconNetworkApiServer for BeaconNetworkApi {
         let endpoint = BeaconEndpoint::FindContent(enr, content_key);
         let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
         let result: ContentInfo = from_value(result)?;
+        Ok(result)
+    }
+
+    /// Get the finalized state root of the finalized beacon header.
+    async fn finalized_state_root(&self) -> RpcResult<B256> {
+        let endpoint = BeaconEndpoint::FinalizedStateRoot;
+        let result = self.proxy_query_to_beacon_subnet(endpoint).await?;
+        let result: B256 = from_value(result)?;
         Ok(result)
     }
 

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -97,6 +97,19 @@ async fn complete_request(network: Arc<BeaconNetwork>, request: BeaconJsonRpcReq
                 None => Err("Beacon client not initialized".to_string()),
             }
         }
+        BeaconEndpoint::FinalizedStateRoot => {
+            let beacon_client = network.beacon_client.lock().await;
+            match beacon_client.as_ref() {
+                Some(client) => {
+                    let header = client.get_finalized_header().await;
+                    match header {
+                        Ok(header) => Ok(json!((header.state_root))),
+                        Err(err) => Err(err.to_string()),
+                    }
+                }
+                None => Err("Beacon client not initialized".to_string()),
+            }
+        }
     };
     let _ = request.resp.send(response);
 }


### PR DESCRIPTION
### What was wrong?
To be able to validate `HistoricalSummariesWithProof`, we want to access the latest finalized beacon state root from the light client module.

The current design in HeaderOracle [relies on JSON-RPC](https://github.com/ethereum/trin/blob/8e36266c8a43d70fe81eb57d933058ea5d2f9c99/trin-validation/src/oracle.rs#L27) requests for accessing the data from the overlay networks.

This endpoint is required for fixing #1323.

Here is a [PR](https://github.com/ethereum/portal-network-specs/pull/331) to add the endpoint to beacon json-rpc specs as it will be useful for hive testing.

### How was it fixed?
- implement `portal_beaconFinalizedStateRoot` json-rpc endpoint.

This endpoint was tested locally with beacon synced node.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
