### PR TITLE
feat: define state related eth_* rpc endpoints

### DIFF
--- a/ethportal-api/src/eth.rs
+++ b/ethportal-api/src/eth.rs
@@ -1,6 +1,6 @@
-use alloy_primitives::{B256, U256};
+use alloy_primitives::{Address, Bytes, B256, U256};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_rpc_types::Block;
+use reth_rpc_types::{Block, BlockId};
 
 /// Web3 JSON-RPC endpoints
 #[rpc(client, server, namespace = "eth")]
@@ -14,4 +14,18 @@ pub trait EthApi {
         block_hash: B256,
         hydrated_transactions: bool,
     ) -> RpcResult<Block>;
+
+    #[method(name = "getBalance")]
+    async fn get_balance(&self, address: Address, block: BlockId) -> RpcResult<U256>;
+
+    #[method(name = "getCode")]
+    async fn get_code(&self, address: Address, block: BlockId) -> RpcResult<Bytes>;
+
+    #[method(name = "getStorageAt")]
+    async fn get_storage_at(
+        &self,
+        address: Address,
+        slot: U256,
+        block: BlockId,
+    ) -> RpcResult<Bytes>;
 }

--- a/rpc/src/builder.rs
+++ b/rpc/src/builder.rs
@@ -412,7 +412,8 @@ impl RpcModuleBuilder {
                                 .history_tx
                                 .clone()
                                 .expect("History protocol not initialized");
-                            EthApi::new(history_tx).into_rpc().into()
+                            let state_tx = self.state_tx.clone();
+                            EthApi::new(history_tx, state_tx).into_rpc().into()
                         }
                         PortalRpcModule::History => {
                             let history_tx = self


### PR DESCRIPTION
### What was wrong?

We were missing `eth_getBalance`, `eth_getCode` and `eth_getStorageAt` JSON rpc endpoints.

### How was it fixed?

Defined missing endpoints (using `todo!()` as implementation, for future PR).

We will need other endpoints in the near future (`eth_call` and `eth_estimateGass`), but they require more complicated type (`Transaction`), so I left them for future work.

### To-Do

- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
