### PR TITLE
refactor: simplify json-rpc proxy logic

### DIFF
--- a/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -144,3 +144,27 @@ pub enum BeaconEndpoint {
     /// params: [node_id]
     RecursiveFindNodes(NodeId),
 }
+
+/// The common functionality of subnetwork endpoints.
+pub trait SubnetworkEndpoint {
+    /// The subnetwork name.
+    fn subnetwork() -> &'static str;
+}
+
+impl SubnetworkEndpoint for StateEndpoint {
+    fn subnetwork() -> &'static str {
+        "state"
+    }
+}
+
+impl SubnetworkEndpoint for HistoryEndpoint {
+    fn subnetwork() -> &'static str {
+        "history"
+    }
+}
+
+impl SubnetworkEndpoint for BeaconEndpoint {
+    fn subnetwork() -> &'static str {
+        "beacon"
+    }
+}

--- a/ethportal-api/src/types/jsonrpc/request.rs
+++ b/ethportal-api/src/types/jsonrpc/request.rs
@@ -42,26 +42,23 @@ impl Default for JsonRequest {
     }
 }
 
-/// History network JSON-RPC request
+/// The network JSON-RPC request.
+///
+/// The <T> generic corresponds to the endpoint type.
 #[derive(Debug, Clone)]
-pub struct HistoryJsonRpcRequest {
-    pub endpoint: HistoryEndpoint,
+pub struct JsonRpcRequest<T> {
+    pub endpoint: T,
     pub resp: Responder<Value, String>,
 }
+
+/// History network JSON-RPC request
+pub type HistoryJsonRpcRequest = JsonRpcRequest<HistoryEndpoint>;
 
 /// State network JSON-RPC request
-#[derive(Debug)]
-pub struct StateJsonRpcRequest {
-    pub endpoint: StateEndpoint,
-    pub resp: Responder<Value, String>,
-}
+pub type StateJsonRpcRequest = JsonRpcRequest<StateEndpoint>;
 
 /// Beacon chain network JSON-RPC request
-#[derive(Debug)]
-pub struct BeaconJsonRpcRequest {
-    pub endpoint: BeaconEndpoint,
-    pub resp: Responder<Value, String>,
-}
+pub type BeaconJsonRpcRequest = JsonRpcRequest<BeaconEndpoint>;
 
 fn default_params() -> Params {
     Params::None

--- a/rpc/src/errors.rs
+++ b/rpc/src/errors.rs
@@ -7,6 +7,7 @@ use crate::{
     PortalRpcModule,
 };
 use ethportal_api::types::query_trace::QueryTrace;
+use serde::{Deserialize, Serialize};
 use std::io;
 
 /// Rpc Errors.
@@ -78,6 +79,22 @@ impl From<RpcServeError> for ErrorObjectOwned {
             RpcServeError::ContentNotFound { message, trace } => {
                 ErrorObject::owned(-39001, message, Some(trace))
             }
+        }
+    }
+}
+
+/// The JSON format of the "ContentNotFound" error.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContentNotFoundJsonError {
+    pub message: String,
+    pub trace: Option<QueryTrace>,
+}
+
+impl From<ContentNotFoundJsonError> for RpcServeError {
+    fn from(e: ContentNotFoundJsonError) -> Self {
+        RpcServeError::ContentNotFound {
+            message: e.message,
+            trace: e.trace,
         }
     }
 }

--- a/rpc/src/fetch.rs
+++ b/rpc/src/fetch.rs
@@ -1,58 +1,72 @@
+use std::fmt::Debug;
+
 use alloy_primitives::B256;
-/// Fetch data from related Portal networks
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::mpsc;
 
 use ethportal_api::{
     types::{
         execution::{block_body::BlockBody, header::Header},
-        jsonrpc::{endpoints::HistoryEndpoint, request::HistoryJsonRpcRequest},
+        history::ContentInfo,
+        jsonrpc::{
+            endpoints::{HistoryEndpoint, SubnetworkEndpoint},
+            request::{HistoryJsonRpcRequest, JsonRpcRequest},
+        },
+        query_trace::QueryTrace,
     },
-    utils::bytes::hex_decode,
-    ContentValue, HistoryContentKey, HistoryContentValue,
+    HistoryContentKey, HistoryContentValue,
 };
 
-use crate::errors::RpcServeError;
+use crate::{
+    errors::{ContentNotFoundJsonError, RpcServeError},
+    serde::from_value,
+};
 
-pub async fn proxy_query_to_history_subnet(
-    network: &mpsc::UnboundedSender<HistoryJsonRpcRequest>,
-    endpoint: HistoryEndpoint,
-) -> Result<Value, RpcServeError> {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ContentNotFoundError {
+    message: String,
+    trace: Option<QueryTrace>,
+}
+
+/// Fetch and deserialize data from Portal subnetwork.
+pub async fn proxy_to_subnet<TEndpoint, TOutput>(
+    network: &mpsc::UnboundedSender<JsonRpcRequest<TEndpoint>>,
+    endpoint: TEndpoint,
+) -> Result<TOutput, RpcServeError>
+where
+    TEndpoint: SubnetworkEndpoint + Clone,
+    TOutput: serde::de::DeserializeOwned,
+{
     let (resp_tx, mut resp_rx) = mpsc::unbounded_channel::<Result<Value, String>>();
-    let message = HistoryJsonRpcRequest {
+    let message = JsonRpcRequest {
         endpoint,
         resp: resp_tx,
     };
     let _ = network.send(message);
 
-    match resp_rx.recv().await {
-        Some(val) => match val {
-            Ok(result) => Ok(result),
-            Err(msg) => {
-                if msg.contains("Unable to locate content on the network") {
-                    let error_details: Value = serde_json::from_str(&msg).map_err(|e| {
-                        RpcServeError::Message(format!(
-                            "Failed to parse error message from history subnet: {e:?}",
-                        ))
-                    })?;
-                    let message = error_details["message"]
-                        .as_str()
-                        .expect("Failed to parse error message from history subnet")
-                        .to_string();
-                    let trace = match error_details.get("trace") {
-                        Some(trace) => serde_json::from_value(trace.clone())
-                            .expect("Failed to parse query trace"),
-                        None => None,
-                    };
-                    Err(RpcServeError::ContentNotFound { message, trace })
-                } else {
-                    Err(RpcServeError::Message(msg))
-                }
+    let Some(response) = resp_rx.recv().await else {
+        return Err(RpcServeError::Message(format!(
+            "Internal error: No response from {} subnetwork",
+            TEndpoint::subnetwork()
+        )));
+    };
+
+    match response {
+        Ok(result) => from_value(result),
+        Err(msg) => {
+            if msg.contains("Unable to locate content on the network") {
+                let error: ContentNotFoundJsonError = serde_json::from_str(&msg).map_err(|e| {
+                    RpcServeError::Message(format!(
+                        "Failed to parse error message from {} subnetwork: {e:?}",
+                        TEndpoint::subnetwork()
+                    ))
+                })?;
+                Err(error.into())
+            } else {
+                Err(RpcServeError::Message(msg))
             }
-        },
-        None => Err(RpcServeError::Message(
-            "Internal error: No response from chain history subnetwork".to_string(),
-        )),
+        }
     }
 }
 
@@ -61,10 +75,10 @@ pub async fn find_header_by_hash(
     block_hash: B256,
 ) -> Result<Header, RpcServeError> {
     // Request the block header from the history subnet.
-    let content_key: HistoryContentKey = HistoryContentKey::BlockHeaderWithProof(block_hash.into());
-    let header = find_content_by_hash(network, content_key).await?;
+    let content_key = HistoryContentKey::BlockHeaderWithProof(block_hash.into());
+    let content_value = find_content_by_hash(network, content_key).await?;
 
-    match header {
+    match content_value {
         HistoryContentValue::BlockHeaderWithProof(h) => Ok(h.header),
         wrong_val => Err(RpcServeError::Message(format!(
             "Internal trin error: got back a non-header from a key that must only point to headers; got {wrong_val:?}"
@@ -77,10 +91,10 @@ pub async fn find_block_body_by_hash(
     block_hash: B256,
 ) -> Result<BlockBody, RpcServeError> {
     // Request the block body from the history subnet.
-    let content_key: HistoryContentKey = HistoryContentKey::BlockBody(block_hash.into());
-    let body = find_content_by_hash(network, content_key).await?;
+    let content_key = HistoryContentKey::BlockBody(block_hash.into());
+    let content_value = find_content_by_hash(network, content_key).await?;
 
-    match body {
+    match content_value {
         HistoryContentValue::BlockBody(body) => Ok(body),
         wrong_val => Err(RpcServeError::Message(format!(
             "Internal trin error: got back a non-body from a key that must only point to bodies; got {wrong_val:?}"
@@ -92,21 +106,13 @@ async fn find_content_by_hash(
     network: &mpsc::UnboundedSender<HistoryJsonRpcRequest>,
     content_key: HistoryContentKey,
 ) -> Result<HistoryContentValue, RpcServeError> {
-    let endpoint = HistoryEndpoint::RecursiveFindContent(content_key.clone());
-    let mut result = proxy_query_to_history_subnet(network, endpoint).await?;
-    let content = match result["content"].take() {
-        serde_json::Value::String(s) => s,
-        wrong_type => {
-            let message =
-                format!("Invalid internal representation of {content_key:?}; json: {wrong_type:?}");
-            return Err(RpcServeError::Message(message));
-        }
+    let endpoint = HistoryEndpoint::RecursiveFindContent(content_key);
+    let response: ContentInfo = proxy_to_subnet(network, endpoint).await?;
+    let ContentInfo::Content { content, .. } = response else {
+        return Err(RpcServeError::Message(format!(
+            "Invalid response variant: RecursiveFindContent should contain content value; got {response:?}"
+        )));
     };
-    let content: Vec<u8> =
-        hex_decode(&content).expect("decoding the trin hex-encoded data failed, odd");
-    HistoryContentValue::decode(&content).map_err(|err| {
-        let message =
-            format!("Invalid internal representation of {content_key:?}; could not decode: {err}");
-        RpcServeError::Message(message)
-    })
+
+    Ok(content)
 }

--- a/rpc/src/state_rpc.rs
+++ b/rpc/src/state_rpc.rs
@@ -1,4 +1,6 @@
 use discv5::enr::NodeId;
+use tokio::sync::mpsc;
+
 use ethportal_api::{
     types::{
         enr::Enr,
@@ -8,13 +10,10 @@ use ethportal_api::{
     },
     RoutingTableInfo, StateContentKey, StateContentValue, StateNetworkApiServer,
 };
-use serde_json::Value;
-use tokio::sync::mpsc;
 
 use crate::{
-    errors::RpcServeError,
+    fetch::proxy_to_subnet,
     jsonrpsee::core::{async_trait, RpcResult},
-    serde::from_value,
 };
 
 pub struct StateNetworkApi {
@@ -25,28 +24,6 @@ impl StateNetworkApi {
     pub fn new(network: mpsc::UnboundedSender<StateJsonRpcRequest>) -> Self {
         Self { network }
     }
-
-    pub async fn proxy_query_to_state_subnet(
-        &self,
-        endpoint: StateEndpoint,
-    ) -> Result<Value, RpcServeError> {
-        let (resp_tx, mut resp_rx) = mpsc::unbounded_channel::<Result<Value, String>>();
-        let message = StateJsonRpcRequest {
-            endpoint,
-            resp: resp_tx,
-        };
-        let _ = self.network.send(message);
-
-        match resp_rx.recv().await {
-            Some(val) => match val {
-                Ok(result) => Ok(result),
-                Err(msg) => Err(RpcServeError::Message(msg)),
-            },
-            None => Err(RpcServeError::Message(
-                "Internal error: No response from chain state subnetwork".to_string(),
-            )),
-        }
-    }
 }
 
 #[async_trait]
@@ -54,90 +31,68 @@ impl StateNetworkApiServer for StateNetworkApi {
     /// Returns meta information about overlay routing table.
     async fn routing_table_info(&self) -> RpcResult<RoutingTableInfo> {
         let endpoint = StateEndpoint::RoutingTableInfo;
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: RoutingTableInfo = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Write an Ethereum Node Record to the overlay routing table.
     async fn add_enr(&self, enr: Enr) -> RpcResult<bool> {
         let endpoint = StateEndpoint::AddEnr(enr);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: bool = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Fetch the latest ENR associated with the given node ID.
     async fn get_enr(&self, node_id: NodeId) -> RpcResult<Enr> {
         let endpoint = StateEndpoint::GetEnr(node_id);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: Enr = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Delete Node ID from the overlay routing table.
     async fn delete_enr(&self, node_id: NodeId) -> RpcResult<bool> {
         let endpoint = StateEndpoint::DeleteEnr(node_id);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: bool = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Fetch the ENR representation associated with the given Node ID.
     async fn lookup_enr(&self, node_id: NodeId) -> RpcResult<Enr> {
         let endpoint = StateEndpoint::LookupEnr(node_id);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: Enr = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Send a PING message to the designated node and wait for a PONG response
     async fn ping(&self, enr: Enr) -> RpcResult<PongInfo> {
         let endpoint = StateEndpoint::Ping(enr);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: PongInfo = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Send a FINDNODES request for nodes that fall within the given set of distances, to the
     /// designated peer and wait for a response
     async fn find_nodes(&self, enr: Enr, distances: Vec<u16>) -> RpcResult<FindNodesInfo> {
         let endpoint = StateEndpoint::FindNodes(enr, distances);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: FindNodesInfo = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Lookup a target node within in the network
     async fn recursive_find_nodes(&self, node_id: NodeId) -> RpcResult<Vec<Enr>> {
         let endpoint = StateEndpoint::RecursiveFindNodes(node_id);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: Vec<Enr> = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Lookup a target node within in the network
     async fn radius(&self) -> RpcResult<DataRadius> {
         let endpoint = StateEndpoint::DataRadius;
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: DataRadius = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Send FINDCONTENT message to get the content with a content key.
     async fn find_content(&self, enr: Enr, content_key: StateContentKey) -> RpcResult<ContentInfo> {
         let endpoint = StateEndpoint::FindContent(enr, content_key);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: ContentInfo = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Lookup a target content key in the network
     async fn recursive_find_content(&self, content_key: StateContentKey) -> RpcResult<ContentInfo> {
         let endpoint = StateEndpoint::RecursiveFindContent(content_key);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: ContentInfo = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Lookup a target content key in the network. Return tracing info.
@@ -146,9 +101,7 @@ impl StateNetworkApiServer for StateNetworkApi {
         content_key: StateContentKey,
     ) -> RpcResult<TraceContentInfo> {
         let endpoint = StateEndpoint::TraceRecursiveFindContent(content_key);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let info: TraceContentInfo = from_value(result)?;
-        Ok(info)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Pagination of local content keys
@@ -158,9 +111,7 @@ impl StateNetworkApiServer for StateNetworkApi {
         limit: u64,
     ) -> RpcResult<PaginateLocalContentInfo> {
         let endpoint = StateEndpoint::PaginateLocalContentKeys(offset, limit);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: PaginateLocalContentInfo = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Send the provided content to interested peers. Clients may choose to send to some or all
@@ -171,9 +122,7 @@ impl StateNetworkApiServer for StateNetworkApi {
         content_value: StateContentValue,
     ) -> RpcResult<u32> {
         let endpoint = StateEndpoint::Gossip(content_key, content_value);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: u32 = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Send the provided content to interested peers. Clients may choose to send to some or all
@@ -184,9 +133,7 @@ impl StateNetworkApiServer for StateNetworkApi {
         content_value: StateContentValue,
     ) -> RpcResult<TraceGossipInfo> {
         let endpoint = StateEndpoint::TraceGossip(content_key, content_value);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: TraceGossipInfo = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Send an OFFER request with given ContentKey, to the designated peer and wait for a response.
@@ -200,9 +147,7 @@ impl StateNetworkApiServer for StateNetworkApi {
         content_value: StateContentValue,
     ) -> RpcResult<AcceptInfo> {
         let endpoint = StateEndpoint::Offer(enr, content_key, content_value);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: AcceptInfo = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Store content key with a content data to the local database.
@@ -212,16 +157,13 @@ impl StateNetworkApiServer for StateNetworkApi {
         content_value: StateContentValue,
     ) -> RpcResult<bool> {
         let endpoint = StateEndpoint::Store(content_key, content_value);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        let result: bool = from_value(result)?;
-        Ok(result)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Get a content from the local database.
     async fn local_content(&self, content_key: StateContentKey) -> RpcResult<StateContentValue> {
         let endpoint = StateEndpoint::LocalContent(content_key);
-        let result = self.proxy_query_to_state_subnet(endpoint).await?;
-        Ok(from_value(result)?)
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 }
 


### PR DESCRIPTION
### What was wrong?

We proxy the JSON rpc requests to the corresponding network. This required some duplicated logic for each subnetwork (and it wasn't consistent).

### How was it fixed?

Introduced new type using generics and managed to create one functions that can proxy requests to each subnetwork.

While this is an improvement, I'm not completely satisfied with the current state because I believe that we still have some unnecessary json serialization / deserializaion. But that will be left for some potential future improvements.

### To-Do

- [x] Run hive tests locally and make sure there is no regression.
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
