### PR TITLE
feat(beacon-network): validate `HistoricalSummariesWithProof` against finalized state root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7882,6 +7882,7 @@ dependencies = [
 name = "trin-beacon"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
  "chrono",
  "discv5",
@@ -7899,6 +7900,7 @@ dependencies = [
  "ssz_types",
  "tokio",
  "tracing",
+ "tree_hash",
  "trin-metrics",
  "trin-storage",
  "trin-validation",

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -11,6 +11,7 @@ description = "Beacon network subprotocol for Trin."
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
+alloy-primitives = "0.7.0"
 anyhow = "1.0.68"
 chrono = "0.4.38"
 discv5 = { version = "0.4.1", features = ["serde"] }
@@ -26,6 +27,7 @@ serde_json = "1.0.89"
 ssz_types = { git = "https://github.com/KolbyML/ssz_types.git", rev = "2a5922de75f00746890bf4ea9ad663c9d5d58efe" }
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.36"
+tree_hash = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }
 trin-metrics = { path = "../trin-metrics" }
 trin-storage = { path = "../trin-storage" }
 trin-validation = { path = "../trin-validation" }

--- a/trin-beacon/src/lib.rs
+++ b/trin-beacon/src/lib.rs
@@ -11,7 +11,6 @@ mod test_utils;
 pub mod validation;
 
 use std::sync::Arc;
-
 use tokio::{
     sync::{broadcast, mpsc, RwLock},
     task::JoinHandle,

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -770,7 +770,7 @@ mod test {
     fn test_beacon_storage_get_put_historical_summaries() {
         let (_temp_dir, config) = create_test_portal_storage_config_with_capacity(10).unwrap();
         let mut storage = BeaconStorage::new(config).unwrap();
-        let value = test_utils::get_history_summaries_with_proof();
+        let (value, _) = test_utils::get_history_summaries_with_proof();
         let epoch = value.historical_summaries_with_proof.epoch;
         let key = BeaconContentKey::HistoricalSummariesWithProof(HistoricalSummariesWithProofKey {
             epoch,

--- a/trin-beacon/src/test_utils.rs
+++ b/trin-beacon/src/test_utils.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::B256;
 use ethportal_api::{
     consensus::{
         beacon_state::BeaconStateDeneb,
@@ -15,6 +16,7 @@ use ethportal_api::{
     },
 };
 use serde_json::Value;
+use tree_hash::TreeHash;
 
 // Valid number range for the test cases is 0..4
 pub fn get_light_client_bootstrap(number: u8) -> ForkVersionedLightClientBootstrap {
@@ -84,7 +86,7 @@ pub fn get_light_client_optimistic_update(number: u8) -> ForkVersionedLightClien
     }
 }
 
-pub fn get_history_summaries_with_proof() -> ForkVersionedHistoricalSummariesWithProof {
+pub fn get_history_summaries_with_proof() -> (ForkVersionedHistoricalSummariesWithProof, B256) {
     let value = std::fs::read_to_string(
         "../test_assets/beacon/deneb/BeaconState/ssz_random/case_0/value.yaml",
     )
@@ -102,8 +104,11 @@ pub fn get_history_summaries_with_proof() -> ForkVersionedHistoricalSummariesWit
         proof: historical_summaries_state_proof.clone(),
     };
 
-    ForkVersionedHistoricalSummariesWithProof {
-        fork_name: ForkName::Deneb,
-        historical_summaries_with_proof,
-    }
+    (
+        ForkVersionedHistoricalSummariesWithProof {
+            fork_name: ForkName::Deneb,
+            historical_summaries_with_proof,
+        },
+        beacon_state.tree_hash_root(),
+    )
 }


### PR DESCRIPTION
### What was wrong?
Fixes #1323 

### How was it fixed?
- add a method to get the latest finalized state root in `HeaderOracle`.
- implement validation methods in `BeaconValidator`.

Note: I had to use some creativity to write the unit tests for this validation because it is impossible to mock the jsno-rpc calls to the beacon overlay at this point.
This is why I split the validation into two methods and tested them individually, instead of one integration test of the `validate_content` method.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
