### PR TITLE
fix(e2store): era missing a beacon block off by 1 error

### DIFF
--- a/e2store/src/era.rs
+++ b/e2store/src/era.rs
@@ -50,10 +50,10 @@ impl Era {
 
         // Iterate over the block entries. Skip the first and last 3 entries.
         let mut next_slot = slot_index_block.slot_index.starting_slot;
-        for idx in 1..entries_length - 4 {
-            let entry: Entry = file.entries[idx].clone();
+        for idx in 1..entries_length - 3 {
+            let entry = &file.entries[idx];
             let fork = get_beacon_fork(next_slot);
-            let beacon_block = CompressedSignedBeaconBlock::try_from(&entry, fork)?;
+            let beacon_block = CompressedSignedBeaconBlock::try_from(entry, fork)?;
             next_slot = beacon_block.block.slot() + 1;
             blocks.push(beacon_block);
         }


### PR DESCRIPTION
### What was wrong?
When I was testing reading beacon blocks from era files when I compared the result of era 600 and era 601 their execution numbers didn't line up by 1 block, when I fixed this they lined up and I could linearly scan blocks from era files

I tested this for a few other sequential era files and the issues remained the same
### How was it fixed?

change the 4 to a 3
