### PR TITLE
feat: create json-rpc mock builder

### DIFF
--- a/ethportal-api/src/types/jsonrpc/json_rpc_mock.rs
+++ b/ethportal-api/src/types/jsonrpc/json_rpc_mock.rs
@@ -1,0 +1,91 @@
+use serde::Serialize;
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use super::request::JsonRpcRequest;
+
+type FilterFn<T> = Box<dyn Fn(&T) -> bool + Send>;
+
+/// Defines whether and how to respond to the request.
+struct Interaction<T> {
+    request_selector_fn: FilterFn<T>,
+    response: Result<Value, String>,
+}
+
+impl<T> Interaction<T> {
+    /// Returns `Some(response)` if selector returns `true`, `None` otherwise.
+    fn maybe_respond(&self, request: &T) -> Option<Result<Value, String>> {
+        if (self.request_selector_fn)(request) {
+            Some(self.response.clone())
+        } else {
+            None
+        }
+    }
+}
+
+/// Builder for mocking the JSPN-RPC handler.
+pub struct MockJsonRpcBuilder<T> {
+    interactions: Vec<Interaction<T>>,
+}
+
+impl<T: PartialEq + Send + 'static> MockJsonRpcBuilder<T> {
+    pub fn new_builder() -> Self {
+        Self {
+            interactions: vec![],
+        }
+    }
+
+    pub fn with_response(mut self, request: T, response: impl Serialize) -> Self {
+        self.interactions.push(Interaction {
+            request_selector_fn: Box::new(move |r| r == &request),
+            response: serde_json::to_value(response).map_err(|err| err.to_string()),
+        });
+        self
+    }
+
+    pub fn with_error(mut self, request: T, error: impl ToString) -> Self {
+        self.interactions.push(Interaction {
+            request_selector_fn: Box::new(move |r| r == &request),
+            response: Err(error.to_string()),
+        });
+        self
+    }
+
+    pub fn with_custom_trigger(
+        mut self,
+        trigger_fn: FilterFn<T>,
+        response: Result<Value, String>,
+    ) -> Self {
+        self.interactions.push(Interaction {
+            request_selector_fn: trigger_fn,
+            response,
+        });
+        self
+    }
+
+    pub fn or_else(mut self, response: impl Serialize) -> mpsc::UnboundedSender<JsonRpcRequest<T>> {
+        self.interactions.push(Interaction {
+            request_selector_fn: Box::new(|_| true),
+            response: serde_json::to_value(response).map_err(|err| err.to_string()),
+        });
+        self.or_fail()
+    }
+
+    pub fn or_fail(self) -> mpsc::UnboundedSender<JsonRpcRequest<T>> {
+        let (tx, mut rx) = mpsc::unbounded_channel::<JsonRpcRequest<T>>();
+        tokio::spawn(async move {
+            while let Some(request) = rx.recv().await {
+                let response = self
+                    .interactions
+                    .iter()
+                    .find_map(|interaction| interaction.maybe_respond(&request.endpoint))
+                    .unwrap_or_else(|| Err("No expected response found".to_string()));
+                request
+                    .resp
+                    .send(response)
+                    .expect("Something should receive response");
+            }
+        });
+        tx
+    }
+}

--- a/ethportal-api/src/types/jsonrpc/json_rpc_mock.rs
+++ b/ethportal-api/src/types/jsonrpc/json_rpc_mock.rs
@@ -29,7 +29,7 @@ pub struct MockJsonRpcBuilder<T> {
 }
 
 impl<T: PartialEq + Send + 'static> MockJsonRpcBuilder<T> {
-    pub fn new_builder() -> Self {
+    pub fn new() -> Self {
         Self {
             interactions: vec![],
         }
@@ -87,5 +87,11 @@ impl<T: PartialEq + Send + 'static> MockJsonRpcBuilder<T> {
             }
         });
         tx
+    }
+}
+
+impl<T: PartialEq + Send + 'static> Default for MockJsonRpcBuilder<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/ethportal-api/src/types/jsonrpc/mod.rs
+++ b/ethportal-api/src/types/jsonrpc/mod.rs
@@ -1,3 +1,4 @@
 pub mod endpoints;
+pub mod json_rpc_mock;
 pub mod params;
 pub mod request;


### PR DESCRIPTION
### What was wrong?

There is no easy way to mock our json-rpc request/responses which makes unit test of certain parts of the codebase very challenging.

### How was it fixed?

Created json-rpc mock builder, that is very customization.

See example of the real PR use case [here](https://github.com/ethereum/trin/blob/625839ee127798cdc6b1ffaa14a86366c1732503/trin-state/src/validation/validator.rs#L224C1-L229C24)

That case can be simplified even further (since it only cares about one response) in the following way:
```rust
let history_jsonrpc_tx = MockJsonRpcBuilder::new_builder().or_else(content_info);
```

For more complex logic, one can do something like this:
```rust
let history_jsonrpc_tx = MockJsonRpcBuilder::new_builder()
    // respond to RecursiveFindContent with one respond
    .with_response(
        HistoryEndpoint::RecursiveFindContent(content_key_1),
        content_info_1
    )
    // to another content key with another
    .with_response(
        HistoryEndpoint::RecursiveFindContent(content_key_2),
        content_info_2
    )
    // to gossip with completely different type
    .with_response(
        HistoryEndpoint::Gossip(content_key, content_value),
        42 // number of nodes that received gossip
    )
    // even custom trigger that handles all Ping requests
    .with_custom_trigger(
        |request| matches!(request, HistoryEndpoint::Ping(_)), // respond the same for every ping request
        pong_info,
    )
    // fail otherwise
    .of_fail();
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
