### PR TITLE
feat: use weight for setting storage capacity per network

### DIFF
--- a/ethportal-peertest/src/lib.rs
+++ b/ethportal-peertest/src/lib.rs
@@ -3,11 +3,7 @@
 pub mod scenarios;
 pub mod utils;
 
-use std::{
-    net::{IpAddr, Ipv4Addr},
-    path::PathBuf,
-    thread, time,
-};
+use std::{net::Ipv4Addr, path::PathBuf, thread, time};
 
 use ethportal_api::{
     types::{
@@ -59,75 +55,62 @@ async fn launch_node(trin_config: TrinConfig) -> anyhow::Result<PeertestNode> {
     })
 }
 
-fn generate_trin_config(id: u16, bootnode_enr: Option<&Enr>) -> TrinConfig {
-    let discovery_port: u16 = DEFAULT_DISCOVERY_PORT + id;
-    let discovery_port: String = discovery_port.to_string();
+fn generate_trin_config(
+    id: u16,
+    network: &str,
+    subnetworks: &str,
+    bootnode_enr: Option<&Enr>,
+) -> TrinConfig {
+    let bootnodes_arg = bootnode_enr
+        .map(|enr| enr.to_base64())
+        .unwrap_or("none".to_string());
+
+    let ip_addr = bootnode_enr
+        .map(|enr| enr.ip4().expect("bootnode must have IP"))
+        .unwrap_or(Ipv4Addr::new(127, 0, 0, 1));
+    let discovery_port = (DEFAULT_DISCOVERY_PORT + id).to_string();
+    let external_addr = format!("{ip_addr}:{discovery_port}");
+
     let web3_ipc_path = PathBuf::from(format!("/tmp/ethportal-peertest-buddy-{id}.ipc"));
+    let web3_ipc_path_str = web3_ipc_path
+        .to_str()
+        .expect("web3_ipc_path should be unicode");
+
     // This specific private key scheme is chosen to enforce that the first peer node will be in
     // the 256 kbucket of the bootnode, to ensure consistent `FindNodes` tests.
     let mut private_key = vec![id as u8; 3];
     private_key.append(&mut vec![0u8; 29]);
     let private_key = hex_encode(private_key);
-    match bootnode_enr {
-        Some(enr) => {
-            let external_addr = format!(
-                "{}:{}",
-                enr.ip4().expect("bootnode must have IP"),
-                discovery_port
-            );
-            let enr_base64 = enr.to_base64();
-            let web3_ipc_path_str = web3_ipc_path.as_path().display().to_string();
-            let trin_config_args = vec![
-                "trin",
-                "--portal-subnetworks",
-                "history,beacon,state",
-                "--external-address",
-                external_addr.as_str(),
-                "--bootnodes",
-                enr_base64.as_str(),
-                "--discovery-port",
-                discovery_port.as_str(),
-                "--web3-ipc-path",
-                &web3_ipc_path_str[..],
-                "--unsafe-private-key",
-                private_key.as_str(),
-                "--ephemeral",
-            ];
-            TrinConfig::new_from(trin_config_args.iter()).unwrap()
-        }
-        None => {
-            let ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-            let external_addr = format!("{ip_addr}:{discovery_port}");
-            let web3_ipc_path_str = web3_ipc_path.as_path().display().to_string();
-            let trin_config_args = vec![
-                "trin",
-                "--portal-subnetworks",
-                "history,beacon,state",
-                "--external-address",
-                external_addr.as_str(),
-                "--bootnodes",
-                "none",
-                "--discovery-port",
-                discovery_port.as_str(),
-                "--web3-ipc-path",
-                &web3_ipc_path_str[..],
-                "--unsafe-private-key",
-                private_key.as_str(),
-                "--ephemeral",
-            ];
-            TrinConfig::new_from(trin_config_args.iter()).unwrap()
-        }
-    }
+
+    let trin_config_args = vec![
+        "trin",
+        "--network",
+        network,
+        "--portal-subnetworks",
+        subnetworks,
+        "--bootnodes",
+        bootnodes_arg.as_str(),
+        "--discovery-port",
+        discovery_port.as_str(),
+        "--external-address",
+        external_addr.as_str(),
+        "--web3-ipc-path",
+        web3_ipc_path_str,
+        "--unsafe-private-key",
+        private_key.as_str(),
+        "--ephemeral",
+    ];
+    TrinConfig::new_from(trin_config_args.iter()).unwrap()
 }
 
-pub async fn launch_peertest_nodes(count: u16) -> Peertest {
+pub async fn launch_peertest_nodes(count: u16, network: &str, subnetworks: &str) -> Peertest {
     // Bootnode uses a peertest id of 1
-    let bootnode_config = generate_trin_config(1, None);
+    let bootnode_config = generate_trin_config(1, network, subnetworks, None);
     let bootnode = launch_node(bootnode_config).await.unwrap();
     let bootnode_enr = &bootnode.enr;
     // All other peertest node ids begin at 2, and increment from there
-    let nodes = future::try_join_all((2..count + 1).map(|id| {
-        let node_config = generate_trin_config(id, Some(bootnode_enr));
+    let nodes = future::try_join_all((2..=count).map(|id| {
+        let node_config = generate_trin_config(id, network, subnetworks, Some(bootnode_enr));
         launch_node(node_config)
     }))
     .await

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -135,8 +135,8 @@ pub async fn test_ping(protocol: ProtocolId, target: &Client, peertest: &Peertes
 
 pub async fn test_ping_cross_network(mainnet_target: &Client, angelfood_node: &PeertestNode) {
     info!("Testing ping for history cross mainnet and angelfood discv5 protocol id");
-    let bootnode_enr = angelfood_node.enr.clone();
-    if let Ok(pong) = HistoryNetworkApiClient::ping(mainnet_target, bootnode_enr).await {
+    let angelfood_enr = angelfood_node.enr.clone();
+    if let Ok(pong) = HistoryNetworkApiClient::ping(mainnet_target, angelfood_enr).await {
         panic!("Expected ping to fail as mainnet/angelfood history nodes shouldn't be able to communicate {pong:?}");
     };
 }

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -1,4 +1,4 @@
-use crate::{utils::fixture_header_with_proof, Peertest};
+use crate::{utils::fixture_header_with_proof, Peertest, PeertestNode};
 use alloy_primitives::{B256, U256};
 use ethportal_api::{
     types::{distance::Distance, portal_wire::ProtocolId},
@@ -133,10 +133,10 @@ pub async fn test_ping(protocol: ProtocolId, target: &Client, peertest: &Peertes
     assert_eq!(result.enr_seq, 1);
 }
 
-pub async fn test_ping_cross_network(target: &Client, peertest: &Peertest) {
+pub async fn test_ping_cross_network(mainnet_target: &Client, angelfood_node: &PeertestNode) {
     info!("Testing ping for history cross mainnet and angelfood discv5 protocol id");
-    let bootnode_enr = peertest.bootnode.enr.clone();
-    if let Ok(pong) = HistoryNetworkApiClient::ping(target, bootnode_enr).await {
+    let bootnode_enr = angelfood_node.enr.clone();
+    if let Ok(pong) = HistoryNetworkApiClient::ping(mainnet_target, bootnode_enr).await {
         panic!("Expected ping to fail as mainnet/angelfood history nodes shouldn't be able to communicate {pong:?}");
     };
 }

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -6,7 +6,10 @@ use std::{
 };
 
 use ethportal_api::types::{
-    cli::{TrinConfig, DEFAULT_WEB3_HTTP_ADDRESS, DEFAULT_WEB3_IPC_PATH},
+    cli::{
+        TrinConfig, BEACON_NETWORK, DEFAULT_WEB3_HTTP_ADDRESS, DEFAULT_WEB3_IPC_PATH,
+        HISTORY_NETWORK, STATE_NETWORK,
+    },
     portal_wire::ProtocolId,
 };
 use ethportal_peertest as peertest;
@@ -26,7 +29,8 @@ async fn peertest_stateless() {
     // without needing to reset the database between tests.
     // If a scenario is testing the state of the content database,
     // it should be added to its own test function.
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) =
+        setup_peertest("mainnet", &[HISTORY_NETWORK, BEACON_NETWORK, STATE_NETWORK]).await;
 
     peertest::scenarios::paginate::test_paginate_local_storage(&peertest).await;
     peertest::scenarios::basic::test_web3_client_version(&target).await;
@@ -59,7 +63,7 @@ async fn peertest_stateless() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_populated_offer() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::offer_accept::test_populated_offer(&peertest, &target).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -68,7 +72,7 @@ async fn peertest_populated_offer() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_unpopulated_offer() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::offer_accept::test_unpopulated_offer(&peertest, &target).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -77,7 +81,7 @@ async fn peertest_unpopulated_offer() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_unpopulated_offer_fails_with_missing_content() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::offer_accept::test_unpopulated_offer_fails_with_missing_content(
         &peertest, &target,
     )
@@ -89,7 +93,7 @@ async fn peertest_unpopulated_offer_fails_with_missing_content() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_gossip_with_trace() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::gossip::test_gossip_with_trace(&peertest, &target).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -98,7 +102,7 @@ async fn peertest_gossip_with_trace() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_find_content_return_enr() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::find::test_find_content_return_enr(&target, &peertest).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -107,7 +111,7 @@ async fn peertest_find_content_return_enr() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_trace_recursive_find_content_local_db() {
-    let (peertest, _target, handle) = setup_peertest("mainnet").await;
+    let (peertest, _target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::find::test_trace_recursive_find_content_local_db(&peertest).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -116,7 +120,7 @@ async fn peertest_trace_recursive_find_content_local_db() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_trace_recursive_find_content_for_absent_content() {
-    let (peertest, _target, handle) = setup_peertest("mainnet").await;
+    let (peertest, _target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::find::test_trace_recursive_find_content_for_absent_content(&peertest)
         .await;
     peertest.exit_all_nodes();
@@ -126,7 +130,7 @@ async fn peertest_trace_recursive_find_content_for_absent_content() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_trace_recursive_find_content() {
-    let (peertest, _target, handle) = setup_peertest("mainnet").await;
+    let (peertest, _target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::find::test_trace_recursive_find_content(&peertest).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -135,7 +139,7 @@ async fn peertest_trace_recursive_find_content() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_validate_pre_merge_header_with_proof() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::validation::test_validate_pre_merge_header_with_proof(&peertest, &target)
         .await;
     peertest.exit_all_nodes();
@@ -145,7 +149,7 @@ async fn peertest_validate_pre_merge_header_with_proof() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_invalidate_header_by_hash() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::validation::test_invalidate_header_by_hash(&peertest, &target).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -154,7 +158,7 @@ async fn peertest_invalidate_header_by_hash() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_validate_block_body() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::validation::test_validate_pre_merge_block_body(&peertest, &target).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -163,7 +167,7 @@ async fn peertest_validate_block_body() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_validate_receipts() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::validation::test_validate_pre_merge_receipts(&peertest, &target).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -172,7 +176,7 @@ async fn peertest_validate_receipts() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_recursive_utp() {
-    let (peertest, _target, handle) = setup_peertest("mainnet").await;
+    let (peertest, _target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::utp::test_recursive_utp(&peertest).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -181,7 +185,7 @@ async fn peertest_recursive_utp() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_trace_recursive_utp() {
-    let (peertest, _target, handle) = setup_peertest("mainnet").await;
+    let (peertest, _target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::utp::test_trace_recursive_utp(&peertest).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -190,7 +194,8 @@ async fn peertest_trace_recursive_utp() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_state_offer_account_trie_node() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) =
+        setup_peertest("mainnet", &[HISTORY_NETWORK, STATE_NETWORK]).await;
     peertest::scenarios::state::test_state_offer_account_trie_node(&peertest, &target).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -199,7 +204,8 @@ async fn peertest_state_offer_account_trie_node() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_state_offer_contract_storage_trie_node() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) =
+        setup_peertest("mainnet", &[HISTORY_NETWORK, STATE_NETWORK]).await;
     peertest::scenarios::state::test_state_gossip_contract_storage_trie_node(&peertest, &target)
         .await;
     peertest.exit_all_nodes();
@@ -209,7 +215,8 @@ async fn peertest_state_offer_contract_storage_trie_node() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_state_offer_contract_bytecode() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) =
+        setup_peertest("mainnet", &[HISTORY_NETWORK, STATE_NETWORK]).await;
     peertest::scenarios::state::test_state_gossip_contract_bytecode(&peertest, &target).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -218,7 +225,7 @@ async fn peertest_state_offer_contract_bytecode() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_history_offer_propagates_gossip() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::offer_accept::test_offer_propagates_gossip(&peertest, &target).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -227,7 +234,7 @@ async fn peertest_history_offer_propagates_gossip() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_history_offer_propagates_gossip_with_large_content() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::offer_accept::test_offer_propagates_gossip_with_large_content(
         &peertest, &target,
     )
@@ -239,7 +246,7 @@ async fn peertest_history_offer_propagates_gossip_with_large_content() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_history_offer_propagates_gossip_multiple_content_values() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::offer_accept::test_offer_propagates_gossip_multiple_content_values(
         &peertest, &target,
     )
@@ -251,7 +258,7 @@ async fn peertest_history_offer_propagates_gossip_multiple_content_values() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_history_offer_propagates_gossip_multiple_large_content_values() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::offer_accept::test_offer_propagates_gossip_multiple_large_content_values(
         &peertest, &target,
     )
@@ -263,7 +270,7 @@ async fn peertest_history_offer_propagates_gossip_multiple_large_content_values(
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_history_gossip_dropped_with_offer() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::gossip::test_gossip_dropped_with_offer(&peertest, &target).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -272,7 +279,7 @@ async fn peertest_history_gossip_dropped_with_offer() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_history_gossip_dropped_with_find_content() {
-    let (peertest, target, handle) = setup_peertest("mainnet").await;
+    let (peertest, target, handle) = setup_peertest("mainnet", &[HISTORY_NETWORK]).await;
     peertest::scenarios::gossip::test_gossip_dropped_with_find_content(&peertest, &target).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -281,16 +288,59 @@ async fn peertest_history_gossip_dropped_with_find_content() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_ping_cross_discv5_protocol_id() {
-    let (peertest, target, handle) = setup_peertest("angelfood").await;
-    peertest::scenarios::basic::test_ping_cross_network(&target, &peertest).await;
-    peertest.exit_all_nodes();
-    handle.stop().unwrap();
+    // Run peernodes on angelfood
+    let angelfood_peertest = peertest::launch_peertest_nodes(2, "angelfood", HISTORY_NETWORK).await;
+
+    // Run a client on the mainnet, to be tested
+    // Use an uncommon port for the peertest to avoid clashes.
+    let test_discovery_port = 8999;
+    let external_addr = format!("{}:{test_discovery_port}", Ipv4Addr::new(127, 0, 0, 1));
+
+    let trin_config = TrinConfig::new_from(
+        [
+            "trin",
+            "--network",
+            "mainnet",
+            "--portal-subnetworks",
+            HISTORY_NETWORK,
+            "--external-address",
+            external_addr.as_str(),
+            "--web3-ipc-path",
+            DEFAULT_WEB3_IPC_PATH,
+            "--ephemeral",
+            "--discovery-port",
+            test_discovery_port.to_string().as_ref(),
+            "--bootnodes",
+            "none",
+        ]
+        .iter(),
+    )
+    .unwrap();
+    let mainnet_handle = trin::run_trin(trin_config).await.unwrap();
+    let mainnet_target = reth_ipc::client::IpcClientBuilder::default()
+        .build(DEFAULT_WEB3_IPC_PATH)
+        .await
+        .unwrap();
+
+    peertest::scenarios::basic::test_ping_cross_network(
+        &mainnet_target,
+        &angelfood_peertest.bootnode,
+    )
+    .await;
+    angelfood_peertest.exit_all_nodes();
+    mainnet_handle.stop().unwrap();
 }
 
-async fn setup_peertest(network: &str) -> (peertest::Peertest, Client, RpcServerHandle) {
+async fn setup_peertest(
+    network: &str,
+    subnetworks: &[&str],
+) -> (peertest::Peertest, Client, RpcServerHandle) {
     utils::init_tracing();
+
+    let subnetworks = subnetworks.join(",");
+
     // Run a client, as a buddy peer for ping tests, etc.
-    let peertest = peertest::launch_peertest_nodes(2).await;
+    let peertest = peertest::launch_peertest_nodes(2, network, &subnetworks).await;
     // Short sleep to make sure all peertest nodes can connect
     sleep(Duration::from_millis(100)).await;
 
@@ -303,8 +353,10 @@ async fn setup_peertest(network: &str) -> (peertest::Peertest, Client, RpcServer
     let trin_config = TrinConfig::new_from(
         [
             "trin",
+            "--network",
+            network,
             "--portal-subnetworks",
-            "history,beacon,state",
+            subnetworks.as_str(),
             "--external-address",
             external_addr.as_str(),
             "--web3-ipc-path",
@@ -314,8 +366,6 @@ async fn setup_peertest(network: &str) -> (peertest::Peertest, Client, RpcServer
             test_discovery_port.to_string().as_ref(),
             "--bootnodes",
             "none",
-            "--network",
-            network,
         ]
         .iter(),
     )
@@ -329,10 +379,13 @@ async fn setup_peertest(network: &str) -> (peertest::Peertest, Client, RpcServer
     (peertest, target, test_client_rpc_handle)
 }
 
-async fn setup_peertest_bridge() -> (Peertest, HttpClient, RpcServerHandle) {
+async fn setup_peertest_bridge(subnetworks: &[&str]) -> (Peertest, HttpClient, RpcServerHandle) {
     utils::init_tracing();
+
+    let network = "mainnet";
+    let subnetworks = subnetworks.join(",");
     // Run a client, as a buddy peer for ping tests, etc.
-    let peertest = peertest::launch_peertest_nodes(1).await;
+    let peertest = peertest::launch_peertest_nodes(1, network, &subnetworks).await;
     // Short sleep to make sure all peertest nodes can connect
     sleep(Duration::from_millis(100)).await;
 
@@ -348,8 +401,10 @@ async fn setup_peertest_bridge() -> (Peertest, HttpClient, RpcServerHandle) {
     let trin_config = TrinConfig::new_from(
         [
             "trin",
+            "--network",
+            network,
             "--portal-subnetworks",
-            "history,beacon,state",
+            subnetworks.as_str(),
             "--external-address",
             external_addr.as_str(),
             // Run bridge test with http, since bridge doesn't support ipc yet.
@@ -377,7 +432,7 @@ async fn setup_peertest_bridge() -> (Peertest, HttpClient, RpcServerHandle) {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_history_bridge() {
-    let (peertest, target, handle) = setup_peertest_bridge().await;
+    let (peertest, target, handle) = setup_peertest_bridge(&[HISTORY_NETWORK]).await;
     peertest::scenarios::bridge::test_history_bridge(&peertest, &target).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -386,7 +441,7 @@ async fn peertest_history_bridge() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_beacon_bridge() {
-    let (peertest, target, handle) = setup_peertest_bridge().await;
+    let (peertest, target, handle) = setup_peertest_bridge(&[BEACON_NETWORK]).await;
     peertest::scenarios::bridge::test_beacon_bridge(&peertest, &target).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -31,7 +31,7 @@ use trin_storage::{
         LC_UPDATE_TOTAL_SIZE_QUERY, TOTAL_DATA_SIZE_QUERY_BEACON,
     },
     utils::get_total_size_of_directory_in_bytes,
-    ContentStore, DataSize, PortalStorageConfig, ShouldWeStoreContent, BYTES_IN_MB_U64,
+    ContentStore, DataSize, PortalStorageConfig, ShouldWeStoreContent,
 };
 
 /// Store ephemeral light client data in memory
@@ -137,7 +137,6 @@ impl BeaconStorageCache {
 pub struct BeaconStorage {
     node_data_dir: PathBuf,
     sql_connection_pool: Pool<SqliteConnectionManager>,
-    storage_capacity_in_bytes: u64,
     metrics: StorageMetricsReporter,
     cache: BeaconStorageCache,
 }
@@ -329,15 +328,9 @@ impl BeaconStorage {
         let storage = Self {
             node_data_dir: config.node_data_dir,
             sql_connection_pool: config.sql_connection_pool,
-            storage_capacity_in_bytes: config.storage_capacity_mb * BYTES_IN_MB_U64,
             metrics: StorageMetricsReporter::new(ProtocolId::Beacon),
             cache: BeaconStorageCache::new(),
         };
-
-        // Report current storage capacity.
-        storage
-            .metrics
-            .report_storage_capacity_bytes(storage.storage_capacity_in_bytes as f64);
 
         // Report current total storage usage.
         let total_storage_usage = storage.get_total_storage_usage_in_bytes_on_disk()?;

--- a/trin-storage/src/config.rs
+++ b/trin-storage/src/config.rs
@@ -7,6 +7,8 @@ use r2d2_sqlite::SqliteConnectionManager;
 
 use crate::{error::ContentStoreError, utils::setup_sql, DistanceFunction};
 
+const BYTES_IN_MB_U64: u64 = 1000 * 1000;
+
 /// Factory for creating [PortalStorageConfig] instances
 pub struct PortalStorageConfigFactory {
     node_id: NodeId,
@@ -18,7 +20,7 @@ pub struct PortalStorageConfigFactory {
 
 impl PortalStorageConfigFactory {
     const HISTORY_CAPACITY_WEIGHT: u64 = 1;
-    const STATE_CAPACITY_WEIGHT: u64 = 100;
+    const STATE_CAPACITY_WEIGHT: u64 = 99;
     const BEACON_CAPACITY_WEIGHT: u64 = 0; // Beacon doesn't care about given capacity
 
     pub fn new(
@@ -45,13 +47,13 @@ impl PortalStorageConfigFactory {
 
     pub fn create(&self, subnetwork: &str) -> PortalStorageConfig {
         let capacity_weight = Self::get_capacity_weight(subnetwork);
-        let capacity_mb = if self.total_capacity_weight == 0 {
+        let capacity_bytes = if self.total_capacity_weight == 0 {
             0
         } else {
-            self.total_capacity_mb * capacity_weight / self.total_capacity_weight
+            BYTES_IN_MB_U64 * self.total_capacity_mb * capacity_weight / self.total_capacity_weight
         };
         PortalStorageConfig {
-            storage_capacity_mb: capacity_mb,
+            storage_capacity_bytes: capacity_bytes,
             node_id: self.node_id,
             node_data_dir: self.node_data_dir.clone(),
             distance_fn: DistanceFunction::Xor,
@@ -71,7 +73,7 @@ impl PortalStorageConfigFactory {
 
 #[derive(Clone)]
 pub struct PortalStorageConfig {
-    pub storage_capacity_mb: u64,
+    pub storage_capacity_bytes: u64,
     pub node_id: NodeId,
     pub node_data_dir: PathBuf,
     pub distance_fn: DistanceFunction,

--- a/trin-storage/src/config.rs
+++ b/trin-storage/src/config.rs
@@ -1,0 +1,79 @@
+use std::path::PathBuf;
+
+use discv5::enr::NodeId;
+use ethportal_api::types::cli::{BEACON_NETWORK, HISTORY_NETWORK, STATE_NETWORK};
+use r2d2::Pool;
+use r2d2_sqlite::SqliteConnectionManager;
+
+use crate::{error::ContentStoreError, utils::setup_sql, DistanceFunction};
+
+/// Factory for creating [PortalStorageConfig] instances
+pub struct PortalStorageConfigFactory {
+    node_id: NodeId,
+    node_data_dir: PathBuf,
+    total_capacity_mb: u64,
+    total_capacity_weight: u64,
+    sql_connection_pool: Pool<SqliteConnectionManager>,
+}
+
+impl PortalStorageConfigFactory {
+    const HISTORY_CAPACITY_WEIGHT: u64 = 1;
+    const STATE_CAPACITY_WEIGHT: u64 = 100;
+    const BEACON_CAPACITY_WEIGHT: u64 = 0; // Beacon doesn't care about given capacity
+
+    pub fn new(
+        total_capacity_mb: u64,
+        subnetworks: &[String],
+        node_id: NodeId,
+        node_data_dir: PathBuf,
+    ) -> Result<Self, ContentStoreError> {
+        let total_capacity_weight = subnetworks
+            .iter()
+            .map(|subnetwork| Self::get_capacity_weight(subnetwork))
+            .sum();
+
+        let sql_connection_pool = setup_sql(&node_data_dir)?;
+
+        Ok(Self {
+            node_data_dir,
+            node_id,
+            total_capacity_mb,
+            total_capacity_weight,
+            sql_connection_pool,
+        })
+    }
+
+    pub fn create(&self, subnetwork: &str) -> PortalStorageConfig {
+        let capacity_weight = Self::get_capacity_weight(subnetwork);
+        let capacity_mb = if self.total_capacity_weight == 0 {
+            0
+        } else {
+            self.total_capacity_mb * capacity_weight / self.total_capacity_weight
+        };
+        PortalStorageConfig {
+            storage_capacity_mb: capacity_mb,
+            node_id: self.node_id,
+            node_data_dir: self.node_data_dir.clone(),
+            distance_fn: DistanceFunction::Xor,
+            sql_connection_pool: self.sql_connection_pool.clone(),
+        }
+    }
+
+    fn get_capacity_weight(subnetwork: &str) -> u64 {
+        match subnetwork {
+            HISTORY_NETWORK => Self::HISTORY_CAPACITY_WEIGHT,
+            STATE_NETWORK => Self::STATE_CAPACITY_WEIGHT,
+            BEACON_NETWORK => Self::BEACON_CAPACITY_WEIGHT,
+            _ => panic!("Invalid subnetwork: {subnetwork}"),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct PortalStorageConfig {
+    pub storage_capacity_mb: u64,
+    pub node_id: NodeId,
+    pub node_data_dir: PathBuf,
+    pub distance_fn: DistanceFunction,
+    pub sql_connection_pool: Pool<SqliteConnectionManager>,
+}

--- a/trin-storage/src/lib.rs
+++ b/trin-storage/src/lib.rs
@@ -1,10 +1,10 @@
+pub mod config;
 pub mod error;
 pub mod sql;
 pub mod test_utils;
 pub mod utils;
 pub mod versioned;
 
-use crate::utils::setup_sql;
 use alloy_primitives::B256;
 use discv5::enr::NodeId;
 use error::ContentStoreError;
@@ -12,10 +12,10 @@ use ethportal_api::types::{
     content_key::overlay::{IdentityContentKey, OverlayContentKey},
     distance::{Distance, Metric, XorMetric},
 };
-use r2d2::Pool;
-use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::types::{FromSql, FromSqlError, ValueRef};
-use std::{ops::Deref, path::PathBuf, str::FromStr};
+use std::{ops::Deref, str::FromStr};
+
+pub use config::{PortalStorageConfig, PortalStorageConfigFactory};
 
 pub const DATABASE_NAME: &str = "trin.sqlite";
 pub const BYTES_IN_MB_U64: u64 = 1000 * 1000;
@@ -150,33 +150,6 @@ impl ContentStore for MemoryContentStore {
 
     fn radius(&self) -> Distance {
         self.radius
-    }
-}
-
-/// Struct for configuring a `PortalStorage` instance.
-#[derive(Clone)]
-pub struct PortalStorageConfig {
-    pub storage_capacity_mb: u64,
-    pub node_id: NodeId,
-    pub node_data_dir: PathBuf,
-    pub distance_fn: DistanceFunction,
-    pub sql_connection_pool: Pool<SqliteConnectionManager>,
-}
-
-impl PortalStorageConfig {
-    pub fn new(
-        storage_capacity_mb: u64,
-        node_data_dir: PathBuf,
-        node_id: NodeId,
-    ) -> Result<Self, ContentStoreError> {
-        let sql_connection_pool = setup_sql(&node_data_dir)?;
-        Ok(Self {
-            storage_capacity_mb,
-            node_id,
-            node_data_dir,
-            distance_fn: DistanceFunction::Xor,
-            sql_connection_pool,
-        })
     }
 }
 

--- a/trin-storage/src/lib.rs
+++ b/trin-storage/src/lib.rs
@@ -18,7 +18,6 @@ use std::{ops::Deref, str::FromStr};
 pub use config::{PortalStorageConfig, PortalStorageConfigFactory};
 
 pub const DATABASE_NAME: &str = "trin.sqlite";
-pub const BYTES_IN_MB_U64: u64 = 1000 * 1000;
 
 // TODO: Replace enum with generic type parameter. This will require that we have a way to
 // associate a "find farthest" query with the generic Metric.

--- a/trin-storage/src/test_utils.rs
+++ b/trin-storage/src/test_utils.rs
@@ -1,15 +1,22 @@
 use discv5::enr::NodeId;
+use ethportal_api::types::cli::HISTORY_NETWORK;
 use tempfile::TempDir;
 
-use crate::{error::ContentStoreError, PortalStorageConfig};
+use crate::{error::ContentStoreError, PortalStorageConfig, PortalStorageConfigFactory};
 
 /// Creates temporary directory and PortalStorageConfig.
 pub fn create_test_portal_storage_config_with_capacity(
     capacity_mb: u64,
 ) -> Result<(TempDir, PortalStorageConfig), ContentStoreError> {
     let temp_dir = TempDir::new()?;
-    let config =
-        PortalStorageConfig::new(capacity_mb, temp_dir.path().to_path_buf(), NodeId::random())?;
+    let config = PortalStorageConfigFactory::new(
+        capacity_mb,
+        &[HISTORY_NETWORK.to_string()],
+        NodeId::random(),
+        temp_dir.path().to_path_buf(),
+    )
+    .unwrap()
+    .create(HISTORY_NETWORK);
     Ok((temp_dir, config))
 }
 

--- a/trin-storage/src/versioned/id_indexed_v1/config.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/config.rs
@@ -5,7 +5,7 @@ use ethportal_api::types::portal_wire::ProtocolId;
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 
-use crate::{versioned::ContentType, DistanceFunction, PortalStorageConfig, BYTES_IN_MB_U64};
+use crate::{versioned::ContentType, DistanceFunction, PortalStorageConfig};
 
 use super::pruning_strategy::PruningConfig;
 
@@ -33,7 +33,7 @@ impl IdIndexedV1StoreConfig {
             network,
             node_id: config.node_id,
             node_data_dir: config.node_data_dir,
-            storage_capacity_bytes: config.storage_capacity_mb * BYTES_IN_MB_U64,
+            storage_capacity_bytes: config.storage_capacity_bytes,
             sql_connection_pool: config.sql_connection_pool,
             distance_fn: config.distance_fn,
             // consider making this a parameter if we start using non-default value


### PR DESCRIPTION
### What was wrong?

Currently, we only have one flag to setting storage capacity that applies to each subnetwork separately. See #1387 for more info.

### How was it fixed?

As discussed in the meeting, we will use predefined weight per subnetwork (for the short/medium term).

I put following weights as a placeholder. Let me know if you have other suggestions:
- history: 1
- state: 99
- beacon: 0 (beacon doesn't use capacity in any meaningful way (in only reports it to the metrics). 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
