### PR TITLE
feat(portal-bridge(beacon)): generate and gossip `HistoricalSummariesWithProof` content

### DIFF
--- a/ethportal-api/src/types/consensus/beacon_state.rs
+++ b/ethportal-api/src/types/consensus/beacon_state.rs
@@ -64,6 +64,7 @@ pub struct BeaconState {
     #[superstruct(getter(copy))]
     pub genesis_validators_root: B256,
     #[superstruct(getter(copy))]
+    #[serde(deserialize_with = "as_u64")]
     pub slot: u64,
     #[superstruct(getter(copy))]
     pub fork: Fork,
@@ -84,12 +85,14 @@ pub struct BeaconState {
 
     // Registry
     pub validators: VariableList<Validator, ValidatorRegistryLimit>,
+    #[serde(deserialize_with = "ssz_types::serde_utils::quoted_u64_var_list::deserialize")]
     pub balances: VariableList<u64, ValidatorRegistryLimit>,
 
     // Randomness
     pub randao_mixes: FixedVector<B256, EpochsPerHistoricalVector>,
 
     // Slashings
+    #[serde(deserialize_with = "ssz_types::serde_utils::quoted_u64_fixed_vec::deserialize")]
     pub slashings: FixedVector<u64, EpochsPerSlashingsVector>,
 
     // Participation (Altair and later)
@@ -109,6 +112,7 @@ pub struct BeaconState {
 
     // Inactivity
     #[superstruct(only(Bellatrix, Capella, Deneb))]
+    #[serde(deserialize_with = "ssz_types::serde_utils::quoted_u64_var_list::deserialize")]
     pub inactivity_scores: VariableList<u64, ValidatorRegistryLimit>,
 
     // Light-client sync committees
@@ -366,9 +370,7 @@ mod test {
             "../test_assets/beacon/bellatrix/BeaconState/ssz_random/{case}/value.yaml"
         ))
         .expect("cannot find test asset");
-        let value: Value = serde_yaml::from_str(&value).unwrap();
-        let content: BeaconStateBellatrix = serde_json::from_value(value).unwrap();
-
+        let content: BeaconStateBellatrix = serde_yaml::from_str(&value).unwrap();
         let compressed = std::fs::read(format!(
             "../test_assets/beacon/bellatrix/BeaconState/ssz_random/{case}/serialized.ssz_snappy"
         ))
@@ -401,9 +403,7 @@ mod test {
             "../test_assets/beacon/capella/BeaconState/ssz_random/{case}/value.yaml"
         ))
         .expect("cannot find test asset");
-        let value: Value = serde_yaml::from_str(&value).unwrap();
-        let content: BeaconStateCapella = serde_json::from_value(value).unwrap();
-
+        let content: BeaconStateCapella = serde_yaml::from_str(&value).unwrap();
         let compressed = std::fs::read(format!(
             "../test_assets/beacon/capella/BeaconState/ssz_random/{case}/serialized.ssz_snappy"
         ))
@@ -432,8 +432,13 @@ mod test {
             "../test_assets/beacon/deneb/BeaconState/ssz_random/case_0/value.yaml",
         )
         .expect("cannot find test asset");
-        let value: Value = serde_yaml::from_str(&value).unwrap();
-        let content: BeaconStateDeneb = serde_json::from_value(value).unwrap();
+        let content: BeaconStateDeneb = serde_yaml::from_str(&value).unwrap();
+        let pandaops_value = std::fs::read_to_string(
+            "../test_assets/beacon/deneb/BeaconState/ssz_random/case_0/pandaops_value.yaml",
+        )
+        .expect("cannot find test asset");
+        let pandaops_content: BeaconStateDeneb = serde_yaml::from_str(&pandaops_value).unwrap();
+        assert_eq!(content, pandaops_content);
 
         let compressed = std::fs::read(
             "../test_assets/beacon/deneb/BeaconState/ssz_random/case_0/serialized.ssz_snappy",
@@ -467,9 +472,7 @@ mod test {
             "../test_assets/beacon/bellatrix/HistoricalBatch/ssz_random/{case}/value.yaml"
         ))
         .expect("cannot find test asset");
-        let value: Value = serde_yaml::from_str(&value).unwrap();
-        let content: HistoricalBatch = serde_json::from_value(value).unwrap();
-
+        let content: HistoricalBatch = serde_yaml::from_str(&value).unwrap();
         let compressed = std::fs::read(format!(
             "../test_assets/beacon/bellatrix/HistoricalBatch/ssz_random/{case}/serialized.ssz_snappy"
         ))
@@ -486,9 +489,7 @@ mod test {
             "../test_assets/beacon/bellatrix/HistoricalBatch/ssz_random/case_0/value.yaml",
         )
         .expect("cannot find test asset");
-        let value: Value = serde_yaml::from_str(&value).unwrap();
-        let content: HistoricalBatch = serde_json::from_value(value).unwrap();
-
+        let content: HistoricalBatch = serde_yaml::from_str(&value).unwrap();
         let expected_proof = [
             "0xad500369fa624b7bb451bf1c5119bb6e5e623bab76a0d06948d04a38f35a740d",
             "0x222151dcdfbace03dd6f2428ee1a12acffaa1ce03e6966aefd4a48282a776e8e",
@@ -519,8 +520,7 @@ mod test {
             "../test_assets/beacon/deneb/BeaconState/ssz_random/case_0/value.yaml",
         )
         .expect("cannot find test asset");
-        let value: Value = serde_yaml::from_str(&value).unwrap();
-        let beacon_state: BeaconStateDeneb = serde_json::from_value(value).unwrap();
+        let beacon_state: BeaconStateDeneb = serde_yaml::from_str(&value).unwrap();
         let historical_summaries_proof = beacon_state.build_historical_summaries_proof();
         assert_eq!(historical_summaries_proof.len(), 5);
     }

--- a/ethportal-api/src/types/consensus/body.rs
+++ b/ethportal-api/src/types/consensus/body.rs
@@ -213,6 +213,7 @@ pub struct VoluntaryExit {
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize, Decode, Encode, TreeHash)]
 pub struct Eth1Data {
     pub deposit_root: B256,
+    #[serde(deserialize_with = "as_u64")]
     pub deposit_count: u64,
     pub block_hash: B256,
 }

--- a/ethportal-api/src/types/consensus/participation_flags.rs
+++ b/ethportal-api/src/types/consensus/participation_flags.rs
@@ -6,6 +6,7 @@ use tree_hash::{Hash256, PackedEncoding, TreeHash, TreeHashType};
 #[derive(Debug, Default, Clone, Copy, PartialEq, Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct ParticipationFlags {
+    #[serde(deserialize_with = "serde_utils::quoted_u8::deserialize")]
     bits: u8,
 }
 

--- a/portal-bridge/src/api/consensus.rs
+++ b/portal-bridge/src/api/consensus.rs
@@ -30,6 +30,18 @@ impl ConsensusApi {
         Ok(Self { primary, fallback })
     }
 
+    /// Requests the `BeaconState` structure corresponding to the current head of the beacon chain.
+    pub async fn get_beacon_state(&self) -> anyhow::Result<String> {
+        let endpoint = "/eth/v2/debug/beacon/states/finalized".to_string();
+        self.request(endpoint).await
+    }
+
+    /// Request the finalized root of the beacon state.
+    pub async fn get_beacon_state_finalized_root(&self) -> anyhow::Result<String> {
+        let endpoint = "/eth/v1/beacon/states/finalized/root".to_string();
+        self.request(endpoint).await
+    }
+
     /// Requests the `LightClientBootstrap` structure corresponding to a given post-Altair beacon
     /// block root.
     pub async fn get_lc_bootstrap<S: AsRef<str> + Display>(

--- a/portal-bridge/src/lib.rs
+++ b/portal-bridge/src/lib.rs
@@ -23,5 +23,5 @@ pub const DEFAULT_BASE_EL_ENDPOINT: &str = "https://geth-lighthouse.mainnet.eu1.
 pub const FALLBACK_BASE_EL_ENDPOINT: &str = "https://geth-lighthouse.mainnet.eu1.ethpandaops.io/";
 /// Consensus layer PandaOps endpoint
 /// We use Nimbus as the CL client, because it supports light client data by default.
-pub const DEFAULT_BASE_CL_ENDPOINT: &str = "https://nimbus.mainnet.eu1.ethpandaops.io/";
-pub const FALLBACK_BASE_CL_ENDPOINT: &str = "https://nimbus.mainnet.eu1.ethpandaops.io/";
+pub const DEFAULT_BASE_CL_ENDPOINT: &str = "https://nimbus-geth.mainnet.eu1.ethpandaops.io/";
+pub const FALLBACK_BASE_CL_ENDPOINT: &str = "https://nimbus.mainnet.na1.ethpandaops.io/";

--- a/portal-bridge/src/stats.rs
+++ b/portal-bridge/src/stats.rs
@@ -51,6 +51,12 @@ impl StatsReporter<BeaconContentKey> for BeaconSlotStats {
             info!("GossipReport: slot#{slot_number} - optimistic_update - {stats}");
             debug!("GossipReport: slot#{slot_number} - optimistic_update - {stats:?}");
         }
+        if let Some(stats) = &self.historical_summaries_with_proof {
+            info!("GossipReport: slot#{slot_number} - historical_summaries_with_proof - {stats}");
+            debug!(
+                "GossipReport: slot#{slot_number} - historical_summaries_with_proof - {stats:?}"
+            );
+        }
     }
 
     fn update(&mut self, content_key: BeaconContentKey, results: ContentStats) {


### PR DESCRIPTION
### What was wrong?

Fixes #1365.

### How was it fixed?
1. Add logic to generate and gossip `HistoricalSummariesWithProof`  to the beacon network.
2. Refactor how we spawn the tokio tasks to generate the beacon content in every slot. An issue was blocking the main loop if some of the tasks took longer to complete.
3. Add some improvements to the BeaconState's deserializations from JSON strings. This was required to successfully deserialize the JSON responses from the pandaops node. Test asset was added to match the pandaops format.
4. Update main and fallback consensus API endpoints (We are bypassing the load balancer on the main endpoint because there are some issues with it).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
