### PR TITLE
fix(state-bridge): storage trie changes weren't being gossiped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2389,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "eth_trie"
 version = "0.4.0"
-source = "git+https://github.com/kolbyml/eth-trie.rs.git?rev=7e57d3dfadee126cc9fda2696fb039bf7b6ed688#7e57d3dfadee126cc9fda2696fb039bf7b6ed688"
+source = "git+https://github.com/kolbyml/eth-trie.rs.git?rev=7947a83091192a7988f359b750b05121d5d7ba8c#7947a83091192a7988f359b750b05121d5d7ba8c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -22,7 +22,7 @@ const_format = {version = "0.2.0", features = ["rust_1_64"]}
 c-kzg = "1.0.0"
 discv5 = { version = "0.4.1", features = ["serde"] }
 ethereum_hashing = "0.6.0"
-eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "7e57d3dfadee126cc9fda2696fb039bf7b6ed688" }
+eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "7947a83091192a7988f359b750b05121d5d7ba8c" }
 ethereum_serde_utils = "0.5.2"
 ethereum_ssz = "0.5.3"
 ethereum_ssz_derive = "0.5.3"

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "4.2.1", features = ["derive"] }
 discv5 = { version = "0.4.1", features = ["serde"] }
 ethereum_ssz = "0.5.3"
 ethportal-api = { path = "../ethportal-api" }
-eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "7e57d3dfadee126cc9fda2696fb039bf7b6ed688" }
+eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "7947a83091192a7988f359b750b05121d5d7ba8c" }
 e2store = { path = "../e2store" }
 futures = "0.3.21"
 jsonrpsee = { version = "0.20.0", features = [

--- a/portal-bridge/src/bridge/state.rs
+++ b/portal-bridge/src/bridge/state.rs
@@ -191,9 +191,7 @@ impl StateBridge {
                 }
 
                 // gossip contract storage
-                let storage_changed_nodes = state
-                    .database
-                    .get_storage_trie_diff(account.storage_root, address_hash);
+                let storage_changed_nodes = state.database.get_storage_trie_diff(address_hash);
 
                 let storage_walk_diff =
                     TrieWalker::new(account.storage_root, storage_changed_nodes);

--- a/portal-bridge/src/bridge/state.rs
+++ b/portal-bridge/src/bridge/state.rs
@@ -168,11 +168,6 @@ impl StateBridge {
                 };
                 let account: AccountStateInfo = Decodable::decode(&mut leaf.value.as_slice())?;
 
-                // if the code_hash is empty then it isn't a contract so we can skip it
-                if account.code_hash == keccak256([]) {
-                    continue;
-                }
-
                 // reconstruct the address hash from the path so that we can fetch the
                 // address from the database
                 let mut partial_key_path = leaf.key.get_data().to_vec();
@@ -181,19 +176,24 @@ impl StateBridge {
                     [&account_proof.path.clone(), partial_key_path.as_slice()].concat();
                 let address_hash = full_nibble_path_to_address_hash(&full_key_path);
 
-                // gossip contract bytecode
-                let code = state.database.code_by_hash_ref(account.code_hash)?;
-                self.gossip_contract_bytecode(
-                    address_hash,
-                    &account_proof,
-                    block_tuple.header.header.hash(),
-                    account.code_hash,
-                    code,
-                )
-                .await?;
+                // if the code_hash is empty then then don't try to gossip the contract bytecode
+                if account.code_hash != keccak256([]) {
+                    // gossip contract bytecode
+                    let code = state.database.code_by_hash_ref(account.code_hash)?;
+                    self.gossip_contract_bytecode(
+                        address_hash,
+                        &account_proof,
+                        block_tuple.header.header.hash(),
+                        account.code_hash,
+                        code,
+                    )
+                    .await?;
+                }
 
                 // gossip contract storage
-                let storage_changed_nodes = state.database.get_storage_trie_diff(address_hash);
+                let storage_changed_nodes = state
+                    .database
+                    .get_storage_trie_diff(account.storage_root, address_hash);
 
                 let storage_walk_diff =
                     TrieWalker::new(account.storage_root, storage_changed_nodes);
@@ -209,6 +209,7 @@ impl StateBridge {
                     .await?;
                 }
             }
+
             // flush the database cache
             // This is used for gossiping storage trie diffs
             state.database.storage_cache.clear();

--- a/trin-execution/Cargo.toml
+++ b/trin-execution/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "4.2.1", features = ["derive"] }
 directories = "3.0"
 ethportal-api = { path = "../ethportal-api" }
 e2store = { path = "../e2store" }
-eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "7e57d3dfadee126cc9fda2696fb039bf7b6ed688" }
+eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "7947a83091192a7988f359b750b05121d5d7ba8c" }
 hashbrown = "0.14.0"
 lazy_static = "1.4.0"
 parking_lot = "0.11.2"

--- a/trin-execution/src/content.rs
+++ b/trin-execution/src/content.rs
@@ -56,7 +56,7 @@ pub fn create_contract_content_value(
     Ok(StateContentValue::ContractBytecodeWithProof(
         ContractBytecodeWithProof {
             block_hash,
-            code: code.bytecode.to_vec().into(),
+            code: code.original_bytes().to_vec().into(),
             account_proof: account_proof.into(),
         },
     ))

--- a/trin-execution/src/storage/account_db.rs
+++ b/trin-execution/src/storage/account_db.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use alloy_primitives::{keccak256, Address, B256};
+use alloy_primitives::{keccak256, B256};
 use eth_trie::DB;
 use rocksdb::DB as RocksDB;
 
@@ -16,11 +16,8 @@ pub struct AccountDB {
 }
 
 impl AccountDB {
-    pub fn new(address: Address, db: Arc<RocksDB>) -> Self {
-        Self {
-            address_hash: keccak256(address),
-            db,
-        }
+    pub fn new(address_hash: B256, db: Arc<RocksDB>) -> Self {
+        Self { address_hash, db }
     }
 
     fn get_db_key(&self, key: &[u8]) -> Vec<u8> {
@@ -72,7 +69,7 @@ mod test_account_db {
     #[test]
     fn test_account_db_get() {
         let rocksdb = setup_rocksdb(setup_temp_dir().unwrap().into_path()).unwrap();
-        let accdb = AccountDB::new(Address::ZERO, Arc::new(rocksdb));
+        let accdb = AccountDB::new(B256::ZERO, Arc::new(rocksdb));
         accdb
             .insert(keccak256(b"test-key").as_slice(), b"test-value".to_vec())
             .unwrap();
@@ -86,7 +83,7 @@ mod test_account_db {
     #[test]
     fn test_account_db_remove() {
         let rocksdb = setup_rocksdb(setup_temp_dir().unwrap().into_path()).unwrap();
-        let accdb = AccountDB::new(Address::ZERO, Arc::new(rocksdb));
+        let accdb = AccountDB::new(B256::ZERO, Arc::new(rocksdb));
         accdb
             .insert(keccak256(b"test").as_slice(), b"test".to_vec())
             .unwrap();

--- a/trin-execution/src/storage/evm_db.rs
+++ b/trin-execution/src/storage/evm_db.rs
@@ -4,7 +4,7 @@ use crate::{config::StateConfig, storage::error::EVMError};
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_primitives::{Address, B256, U256};
 use alloy_rlp::{Decodable, EMPTY_STRING_CODE};
-use eth_trie::{EthTrie, RootWithTrieDiff, Trie, DB};
+use eth_trie::{EthTrie, RootWithTrieDiff, Trie};
 use ethportal_api::{
     types::state_trie::account_state::AccountState as AccountStateInfo, utils::bytes::hex_encode,
 };
@@ -86,29 +86,22 @@ impl EvmDB {
         }
     }
 
-    pub fn get_storage_trie_diff(
-        &self,
-        storage_root: B256,
-        address_hash: B256,
-    ) -> BrownHashMap<B256, Vec<u8>> {
+    pub fn get_storage_trie_diff(&self, address_hash: B256) -> BrownHashMap<B256, Vec<u8>> {
         let mut trie_diff = BrownHashMap::new();
-
-        let account_db = AccountDB::new(address_hash, self.db.clone());
-        let trie = if storage_root == keccak256([EMPTY_STRING_CODE]) {
-            EthTrie::new(Arc::new(account_db))
-        } else {
-            EthTrie::from(Arc::new(account_db), storage_root)
-                .expect("Creating trie should never fail")
-        };
 
         for key in self
             .storage_cache
             .get(&address_hash)
             .unwrap_or(&HashSet::new())
         {
-            let value = trie
+            // storage trie keys are prefixed with the address hash in the database
+            let value = self
                 .db
-                .get(key.as_slice())
+                .get(
+                    [address_hash.as_slice(), key.as_slice()]
+                        .concat()
+                        .as_slice(),
+                )
                 .expect("Getting storage value should never fail");
 
             if let Some(raw_value) = value {

--- a/trin-execution/src/trie_walker.rs
+++ b/trin-execution/src/trie_walker.rs
@@ -39,8 +39,10 @@ pub struct TrieWalker {
 impl TrieWalker {
     pub fn new(root_hash: B256, nodes: BrownHashMap<B256, Vec<u8>>) -> Self {
         // if the storage root is empty then there is no storage to gossip
-        if root_hash == keccak256([EMPTY_STRING_CODE]) && !nodes.is_empty() {
-            panic!("Root hash is empty but there are nodes to gossip. This should never happen.");
+        if root_hash == keccak256([EMPTY_STRING_CODE]) {
+            return Self {
+                nodes: BrownHashMap::new(),
+            };
         }
 
         if nodes.is_empty() {

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -15,7 +15,7 @@ alloy-primitives = { version = "0.7.0", features = ["getrandom"] }
 alloy-rlp = "0.3.4"
 anyhow = "1.0.68"
 discv5 = { version = "0.4.1", features = ["serde"] }
-eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "7e57d3dfadee126cc9fda2696fb039bf7b6ed688" }
+eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "7947a83091192a7988f359b750b05121d5d7ba8c" }
 ethportal-api = { path = "../ethportal-api" }
 keccak-hash = "0.10.0"
 parking_lot = "0.11.2"


### PR DESCRIPTION
### What was wrong?
Storage trie changes weren't being gossiped due to fetching the storage trie diff code being incorrect.

There was also another problem apparently early on in Ethereum Storage could be modified well "creating" a new contract without changing the contracts code
### How was it fixed?

- if the contract is empty don't skip gossiping storage trie changes
- correctly fetch storage trie nodes from the database

