### PR TITLE
Continue the RecursiveFindContent query until the uTP transfer is complete and the content is validated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,6 +1561,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4519,6 +4528,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
+ "crossbeam-channel",
  "delay_map 0.4.0",
  "directories",
  "discv5",

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -15,6 +15,7 @@ alloy-primitives.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
+crossbeam-channel = "0.5.13"
 delay_map.workspace = true
 directories.workspace = true
 discv5.workspace = true

--- a/portalnet/src/find/iterators/query.rs
+++ b/portalnet/src/find/iterators/query.rs
@@ -70,6 +70,9 @@ pub trait Query<TNodeId> {
     /// The type of the result produced by the query.
     type Result;
 
+    /// The type of a pending result that is waiting for validation.
+    type PendingValidationResult;
+
     /// Returns the target of the query.
     fn target(&self) -> Key<TNodeId>;
 
@@ -110,6 +113,10 @@ pub trait Query<TNodeId> {
 
     /// Consumes the query, returning the result.
     fn into_result(self) -> Self::Result;
+
+    /// Returns a result that is waiting for validation. The attached peer is used to look up which
+    /// pending result to return.
+    fn pending_validation_result(&self, sending_peer: TNodeId) -> Self::PendingValidationResult;
 }
 
 /// Stage of the query.

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -154,6 +154,7 @@ async fn recursive_find_content(
             let local_enr = network.overlay.local_enr();
             let mut trace = QueryTrace::new(&network.overlay.local_enr(), content_key.content_id());
             trace.node_responded_with_content(&local_enr);
+            trace.content_validated(local_enr.into());
             (val, false, if is_trace { Some(trace) } else { None })
         }
         // data is not available locally, make network request

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -115,6 +115,7 @@ async fn recursive_find_content(
             let local_enr = network.overlay.local_enr();
             let mut trace = QueryTrace::new(&network.overlay.local_enr(), content_key.content_id());
             trace.node_responded_with_content(&local_enr);
+            trace.content_validated(local_enr.into());
             (val, false, if is_trace { Some(trace) } else { None })
         }
         // data is not available locally, make network request

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -235,6 +235,7 @@ async fn recursive_find_content(
                 let local_enr = network.overlay.local_enr();
                 let mut trace = QueryTrace::new(&local_enr, content_key.content_id());
                 trace.node_responded_with_content(&local_enr);
+                trace.content_validated(local_enr.into());
                 Some(trace)
             } else {
                 None


### PR DESCRIPTION
### What was wrong?

Work toward #1383 

### How was it fixed?

This PR *will* delay completion of RFC until data is validated, but will *not* continue the search with other peers. I decided it was getting too big. I will do the follow-up work in another PR.

There are quite a few moving parts here, so the goal was to minimize the
number of functional changes in this refactor.

Overall: add a new query state for while the content is being validated.
Don't exit the query until validation is complete.

Some other changes along the way:

#### Moving the bigendian conversion of connection ID

Note that when handling the FindContentQueryResponse::ConnectionId in
findcontent.rs, we don't do the bigendian conversion anymore. That has
been moved to earlier in the process, when handling the Content message,
to reduce the number of places that the conversion needs to be handled.

#### The query trace has slightly different end-stage behavior

The received_from peer and the cancelled peers are not set in the query
until the content gets validated.

#### Naturally, tests need to reflect the new query structure

For example:
- the query trace test needs to have the content be marked validated to
  progress
- update overlay service tests to use new Validating query step
- immediately mark content as verified, after marking it as received,
  during the test

#### bugfix: the content search continues even if many peers don't have it

Formerly, the content query would exit out if too many peers replied
successfully (even if the responses were just more nodes to look up).

Best we can tell, the limit on the number of maximum results is
copy-pasta from the recursive-find-nodes logic. (Confirmation from
Mike)

Now, the query continues until the content is found. It doesn't track
the number of successful responses at all.

(Perhaps worth noting that tests fail without this last change. I didn't look that hard into why they weren't failing before)

### Refactor

At first, I was trying to change as little as possible. That meant that I kind of shoe-horned the pending result into the Query::Result enum. It works, but is ugly, because of having to handle the pending results in some logic, and the final results in other logic. 

So e0e54378 goes a little further and adds a new Pending result enum. It still leaves us with some assertions that certain code paths should be unreachable, but I don't see any better alternatives. I explored another Query trait type, but it required duplicating too much of `query_event_poll` logic. So I landed on this approach, largely implemented by @morph-dev 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] trin compiles locally
- [x] Manual gut-check that RFC still works on the happy path (when this PR was first opened, it did not yet)
  - [x] always delay Finished until validation succeeds (previously it was exploring all nodes, then exiting immediately)
  - [x] Fix uTP transfer. I seem to have broken it, because it never connects successfully now. Last I checked, it was still working fine on master
- [x] Constrain active number of downloads/validations to 1
  - [x] hacky version that only allows one concurrent
  - [x] stop querying peers for content when there are active validations
  - [x] move the follow-ups to the tracking issue
- [x] Tests
  - [x] ethportal-api
  - [x] overlay service
  - [x] findcontent
  - [x] findnodes
  - [x] peertest
- [x] The FindContent queries shouldn't have a maximum number of results, it should just run till completion. In findcontent.rs, see `if *count >= self.config.num_results {`
- [x] Rebase on #1447 
  - [x] after 1447 tests pass
  - [x] after merge
- [x] After addressing PR feedback, clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
