### PR TITLE
fix: trie_walker shouldn't assume that all nodes are useful

### DIFF
--- a/trin-execution/src/trie_walker.rs
+++ b/trin-execution/src/trie_walker.rs
@@ -2,7 +2,6 @@ use std::collections::VecDeque;
 
 use alloy_primitives::B256;
 use alloy_rlp::EMPTY_STRING_CODE;
-use anyhow::ensure;
 use eth_trie::{decode_node, node::Node};
 use hashbrown::HashMap as BrownHashMap;
 use revm_primitives::keccak256;
@@ -135,9 +134,6 @@ impl TrieWalker {
                 _ => {}
             }
         }
-
-        // Ensure we discovered all nodes (root is not present in the trie_walker_nodes)
-        ensure!(nodes.len() == trie_walker_nodes.len(), "We expect the node length and trie_walker_nodes length to be the same, as we should have discovered all nodes in the trie. If this fails it implies an invalid trie was provided with an unnavigable path.");
 
         Ok(trie_walker_nodes)
     }

--- a/trin-execution/tests/content_generation.rs
+++ b/trin-execution/tests/content_generation.rs
@@ -23,8 +23,15 @@ use trin_execution::{
     utils::full_nibble_path_to_address_hash,
 };
 
-// This test is variable and configurable by settings `blocks`
-// The time the test takes to run is dependent on the value of `blocks`
+/// Tests that we can execute and generate content up to a specified block.
+///
+/// The block is specified manually by set `blocks` variable.
+///
+/// Following command should be used for running:
+///
+/// ```
+/// cargo test -p trin-execution --test content_generation -- --include-ignored --nocapture
+/// ```
 #[tokio::test]
 #[traced_test]
 #[ignore = "takes too long"]

--- a/trin-execution/tests/content_generation.rs
+++ b/trin-execution/tests/content_generation.rs
@@ -1,0 +1,155 @@
+use alloy_rlp::Decodable;
+use anyhow::{anyhow, ensure, Result};
+use e2store::{
+    era1::{Era1, BLOCK_TUPLE_COUNT},
+    utils::get_shuffled_era1_files,
+};
+use eth_trie::{decode_node, node::Node, RootWithTrieDiff};
+use ethportal_api::types::state_trie::account_state::AccountState;
+use revm::DatabaseRef;
+use revm_primitives::keccak256;
+use surf::{Client, Config};
+use tracing_test::traced_test;
+use trin_execution::{
+    config::StateConfig,
+    content::{
+        create_account_content_key, create_account_content_value, create_contract_content_key,
+        create_contract_content_value, create_storage_content_key, create_storage_content_value,
+    },
+    execution::State,
+    storage::utils::setup_temp_dir,
+    trie_walker::TrieWalker,
+    types::block_to_trace::BlockToTrace,
+    utils::full_nibble_path_to_address_hash,
+};
+
+// This test is variable and configurable by settings `blocks`
+// The time the test takes to run is dependent on the value of `blocks`
+#[tokio::test]
+#[traced_test]
+#[ignore = "takes too long"]
+async fn test_we_can_generate_content_key_values_up_to_x() -> Result<()> {
+    // set last block to test for
+    let blocks = 1_000_000;
+
+    let http_client: Client = Config::new()
+        .add_header("Content-Type", "application/xml")
+        .expect("to be able to add header")
+        .try_into()?;
+
+    let era1_files = get_shuffled_era1_files(&http_client).await?;
+    let mut era1 = get_era1(0, &era1_files, &http_client).await?;
+
+    let temp_directory = setup_temp_dir()?;
+
+    let mut state = State::new(
+        Some(temp_directory.path().to_path_buf()),
+        StateConfig {
+            cache_contract_storage_changes: true,
+            block_to_trace: BlockToTrace::None,
+        },
+    )?;
+
+    for block_number in 0..=blocks {
+        println!("Starting block: {block_number}");
+        if era1.epoch_number() != Era1::epoch_number_from_block_number(block_number) {
+            era1 = get_era1(
+                Era1::epoch_number_from_block_number(block_number),
+                &era1_files,
+                &http_client,
+            )
+            .await?
+        }
+        let block_tuple = &era1.block_tuples[block_number as usize % BLOCK_TUPLE_COUNT];
+        ensure!(
+            block_number == block_tuple.header.header.number,
+            "Block number doesn't match!"
+        );
+
+        let RootWithTrieDiff {
+            root: root_hash,
+            trie_diff: changed_nodes,
+        } = match block_number == 0 {
+            true => state
+                .initialize_genesis()
+                .map_err(|e| anyhow!("unable to create genesis state: {e}"))?,
+            false => state.process_block(block_tuple)?,
+        };
+        ensure!(
+            state.get_root()? == block_tuple.header.header.state_root,
+            "State root doesn't match"
+        );
+
+        let mut content_pairs = 0;
+        let walk_diff = TrieWalker::new(root_hash, changed_nodes);
+        for node in walk_diff.nodes.keys() {
+            let block_hash = block_tuple.header.header.hash();
+            let account_proof = walk_diff.get_proof(*node);
+
+            // check account content key/value
+            assert!(create_account_content_key(&account_proof).is_ok());
+            assert!(create_account_content_value(block_hash, &account_proof).is_ok());
+            content_pairs += 1;
+
+            let Some(encoded_last_node) = account_proof.proof.last() else {
+                panic!("Account proof is empty");
+            };
+
+            let Node::Leaf(leaf) = decode_node(&mut encoded_last_node.as_ref())? else {
+                continue;
+            };
+            let account: AccountState = Decodable::decode(&mut leaf.value.as_slice())?;
+
+            // reconstruct the address hash from the path so that we can fetch the
+            // address from the database
+            let mut partial_key_path = leaf.key.get_data().to_vec();
+            partial_key_path.pop();
+            let full_key_path = [&account_proof.path.clone(), partial_key_path.as_slice()].concat();
+            let address_hash = full_nibble_path_to_address_hash(&full_key_path);
+
+            // check contract code content key/value
+            if account.code_hash != keccak256([]) {
+                let code = state.database.code_by_hash_ref(account.code_hash)?;
+                assert!(create_contract_content_key(address_hash, account.code_hash).is_ok());
+                assert!(create_contract_content_value(block_hash, &account_proof, code).is_ok());
+                content_pairs += 1;
+            }
+
+            // check contract storage content key/value
+            let storage_changed_nodes = state.database.get_storage_trie_diff(address_hash);
+            let storage_walk_diff = TrieWalker::new(account.storage_root, storage_changed_nodes);
+            for storage_node in storage_walk_diff.nodes.keys() {
+                let storage_proof = storage_walk_diff.get_proof(*storage_node);
+                assert!(create_storage_content_key(&storage_proof, address_hash).is_ok());
+                assert!(
+                    create_storage_content_value(block_hash, &account_proof, &storage_proof)
+                        .is_ok()
+                );
+                content_pairs += 1;
+            }
+        }
+
+        // flush the database cache
+        // This is used for gossiping storage trie diffs
+        state.database.storage_cache.clear();
+        println!("Block {block_number} finished. Total content key/value pairs: {content_pairs}");
+    }
+    Ok(())
+}
+
+async fn get_era1(
+    epoch_index: u64,
+    era1_files: impl IntoIterator<Item = &String>,
+    http_client: &Client,
+) -> Result<Era1> {
+    let path = era1_files
+        .into_iter()
+        .find(|file| file.contains(&format!("mainnet-{epoch_index:05}-")))
+        .expect("to be able to find era1 file");
+    let raw_era1 = http_client
+        .get(path.clone())
+        .recv_bytes()
+        .await
+        .map_err(|err| anyhow!("unable to read era1 file at path: {path:?} : {err}"))?;
+    Era1::deserialize(&raw_era1)
+}


### PR DESCRIPTION
### What was wrong?

The `TrieWalker` can't assume that all provided nodes are useful and it shouldn't check for it.

Ideally, TrieWalker should be able to make such assumption, but not with the current implementation. Currently we write to db after every transaction, and cache all contract storage writes. When the same contact storage is updated in different transactions within the same block, this results in cache containing nodes that are no longer valid.

This can be solved by keeping all state changes in memory and writing them at the end of the block (instead of after every transaction). This was already planned improvement: #1333 .

### How was it fixed?

As we are working on the proper fix (#1337), this PR disables the check.
Also adding test that executes and creates content key/value pairs up to a given block (disabled by default as it takes too long to run for anything meaningful)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
