### PR TITLE
feat: implement eth_getBalance, eth_getCode and eth_getStorageAt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5900,7 +5900,9 @@ name = "rpc"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
  "discv5",
+ "eth_trie",
  "ethportal-api",
  "hyper",
  "portalnet",

--- a/ethportal-api/src/eth.rs
+++ b/ethportal-api/src/eth.rs
@@ -22,10 +22,6 @@ pub trait EthApi {
     async fn get_code(&self, address: Address, block: BlockId) -> RpcResult<Bytes>;
 
     #[method(name = "getStorageAt")]
-    async fn get_storage_at(
-        &self,
-        address: Address,
-        slot: U256,
-        block: BlockId,
-    ) -> RpcResult<Bytes>;
+    async fn get_storage_at(&self, address: Address, slot: U256, block: BlockId)
+        -> RpcResult<B256>;
 }

--- a/ethportal-api/src/types/state_trie/trie_traversal.rs
+++ b/ethportal-api/src/types/state_trie/trie_traversal.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy_primitives::{Bytes, B256};
 use eth_trie::node::Node;
 use thiserror::Error;
 
@@ -43,7 +43,7 @@ pub enum TraversalResult<'path> {
     /// Path leads to empty node.
     Empty(EmptyNodeInfo),
     /// Path leads to value.
-    Value(Vec<u8>),
+    Value(Bytes),
     /// Path leads to a next node.
     Node(NextTraversalNode<'path>),
     /// Unexpected error happened, most likely malformed node or programmers error.
@@ -73,7 +73,7 @@ impl NodeTraversal for Node {
                 if nibbles != path {
                     TraversalResult::Empty(EmptyNodeInfo::DifferentLeafPrefix)
                 } else {
-                    TraversalResult::Value(leaf_node.value.clone())
+                    TraversalResult::Value(Bytes::from_iter(&leaf_node.value))
                 }
             }
             Node::Extension(extension_node) => {
@@ -98,7 +98,7 @@ impl NodeTraversal for Node {
                         branch_node.children[*first as usize].traverse(remaining_path)
                     }
                     None => match &branch_node.value {
-                        Some(value) => TraversalResult::Value(value.clone()),
+                        Some(value) => TraversalResult::Value(Bytes::from_iter(value)),
                         None => TraversalResult::Empty(EmptyNodeInfo::EmptyBranchValue),
                     },
                 }
@@ -279,7 +279,10 @@ mod tests {
         &[1, 2, 3, 4, 5],
     )]
     fn to_value(#[case] node: Node, #[case] path: &[u8]) {
-        assert_eq!(node.traverse(path), TraversalResult::Value(VALUE.to_vec()))
+        assert_eq!(
+            node.traverse(path),
+            TraversalResult::Value(Bytes::from_static(VALUE))
+        )
     }
 
     // Util functions for creating Trie nodes

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -12,7 +12,9 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
 alloy-primitives = "0.7.0"
+alloy-rlp = "0.3.4"
 discv5 = { version = "0.4.1", features = ["serde"] }
+eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "7947a83091192a7988f359b750b05121d5d7ba8c" }
 ethportal-api = { path = "../ethportal-api"}
 portalnet = { path = "../portalnet"}
 tracing = "0.1.27"

--- a/rpc/src/errors.rs
+++ b/rpc/src/errors.rs
@@ -53,7 +53,6 @@ impl RpcError {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
 pub enum RpcServeError {
     /// A generic error with no data
     Message(String),
@@ -62,7 +61,7 @@ pub enum RpcServeError {
     /// ContentNotFound
     ContentNotFound {
         message: String,
-        trace: Option<QueryTrace>,
+        trace: Option<Box<QueryTrace>>,
     },
 }
 
@@ -94,7 +93,7 @@ impl From<ContentNotFoundJsonError> for RpcServeError {
     fn from(e: ContentNotFoundJsonError) -> Self {
         RpcServeError::ContentNotFound {
             message: e.message,
-            trace: e.trace,
+            trace: e.trace.map(Box::new),
         }
     }
 }

--- a/rpc/src/eth_rpc.rs
+++ b/rpc/src/eth_rpc.rs
@@ -1,25 +1,38 @@
-use alloy_primitives::{Address, Bytes, B256, U256};
+use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
+use alloy_rlp::Decodable;
+use eth_trie::node::Node;
 use reth_rpc_types::{other::OtherFields, Block, BlockId, BlockTransactions};
 use tokio::sync::mpsc;
 
 use ethportal_api::{
     types::{
+        content_key::state::{AccountTrieNodeKey, ContractBytecodeKey, ContractStorageTrieNodeKey},
         execution::block_body::BlockBody,
-        jsonrpc::request::{HistoryJsonRpcRequest, StateJsonRpcRequest},
+        jsonrpc::{
+            endpoints::{HistoryEndpoint, StateEndpoint},
+            request::{HistoryJsonRpcRequest, StateJsonRpcRequest},
+        },
+        portal::ContentInfo,
+        state_trie::{
+            account_state::AccountState,
+            nibbles::Nibbles,
+            trie_traversal::{NodeTraversal, TraversalResult},
+        },
     },
-    EthApiServer,
+    ContentValue, EthApiServer, Header, HistoryContentKey, HistoryContentValue, StateContentKey,
+    StateContentValue,
 };
 use trin_validation::constants::CHAIN_ID;
 
 use crate::{
     errors::RpcServeError,
-    fetch::{find_block_body_by_hash, find_header_by_hash},
+    fetch::proxy_to_subnet,
     jsonrpsee::core::{async_trait, RpcResult},
 };
 
 pub struct EthApi {
     history_network: mpsc::UnboundedSender<HistoryJsonRpcRequest>,
-    _state_network: Option<mpsc::UnboundedSender<StateJsonRpcRequest>>,
+    state_network: Option<mpsc::UnboundedSender<StateJsonRpcRequest>>,
 }
 
 impl EthApi {
@@ -29,7 +42,7 @@ impl EthApi {
     ) -> Self {
         Self {
             history_network,
-            _state_network: state_network,
+            state_network,
         }
     }
 }
@@ -52,8 +65,8 @@ impl EthApiServer for EthApi {
             .into());
         }
 
-        let header = find_header_by_hash(&self.history_network, block_hash).await?;
-        let body = find_block_body_by_hash(&self.history_network, block_hash).await?;
+        let header = self.fetch_header_by_hash(block_hash).await?;
+        let body = self.fetch_block_body(block_hash).await?;
         let transactions = match body {
             BlockBody::Legacy(body) => body.txs,
             BlockBody::Merge(body) => body.txs,
@@ -78,21 +91,244 @@ impl EthApiServer for EthApi {
         Ok(block)
     }
 
-    async fn get_balance(&self, _address: Address, _block: BlockId) -> RpcResult<U256> {
-        todo!()
+    async fn get_balance(&self, address: Address, block: BlockId) -> RpcResult<U256> {
+        let address_hash = keccak256(address);
+        let block_hash = as_block_hash(block)?;
+        let header = self.fetch_header_by_hash(block_hash).await?;
+
+        let account_state = self
+            .fetch_account_state(header.state_root, address_hash)
+            .await?;
+
+        match account_state {
+            Some(account_state) => Ok(account_state.balance),
+            None => Ok(U256::ZERO),
+        }
     }
 
-    async fn get_code(&self, _address: Address, _block: BlockId) -> RpcResult<Bytes> {
-        todo!()
+    async fn get_code(&self, address: Address, block: BlockId) -> RpcResult<Bytes> {
+        let address_hash = keccak256(address);
+        let block_hash = as_block_hash(block)?;
+        let header = self.fetch_header_by_hash(block_hash).await?;
+
+        let account_state = self
+            .fetch_account_state(header.state_root, address_hash)
+            .await?;
+
+        match account_state {
+            Some(account_state) => Ok(self
+                .fetch_contract_bytecode(address_hash, account_state.code_hash)
+                .await?),
+            None => Ok(Bytes::new()),
+        }
     }
 
     async fn get_storage_at(
         &self,
-        _address: Address,
-        _slot: U256,
-        _block: BlockId,
-    ) -> RpcResult<Bytes> {
-        todo!()
+        address: Address,
+        slot: U256,
+        block: BlockId,
+    ) -> RpcResult<B256> {
+        let address_hash = keccak256(address);
+        let block_hash = as_block_hash(block)?;
+        let header = self.fetch_header_by_hash(block_hash).await?;
+
+        let account_state = self
+            .fetch_account_state(header.state_root, address_hash)
+            .await?;
+
+        match account_state {
+            Some(account_state) => Ok(self
+                .fetch_contract_storage_at_slot(account_state.storage_root, address_hash, slot)
+                .await?),
+            None => Ok(B256::ZERO),
+        }
+    }
+}
+
+impl EthApi {
+    // History network related functions
+
+    async fn fetch_history_content(
+        &self,
+        content_key: HistoryContentKey,
+    ) -> Result<HistoryContentValue, RpcServeError> {
+        let endpoint = HistoryEndpoint::RecursiveFindContent(content_key.clone());
+        let response: ContentInfo = proxy_to_subnet(&self.history_network, endpoint).await?;
+        let ContentInfo::Content { content, .. } = response else {
+            return Err(RpcServeError::Message(format!(
+                "Invalid response variant: History RecursiveFindContent should contain content value; got {response:?}"
+            )));
+        };
+
+        let content_value = HistoryContentValue::decode(&content_key, &content)?;
+        Ok(content_value)
+    }
+
+    async fn fetch_header_by_hash(&self, block_hash: B256) -> Result<Header, RpcServeError> {
+        let content_value = self
+            .fetch_history_content(HistoryContentKey::BlockHeaderWithProof(block_hash.into()))
+            .await?;
+        let HistoryContentValue::BlockHeaderWithProof(header_with_proof) = content_value else {
+            return Err(RpcServeError::Message(format!(
+                "Invalid response: expected block header; got {content_value:?}"
+            )));
+        };
+        Ok(header_with_proof.header)
+    }
+
+    async fn fetch_block_body(&self, block_hash: B256) -> Result<BlockBody, RpcServeError> {
+        let content_value = self
+            .fetch_history_content(HistoryContentKey::BlockBody(block_hash.into()))
+            .await?;
+        let HistoryContentValue::BlockBody(block_body) = content_value else {
+            return Err(RpcServeError::Message(format!(
+                "Invalid response: expected block body; got {content_value:?}"
+            )));
+        };
+        Ok(block_body)
+    }
+
+    // State network related functions
+
+    async fn fetch_state_content(
+        &self,
+        content_key: StateContentKey,
+    ) -> Result<StateContentValue, RpcServeError> {
+        let Some(state_network) = &self.state_network else {
+            return Err(RpcServeError::Message(format!(
+                "State network not enabled. Can't find: {content_key}"
+            )));
+        };
+
+        let endpoint = StateEndpoint::RecursiveFindContent(content_key.clone());
+        let response: ContentInfo = proxy_to_subnet(state_network, endpoint).await?;
+        let ContentInfo::Content { content, .. } = response else {
+            return Err(RpcServeError::Message(format!(
+                "Invalid response variant: State RecursiveFindContent should contain content value; got {response:?}"
+            )));
+        };
+
+        let content_value = StateContentValue::decode(&content_key, &content)?;
+        Ok(content_value)
+    }
+
+    async fn fetch_trie_node(&self, content_key: StateContentKey) -> Result<Node, RpcServeError> {
+        let content_value = self.fetch_state_content(content_key).await?;
+        let StateContentValue::TrieNode(trie_node) = content_value else {
+            return Err(RpcServeError::Message(format!(
+                "Invalid response: expected trie node; got {content_value:?}",
+            )));
+        };
+        trie_node
+            .node
+            .as_trie_node()
+            .map_err(|err| RpcServeError::Message(format!("Can't decode trie_node: {err}")))
+    }
+
+    async fn fetch_contract_bytecode(
+        &self,
+        address_hash: B256,
+        code_hash: B256,
+    ) -> Result<Bytes, RpcServeError> {
+        let content_key = StateContentKey::ContractBytecode(ContractBytecodeKey {
+            address_hash,
+            code_hash,
+        });
+        let content_value = self.fetch_state_content(content_key).await?;
+        let StateContentValue::ContractBytecode(contract_bytecode) = content_value else {
+            return Err(RpcServeError::Message(format!(
+                "Invalid response: expected contract bytecode; got {content_value:?}",
+            )));
+        };
+        let bytes = Vec::from(contract_bytecode.code);
+        Ok(Bytes::from(bytes))
+    }
+
+    async fn fetch_account_state(
+        &self,
+        state_root: B256,
+        address_hash: B256,
+    ) -> Result<Option<AccountState>, RpcServeError> {
+        self.traverse_trie(state_root, address_hash, |path, node_hash| {
+            StateContentKey::AccountTrieNode(AccountTrieNodeKey { path, node_hash })
+        })
+        .await
+    }
+
+    async fn fetch_contract_storage_at_slot(
+        &self,
+        storage_root: B256,
+        address_hash: B256,
+        storage_slot: U256,
+    ) -> Result<B256, RpcServeError> {
+        let path = keccak256(storage_slot.to_be_bytes::<32>());
+        let value = self
+            .traverse_trie::<Bytes>(storage_root, path, |path, node_hash| {
+                StateContentKey::ContractStorageTrieNode(ContractStorageTrieNodeKey {
+                    address_hash,
+                    path,
+                    node_hash,
+                })
+            })
+            .await?
+            .unwrap_or_default();
+        if value.len() > B256::len_bytes() {
+            return Err(RpcServeError::Message(format!(
+                "Storage value is too long. value: {value}"
+            )));
+        }
+
+        Ok(B256::left_padding_from(&value))
+    }
+
+    /// Utility function for fetching trie nodes and traversing the trie.
+    ///
+    /// This function works both with the account trie and the contract state trie.
+    async fn traverse_trie<T: Decodable>(
+        &self,
+        root: B256,
+        path: B256,
+        content_key_fn: impl Fn(Nibbles, B256) -> StateContentKey,
+    ) -> Result<Option<T>, RpcServeError> {
+        let path = Nibbles::unpack_nibbles(path.as_slice());
+
+        let mut node_hash = root;
+        let mut remaining_path = path.as_slice();
+
+        let value = loop {
+            let path_from_root = path
+                .strip_suffix(remaining_path)
+                .expect("Remaining path should be suffix of the path");
+
+            let content_key = content_key_fn(
+                Nibbles::try_from_unpacked_nibbles(path_from_root)
+                    .expect("we should be able to create Nibbles from path"),
+                node_hash,
+            );
+            let node = self.fetch_trie_node(content_key).await?;
+
+            match node.traverse(remaining_path) {
+                TraversalResult::Empty(_) => break None,
+                TraversalResult::Value(value) => break Some(value),
+                TraversalResult::Node(next_node) => {
+                    node_hash = next_node.hash;
+                    remaining_path = next_node.remaining_path;
+                }
+                TraversalResult::Error(err) => {
+                    return Err(RpcServeError::Message(format!(
+                        "Error traversing trie node: {err}"
+                    )))
+                }
+            }
+        };
+
+        value
+            .map(|value| T::decode(&mut value.as_ref()))
+            .transpose()
+            .map_err(|err| {
+                RpcServeError::Message(format!("Error decoding value from the leaf node: {err}"))
+            })
     }
 }
 
@@ -100,4 +336,10 @@ impl std::fmt::Debug for EthApi {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EthApi").finish_non_exhaustive()
     }
+}
+
+fn as_block_hash(block: BlockId) -> Result<B256, RpcServeError> {
+    block.as_block_hash().ok_or_else(|| {
+        RpcServeError::Message("Only block hash is accepted as block id".to_string())
+    })
 }

--- a/rpc/src/fetch.rs
+++ b/rpc/src/fetch.rs
@@ -1,33 +1,12 @@
-use std::fmt::Debug;
-
-use alloy_primitives::B256;
-use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::mpsc;
 
-use ethportal_api::{
-    types::{
-        execution::{block_body::BlockBody, header::Header},
-        jsonrpc::{
-            endpoints::{HistoryEndpoint, SubnetworkEndpoint},
-            request::{HistoryJsonRpcRequest, JsonRpcRequest},
-        },
-        portal::ContentInfo,
-        query_trace::QueryTrace,
-    },
-    ContentValue, HistoryContentKey, HistoryContentValue,
-};
+use ethportal_api::types::jsonrpc::{endpoints::SubnetworkEndpoint, request::JsonRpcRequest};
 
 use crate::{
     errors::{ContentNotFoundJsonError, RpcServeError},
     serde::from_value,
 };
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct ContentNotFoundError {
-    message: String,
-    trace: Option<QueryTrace>,
-}
 
 /// Fetch and deserialize data from Portal subnetwork.
 pub async fn proxy_to_subnet<TEndpoint, TOutput>(
@@ -68,51 +47,4 @@ where
             }
         }
     }
-}
-
-pub async fn find_header_by_hash(
-    network: &mpsc::UnboundedSender<HistoryJsonRpcRequest>,
-    block_hash: B256,
-) -> Result<Header, RpcServeError> {
-    // Request the block header from the history subnet.
-    let content_key = HistoryContentKey::BlockHeaderWithProof(block_hash.into());
-    let content_value = find_content_by_hash(network, content_key).await?;
-
-    match content_value {
-        HistoryContentValue::BlockHeaderWithProof(h) => Ok(h.header),
-        wrong_val => Err(RpcServeError::Message(format!(
-            "Internal trin error: got back a non-header from a key that must only point to headers; got {wrong_val:?}"
-        ))),
-    }
-}
-
-pub async fn find_block_body_by_hash(
-    network: &mpsc::UnboundedSender<HistoryJsonRpcRequest>,
-    block_hash: B256,
-) -> Result<BlockBody, RpcServeError> {
-    // Request the block body from the history subnet.
-    let content_key = HistoryContentKey::BlockBody(block_hash.into());
-    let content_value = find_content_by_hash(network, content_key).await?;
-
-    match content_value {
-        HistoryContentValue::BlockBody(body) => Ok(body),
-        wrong_val => Err(RpcServeError::Message(format!(
-            "Internal trin error: got back a non-body from a key that must only point to bodies; got {wrong_val:?}"
-        ))),
-    }
-}
-
-async fn find_content_by_hash(
-    network: &mpsc::UnboundedSender<HistoryJsonRpcRequest>,
-    content_key: HistoryContentKey,
-) -> Result<HistoryContentValue, RpcServeError> {
-    let endpoint = HistoryEndpoint::RecursiveFindContent(content_key.clone());
-    let response: ContentInfo = proxy_to_subnet(network, endpoint).await?;
-    let ContentInfo::Content { content, .. } = response else {
-        return Err(RpcServeError::Message(format!(
-            "Invalid response variant: RecursiveFindContent should contain content value; got {response:?}"
-        )));
-    };
-
-    Ok(HistoryContentValue::decode(&content_key, &content)?)
 }

--- a/trin-state/src/validation/trie.rs
+++ b/trin-state/src/validation/trie.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy_primitives::{Bytes, B256};
 use alloy_rlp::Decodable;
 
 use ethportal_api::types::state_trie::{
@@ -103,7 +103,7 @@ fn check_traversal_result_is_node(
 
 fn check_traversal_result_is_value(
     traversal_result: TraversalResult,
-) -> Result<Vec<u8>, StateValidationError> {
+) -> Result<Bytes, StateValidationError> {
     match traversal_result {
         TraversalResult::Empty(empty_node_info) => {
             Err(StateValidationError::UnexpectedEmptyNode(empty_node_info))


### PR DESCRIPTION
### What was wrong?

The `eth_getBalance`, `eth_getCode` and `eth_getStorageAt` weren't implemented.

### How was it fixed?

Implemented them by fetching data from history (block header) and state network (traversing tries).

I also tested it locally by running trin myself and getting data from block 51208 (I knew that block was gossiped already).

### Future improvements

All these requests support passing block as one of:
- block number
- block hash
- tag (i.e. latest / finalized / safe / earliest / pending)

Currently we only support block hash, but in the future we want to support block number as well (e.g. when we have block index network).
I think in the future we can support tags as well, but I would say that's the lowest of priorities at the moment.

### To-Do
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
