### PR TITLE
feat(beacon): store `HistoricalSummariesWithProof` into db instead of cache

### DIFF
--- a/trin-storage/src/sql.rs
+++ b/trin-storage/src/sql.rs
@@ -54,5 +54,29 @@ pub const LC_UPDATE_PERIOD_LOOKUP_QUERY: &str =
 
 pub const LC_UPDATE_TOTAL_SIZE_QUERY: &str = "SELECT TOTAL(update_size) FROM lc_update";
 
+/// Create the historical summaries table. Add CHECK constraint to ensure that only one row is
+/// inserted.
+pub const HISTORICAL_SUMMARIES_CREATE_TABLE: &str =
+    "CREATE TABLE IF NOT EXISTS historical_summaries (
+        ID INTEGER PRIMARY KEY CHECK (ID = 1),
+        epoch INTEGER NOT NULL,
+        value BLOB NOT NULL,
+        update_size INTEGER
+    );";
+
+/// Query to insert or update the historical summaries table.
+pub const INSERT_OR_REPLACE_HISTORICAL_SUMMARIES_QUERY: &str =
+    "INSERT OR REPLACE INTO historical_summaries (id, epoch, value, update_size)
+                      VALUES (?1, ?2, ?3, ?4)";
+
+/// Query to get the historical summary that is greater than or equal to the given epoch.
+pub const HISTORICAL_SUMMARIES_LOOKUP_QUERY: &str =
+    "SELECT value FROM historical_summaries WHERE epoch >= (?1) LIMIT 1";
+
+/// Query to get the epoch of the first historical summary that is greater than or equal to the
+/// given epoch.
+pub const HISTORICAL_SUMMARIES_EPOCH_LOOKUP_QUERY: &str =
+    "SELECT epoch FROM historical_summaries WHERE epoch >= (?1) LIMIT 1";
+
 // todo: remove this in the future
 pub const DROP_USAGE_STATS_DB: &str = "DROP TABLE IF EXISTS usage_stats;";

--- a/trin-storage/src/utils.rs
+++ b/trin-storage/src/utils.rs
@@ -1,6 +1,9 @@
 use crate::{
     error::ContentStoreError,
-    sql::{CREATE_QUERY_DB_BEACON, DROP_USAGE_STATS_DB, LC_UPDATE_CREATE_TABLE},
+    sql::{
+        CREATE_QUERY_DB_BEACON, DROP_USAGE_STATS_DB, HISTORICAL_SUMMARIES_CREATE_TABLE,
+        LC_UPDATE_CREATE_TABLE,
+    },
     versioned::sql::STORE_INFO_CREATE_TABLE,
     DATABASE_NAME,
 };
@@ -19,6 +22,7 @@ pub fn setup_sql(node_data_dir: &Path) -> Result<Pool<SqliteConnectionManager>, 
     let conn = pool.get()?;
     conn.execute_batch(CREATE_QUERY_DB_BEACON)?;
     conn.execute_batch(LC_UPDATE_CREATE_TABLE)?;
+    conn.execute_batch(HISTORICAL_SUMMARIES_CREATE_TABLE)?;
     conn.execute_batch(STORE_INFO_CREATE_TABLE)?;
     conn.execute_batch(DROP_USAGE_STATS_DB)?;
     Ok(pool)


### PR DESCRIPTION
### What was wrong?
Fixes #1322 

### How was it fixed?
- create a new `historical_summaries` table in the database on startup. This table will hold only one record.
- add insert and lookup queries
- cleanup unused cache code

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
