### PR TITLE
refactor: remove duplicate Withdrawal type

### DIFF
--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography::cryptocurrencies"]
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy-primitives = { workspace = true, features = ["ssz"] }
 alloy-rlp.workspace = true
 anyhow.workspace = true
 base64 = "0.13.0"

--- a/ethportal-api/src/types/consensus/execution_payload.rs
+++ b/ethportal-api/src/types/consensus/execution_payload.rs
@@ -1,4 +1,7 @@
-use super::serde::{de_hex_to_txs, de_number_to_u256, se_hex_to_number, se_txs_to_hex};
+use super::{
+    serde::{de_hex_to_txs, de_number_to_u256, se_hex_to_number, se_txs_to_hex},
+    withdrawal::Withdrawal,
+};
 use crate::{
     types::{
         bytes::ByteList32,
@@ -147,17 +150,6 @@ impl ExecutionPayloadDeneb {
     pub fn withdrawals_root(&self) -> B256 {
         self.withdrawals.tree_hash_root()
     }
-}
-
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
-pub struct Withdrawal {
-    #[serde(deserialize_with = "as_u64")]
-    pub index: u64,
-    #[serde(deserialize_with = "as_u64")]
-    pub validator_index: u64,
-    pub address: Address,
-    #[serde(deserialize_with = "as_u64")]
-    pub amount: u64,
 }
 
 #[superstruct(

--- a/ethportal-api/src/types/consensus/withdrawal.rs
+++ b/ethportal-api/src/types/consensus/withdrawal.rs
@@ -1,24 +1,31 @@
 use alloy_primitives::Address;
 use alloy_rlp::{RlpDecodable, RlpEncodable};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
+use serde_this_or_that::as_u64;
+use ssz_derive::{Decode, Encode};
+use tree_hash_derive::TreeHash;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, RlpDecodable, RlpEncodable)]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    RlpDecodable,
+    RlpEncodable,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct Withdrawal {
-    #[serde(deserialize_with = "string_to_u64")]
+    #[serde(deserialize_with = "as_u64")]
     pub index: u64,
-    #[serde(deserialize_with = "string_to_u64")]
+    #[serde(deserialize_with = "as_u64")]
     pub validator_index: u64,
     pub address: Address,
-    #[serde(deserialize_with = "string_to_u64")]
+    #[serde(deserialize_with = "as_u64")]
     pub amount: u64,
-}
-
-fn string_to_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s: String = Deserialize::deserialize(deserializer)?;
-    u64::from_str_radix(s.trim_start_matches("0x"), 16)
-        .map_err(|_| serde::de::Error::custom("failed to parse hex string"))
 }


### PR DESCRIPTION
### What was wrong?
we defined the same type for Withdrawals twice
### How was it fixed?

removed the redundant code