### PR TITLE
fix: add `ssz` feature back for alloy-primitives to fix test compiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography::cryptocurrencies"]
 description = "A Rust implementation of the Ethereum Portal Network"
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy-primitives = { workspace = true, features = ["ssz"] }
 anyhow.workspace = true
 clap.workspace = true
 dirs = "5.0.1"

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography::cryptocurrencies"]
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-primitives = { workspace = true, features = ["ssz"] }
+alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 anyhow.workspace = true
 base64 = "0.13.0"

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography::cryptocurrencies"]
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy-primitives = { workspace = true, features = ["ssz"] }
 alloy-rlp.workspace = true
 anyhow.workspace = true
 base64 = "0.13.0"

--- a/trin-validation/Cargo.toml
+++ b/trin-validation/Cargo.toml
@@ -11,7 +11,7 @@ description = "Validation layer for the Portal Network data."
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-primitives = { workspace = true, features = ["ssz"] }
+alloy-primitives.workspace = true
 anyhow.workspace = true
 enr = "0.10.0"
 eth2_hashing = "0.2.0"


### PR DESCRIPTION
### What was wrong?
the tests I am trying to run locally are all failing, because we removed the `ssz` feature from alloy-primitives in the PR updating Cargo to properly use workplace 

so I got thousands of error's stating can't derive ssz for B256, ... 5 billion other errors etc. I was running tests in `block_body.rs`

depends
### How was it fixed?
by adding the feature back which was removed
