### PR TITLE
fix: era `get_block_slot_indexes()` not working

### DIFF
--- a/e2store/src/era.rs
+++ b/e2store/src/era.rs
@@ -105,9 +105,9 @@ impl Era {
             .into_iter()
             .enumerate()
             .map(move |(index, slot)| {
-                let entry: Entry = file.entries[index + 1].clone();
                 let fork = get_beacon_fork(slot);
-                let beacon_block = CompressedSignedBeaconBlock::try_from(&entry, fork)?;
+                let beacon_block =
+                    CompressedSignedBeaconBlock::try_from(&file.entries[index + 1], fork)?;
                 Ok(beacon_block)
             }))
     }

--- a/e2store/src/era.rs
+++ b/e2store/src/era.rs
@@ -286,17 +286,15 @@ impl TryInto<Entry> for SlotIndexBlockEntry {
     type Error = anyhow::Error;
 
     fn try_into(self) -> Result<Entry, Self::Error> {
-        let mut buf: Vec<u64> = vec![];
-        buf.push(self.slot_index.starting_slot);
+        let mut buf = vec![];
+
+        buf.extend_from_slice(&self.slot_index.starting_slot.to_le_bytes());
         for index in &self.slot_index.indices {
-            buf.push(*index as u64);
+            buf.extend_from_slice(&index.to_le_bytes());
         }
-        buf.push(self.slot_index.count);
-        let encoded = buf
-            .iter()
-            .flat_map(|i| i.to_le_bytes().to_vec())
-            .collect::<Vec<u8>>();
-        Ok(Entry::new(0x3269, encoded))
+        buf.extend_from_slice(&self.slot_index.count.to_le_bytes());
+
+        Ok(Entry::new(0x3269, buf))
     }
 }
 
@@ -373,17 +371,15 @@ impl TryInto<Entry> for SlotIndexStateEntry {
     type Error = anyhow::Error;
 
     fn try_into(self) -> Result<Entry, Self::Error> {
-        let mut buf: Vec<u64> = vec![];
-        buf.push(self.slot_index.starting_slot);
+        let mut buf = vec![];
+
+        buf.extend_from_slice(&self.slot_index.starting_slot.to_le_bytes());
         for index in &self.slot_index.indices {
-            buf.push(*index as u64);
+            buf.extend_from_slice(&index.to_le_bytes());
         }
-        buf.push(self.slot_index.count);
-        let encoded = buf
-            .iter()
-            .flat_map(|i| i.to_le_bytes().to_vec())
-            .collect::<Vec<u8>>();
-        Ok(Entry::new(0x3269, encoded))
+        buf.extend_from_slice(&self.slot_index.count.to_le_bytes());
+
+        Ok(Entry::new(0x3269, buf))
     }
 }
 

--- a/e2store/src/era.rs
+++ b/e2store/src/era.rs
@@ -109,13 +109,19 @@ impl Era {
     }
 
     fn get_block_slot_indexes(slot_index_block_entry: &SlotIndexBlockEntry) -> Vec<u64> {
+        if slot_index_block_entry.slot_index.indices.is_empty() {
+            return vec![];
+        }
+        // minus 8 because the first 8 bytes are the starting slot
+        let beginning_of_index_record = slot_index_block_entry.slot_index.indices[0] - 8;
+
         slot_index_block_entry
             .slot_index
             .indices
             .iter()
             .enumerate()
-            .filter_map(|(i, index)| {
-                if *index != 0 {
+            .filter_map(|(i, offset)| {
+                if *offset != beginning_of_index_record {
                     Some(slot_index_block_entry.slot_index.starting_slot + i as u64)
                 } else {
                     None


### PR DESCRIPTION
### What was wrong?
- `get_block_slot_indexes()` apparently it is the 0ed offset, from the start of the slot_index not 0
### How was it fixed?

implemented `get_block_slot_indexes()` to work based 0ed offset from the start of slot_index