### PR TITLE
feat(beacon): store `LightClientBootstrap` in separate db table

### DIFF
--- a/trin-storage/src/utils.rs
+++ b/trin-storage/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::ContentStoreError,
     sql::{
-        CREATE_QUERY_DB_BEACON, DROP_USAGE_STATS_DB, HISTORICAL_SUMMARIES_CREATE_TABLE,
+        DROP_USAGE_STATS_DB, HISTORICAL_SUMMARIES_CREATE_TABLE, LC_BOOTSTRAP_CREATE_TABLE,
         LC_UPDATE_CREATE_TABLE,
     },
     versioned::sql::STORE_INFO_CREATE_TABLE,
@@ -20,7 +20,7 @@ pub fn setup_sql(node_data_dir: &Path) -> Result<Pool<SqliteConnectionManager>, 
     let manager = SqliteConnectionManager::file(sql_path);
     let pool = Pool::new(manager)?;
     let conn = pool.get()?;
-    conn.execute_batch(CREATE_QUERY_DB_BEACON)?;
+    conn.execute_batch(LC_BOOTSTRAP_CREATE_TABLE)?;
     conn.execute_batch(LC_UPDATE_CREATE_TABLE)?;
     conn.execute_batch(HISTORICAL_SUMMARIES_CREATE_TABLE)?;
     conn.execute_batch(STORE_INFO_CREATE_TABLE)?;


### PR DESCRIPTION
### What was wrong?
This PR stores `LightClientBootstrap` beacon content in a separate table in the database. This is required because:

1. To fix #1405, we need a way to get the latest stored block root from the latest bootstrap in the DB. This is solved by storing the block root as a primary key for the new bootstrap table. (content-id is not needed for the beacon network because the node radius does not apply to this overlay network).
2. We want to purge all bootstraps older than 4 months. We can do this by adding a slot column in the bootstrap table and periodically purging all content where slot number < 4 months old.

### How was it fixed?
- create a new `lc_bootstrap` db table
- update insert and lookup queries
- update total beacon content size query

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
