### PR TITLE
feat: implement eth_call and refactor trin-execution to support async db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5910,6 +5910,7 @@ dependencies = [
  "portalnet",
  "reth-ipc",
  "reth-rpc-types",
+ "revm",
  "serde",
  "serde_json",
  "strum",
@@ -5918,6 +5919,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "trin-execution",
  "trin-utils",
  "trin-validation",
 ]
@@ -7936,6 +7938,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "prometheus_exporter",
  "rayon",
+ "reth-rpc-types",
  "revm",
  "revm-inspectors",
  "revm-primitives",

--- a/ethportal-api/src/eth.rs
+++ b/ethportal-api/src/eth.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{Address, Bytes, B256, U256};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_rpc_types::{Block, BlockId};
+use reth_rpc_types::{Block, BlockId, TransactionRequest};
 
 /// Web3 JSON-RPC endpoints
 #[rpc(client, server, namespace = "eth")]
@@ -24,4 +24,11 @@ pub trait EthApi {
     #[method(name = "getStorageAt")]
     async fn get_storage_at(&self, address: Address, slot: U256, block: BlockId)
         -> RpcResult<B256>;
+
+    #[method(name = "call")]
+    async fn call(
+        &self,
+        transaction_request: TransactionRequest,
+        block: BlockId,
+    ) -> RpcResult<Bytes>;
 }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -20,6 +20,7 @@ hyper.workspace = true
 portalnet.workspace = true
 reth-ipc.workspace = true
 reth-rpc-types.workspace = true
+revm = { workspace = true, features = ["optional_block_gas_limit"] }
 serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
@@ -28,5 +29,6 @@ tokio.workspace = true
 tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4.4", features = ["full"] }
 tracing.workspace = true
+trin-execution.workspace = true
 trin-utils.workspace = true
 trin-validation.workspace = true

--- a/rpc/src/errors.rs
+++ b/rpc/src/errors.rs
@@ -53,12 +53,16 @@ impl RpcError {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum RpcServeError {
     /// A generic error with no data
+    #[error("Error: {0}")]
     Message(String),
     /// Method not available
+    #[error("Method not available: {0}")]
     MethodNotFound(String),
     /// ContentNotFound
+    #[error("Content not found: {message}")]
     ContentNotFound {
         message: String,
         trace: Option<Box<QueryTrace>>,

--- a/rpc/src/eth_rpc.rs
+++ b/rpc/src/eth_rpc.rs
@@ -1,31 +1,24 @@
-use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
-use alloy_rlp::Decodable;
-use eth_trie::node::Node;
-use reth_rpc_types::{other::OtherFields, Block, BlockId, BlockTransactions};
+use alloy_primitives::{Address, Bytes, B256, U256};
+use reth_rpc_types::{other::OtherFields, Block, BlockId, BlockTransactions, TransactionRequest};
 use tokio::sync::mpsc;
 
 use ethportal_api::{
     types::{
-        content_key::state::{AccountTrieNodeKey, ContractBytecodeKey, ContractStorageTrieNodeKey},
         execution::block_body::BlockBody,
         jsonrpc::{
-            endpoints::{HistoryEndpoint, StateEndpoint},
+            endpoints::HistoryEndpoint,
             request::{HistoryJsonRpcRequest, StateJsonRpcRequest},
         },
         portal::ContentInfo,
-        state_trie::{
-            account_state::AccountState,
-            nibbles::Nibbles,
-            trie_traversal::{NodeTraversal, TraversalResult},
-        },
     },
-    ContentValue, EthApiServer, Header, HistoryContentKey, HistoryContentValue, StateContentKey,
-    StateContentValue,
+    ContentValue, EthApiServer, Header, HistoryContentKey, HistoryContentValue,
 };
+use trin_execution::evm::{create_evm_environment, db::AsyncDatabaseRef, execute_transaction};
 use trin_validation::constants::CHAIN_ID;
 
 use crate::{
     errors::RpcServeError,
+    evm_state::EvmBlockState,
     fetch::proxy_to_subnet,
     jsonrpsee::core::{async_trait, RpcResult},
 };
@@ -92,35 +85,12 @@ impl EthApiServer for EthApi {
     }
 
     async fn get_balance(&self, address: Address, block: BlockId) -> RpcResult<U256> {
-        let address_hash = keccak256(address);
-        let block_hash = as_block_hash(block)?;
-        let header = self.fetch_header_by_hash(block_hash).await?;
+        let evm_block_state = self.evm_block_state(block).await?;
 
-        let account_state = self
-            .fetch_account_state(header.state_root, address_hash)
-            .await?;
-
-        match account_state {
-            Some(account_state) => Ok(account_state.balance),
-            None => Ok(U256::ZERO),
-        }
-    }
-
-    async fn get_code(&self, address: Address, block: BlockId) -> RpcResult<Bytes> {
-        let address_hash = keccak256(address);
-        let block_hash = as_block_hash(block)?;
-        let header = self.fetch_header_by_hash(block_hash).await?;
-
-        let account_state = self
-            .fetch_account_state(header.state_root, address_hash)
-            .await?;
-
-        match account_state {
-            Some(account_state) => Ok(self
-                .fetch_contract_bytecode(address_hash, account_state.code_hash)
-                .await?),
-            None => Ok(Bytes::new()),
-        }
+        let Some(account_info) = evm_block_state.basic_async(address).await? else {
+            return Ok(U256::ZERO);
+        };
+        Ok(account_info.balance)
     }
 
     async fn get_storage_at(
@@ -129,20 +99,49 @@ impl EthApiServer for EthApi {
         slot: U256,
         block: BlockId,
     ) -> RpcResult<B256> {
-        let address_hash = keccak256(address);
-        let block_hash = as_block_hash(block)?;
-        let header = self.fetch_header_by_hash(block_hash).await?;
+        let evm_block_state = self.evm_block_state(block).await?;
 
-        let account_state = self
-            .fetch_account_state(header.state_root, address_hash)
-            .await?;
+        let value = evm_block_state.storage_async(address, slot).await?;
+        Ok(B256::from(value))
+    }
 
-        match account_state {
-            Some(account_state) => Ok(self
-                .fetch_contract_storage_at_slot(account_state.storage_root, address_hash, slot)
-                .await?),
-            None => Ok(B256::ZERO),
+    async fn get_code(&self, address: Address, block: BlockId) -> RpcResult<Bytes> {
+        let evm_block_state = self.evm_block_state(block).await?;
+
+        let Some(account_info) = evm_block_state.basic_async(address).await? else {
+            return Ok(Bytes::new());
+        };
+
+        if account_info.is_empty_code_hash() {
+            return Ok(Bytes::new());
         }
+
+        let bytecode = match account_info.code {
+            Some(code) => code,
+            None => {
+                evm_block_state
+                    .code_by_hash_async(account_info.code_hash())
+                    .await?
+            }
+        };
+        Ok(bytecode.original_bytes())
+    }
+
+    async fn call(
+        &self,
+        transaction_request: TransactionRequest,
+        block: BlockId,
+    ) -> RpcResult<Bytes> {
+        let evm_block_state = self.evm_block_state(block).await?;
+
+        let mut evm = create_evm_environment(evm_block_state.block_header());
+        // Allow unlimited gas
+        evm.cfg.disable_block_gas_limit = true;
+        let result_and_state = execute_transaction(transaction_request, evm, evm_block_state)
+            .await
+            .map_err(|err| RpcServeError::Message(err.to_string()))?;
+        let output = result_and_state.result.into_output().unwrap_or_default();
+        Ok(output)
     }
 }
 
@@ -191,144 +190,15 @@ impl EthApi {
 
     // State network related functions
 
-    async fn fetch_state_content(
-        &self,
-        content_key: StateContentKey,
-    ) -> Result<StateContentValue, RpcServeError> {
+    async fn evm_block_state(&self, block: BlockId) -> Result<EvmBlockState, RpcServeError> {
         let Some(state_network) = &self.state_network else {
-            return Err(RpcServeError::Message(format!(
-                "State network not enabled. Can't find: {content_key}"
-            )));
+            return Err(RpcServeError::Message(
+                "State network not enabled. Can't process request!".to_string(),
+            ));
         };
-
-        let endpoint = StateEndpoint::RecursiveFindContent(content_key.clone());
-        let response: ContentInfo = proxy_to_subnet(state_network, endpoint).await?;
-        let ContentInfo::Content { content, .. } = response else {
-            return Err(RpcServeError::Message(format!(
-                "Invalid response variant: State RecursiveFindContent should contain content value; got {response:?}"
-            )));
-        };
-
-        let content_value = StateContentValue::decode(&content_key, &content)?;
-        Ok(content_value)
-    }
-
-    async fn fetch_trie_node(&self, content_key: StateContentKey) -> Result<Node, RpcServeError> {
-        let content_value = self.fetch_state_content(content_key).await?;
-        let StateContentValue::TrieNode(trie_node) = content_value else {
-            return Err(RpcServeError::Message(format!(
-                "Invalid response: expected trie node; got {content_value:?}",
-            )));
-        };
-        trie_node
-            .node
-            .as_trie_node()
-            .map_err(|err| RpcServeError::Message(format!("Can't decode trie_node: {err}")))
-    }
-
-    async fn fetch_contract_bytecode(
-        &self,
-        address_hash: B256,
-        code_hash: B256,
-    ) -> Result<Bytes, RpcServeError> {
-        let content_key = StateContentKey::ContractBytecode(ContractBytecodeKey {
-            address_hash,
-            code_hash,
-        });
-        let content_value = self.fetch_state_content(content_key).await?;
-        let StateContentValue::ContractBytecode(contract_bytecode) = content_value else {
-            return Err(RpcServeError::Message(format!(
-                "Invalid response: expected contract bytecode; got {content_value:?}",
-            )));
-        };
-        let bytes = Vec::from(contract_bytecode.code);
-        Ok(Bytes::from(bytes))
-    }
-
-    async fn fetch_account_state(
-        &self,
-        state_root: B256,
-        address_hash: B256,
-    ) -> Result<Option<AccountState>, RpcServeError> {
-        self.traverse_trie(state_root, address_hash, |path, node_hash| {
-            StateContentKey::AccountTrieNode(AccountTrieNodeKey { path, node_hash })
-        })
-        .await
-    }
-
-    async fn fetch_contract_storage_at_slot(
-        &self,
-        storage_root: B256,
-        address_hash: B256,
-        storage_slot: U256,
-    ) -> Result<B256, RpcServeError> {
-        let path = keccak256(storage_slot.to_be_bytes::<32>());
-        let value = self
-            .traverse_trie::<Bytes>(storage_root, path, |path, node_hash| {
-                StateContentKey::ContractStorageTrieNode(ContractStorageTrieNodeKey {
-                    address_hash,
-                    path,
-                    node_hash,
-                })
-            })
-            .await?
-            .unwrap_or_default();
-        if value.len() > B256::len_bytes() {
-            return Err(RpcServeError::Message(format!(
-                "Storage value is too long. value: {value}"
-            )));
-        }
-
-        Ok(B256::left_padding_from(&value))
-    }
-
-    /// Utility function for fetching trie nodes and traversing the trie.
-    ///
-    /// This function works both with the account trie and the contract state trie.
-    async fn traverse_trie<T: Decodable>(
-        &self,
-        root: B256,
-        path: B256,
-        content_key_fn: impl Fn(Nibbles, B256) -> StateContentKey,
-    ) -> Result<Option<T>, RpcServeError> {
-        let path = Nibbles::unpack_nibbles(path.as_slice());
-
-        let mut node_hash = root;
-        let mut remaining_path = path.as_slice();
-
-        let value = loop {
-            let path_from_root = path
-                .strip_suffix(remaining_path)
-                .expect("Remaining path should be suffix of the path");
-
-            let content_key = content_key_fn(
-                Nibbles::try_from_unpacked_nibbles(path_from_root)
-                    .expect("we should be able to create Nibbles from path"),
-                node_hash,
-            );
-            let node = self.fetch_trie_node(content_key).await?;
-
-            match node.traverse(remaining_path) {
-                TraversalResult::Empty(_) => break None,
-                TraversalResult::Value(value) => break Some(value),
-                TraversalResult::Node(next_node) => {
-                    node_hash = next_node.hash;
-                    remaining_path = next_node.remaining_path;
-                }
-                TraversalResult::Error(err) => {
-                    return Err(RpcServeError::Message(format!(
-                        "Error traversing trie node: {err}"
-                    )))
-                }
-            }
-        };
-
-        value
-            .map(|value| T::decode(&mut value.as_ref()))
-            .transpose()
-            .map_err(|err| {
-                RpcServeError::Message(format!("Error decoding value from the leaf node: {err}"))
-            })
+        let block_hash = as_block_hash(block)?;
+        let header = self.fetch_header_by_hash(block_hash).await?;
+        Ok(EvmBlockState::new(header, state_network.clone()))
     }
 }
 

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -7,6 +7,7 @@ mod cors;
 mod discv5_rpc;
 mod errors;
 mod eth_rpc;
+mod evm_state;
 mod fetch;
 mod history_rpc;
 mod rpc_server;

--- a/trin-execution/Cargo.toml
+++ b/trin-execution/Cargo.toml
@@ -26,6 +26,7 @@ lazy_static.workspace = true
 parking_lot.workspace = true
 prometheus_exporter.workspace = true
 rayon = "1.10.0"
+reth-rpc-types.workspace = true
 revm.workspace = true
 revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "848d568" }
 revm-primitives.workspace = true

--- a/trin-execution/src/evm/blocking.rs
+++ b/trin-execution/src/evm/blocking.rs
@@ -1,0 +1,38 @@
+use revm::{
+    db::WrapDatabaseRef, inspector_handle_register, inspectors::NoOpInspector, DatabaseRef, Evm,
+    GetInspector,
+};
+use revm_primitives::{EVMResult, Env};
+
+use crate::{spec_id::get_spec_id, transaction::TxEnvModifier};
+
+/// Executes the transaction in the blocking manner.
+pub fn execute_transaction<DB: DatabaseRef>(
+    tx: &impl TxEnvModifier,
+    evm_environment: Env,
+    database: DB,
+) -> EVMResult<DB::Error> {
+    execute_transaction_with_external_context(tx, evm_environment, NoOpInspector, database)
+}
+
+/// Executes the transaction with external context in the blocking manner.
+pub fn execute_transaction_with_external_context<
+    DB: DatabaseRef,
+    EXT: GetInspector<WrapDatabaseRef<DB>>,
+>(
+    tx: &impl TxEnvModifier,
+    evm_environment: Env,
+    external_context: EXT,
+    database: DB,
+) -> EVMResult<DB::Error> {
+    let block_number = evm_environment.block.number.to::<u64>();
+    Evm::builder()
+        .with_ref_db(database)
+        .with_env(Box::new(evm_environment))
+        .with_spec_id(get_spec_id(block_number))
+        .modify_tx_env(|tx_env| tx.modify(block_number, tx_env))
+        .with_external_context(external_context)
+        .append_handler_register(inspector_handle_register)
+        .build()
+        .transact()
+}

--- a/trin-execution/src/evm/db.rs
+++ b/trin-execution/src/evm/db.rs
@@ -1,0 +1,70 @@
+use std::future::Future;
+
+use revm::DatabaseRef;
+use revm_primitives::{AccountInfo, Address, Bytecode, B256, U256};
+use tokio::runtime;
+
+/// The async version of the [DatabaseRef].
+pub trait AsyncDatabaseRef {
+    /// The database error type.
+    type Error;
+
+    /// Get basic account information.
+    fn basic_async(
+        &self,
+        address: Address,
+    ) -> impl Future<Output = Result<Option<AccountInfo>, Self::Error>> + Send;
+
+    /// Get account code by its hash.
+    fn code_by_hash_async(
+        &self,
+        code_hash: B256,
+    ) -> impl Future<Output = Result<Bytecode, Self::Error>> + Send;
+
+    /// Get storage value of address at index.
+    fn storage_async(
+        &self,
+        address: Address,
+        index: U256,
+    ) -> impl Future<Output = Result<U256, Self::Error>> + Send;
+
+    /// Get block hash by block number.
+    fn block_hash_async(
+        &self,
+        number: U256,
+    ) -> impl Future<Output = Result<B256, Self::Error>> + Send;
+}
+
+/// Wraps the [AsyncDatabaseRef] to provide [DatabaseRef] implementation.
+///
+/// This should only be used when blocking thread is allowed, e.g. from within spawn::blocking.
+pub(super) struct WrapAsyncDatabaseRef<DB: AsyncDatabaseRef> {
+    db: DB,
+    rt: runtime::Runtime,
+}
+
+impl<DB: AsyncDatabaseRef> WrapAsyncDatabaseRef<DB> {
+    pub fn new(db: DB, rt: runtime::Runtime) -> Self {
+        Self { db, rt }
+    }
+}
+
+impl<DB: AsyncDatabaseRef> DatabaseRef for WrapAsyncDatabaseRef<DB> {
+    type Error = DB::Error;
+
+    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.rt.block_on(self.db.basic_async(address))
+    }
+
+    fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.rt.block_on(self.db.code_by_hash_async(code_hash))
+    }
+
+    fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        self.rt.block_on(self.db.storage_async(address, index))
+    }
+
+    fn block_hash_ref(&self, number: U256) -> Result<B256, Self::Error> {
+        self.rt.block_on(self.db.block_hash_async(number))
+    }
+}

--- a/trin-execution/src/evm/mod.rs
+++ b/trin-execution/src/evm/mod.rs
@@ -1,0 +1,58 @@
+use db::{AsyncDatabaseRef, WrapAsyncDatabaseRef};
+use ethportal_api::Header;
+use revm_primitives::{EVMError, EVMResult, Env, SpecId, U256};
+use tokio::{runtime, task};
+
+use crate::{spec_id::get_spec_id, transaction::TxEnvModifier};
+
+pub mod blocking;
+pub mod db;
+
+/// Creates the EVM environment for a given block header.
+pub fn create_evm_environment(header: &Header) -> Env {
+    let mut env = Env::default();
+
+    let block = &mut env.block;
+    block.number = U256::from(header.number);
+    block.coinbase = header.author;
+    block.timestamp = U256::from(header.timestamp);
+    if get_spec_id(header.number).is_enabled_in(SpecId::MERGE) {
+        block.difficulty = U256::ZERO;
+        block.prevrandao = header.mix_hash;
+    } else {
+        block.difficulty = header.difficulty;
+        block.prevrandao = None;
+    }
+
+    block.gas_limit = header.gas_limit;
+    block.basefee = header.base_fee_per_gas.unwrap_or_default();
+
+    // EIP-4844 excess blob gas of this block, introduced in Cancun
+    if let Some(excess_blob_gas) = header.excess_blob_gas {
+        block.set_blob_excess_gas_and_price(excess_blob_gas.to());
+    }
+    env
+}
+
+/// Executes the transaction.
+///
+/// It will spawn blocking thread and execute the transaction in a blocking way on it.
+/// For executing transactions in a blocking manner, see "blocking" module.
+pub async fn execute_transaction<'a, DB, E, T>(tx: T, evm_environment: Env, db: DB) -> EVMResult<E>
+where
+    DB: AsyncDatabaseRef<Error = E> + Send + 'static,
+    E: Send + 'static,
+    T: TxEnvModifier + Send + 'static,
+{
+    task::spawn_blocking(move || {
+        let rt = runtime::Runtime::new().expect("to create Runtime within spawn_blocking");
+        let database = WrapAsyncDatabaseRef::new(db, rt);
+        blocking::execute_transaction(&tx, evm_environment, database)
+    })
+    .await
+    .unwrap_or_else(|err| {
+        Err(EVMError::Custom(format!(
+            "Error while executing transactions asynchronously: {err:?}"
+        )))
+    })
+}

--- a/trin-execution/src/lib.rs
+++ b/trin-execution/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod content;
 pub mod dao_fork;
 pub mod era;
+pub mod evm;
 pub mod execution;
 pub mod metrics;
 pub mod spec_id;


### PR DESCRIPTION
### What was wrong?

The `eth_call` wasn't supported.

### How was it fixed?

Refactored logic in trin-execution crate to make functionality more reusable (and added support for async database).
Also refactored `rpc/src/eth_rpc.rs` by extracting state related functionality into separate file.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
