### PR TITLE
fix: process_beacon_block() doesn't decode all types properly

### DIFF
--- a/trin-execution/src/era/beacon.rs
+++ b/trin-execution/src/era/beacon.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{B64, U64};
+use alloy_primitives::{Bloom, B64, U64};
 use alloy_rlp::Decodable;
 use ethportal_api::{
     consensus::{
@@ -43,8 +43,7 @@ impl ProcessBeaconBlock for SignedBeaconBlockBellatrix {
             state_root: payload.state_root,
             transactions_root: payload.transaction_root(),
             receipts_root: payload.receipts_root,
-            logs_bloom: Decodable::decode(&mut payload.logs_bloom.to_vec().as_slice())
-                .expect("We should always be able to decode the logs bloom of a block"),
+            logs_bloom: Bloom::from_slice(payload.logs_bloom.to_vec().as_slice()),
             difficulty: U256::ZERO,
             number: payload.block_number,
             gas_limit: U256::from(payload.gas_limit),
@@ -78,8 +77,7 @@ impl ProcessBeaconBlock for SignedBeaconBlockCapella {
             state_root: payload.state_root,
             transactions_root: payload.transaction_root(),
             receipts_root: payload.receipts_root,
-            logs_bloom: Decodable::decode(&mut payload.logs_bloom.to_vec().as_slice())
-                .expect("We should always be able to decode the logs bloom of a block"),
+            logs_bloom: Bloom::from_slice(payload.logs_bloom.to_vec().as_slice()),
             difficulty: U256::ZERO,
             number: payload.block_number,
             gas_limit: U256::from(payload.gas_limit),
@@ -113,8 +111,7 @@ impl ProcessBeaconBlock for SignedBeaconBlockDeneb {
             state_root: payload.state_root,
             transactions_root: payload.transaction_root(),
             receipts_root: payload.receipts_root,
-            logs_bloom: Decodable::decode(&mut payload.logs_bloom.to_vec().as_slice())
-                .expect("We should always be able to decode the logs bloom of a block"),
+            logs_bloom: Bloom::from_slice(payload.logs_bloom.to_vec().as_slice()),
             difficulty: U256::ZERO,
             number: payload.block_number,
             gas_limit: U256::from(payload.gas_limit),
@@ -144,9 +141,8 @@ fn process_transactions(
     transactions
         .into_par_iter()
         .map(|raw_tx| {
-            let transaction =
-                Transaction::decode_enveloped_transactions(&mut raw_tx.to_vec().as_slice())
-                    .map_err(|err| anyhow::anyhow!("Failed decoding transaction rlp: {err:?}"))?;
+            let transaction = Transaction::decode(&mut raw_tx.to_vec().as_slice())
+                .map_err(|err| anyhow::anyhow!("Failed decoding transaction rlp: {err:?}"))?;
             transaction
                 .get_transaction_sender_address()
                 .map(|sender_address| TransactionsWithSender {


### PR DESCRIPTION
### What was wrong?
decoding beacon blocks, to processed blocks fails
### How was it fixed?
So bloom is just a 256 bit number, it isn't encoded in RLP.

For transactions I used the wrong decode function for this use case

I tried to write some tests
```nim
#[cfg(test)]
mod tests {
    use crate::era::manager::EraManager;

    use super::*;

    use rstest::rstest;
    use serde_json::Value;

    #[tokio::test]
    async fn hi() {
        let mut era_manager = EraManager::new(19000000).await.unwrap();
        let block = era_manager.get_next_block().await.unwrap();
    }

    #[rstest]
    #[case("bellatrix/SignedBeaconBlock/ssz_random/case_0")]
    #[case("bellatrix/SignedBeaconBlock/ssz_random/case_1")]
    #[case("capella/SignedBeaconBlock/ssz_random/case_0")]
    #[case("capella/SignedBeaconBlock/ssz_random/case_1")]
    #[case("deneb/SignedBeaconBlock/ssz_random/case_0")]
    #[case("deneb/SignedBeaconBlock/ssz_random/case_1")]
    fn serde_signed_beacon_block_bellatrix(#[case] case: &str) {
        let value = std::fs::read_to_string(format!("../test_assets/beacon/{case}/value.yaml"))
            .expect("cannot find test asset");
        let value: Value = serde_yaml::from_str(&value).unwrap();
        let content: SignedBeaconBlock = serde_json::from_value(value.clone()).unwrap();
        content.process_beacon_block().unwrap();
    }
}
```

My second test was meant to be the gold ticket, but the test data we use for consensus testing has invalid transactions, but work for testing consensus types, as the consensus transaction type is Opaque

So I just used the first test to verified it works.

I think I will make an issue for dumping the valid SignedBeaconBlock so we can include this test
