### PR TITLE
chore: add a parallel ci test to ensure all workspace crates compile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,6 +224,32 @@ jobs:
           name: Test Trin workspace
           command: cargo test --workspace -- --nocapture
       - save-sccache-cache
+  # 'cargo check' performs all the compilation without actually building the crate, so it is quicker for the same guarantee
+  check-workspace-crates:
+    executor:
+      name: rust/default
+      tag: 1.79.0
+    # parallelism level should be set to the amount of simulators we have or greater
+    # The reason for this is the CI code currently only supports 1 input at a time
+    # if we have a parallelism level of 5 and 6 sims one test runner will get 2 test sims and fail
+    parallelism: 17
+    steps:
+      - checkout
+      - run:
+          name: Install jq
+          command: sudo apt install jq
+      - run:
+          name: Update packages
+          command: sudo apt update
+      - run:
+          name: Install libclang
+          command: sudo apt install -y clang          
+      - run:
+          name: "Check if crates build"
+          command: |
+            Crate=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name' | circleci tests split --split-by=timings)
+            echo "Checking crate: $Crate"
+            cargo check -p $Crate
   utp-test:
     description: |
       Run uTP network simulator
@@ -306,3 +332,4 @@ workflows:
       - test
       - check-windows
       - utp-test
+      - check-workspace-crates


### PR DESCRIPTION
### What was wrong?
When we updated cargo dependencies
https://github.com/ethereum/trin/pull/1411
https://github.com/ethereum/trin/pull/1414

failures to compile individual crates and this wasn't caught by CI
### How was it fixed?

creating a parallel ci test which checks all workspace crates

https://doc.rust-lang.org/cargo/commands/cargo-check.html here is a link to check, it basically just ensures `cargo build` works, without doing all the work so it is good for CI applications