### PR TITLE
perf: speed up tests by disabling UPnP

### DIFF
--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -2712,6 +2712,7 @@ mod tests {
     ) -> OverlayService<IdentityContentKey, XorMetric, MockValidator, MemoryContentStore> {
         let portal_config = PortalnetConfig {
             no_stun: true,
+            no_upnp: true,
             ..Default::default()
         };
         let temp_dir = setup_temp_dir().unwrap().into_path();

--- a/portalnet/tests/overlay.rs
+++ b/portalnet/tests/overlay.rs
@@ -258,6 +258,7 @@ async fn overlay() {
 async fn overlay_event_stream() {
     let portal_config = PortalnetConfig {
         no_stun: true,
+        no_upnp: true,
         ..Default::default()
     };
     let temp_dir = setup_temp_dir().unwrap().into_path();


### PR DESCRIPTION
Trying and failing to configure UPnP causes a 10second delay during each test that tries it.

### What was wrong?

Some tests were slow locally (and presumably in CI).

### How was it fixed?

Disable upnp during the test.

Comparing [this CI run](https://app.circleci.com/pipelines/github/ethereum/trin/6197/workflows/3f396eb1-4719-441b-8604-ca34fc03e013/jobs/24288) against [a recent test run](https://app.circleci.com/pipelines/github/ethereum/trin/6183/workflows/922467e0-508a-41b9-8c6b-316322470b4c/jobs/24195) shows a test speedup of 2 minutes and 21 seconds -- 8:42 vs 6:21.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
