### PR TITLE
chore: experimental messaging from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,11 @@
 
 Trin is a Rust implementation of a [Portal Network](https://github.com/ethereum/portal-network-specs) client.
 
-The Portal Network is still in the research phase, and this client is experimental.
-
-**Do not rely on Trin in a production setting.**
-
-
 ## How to use Trin
 
 Check out the [Trin book](https://ethereum.github.io/trin) to quickly get up and running with Trin.
 
 > **NOTE**: This project uses [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules). If you just cloned the project, be sure to run: `git submodule update --init`. See our dedicated [page](https://ethereum.github.io/trin/developers/contributing/git/submodules.html) for more info.
-
-## Experimental Status
-
-Trin is a prototype Portal Network client. This implementation and the Portal Network specifications will continue to co-evolve.
-
-In this stage of development, Trin lacks comprehensive data validation.
 
 ## Want to help?
 


### PR DESCRIPTION
### What was wrong?

- the readme says unix only, but this is no longer true (we want it to work with windows and would gladly take issues now)
- I think the experimental messaging is out dated now and counter productive. We expect people Trin is ready to use, but then the readme tells me to not use it, it is counter productive
### How was it fixed?

Removing the 2 issues from the readme.

Programs change overtime for example sigp/discv5 and ethereum/go-ethereum change over time but don't have this kind of messaging in the readme.

If we verbally say we are ready for other's to take us seriously, I think messaging and this PR is the first step.

Same goes for window's support
