### PR TITLE
feat(beacon): load trusted block root from database if not provided via CLI

### DIFF
--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -146,7 +146,7 @@ pub struct TrinConfig {
         value_parser = check_trusted_block_root,
         help = "Hex encoded block root from a trusted checkpoint"
     )]
-    pub trusted_block_root: Option<String>,
+    pub trusted_block_root: Option<B256>,
 
     #[arg(
     long = "portal-subnetworks",
@@ -345,13 +345,13 @@ pub fn network_parser(network_string: &str) -> Result<Arc<NetworkSpec>, String> 
     }
 }
 
-fn check_trusted_block_root(trusted_root: &str) -> Result<String, String> {
+fn check_trusted_block_root(trusted_root: &str) -> Result<B256, String> {
     if !trusted_root.starts_with("0x") {
         return Err("Trusted block root must be prefixed with 0x".to_owned());
     }
 
     if trusted_root.len() == 66 {
-        return Ok(trusted_root.to_string());
+        return B256::from_str(trusted_root).map_err(|err| format!("HexError: {err}"));
     }
     Err(format!(
         "Invalid trusted block root length: {}, expected 66 (0x-prefixed 32 byte hexstring)",

--- a/portalnet/src/config.rs
+++ b/portalnet/src/config.rs
@@ -24,7 +24,7 @@ pub struct PortalnetConfig {
     pub disable_poke: bool,
     // gossip content as it gets dropped from local storage
     pub gossip_dropped: bool,
-    pub trusted_block_root: Option<String>,
+    pub trusted_block_root: Option<B256>,
     // the max number of concurrent utp transfers
     pub utp_transfer_limit: usize,
 }
@@ -59,7 +59,7 @@ impl PortalnetConfig {
             bootnodes: trin_config.bootnodes.clone(),
             disable_poke: trin_config.disable_poke,
             gossip_dropped: trin_config.gossip_dropped,
-            trusted_block_root: trin_config.trusted_block_root.clone(),
+            trusted_block_root: trin_config.trusted_block_root,
             utp_transfer_limit: trin_config.utp_transfer_limit,
             ..Default::default()
         }

--- a/trin-beacon/src/sync.rs
+++ b/trin-beacon/src/sync.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::B256;
 use ethportal_api::BeaconContentKey;
 use light_client::{
     config::networks, consensus::rpc::portal_rpc::PortalRpc, database::FileDB, Client,
@@ -20,7 +21,7 @@ impl BeaconSync {
 
     pub async fn start(
         &self,
-        trusted_block_root: String,
+        trusted_block_root: B256,
     ) -> anyhow::Result<Client<FileDB, PortalRpc>> {
         // Create a new Light Client Builder
         let mut builder = ClientBuilder::new();
@@ -29,7 +30,7 @@ impl BeaconSync {
         builder = builder.network(networks::Network::Mainnet);
 
         // Set the checkpoint to the last known checkpoint
-        builder = builder.checkpoint(&trusted_block_root);
+        builder = builder.checkpoint(&trusted_block_root.to_string());
 
         // Set the data dir
         builder = builder.data_dir(PathBuf::from("/tmp/portal-light-client"));

--- a/trin-storage/src/sql.rs
+++ b/trin-storage/src/sql.rs
@@ -22,6 +22,10 @@ pub const LC_BOOTSTRAP_ROOT_LOOKUP_QUERY: &str =
 pub const LC_BOOTSTRAP_LOOKUP_QUERY: &str =
     "SELECT value FROM lc_bootstrap WHERE block_root = (?1) LIMIT 1";
 
+/// Query to get the block root of the latest bootstrap record.
+pub const LC_BOOTSTRAP_LATEST_BLOCK_ROOT_QUERY: &str =
+    "SELECT block_root FROM lc_bootstrap ORDER BY slot DESC LIMIT 1";
+
 /// Total beacon data size is the combination of lc_bootstrap, lc_update and historical_summaries
 /// tables
 pub const TOTAL_DATA_SIZE_QUERY_BEACON: &str = "SELECT


### PR DESCRIPTION
### What was wrong?

Fixes #1405.

### How was it fixed?
- add logic to check for a recent trusted block root if not provided via CLI
- update `trusted_block_root` argument to `B256`.
- fix `lookup_lc_bootstrap_block_root` method

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
