### PR TITLE
refactor: change RawContentKey to alloy_primites::Bytes

### DIFF
--- a/ethportal-api/src/types/content_key/beacon.rs
+++ b/ethportal-api/src/types/content_key/beacon.rs
@@ -3,7 +3,6 @@ use crate::{
     utils::bytes::hex_encode_compact,
     RawContentKey,
 };
-use alloy_primitives::Bytes;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
 use ssz::{Decode, DecodeError, Encode};
@@ -81,18 +80,6 @@ impl LightClientOptimisticUpdateKey {
 pub struct HistoricalSummariesWithProofKey {
     /// Epoch of the historical summaries.
     pub epoch: u64,
-}
-
-impl From<&BeaconContentKey> for Bytes {
-    fn from(val: &BeaconContentKey) -> Self {
-        val.to_bytes()
-    }
-}
-
-impl From<BeaconContentKey> for Bytes {
-    fn from(val: BeaconContentKey) -> Self {
-        val.to_bytes()
-    }
 }
 
 impl TryFrom<RawContentKey> for BeaconContentKey {

--- a/ethportal-api/src/types/content_key/beacon.rs
+++ b/ethportal-api/src/types/content_key/beacon.rs
@@ -1,7 +1,9 @@
 use crate::{
     types::content_key::{error::ContentKeyError, overlay::OverlayContentKey},
     utils::bytes::hex_encode_compact,
+    RawContentKey,
 };
+use alloy_primitives::Bytes;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
 use ssz::{Decode, DecodeError, Encode};
@@ -81,22 +83,22 @@ pub struct HistoricalSummariesWithProofKey {
     pub epoch: u64,
 }
 
-impl From<&BeaconContentKey> for Vec<u8> {
+impl From<&BeaconContentKey> for Bytes {
     fn from(val: &BeaconContentKey) -> Self {
         val.to_bytes()
     }
 }
 
-impl From<BeaconContentKey> for Vec<u8> {
+impl From<BeaconContentKey> for Bytes {
     fn from(val: BeaconContentKey) -> Self {
         val.to_bytes()
     }
 }
 
-impl TryFrom<Vec<u8>> for BeaconContentKey {
+impl TryFrom<RawContentKey> for BeaconContentKey {
     type Error = ContentKeyError;
 
-    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+    fn try_from(value: RawContentKey) -> Result<Self, Self::Error> {
         let Some((&selector, key)) = value.split_first() else {
             return Err(ContentKeyError::InvalidLength {
                 received: value.len(),
@@ -170,7 +172,7 @@ impl OverlayContentKey for BeaconContentKey {
         sha256.finalize().into()
     }
 
-    fn to_bytes(&self) -> Vec<u8> {
+    fn to_bytes(&self) -> RawContentKey {
         let mut bytes: Vec<u8> = Vec::new();
 
         match self {
@@ -196,7 +198,7 @@ impl OverlayContentKey for BeaconContentKey {
             }
         }
 
-        bytes
+        bytes.into()
     }
 }
 

--- a/ethportal-api/src/types/content_key/history.rs
+++ b/ethportal-api/src/types/content_key/history.rs
@@ -118,18 +118,6 @@ pub struct EpochAccumulatorKey {
     pub epoch_hash: B256,
 }
 
-impl From<&HistoryContentKey> for Vec<u8> {
-    fn from(val: &HistoryContentKey) -> Self {
-        val.to_bytes().to_vec()
-    }
-}
-
-impl From<HistoryContentKey> for Vec<u8> {
-    fn from(val: HistoryContentKey) -> Self {
-        val.to_bytes().to_vec()
-    }
-}
-
 impl TryFrom<RawContentKey> for HistoryContentKey {
     type Error = ContentKeyError;
 

--- a/ethportal-api/src/types/content_key/overlay.rs
+++ b/ethportal-api/src/types/content_key/overlay.rs
@@ -5,13 +5,13 @@ use quickcheck::{Arbitrary, Gen};
 use crate::{
     types::content_key::error::ContentKeyError,
     utils::bytes::{hex_decode, hex_encode, hex_encode_compact},
+    RawContentKey,
 };
 
 /// Types whose values represent keys to lookup content items in an overlay network.
 /// Keys are serializable.
 pub trait OverlayContentKey:
-    Into<Vec<u8>>
-    + TryFrom<Vec<u8>, Error = ContentKeyError>
+    TryFrom<RawContentKey, Error = ContentKeyError>
     + Clone
     + fmt::Debug
     + fmt::Display
@@ -25,7 +25,7 @@ pub trait OverlayContentKey:
     fn content_id(&self) -> [u8; 32];
 
     /// Returns the bytes of the content key.
-    fn to_bytes(&self) -> Vec<u8>;
+    fn to_bytes(&self) -> RawContentKey;
 
     /// Returns the content key as a hex encoded "0x"-prefixed string.
     fn to_hex(&self) -> String {
@@ -34,8 +34,8 @@ pub trait OverlayContentKey:
 
     /// Returns the content key from a hex encoded "0x"-prefixed string.
     fn from_hex(data: &str) -> anyhow::Result<Self> {
-        let bytes = hex_decode(&data.to_lowercase())?;
-        Ok(Self::try_from(bytes)?)
+        let bytes = hex_decode(data)?;
+        Ok(Self::try_from(bytes.into())?)
     }
 }
 
@@ -67,10 +67,10 @@ impl Arbitrary for IdentityContentKey {
     }
 }
 
-impl TryFrom<Vec<u8>> for IdentityContentKey {
+impl TryFrom<RawContentKey> for IdentityContentKey {
     type Error = ContentKeyError;
 
-    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+    fn try_from(value: RawContentKey) -> Result<Self, Self::Error> {
         // Require that length of input is equal to 32.
         if value.len() != 32 {
             return Err(ContentKeyError::InvalidLength {
@@ -116,7 +116,7 @@ impl OverlayContentKey for IdentityContentKey {
     fn content_id(&self) -> [u8; 32] {
         self.value
     }
-    fn to_bytes(&self) -> Vec<u8> {
-        self.value.to_vec()
+    fn to_bytes(&self) -> RawContentKey {
+        self.value.to_vec().into()
     }
 }

--- a/ethportal-api/src/types/content_key/overlay.rs
+++ b/ethportal-api/src/types/content_key/overlay.rs
@@ -4,9 +4,10 @@ use quickcheck::{Arbitrary, Gen};
 
 use crate::{
     types::content_key::error::ContentKeyError,
-    utils::bytes::{hex_decode, hex_encode, hex_encode_compact},
+    utils::bytes::{hex_encode, hex_encode_compact},
     RawContentKey,
 };
+use std::str::FromStr;
 
 /// Types whose values represent keys to lookup content items in an overlay network.
 /// Keys are serializable.
@@ -34,8 +35,7 @@ pub trait OverlayContentKey:
 
     /// Returns the content key from a hex encoded "0x"-prefixed string.
     fn from_hex(data: &str) -> anyhow::Result<Self> {
-        let bytes = hex_decode(data)?;
-        Ok(Self::try_from(bytes.into())?)
+        Ok(Self::try_from(RawContentKey::from_str(data)?)?)
     }
 }
 
@@ -117,6 +117,6 @@ impl OverlayContentKey for IdentityContentKey {
         self.value
     }
     fn to_bytes(&self) -> RawContentKey {
-        self.value.to_vec().into()
+        RawContentKey::from(self.value)
     }
 }

--- a/ethportal-api/src/types/content_key/state.rs
+++ b/ethportal-api/src/types/content_key/state.rs
@@ -92,18 +92,6 @@ impl OverlayContentKey for StateContentKey {
     }
 }
 
-impl From<&StateContentKey> for RawContentKey {
-    fn from(val: &StateContentKey) -> Self {
-        val.to_bytes()
-    }
-}
-
-impl From<StateContentKey> for RawContentKey {
-    fn from(val: StateContentKey) -> Self {
-        val.to_bytes()
-    }
-}
-
 impl TryFrom<RawContentKey> for StateContentKey {
     type Error = ContentKeyError;
     fn try_from(value: RawContentKey) -> Result<Self, Self::Error> {

--- a/ethportal-api/src/types/content_key/state.rs
+++ b/ethportal-api/src/types/content_key/state.rs
@@ -8,7 +8,7 @@ use std::{fmt, hash::Hash};
 use crate::{
     types::{content_key::overlay::OverlayContentKey, state_trie::nibbles::Nibbles},
     utils::bytes::hex_encode_compact,
-    ContentKeyError,
+    ContentKeyError, RawContentKey,
 };
 
 // Prefixes for the different types of state content keys:
@@ -70,7 +70,7 @@ impl OverlayContentKey for StateContentKey {
         sha256.finalize().into()
     }
 
-    fn to_bytes(&self) -> Vec<u8> {
+    fn to_bytes(&self) -> RawContentKey {
         let mut bytes: Vec<u8> = vec![];
 
         match self {
@@ -88,25 +88,25 @@ impl OverlayContentKey for StateContentKey {
             }
         }
 
-        bytes
+        bytes.into()
     }
 }
 
 impl From<&StateContentKey> for Vec<u8> {
     fn from(val: &StateContentKey) -> Self {
-        val.to_bytes()
+        val.to_bytes().to_vec()
     }
 }
 
 impl From<StateContentKey> for Vec<u8> {
     fn from(val: StateContentKey) -> Self {
-        val.to_bytes()
+        val.to_bytes().to_vec()
     }
 }
 
-impl TryFrom<Vec<u8>> for StateContentKey {
+impl TryFrom<RawContentKey> for StateContentKey {
     type Error = ContentKeyError;
-    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+    fn try_from(value: RawContentKey) -> Result<Self, Self::Error> {
         let Some((&selector, key)) = value.split_first() else {
             return Err(ContentKeyError::from_decode_error(
                 DecodeError::InvalidLengthPrefix {
@@ -187,7 +187,7 @@ impl fmt::Display for StateContentKey {
 mod test {
     use std::{path::PathBuf, str::FromStr};
 
-    use alloy_primitives::{keccak256, Address};
+    use alloy_primitives::{bytes, keccak256, Address, Bytes};
     use anyhow::Result;
     use rstest::rstest;
     use serde_yaml::Value;
@@ -242,16 +242,20 @@ mod test {
     #[test]
     fn decode_empty_key_should_fail() {
         assert_eq!(
-            StateContentKey::try_from(vec![]).unwrap_err().to_string(),
+            StateContentKey::try_from(Bytes::new())
+                .unwrap_err()
+                .to_string(),
             "Unable to decode key SSZ bytes 0x due to InvalidLengthPrefix { len: 0, expected: 1 }",
         );
     }
 
     #[test]
     fn decode_key_with_invalid_selector_should_fail() {
-        let invalid_selector_content_key = "0x0024000000c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a4700005000000";
+        let invalid_selector_content_key = bytes!(
+            "0024000000c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a4700005000000"
+        );
         assert_eq!(
-            StateContentKey::try_from(hex_decode(invalid_selector_content_key).unwrap())
+            StateContentKey::try_from(invalid_selector_content_key.clone())
                 .unwrap_err()
                 .to_string(),
             format!("Unable to decode key SSZ bytes {invalid_selector_content_key} due to UnionSelectorInvalid(0)"),
@@ -267,9 +271,9 @@ mod test {
         let yaml = yaml.as_mapping().unwrap();
 
         let content_key_bytes = hex_decode(yaml["content_key"].as_str().unwrap())?;
-        let content_key = StateContentKey::try_from(content_key_bytes.clone())?;
+        let content_key = StateContentKey::try_from(Bytes::from(content_key_bytes.clone()))?;
 
-        assert_eq!(content_key.to_bytes(), content_key_bytes);
+        assert_eq!(content_key.to_bytes(), Bytes::from(content_key_bytes));
         Ok(())
     }
 
@@ -300,7 +304,7 @@ mod test {
         let yaml = yaml.as_mapping().unwrap();
 
         let content_key_bytes = hex_decode(yaml["content_key"].as_str().unwrap())?;
-        let content_key = StateContentKey::try_from(content_key_bytes)?;
+        let content_key = StateContentKey::try_from(Bytes::from(content_key_bytes))?;
         let expected_content_id = yaml_as_b256(&yaml["content_id"]);
 
         assert_eq!(B256::from(content_key.content_id()), expected_content_id);
@@ -337,7 +341,7 @@ mod test {
 
     fn assert_content_key(value: &Value, expected_content_key: StateContentKey) -> Result<()> {
         assert_eq!(
-            StateContentKey::try_from(yaml_as_hex(value))?,
+            StateContentKey::try_from(Bytes::from(yaml_as_hex(value)))?,
             expected_content_key,
             "decoding from bytes {value:?} didn't match expected key {expected_content_key:?}"
         );

--- a/ethportal-api/src/types/content_key/state.rs
+++ b/ethportal-api/src/types/content_key/state.rs
@@ -88,19 +88,19 @@ impl OverlayContentKey for StateContentKey {
             }
         }
 
-        bytes.into()
+        RawContentKey::from(bytes)
     }
 }
 
-impl From<&StateContentKey> for Vec<u8> {
+impl From<&StateContentKey> for RawContentKey {
     fn from(val: &StateContentKey) -> Self {
-        val.to_bytes().to_vec()
+        val.to_bytes()
     }
 }
 
-impl From<StateContentKey> for Vec<u8> {
+impl From<StateContentKey> for RawContentKey {
     fn from(val: StateContentKey) -> Self {
-        val.to_bytes().to_vec()
+        val.to_bytes()
     }
 }
 
@@ -242,7 +242,7 @@ mod test {
     #[test]
     fn decode_empty_key_should_fail() {
         assert_eq!(
-            StateContentKey::try_from(Bytes::new())
+            StateContentKey::try_from(RawContentKey::new())
                 .unwrap_err()
                 .to_string(),
             "Unable to decode key SSZ bytes 0x due to InvalidLengthPrefix { len: 0, expected: 1 }",
@@ -270,10 +270,10 @@ mod test {
         let yaml = read_yaml_file(filename)?;
         let yaml = yaml.as_mapping().unwrap();
 
-        let content_key_bytes = hex_decode(yaml["content_key"].as_str().unwrap())?;
-        let content_key = StateContentKey::try_from(Bytes::from(content_key_bytes.clone()))?;
+        let content_key_bytes = RawContentKey::from_str(yaml["content_key"].as_str().unwrap())?;
+        let content_key = StateContentKey::try_from(content_key_bytes.clone())?;
 
-        assert_eq!(content_key.to_bytes(), Bytes::from(content_key_bytes));
+        assert_eq!(content_key.to_bytes(), content_key_bytes);
         Ok(())
     }
 

--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -7,7 +7,7 @@ use crate::{types::enr::Enr, OverlayContentKey};
 use super::query_trace::QueryTrace;
 
 /// The SSZ encoded representation of content key.
-pub type RawContentKey = Vec<u8>;
+pub type RawContentKey = Bytes;
 /// The SSZ encoded representation of content value.
 pub type RawContentValue = Bytes;
 

--- a/ethportal-api/src/types/portal_wire.rs
+++ b/ethportal-api/src/types/portal_wire.rs
@@ -821,7 +821,7 @@ mod test {
 
     #[test]
     fn message_encoding_offer() {
-        let content_keys = vec![hex_decode("0x010203").unwrap()];
+        let content_keys = vec![hex_decode("0x010203").unwrap().into()];
         let offer = Offer { content_keys };
         let offer = Message::Offer(offer);
 

--- a/ethportal-api/src/types/portal_wire.rs
+++ b/ethportal-api/src/types/portal_wire.rs
@@ -622,6 +622,7 @@ impl From<Accept> for Value {
 #[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
+    use alloy_primitives::bytes;
     use std::str::FromStr;
     use test_log::test;
 
@@ -821,7 +822,7 @@ mod test {
 
     #[test]
     fn message_encoding_offer() {
-        let content_keys = vec![hex_decode("0x010203").unwrap().into()];
+        let content_keys = vec![bytes!("010203")];
         let offer = Offer { content_keys };
         let offer = Message::Offer(offer);
 

--- a/portalnet/src/find/query_info.rs
+++ b/portalnet/src/find/query_info.rs
@@ -73,7 +73,7 @@ impl<TContentKey: OverlayContentKey> QueryInfo<TContentKey> {
                 Request::FindNodes(FindNodes { distances })
             }
             QueryType::FindContent { ref target, .. } => Request::FindContent(FindContent {
-                content_key: target.clone().into(),
+                content_key: target.clone().to_bytes().to_vec(),
             }),
         };
 

--- a/portalnet/src/find/query_info.rs
+++ b/portalnet/src/find/query_info.rs
@@ -73,7 +73,7 @@ impl<TContentKey: OverlayContentKey> QueryInfo<TContentKey> {
                 Request::FindNodes(FindNodes { distances })
             }
             QueryType::FindContent { ref target, .. } => Request::FindContent(FindContent {
-                content_key: target.clone().to_bytes().to_vec(),
+                content_key: target.to_bytes().to_vec(),
             }),
         };
 

--- a/portalnet/src/gossip.rs
+++ b/portalnet/src/gossip.rs
@@ -135,7 +135,7 @@ pub fn propagate_gossip_cross_thread<TContentKey: OverlayContentKey>(
         // change content keys to raw content keys
         let interested_content = interested_content
             .into_iter()
-            .map(|(key, value)| (key.into(), value))
+            .map(|(key, value)| (key.into().into(), value))
             .collect();
         let offer_request = Request::PopulatedOffer(PopulatedOffer {
             content_items: interested_content,
@@ -197,7 +197,7 @@ pub async fn trace_propagate_gossip_cross_thread<TContentKey: OverlayContentKey>
     for enr in interested_enrs.into_iter() {
         let (result_tx, mut result_rx) = tokio::sync::mpsc::unbounded_channel();
         let offer_request = Request::PopulatedOfferWithResult(PopulatedOfferWithResult {
-            content_item: (content_key.clone().into(), data.clone()),
+            content_item: (content_key.clone().into().into(), data.clone()),
             result_tx,
         });
 

--- a/portalnet/src/gossip.rs
+++ b/portalnet/src/gossip.rs
@@ -135,7 +135,7 @@ pub fn propagate_gossip_cross_thread<TContentKey: OverlayContentKey>(
         // change content keys to raw content keys
         let interested_content = interested_content
             .into_iter()
-            .map(|(key, value)| (key.into().into(), value))
+            .map(|(key, value)| (key.to_bytes(), value))
             .collect();
         let offer_request = Request::PopulatedOffer(PopulatedOffer {
             content_items: interested_content,
@@ -197,7 +197,7 @@ pub async fn trace_propagate_gossip_cross_thread<TContentKey: OverlayContentKey>
     for enr in interested_enrs.into_iter() {
         let (result_tx, mut result_rx) = tokio::sync::mpsc::unbounded_channel();
         let offer_request = Request::PopulatedOfferWithResult(PopulatedOfferWithResult {
-            content_item: (content_key.clone().into().into(), data.clone()),
+            content_item: (content_key.clone().to_bytes(), data.clone()),
             result_tx,
         });
 

--- a/portalnet/src/overlay/protocol.rs
+++ b/portalnet/src/overlay/protocol.rs
@@ -94,7 +94,7 @@ impl<
         TStore: 'static + ContentStore<Key = TContentKey> + Send + Sync,
     > OverlayProtocol<TContentKey, TMetric, TValidator, TStore>
 where
-    <TContentKey as TryFrom<Vec<u8>>>::Error: Debug + Display + Send,
+    <TContentKey as TryFrom<RawContentKey>>::Error: Debug + Display + Send,
 {
     pub async fn new(
         config: OverlayConfig,
@@ -441,7 +441,7 @@ where
         let direction = RequestDirection::Outgoing {
             destination: enr.clone(),
         };
-        let content_key = TContentKey::try_from(content_key).map_err(|err| {
+        let content_key = TContentKey::try_from(content_key.into()).map_err(|err| {
             OverlayRequestError::FailedValidation(format!(
                 "Error decoding content key for received utp content: {err}"
             ))

--- a/portalnet/src/overlay/protocol.rs
+++ b/portalnet/src/overlay/protocol.rs
@@ -527,7 +527,7 @@ where
         let content_items = content_keys
             .into_iter()
             .map(|key| match self.store.read().get(&key) {
-                Ok(Some(content)) => Ok((key.into(), content.clone())),
+                Ok(Some(content)) => Ok((key.to_bytes().into(), content.clone())),
                 _ => Err(OverlayRequestError::ContentNotFound {
                     message: format!("Content key not found in local store: {key:02X?}"),
                     utp: false,

--- a/portalnet/src/overlay/protocol.rs
+++ b/portalnet/src/overlay/protocol.rs
@@ -527,7 +527,7 @@ where
         let content_items = content_keys
             .into_iter()
             .map(|key| match self.store.read().get(&key) {
-                Ok(Some(content)) => Ok((key.to_bytes().into(), content.clone())),
+                Ok(Some(content)) => Ok((key.to_bytes(), content.clone())),
                 _ => Err(OverlayRequestError::ContentNotFound {
                     message: format!("Content key not found in local store: {key:02X?}"),
                     utp: false,

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -756,7 +756,7 @@ where
                 TMetric::distance(&node_id.raw(), &content_id) <= node.data_radius;
             if is_within_radius {
                 let content_items: Vec<(RawContentKey, Vec<u8>)> =
-                    vec![(content_key.clone().to_bytes(), content.clone())];
+                    vec![(content_key.to_bytes(), content.clone())];
                 let offer_request = Request::PopulatedOffer(PopulatedOffer { content_items });
 
                 // if we have met the max outbound utp transfer limit continue the loop as we aren't
@@ -1030,7 +1030,7 @@ where
         let content_keys: Vec<TContentKey> = request
             .content_keys
             .into_iter()
-            .map(|k| (TContentKey::try_from)(k.as_ssz_bytes().into()))
+            .map(TContentKey::try_from)
             .collect::<Result<Vec<TContentKey>, _>>()
             .map_err(|_| {
                 OverlayRequestError::AcceptError(
@@ -1654,7 +1654,7 @@ where
             }
         };
         let request = Request::FindContent(FindContent {
-            content_key: content_key.clone().to_bytes().to_vec(),
+            content_key: content_key.to_bytes().to_vec(),
         });
         let direction = RequestDirection::Outgoing {
             destination: fallback_peer.clone(),
@@ -2022,7 +2022,7 @@ where
         let content_keys_offered: Result<Vec<TContentKey>, TContentKey::Error> =
             content_keys_offered
                 .into_iter()
-                .map(|key| TContentKey::try_from(key.as_ssz_bytes().into()))
+                .map(TContentKey::try_from)
                 .collect();
 
         let content_keys_offered: Vec<TContentKey> = content_keys_offered

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -755,7 +755,8 @@ where
             let is_within_radius =
                 TMetric::distance(&node_id.raw(), &content_id) <= node.data_radius;
             if is_within_radius {
-                let content_items: Vec<(RawContentKey, Vec<u8>)> = vec![(content_key.clone().into().into(), content.clone())];
+                let content_items: Vec<(RawContentKey, Vec<u8>)> =
+                    vec![(content_key.clone().into().into(), content.clone())];
                 let offer_request = Request::PopulatedOffer(PopulatedOffer { content_items });
 
                 // if we have met the max outbound utp transfer limit continue the loop as we aren't

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -165,7 +165,7 @@ impl<
         TStore: 'static + ContentStore<Key = TContentKey> + Send + Sync,
     > OverlayService<TContentKey, TMetric, TValidator, TStore>
 where
-    <TContentKey as TryFrom<Vec<u8>>>::Error: Debug,
+    <TContentKey as TryFrom<RawContentKey>>::Error: Debug,
 {
     /// Spawns the overlay network service.
     ///
@@ -192,7 +192,7 @@ where
         gossip_dropped: bool,
     ) -> UnboundedSender<OverlayCommand<TContentKey>>
     where
-        <TContentKey as TryFrom<Vec<u8>>>::Error: Send,
+        <TContentKey as TryFrom<RawContentKey>>::Error: Send,
     {
         let (command_tx, command_rx) = mpsc::unbounded_channel();
         let internal_command_tx = command_tx.clone();
@@ -756,7 +756,7 @@ where
                 TMetric::distance(&node_id.raw(), &content_id) <= node.data_radius;
             if is_within_radius {
                 let content_items: Vec<(RawContentKey, Vec<u8>)> =
-                    vec![(content_key.clone().into().into(), content.clone())];
+                    vec![(content_key.clone().to_bytes(), content.clone())];
                 let offer_request = Request::PopulatedOffer(PopulatedOffer { content_items });
 
                 // if we have met the max outbound utp transfer limit continue the loop as we aren't
@@ -933,7 +933,7 @@ where
             "Handling FindContent message",
         );
 
-        let content_key = match (TContentKey::try_from)(request.content_key) {
+        let content_key = match (TContentKey::try_from)(request.content_key.into()) {
             Ok(key) => key,
             Err(_) => {
                 return Err(OverlayRequestError::InvalidRequest(
@@ -1030,7 +1030,7 @@ where
         let content_keys: Vec<TContentKey> = request
             .content_keys
             .into_iter()
-            .map(|k| (TContentKey::try_from)(k.as_ssz_bytes()))
+            .map(|k| (TContentKey::try_from)(k.as_ssz_bytes().into()))
             .collect::<Result<Vec<TContentKey>, _>>()
             .map_err(|_| {
                 OverlayRequestError::AcceptError(
@@ -1654,7 +1654,7 @@ where
             }
         };
         let request = Request::FindContent(FindContent {
-            content_key: content_key.clone().into(),
+            content_key: content_key.clone().to_bytes().to_vec(),
         });
         let direction = RequestDirection::Outgoing {
             destination: fallback_peer.clone(),
@@ -2022,7 +2022,7 @@ where
         let content_keys_offered: Result<Vec<TContentKey>, TContentKey::Error> =
             content_keys_offered
                 .into_iter()
-                .map(|key| TContentKey::try_from(key.as_ssz_bytes()))
+                .map(|key| TContentKey::try_from(key.as_ssz_bytes().into()))
                 .collect();
 
         let content_keys_offered: Vec<TContentKey> = content_keys_offered

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -755,7 +755,7 @@ where
             let is_within_radius =
                 TMetric::distance(&node_id.raw(), &content_id) <= node.data_radius;
             if is_within_radius {
-                let content_items = vec![(content_key.clone().into(), content.clone())];
+                let content_items: Vec<(RawContentKey, Vec<u8>)> = vec![(content_key.clone().into().into(), content.clone())];
                 let offer_request = Request::PopulatedOffer(PopulatedOffer { content_items });
 
                 // if we have met the max outbound utp transfer limit continue the loop as we aren't
@@ -1029,7 +1029,7 @@ where
         let content_keys: Vec<TContentKey> = request
             .content_keys
             .into_iter()
-            .map(|k| (TContentKey::try_from)(k))
+            .map(|k| (TContentKey::try_from)(k.as_ssz_bytes()))
             .collect::<Result<Vec<TContentKey>, _>>()
             .map_err(|_| {
                 OverlayRequestError::AcceptError(
@@ -2021,7 +2021,7 @@ where
         let content_keys_offered: Result<Vec<TContentKey>, TContentKey::Error> =
             content_keys_offered
                 .into_iter()
-                .map(|key| TContentKey::try_from(key))
+                .map(|key| TContentKey::try_from(key.as_ssz_bytes()))
                 .collect();
 
         let content_keys_offered: Vec<TContentKey> = content_keys_offered

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -353,7 +353,11 @@ async fn offer(
 ) -> Result<Value, String> {
     match network
         .overlay
-        .send_offer(enr, content_key.to_bytes().into(), content_value.encode().to_vec())
+        .send_offer(
+            enr,
+            content_key.to_bytes().into(),
+            content_value.encode().to_vec(),
+        )
         .await
     {
         Ok(accept) => Ok(json!(AcceptInfo {
@@ -372,7 +376,11 @@ async fn trace_offer(
 ) -> Result<Value, String> {
     match network
         .overlay
-        .send_offer_trace(enr,  content_key.to_bytes().into(), content_value.encode().to_vec())
+        .send_offer_trace(
+            enr,
+            content_key.to_bytes().into(),
+            content_value.encode().to_vec(),
+        )
         .await
     {
         Ok(accept) => Ok(json!(accept)),

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -353,7 +353,7 @@ async fn offer(
 ) -> Result<Value, String> {
     match network
         .overlay
-        .send_offer(enr, content_key.into(), content_value.encode().to_vec())
+        .send_offer(enr, content_key.to_bytes().into(), content_value.encode().to_vec())
         .await
     {
         Ok(accept) => Ok(json!(AcceptInfo {
@@ -372,7 +372,7 @@ async fn trace_offer(
 ) -> Result<Value, String> {
     match network
         .overlay
-        .send_offer_trace(enr, content_key.into(), content_value.encode().to_vec())
+        .send_offer_trace(enr,  content_key.to_bytes().into(), content_value.encode().to_vec())
         .await
     {
         Ok(accept) => Ok(json!(accept)),

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -289,7 +289,7 @@ async fn find_content(
     enr: discv5::enr::Enr<discv5::enr::CombinedKey>,
     content_key: BeaconContentKey,
 ) -> Result<Value, String> {
-    match network.overlay.send_find_content(enr, content_key.into()).await {
+    match network.overlay.send_find_content(enr, content_key.to_bytes().to_vec()).await {
         Ok((content, utp_transfer)) => match content{
             Content::ConnectionId(id) => Err(format!(
                 "FindContent request returned a connection id ({id:?}) instead of conducting utp transfer."

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -355,7 +355,7 @@ async fn offer(
         .overlay
         .send_offer(
             enr,
-            content_key.to_bytes().into(),
+            content_key.to_bytes(),
             content_value.encode().to_vec(),
         )
         .await
@@ -378,7 +378,7 @@ async fn trace_offer(
         .overlay
         .send_offer_trace(
             enr,
-            content_key.to_bytes().into(),
+            content_key.to_bytes(),
             content_value.encode().to_vec(),
         )
         .await

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -353,11 +353,7 @@ async fn offer(
 ) -> Result<Value, String> {
     match network
         .overlay
-        .send_offer(
-            enr,
-            content_key.to_bytes(),
-            content_value.encode().to_vec(),
-        )
+        .send_offer(enr, content_key.to_bytes(), content_value.encode().to_vec())
         .await
     {
         Ok(accept) => Ok(json!(AcceptInfo {
@@ -376,11 +372,7 @@ async fn trace_offer(
 ) -> Result<Value, String> {
     match network
         .overlay
-        .send_offer_trace(
-            enr,
-            content_key.to_bytes(),
-            content_value.encode().to_vec(),
-        )
+        .send_offer_trace(enr, content_key.to_bytes(), content_value.encode().to_vec())
         .await
     {
         Ok(accept) => Ok(json!(accept)),

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -125,7 +125,7 @@ impl ContentStore for BeaconStorage {
     type Key = BeaconContentKey;
 
     fn get(&self, key: &Self::Key) -> Result<Option<Vec<u8>>, ContentStoreError> {
-        let content_key: RawContentKey = key.clone().to_bytes();
+        let content_key: RawContentKey = key.to_bytes();
         let beacon_content_key = BeaconContentKey::try_from(content_key).map_err(|err| {
             ContentStoreError::InvalidData {
                 message: format!("Error deserializing BeaconContentKey value: {err:?}"),
@@ -217,7 +217,7 @@ impl ContentStore for BeaconStorage {
         &self,
         key: &Self::Key,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
-        let content_key: RawContentKey = key.clone().to_bytes();
+        let content_key: RawContentKey = key.to_bytes();
         let beacon_content_key = BeaconContentKey::try_from(content_key).map_err(|err| {
             ContentStoreError::InvalidData {
                 message: format!("Error deserializing BeaconContentKey value: {err:?}"),
@@ -379,7 +379,7 @@ impl BeaconStorage {
         value: &Vec<u8>,
     ) -> Result<(), ContentStoreError> {
         let content_id = key.content_id();
-        let content_key: RawContentKey = key.clone().to_bytes();
+        let content_key: RawContentKey = key.to_bytes();
 
         match content_key.first() {
             Some(&LIGHT_CLIENT_BOOTSTRAP_KEY_PREFIX) => {

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -1,5 +1,4 @@
 use alloy_primitives::B256;
-use alloy_primitives::Bytes;
 use ethportal_api::{
     consensus::fork::ForkName,
     types::{

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::B256;
+use alloy_primitives::Bytes;
 use ethportal_api::{
     consensus::fork::ForkName,
     types::{
@@ -16,7 +17,7 @@ use ethportal_api::{
         portal::PaginateLocalContentInfo,
         portal_wire::ProtocolId,
     },
-    BeaconContentKey, OverlayContentKey,
+    BeaconContentKey, OverlayContentKey, RawContentKey,
 };
 use r2d2::Pool;
 use r2d2_sqlite::{rusqlite, SqliteConnectionManager};
@@ -125,7 +126,7 @@ impl ContentStore for BeaconStorage {
     type Key = BeaconContentKey;
 
     fn get(&self, key: &Self::Key) -> Result<Option<Vec<u8>>, ContentStoreError> {
-        let content_key: Vec<u8> = key.clone().into();
+        let content_key: RawContentKey = key.clone().to_bytes();
         let beacon_content_key = BeaconContentKey::try_from(content_key).map_err(|err| {
             ContentStoreError::InvalidData {
                 message: format!("Error deserializing BeaconContentKey value: {err:?}"),
@@ -217,7 +218,7 @@ impl ContentStore for BeaconStorage {
         &self,
         key: &Self::Key,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
-        let content_key: Vec<u8> = key.clone().into();
+        let content_key: RawContentKey = key.clone().to_bytes();
         let beacon_content_key = BeaconContentKey::try_from(content_key).map_err(|err| {
             ContentStoreError::InvalidData {
                 message: format!("Error deserializing BeaconContentKey value: {err:?}"),
@@ -379,7 +380,7 @@ impl BeaconStorage {
         value: &Vec<u8>,
     ) -> Result<(), ContentStoreError> {
         let content_id = key.content_id();
-        let content_key: Vec<u8> = key.clone().into();
+        let content_key: RawContentKey = key.clone().to_bytes();
 
         match content_key.first() {
             Some(&LIGHT_CLIENT_BOOTSTRAP_KEY_PREFIX) => {

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -341,7 +341,7 @@ async fn offer(
         .overlay
         .send_offer(
             enr,
-            content_key.to_bytes().into(),
+            content_key.to_bytes(),
             content_value.encode().to_vec(),
         )
         .await
@@ -364,7 +364,7 @@ async fn trace_offer(
         .overlay
         .send_offer_trace(
             enr,
-            content_key.to_bytes().into(),
+            content_key.to_bytes(),
             content_value.encode().to_vec(),
         )
         .await

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -339,11 +339,7 @@ async fn offer(
 ) -> Result<Value, String> {
     match network
         .overlay
-        .send_offer(
-            enr,
-            content_key.to_bytes(),
-            content_value.encode().to_vec(),
-        )
+        .send_offer(enr, content_key.to_bytes(), content_value.encode().to_vec())
         .await
     {
         Ok(accept) => Ok(json!(AcceptInfo {
@@ -362,11 +358,7 @@ async fn trace_offer(
 ) -> Result<Value, String> {
     match network
         .overlay
-        .send_offer_trace(
-            enr,
-            content_key.to_bytes(),
-            content_value.encode().to_vec(),
-        )
+        .send_offer_trace(enr, content_key.to_bytes(), content_value.encode().to_vec())
         .await
     {
         Ok(accept) => Ok(json!(accept)),

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -339,7 +339,7 @@ async fn offer(
 ) -> Result<Value, String> {
     match network
         .overlay
-        .send_offer(enr, content_key.into(), content_value.encode().to_vec())
+        .send_offer(enr, content_key.to_bytes().into(), content_value.encode().to_vec())
         .await
     {
         Ok(accept) => Ok(json!(AcceptInfo {
@@ -358,7 +358,7 @@ async fn trace_offer(
 ) -> Result<Value, String> {
     match network
         .overlay
-        .send_offer_trace(enr, content_key.into(), content_value.encode().to_vec())
+        .send_offer_trace(enr, content_key.to_bytes().into(), content_value.encode().to_vec())
         .await
     {
         Ok(accept) => Ok(json!(accept)),

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -339,7 +339,11 @@ async fn offer(
 ) -> Result<Value, String> {
     match network
         .overlay
-        .send_offer(enr, content_key.to_bytes().into(), content_value.encode().to_vec())
+        .send_offer(
+            enr,
+            content_key.to_bytes().into(),
+            content_value.encode().to_vec(),
+        )
         .await
     {
         Ok(accept) => Ok(json!(AcceptInfo {
@@ -358,7 +362,11 @@ async fn trace_offer(
 ) -> Result<Value, String> {
     match network
         .overlay
-        .send_offer_trace(enr, content_key.to_bytes().into(), content_value.encode().to_vec())
+        .send_offer_trace(
+            enr,
+            content_key.to_bytes().into(),
+            content_value.encode().to_vec(),
+        )
         .await
     {
         Ok(accept) => Ok(json!(accept)),

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -269,7 +269,7 @@ async fn find_content(
     enr: discv5::enr::Enr<discv5::enr::CombinedKey>,
     content_key: HistoryContentKey,
 ) -> Result<Value, String> {
-    match network.overlay.send_find_content(enr, content_key.into()).await {
+    match network.overlay.send_find_content(enr, content_key.to_bytes().to_vec()).await {
         Ok((content, utp_transfer)) => match content {
             Content::ConnectionId(id) => Err(format!(
                 "FindContent request returned a connection id ({id:?}) instead of conducting utp transfer."

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -309,11 +309,7 @@ async fn offer(
         "Offer",
         network
             .overlay
-            .send_offer(
-                enr,
-                content_key.to_bytes(),
-                content_value.encode().to_vec(),
-            )
+            .send_offer(enr, content_key.to_bytes(), content_value.encode().to_vec())
             .await
             .map(|accept| AcceptInfo {
                 content_keys: accept.content_keys,
@@ -331,11 +327,7 @@ async fn trace_offer(
         "TraceOffer",
         network
             .overlay
-            .send_offer_trace(
-                enr,
-                content_key.to_bytes(),
-                content_value.encode().to_vec(),
-            )
+            .send_offer_trace(enr, content_key.to_bytes(), content_value.encode().to_vec())
             .await,
     )
 }

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -196,7 +196,7 @@ async fn find_content(
 ) -> Result<Value, String> {
     let result = network
     .overlay
-    .send_find_content(enr, content_key.into())
+    .send_find_content(enr, content_key.to_bytes().to_vec())
     .await
     .and_then(|(content, utp_transfer)| match content {
         Content::ConnectionId(id) => Err(OverlayRequestError::Failure(format!(

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -309,7 +309,11 @@ async fn offer(
         "Offer",
         network
             .overlay
-            .send_offer(enr, content_key.to_bytes().into(), content_value.encode().to_vec())
+            .send_offer(
+                enr,
+                content_key.to_bytes().into(),
+                content_value.encode().to_vec(),
+            )
             .await
             .map(|accept| AcceptInfo {
                 content_keys: accept.content_keys,
@@ -327,7 +331,11 @@ async fn trace_offer(
         "TraceOffer",
         network
             .overlay
-            .send_offer_trace(enr, content_key.to_bytes().into(), content_value.encode().to_vec())
+            .send_offer_trace(
+                enr,
+                content_key.to_bytes().into(),
+                content_value.encode().to_vec(),
+            )
             .await,
     )
 }

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -309,7 +309,7 @@ async fn offer(
         "Offer",
         network
             .overlay
-            .send_offer(enr, content_key.into(), content_value.encode().to_vec())
+            .send_offer(enr, content_key.to_bytes().into(), content_value.encode().to_vec())
             .await
             .map(|accept| AcceptInfo {
                 content_keys: accept.content_keys,
@@ -327,7 +327,7 @@ async fn trace_offer(
         "TraceOffer",
         network
             .overlay
-            .send_offer_trace(enr, content_key.into(), content_value.encode().to_vec())
+            .send_offer_trace(enr, content_key.to_bytes().into(), content_value.encode().to_vec())
             .await,
     )
 }

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -311,7 +311,7 @@ async fn offer(
             .overlay
             .send_offer(
                 enr,
-                content_key.to_bytes().into(),
+                content_key.to_bytes(),
                 content_value.encode().to_vec(),
             )
             .await
@@ -333,7 +333,7 @@ async fn trace_offer(
             .overlay
             .send_offer_trace(
                 enr,
-                content_key.to_bytes().into(),
+                content_key.to_bytes(),
                 content_value.encode().to_vec(),
             )
             .await,

--- a/trin-storage/src/versioned/id_indexed_v1/migration.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/migration.rs
@@ -109,7 +109,7 @@ mod tests {
                 INSERT_QUERY_HISTORY,
                 params![
                     content_id.as_slice(),
-                    key,
+                    key.to_vec(),
                     value,
                     distance_u32,
                     content_size

--- a/trin-validation/src/header_validator.rs
+++ b/trin-validation/src/header_validator.rs
@@ -223,7 +223,7 @@ mod test {
     use super::*;
     use std::{fs, str::FromStr};
 
-    use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
+    use alloy_primitives::{Address, Bloom, B256, U256};
     use alloy_rlp::Decodable;
     use rstest::*;
     use serde_json::{json, Value};
@@ -243,7 +243,7 @@ mod test {
             jsonrpc::{endpoints::HistoryEndpoint, request::HistoryJsonRpcRequest},
         },
         utils::bytes::{hex_decode, hex_encode},
-        HistoryContentKey,
+        HistoryContentKey, RawContentKey,
     };
 
     #[rstest]
@@ -273,8 +273,8 @@ mod test {
         let obj = hwps.get(&block_number.to_string()).unwrap();
         // Validate content_key decodes
         let raw_ck = obj.get("content_key").unwrap().as_str().unwrap();
-        let raw_ck = hex_decode(raw_ck).unwrap();
-        let ck = HistoryContentKey::try_from(Bytes::from(raw_ck)).unwrap();
+        let raw_ck = RawContentKey::from_str(raw_ck).unwrap();
+        let ck = HistoryContentKey::try_from(raw_ck).unwrap();
         match ck {
             HistoryContentKey::BlockHeaderWithProof(_) => (),
             _ => panic!("Invalid test, content key decoded improperly"),

--- a/trin-validation/src/header_validator.rs
+++ b/trin-validation/src/header_validator.rs
@@ -223,7 +223,7 @@ mod test {
     use super::*;
     use std::{fs, str::FromStr};
 
-    use alloy_primitives::{Address, Bloom, B256, U256};
+    use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
     use alloy_rlp::Decodable;
     use rstest::*;
     use serde_json::{json, Value};
@@ -274,7 +274,7 @@ mod test {
         // Validate content_key decodes
         let raw_ck = obj.get("content_key").unwrap().as_str().unwrap();
         let raw_ck = hex_decode(raw_ck).unwrap();
-        let ck = HistoryContentKey::try_from(raw_ck).unwrap();
+        let ck = HistoryContentKey::try_from(Bytes::from(raw_ck)).unwrap();
         match ck {
             HistoryContentKey::BlockHeaderWithProof(_) => (),
             _ => panic!("Invalid test, content key decoded improperly"),


### PR DESCRIPTION
### What was wrong?
`Vec<u8>` was being used to represent Raw Content Key.

See #1404 for details

### How was it  #fixed?
Replaced it with `alloy_primites::Bytes`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
