### PR TITLE
feat(beacon): improve `LightClientBootstrap` validation

### DIFF
--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -1,4 +1,5 @@
 use crate::{
+    consensus::header::BeaconBlockHeader,
     types::{
         content_key::beacon::BeaconContentKey,
         enr::Enr,
@@ -47,6 +48,10 @@ pub trait BeaconNetworkApi {
     /// Get the finalized state root of the finalized beacon header.
     #[method(name = "beaconFinalizedStateRoot")]
     async fn finalized_state_root(&self) -> RpcResult<B256>;
+
+    /// Get the finalized beacon header
+    #[method(name = "beaconFinalizedHeader")]
+    async fn finalized_header(&self) -> RpcResult<BeaconBlockHeader>;
 
     /// Send a FINDNODES request for nodes that fall within the given set of distances, to the
     /// designated peer and wait for a response

--- a/ethportal-api/src/types/consensus/light_client/bootstrap.rs
+++ b/ethportal-api/src/types/consensus/light_client/bootstrap.rs
@@ -1,7 +1,10 @@
-use crate::types::consensus::{
-    fork::ForkName,
-    light_client::header::{LightClientHeaderBellatrix, LightClientHeaderCapella},
-    sync_committee::SyncCommittee,
+use crate::{
+    consensus::header::BeaconBlockHeader,
+    types::consensus::{
+        fork::ForkName,
+        light_client::header::{LightClientHeaderBellatrix, LightClientHeaderCapella},
+        sync_committee::SyncCommittee,
+    },
 };
 use alloy_primitives::B256;
 use serde::{Deserialize, Serialize};
@@ -47,6 +50,15 @@ impl LightClientBootstrap {
                 LightClientBootstrapCapella::from_ssz_bytes(bytes).map(Self::Capella)
             }
             ForkName::Deneb => LightClientBootstrapDeneb::from_ssz_bytes(bytes).map(Self::Deneb),
+        }
+    }
+
+    /// Returns the `BeaconBlockHeader` from the `LightClientBootstrap` object.
+    pub fn get_beacon_block_header(self) -> BeaconBlockHeader {
+        match self {
+            LightClientBootstrap::Bellatrix(bootstrap) => bootstrap.header.beacon,
+            LightClientBootstrap::Capella(bootstrap) => bootstrap.header.beacon,
+            LightClientBootstrap::Deneb(bootstrap) => bootstrap.header.beacon,
         }
     }
 }

--- a/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -118,6 +118,8 @@ pub enum BeaconEndpoint {
     /// params: [enr, distances]
     FindNodes(Enr, Vec<u16>),
     /// params: None
+    FinalizedHeader,
+    /// params: None
     FinalizedStateRoot,
     /// params: node_id
     GetEnr(NodeId),

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -2,7 +2,13 @@ use alloy_primitives::B256;
 use discv5::enr::NodeId;
 use tokio::sync::mpsc;
 
+use crate::{
+    errors::RpcServeError,
+    fetch::proxy_to_subnet,
+    jsonrpsee::core::{async_trait, RpcResult},
+};
 use ethportal_api::{
+    consensus::header::BeaconBlockHeader,
     types::{
         enr::Enr,
         jsonrpc::{endpoints::BeaconEndpoint, request::BeaconJsonRpcRequest},
@@ -13,12 +19,6 @@ use ethportal_api::{
     },
     BeaconContentKey, BeaconContentValue, BeaconNetworkApiServer, ContentValue, RawContentValue,
     RoutingTableInfo,
-};
-
-use crate::{
-    errors::RpcServeError,
-    fetch::proxy_to_subnet,
-    jsonrpsee::core::{async_trait, RpcResult},
 };
 
 pub struct BeaconNetworkApi {
@@ -98,6 +98,12 @@ impl BeaconNetworkApiServer for BeaconNetworkApi {
     /// Get the finalized state root of the finalized beacon header.
     async fn finalized_state_root(&self) -> RpcResult<B256> {
         let endpoint = BeaconEndpoint::FinalizedStateRoot;
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
+    }
+
+    /// Get the finalized beacon header.
+    async fn finalized_header(&self) -> RpcResult<BeaconBlockHeader> {
+        let endpoint = BeaconEndpoint::FinalizedHeader;
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -112,6 +112,19 @@ async fn complete_request(network: Arc<BeaconNetwork>, request: BeaconJsonRpcReq
                 None => Err("Beacon client not initialized".to_string()),
             }
         }
+        BeaconEndpoint::FinalizedHeader => {
+            let beacon_client = network.beacon_client.lock().await;
+            match beacon_client.as_ref() {
+                Some(client) => {
+                    let header = client.get_finalized_header().await;
+                    match header {
+                        Ok(header) => Ok(json!((header))),
+                        Err(err) => Err(err.to_string()),
+                    }
+                }
+                None => Err("Beacon client not initialized".to_string()),
+            }
+        }
     };
     let _ = request.resp.send(response);
 }

--- a/trin-beacon/src/validation.rs
+++ b/trin-beacon/src/validation.rs
@@ -58,6 +58,17 @@ impl Validator<BeaconContentKey> for BeaconValidator {
                         bootstrap_slot
                     ));
                 }
+
+                let finalized_header = self.header_oracle.read().await.get_finalized_header().await;
+                let bootstrap_block_header = bootstrap.bootstrap.get_beacon_block_header();
+
+                if let Ok(finalized_header) = finalized_header {
+                    if finalized_header != bootstrap_block_header {
+                        return Err(anyhow!(
+                            "Light client bootstrap header does not match the finalized header: {finalized_header:?} != {bootstrap_block_header:?}",
+                        ));
+                    }
+                }
             }
             BeaconContentKey::LightClientUpdatesByRange(key) => {
                 let lc_updates =

--- a/trin-validation/src/oracle.rs
+++ b/trin-validation/src/oracle.rs
@@ -6,6 +6,7 @@ use tokio::sync::mpsc;
 
 use crate::header_validator::HeaderValidator;
 use ethportal_api::{
+    consensus::header::BeaconBlockHeader,
     types::{
         execution::header_with_proof::HeaderWithProof,
         jsonrpc::{
@@ -195,6 +196,24 @@ impl HeaderOracle {
         let state_root: B256 = serde_json::from_value(state_root)?;
 
         Ok(state_root)
+    }
+
+    /// Return latest finalized beacon header.
+    pub async fn get_finalized_header(&self) -> anyhow::Result<BeaconBlockHeader> {
+        let endpoint = BeaconEndpoint::FinalizedHeader;
+        let (resp, mut resp_rx) = mpsc::unbounded_channel::<Result<Value, String>>();
+        let request = BeaconJsonRpcRequest { endpoint, resp };
+        let tx = self.beacon_jsonrpc_tx()?;
+        tx.send(request)?;
+
+        let header = match resp_rx.recv().await {
+            Some(val) => val.map_err(|err| anyhow!("Beacon network request error: {err:?}"))?,
+            None => return Err(anyhow!("No response from Beacon network")),
+        };
+
+        let header: BeaconBlockHeader = serde_json::from_value(header)?;
+
+        Ok(header)
     }
 }
 


### PR DESCRIPTION
### What was wrong?

Fixes part 1 of #1406.

### How was it fixed?
- Add JSON-RPC endpoint to get the recently finalized beacon block header
- Compare the `LightClientBootstrap` header with the recently finalized beacon block header before gossiping and storing the content.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
