### PR TITLE
feat(beacon): add full validation for light client updates

### DIFF
--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -1,5 +1,6 @@
 use crate::{
     consensus::header::BeaconBlockHeader,
+    light_client::store::LightClientStore,
     types::{
         content_key::beacon::BeaconContentKey,
         enr::Enr,
@@ -36,6 +37,10 @@ pub trait BeaconNetworkApi {
     /// Delete Node ID from the overlay routing table.
     #[method(name = "beaconDeleteEnr")]
     async fn delete_enr(&self, node_id: NodeId) -> RpcResult<bool>;
+
+    /// Returns the local store of the light client.
+    #[method(name = "beaconLightClientStore")]
+    async fn light_client_store(&self) -> RpcResult<LightClientStore>;
 
     /// Fetch the ENR representation associated with the given Node ID.
     #[method(name = "beaconLookupEnr")]

--- a/ethportal-api/src/types/consensus/light_client/mod.rs
+++ b/ethportal-api/src/types/consensus/light_client/mod.rs
@@ -2,4 +2,5 @@ pub mod bootstrap;
 pub mod finality_update;
 pub mod header;
 pub mod optimistic_update;
+pub mod store;
 pub mod update;

--- a/ethportal-api/src/types/consensus/light_client/store.rs
+++ b/ethportal-api/src/types/consensus/light_client/store.rs
@@ -1,0 +1,13 @@
+use crate::consensus::{header::BeaconBlockHeader, sync_committee::SyncCommittee};
+use serde::{Deserialize, Serialize};
+
+/// `LightClientStore` object for the light client sync protocol.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LightClientStore {
+    pub finalized_header: BeaconBlockHeader,
+    pub current_sync_committee: SyncCommittee,
+    pub next_sync_committee: Option<SyncCommittee>,
+    pub optimistic_header: BeaconBlockHeader,
+    pub previous_max_active_participants: u64,
+    pub current_max_active_participants: u64,
+}

--- a/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -123,6 +123,8 @@ pub enum BeaconEndpoint {
     FinalizedStateRoot,
     /// params: node_id
     GetEnr(NodeId),
+    /// params: None
+    LightClientStore,
     /// params: content_key
     LocalContent(BeaconContentKey),
     /// params: node_id

--- a/light-client/src/client.rs
+++ b/light-client/src/client.rs
@@ -6,14 +6,13 @@ use crate::consensus::ConsensusLightClient;
 use log::{error, info, warn};
 use tokio::sync::RwLock;
 
-use ethportal_api::consensus::header::BeaconBlockHeader;
-use std::path::PathBuf;
-use tokio::{spawn, time::sleep};
-
 use crate::{
     config::{client_config::Config, CheckpointFallback, Network},
     consensus::{errors::ConsensusError, rpc::ConsensusRpc},
 };
+use ethportal_api::{consensus::header::BeaconBlockHeader, light_client::store::LightClientStore};
+use std::path::PathBuf;
+use tokio::{spawn, time::sleep};
 
 use crate::{database::Database, errors::NodeError, node::Node};
 
@@ -462,5 +461,9 @@ impl<DB: Database, R: ConsensusRpc + 'static> Client<DB, R> {
 
     pub async fn get_finalized_header(&self) -> Result<BeaconBlockHeader> {
         self.node.read().await.get_finalized_header()
+    }
+
+    pub async fn get_light_client_store(&self) -> Result<LightClientStore> {
+        self.node.read().await.get_light_client_store()
     }
 }

--- a/light-client/src/consensus/consensus_client.rs
+++ b/light-client/src/consensus/consensus_client.rs
@@ -234,121 +234,43 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
         Ok(())
     }
 
-    // implements checks from validate_light_client_update and process_light_client_update in the
-    // specification
-    fn verify_generic_update(&self, update: &GenericUpdate) -> Result<()> {
-        let bits = get_bits(&update.sync_aggregate.sync_committee_bits);
-        if bits == 0 {
-            return Err(ConsensusError::InsufficientParticipation.into());
-        }
-
-        let update_finalized_slot = update.finalized_header.clone().unwrap_or_default().slot;
-        let valid_time = self.expected_current_slot() >= update.signature_slot
-            && update.signature_slot > update.attested_header.slot
-            && update.attested_header.slot >= update_finalized_slot;
-
-        if !valid_time {
-            return Err(ConsensusError::InvalidTimestamp.into());
-        }
-
-        let store_period = calc_sync_period(self.store.finalized_header.slot);
-        let update_sig_period = calc_sync_period(update.signature_slot);
-        let valid_period = if self.store.next_sync_committee.is_some() {
-            update_sig_period == store_period || update_sig_period == store_period + 1
-        } else {
-            update_sig_period == store_period
-        };
-
-        if !valid_period {
-            return Err(ConsensusError::InvalidPeriod.into());
-        }
-
-        let update_attested_period = calc_sync_period(update.attested_header.slot);
-        let update_has_next_committee = self.store.next_sync_committee.is_none()
-            && update.next_sync_committee.is_some()
-            && update_attested_period == store_period;
-
-        if update.attested_header.slot <= self.store.finalized_header.slot
-            && !update_has_next_committee
-        {
-            return Err(ConsensusError::NotRelevant.into());
-        }
-
-        if update.finalized_header.is_some() && update.finality_branch.is_some() {
-            let is_valid = is_finality_proof_valid(
-                &update.attested_header,
-                &mut update
-                    .finalized_header
-                    .clone()
-                    .expect("we know that this is `Some`"),
-                &update
-                    .finality_branch
-                    .clone()
-                    .expect("we know that this is `Some`"),
-            );
-
-            if !is_valid {
-                return Err(ConsensusError::InvalidFinalityProof.into());
-            }
-        }
-
-        if update.next_sync_committee.is_some() && update.next_sync_committee_branch.is_some() {
-            let is_valid = is_next_committee_proof_valid(
-                &update.attested_header,
-                &mut update
-                    .next_sync_committee
-                    .clone()
-                    .expect("we know that this is `Some`"),
-                &update
-                    .next_sync_committee_branch
-                    .clone()
-                    .expect("we know that this is `Some`"),
-            );
-
-            if !is_valid {
-                return Err(ConsensusError::InvalidNextSyncCommitteeProof.into());
-            }
-        }
-
-        let sync_committee = if update_sig_period == store_period {
-            &self.store.current_sync_committee
-        } else {
-            self.store
-                .next_sync_committee
-                .as_ref()
-                .expect("we know that this is `Some` because we are in `valid_period`")
-        };
-
-        let pks =
-            get_participating_keys(sync_committee, &update.sync_aggregate.sync_committee_bits)?;
-
-        let is_valid_sig = self.verify_sync_committee_signature(
-            &pks,
-            &update.attested_header,
-            &update.sync_aggregate.sync_committee_signature,
-            update.signature_slot,
-        );
-
-        if !is_valid_sig {
-            return Err(ConsensusError::InvalidSignature.into());
-        }
-
-        Ok(())
-    }
-
     fn verify_update(&self, update: &LightClientUpdateDeneb) -> Result<()> {
         let update = GenericUpdate::from(update);
-        self.verify_generic_update(&update)
+        let expected_current_slot = expected_current_slot();
+        let genesis_root = &self.config.chain.genesis_root;
+        verify_generic_update(
+            &self.store,
+            &update,
+            expected_current_slot,
+            genesis_root,
+            &self.config.fork_version(update.signature_slot),
+        )
     }
 
     fn verify_finality_update(&self, update: &LightClientFinalityUpdateDeneb) -> Result<()> {
         let update = GenericUpdate::from(update);
-        self.verify_generic_update(&update)
+        let expected_current_slot = expected_current_slot();
+        let genesis_root = &self.config.chain.genesis_root;
+        verify_generic_update(
+            &self.store,
+            &update,
+            expected_current_slot,
+            genesis_root,
+            &self.config.fork_version(update.signature_slot),
+        )
     }
 
     fn verify_optimistic_update(&self, update: &LightClientOptimisticUpdateDeneb) -> Result<()> {
         let update = GenericUpdate::from(update);
-        self.verify_generic_update(&update)
+        let expected_current_slot = expected_current_slot();
+        let genesis_root = &self.config.chain.genesis_root;
+        verify_generic_update(
+            &self.store,
+            &update,
+            expected_current_slot,
+            genesis_root,
+            &self.config.fork_version(update.signature_slot),
+        )
     }
 
     // implements state changes from apply_light_client_update and process_light_client_update in
@@ -499,36 +421,6 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
         ) / 2
     }
 
-    fn verify_sync_committee_signature(
-        &self,
-        pks: &[PublicKey],
-        attested_header: &BeaconBlockHeader,
-        signature: &BlsSignature,
-        signature_slot: u64,
-    ) -> bool {
-        let res: Result<bool> = (move || {
-            let pks: Vec<&PublicKey> = pks.iter().collect();
-            let header_root = bytes_to_bytes32(attested_header.tree_hash_root().as_slice());
-            let signing_root = self.compute_committee_sign_root(header_root, signature_slot)?;
-
-            Ok(is_aggregate_valid(
-                signature,
-                signing_root.r#as_bytes(),
-                &pks,
-            ))
-        })();
-
-        res.unwrap_or_default()
-    }
-
-    fn compute_committee_sign_root(&self, header: Bytes32, slot: u64) -> Result<Node> {
-        let genesis_root = self.config.chain.genesis_root.to_vec().try_into()?;
-        let domain_type = &hex::decode("07000000")?[..];
-        let fork_version = Vector::from_iter(self.config.fork_version(slot));
-        let domain = compute_domain(domain_type, fork_version, genesis_root)?;
-        compute_signing_root(header, domain)
-    }
-
     fn age(&self, slot: u64) -> Duration {
         let expected_time = self.slot_timestamp(slot);
         let now = SystemTime::now()
@@ -583,6 +475,124 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
     }
 }
 
+// implements checks from validate_light_client_update and process_light_client_update in the
+// specification
+pub fn verify_generic_update(
+    store: &LightClientStore,
+    update: &GenericUpdate,
+    expected_slot: u64,
+    genesis_root: &[u8],
+    fork_version: &[u8],
+) -> Result<()> {
+    let bits = get_bits(&update.sync_aggregate.sync_committee_bits);
+    if bits == 0 {
+        return Err(ConsensusError::InsufficientParticipation.into());
+    }
+
+    let update_finalized_slot = update.finalized_header.clone().unwrap_or_default().slot;
+    let valid_time = expected_slot >= update.signature_slot
+        && update.signature_slot > update.attested_header.slot
+        && update.attested_header.slot >= update_finalized_slot;
+
+    if !valid_time {
+        return Err(ConsensusError::InvalidTimestamp.into());
+    }
+
+    let store_period = calc_sync_period(store.finalized_header.slot);
+    let update_sig_period = calc_sync_period(update.signature_slot);
+    let valid_period = if store.next_sync_committee.is_some() {
+        update_sig_period == store_period || update_sig_period == store_period + 1
+    } else {
+        update_sig_period == store_period
+    };
+
+    if !valid_period {
+        return Err(ConsensusError::InvalidPeriod.into());
+    }
+
+    let update_attested_period = calc_sync_period(update.attested_header.slot);
+    let update_has_next_committee = store.next_sync_committee.is_none()
+        && update.next_sync_committee.is_some()
+        && update_attested_period == store_period;
+
+    if update.attested_header.slot <= store.finalized_header.slot && !update_has_next_committee {
+        return Err(ConsensusError::NotRelevant.into());
+    }
+
+    if update.finalized_header.is_some() && update.finality_branch.is_some() {
+        let is_valid = is_finality_proof_valid(
+            &update.attested_header,
+            &mut update
+                .finalized_header
+                .clone()
+                .expect("we know that this is `Some`"),
+            &update
+                .finality_branch
+                .clone()
+                .expect("we know that this is `Some`"),
+        );
+
+        if !is_valid {
+            return Err(ConsensusError::InvalidFinalityProof.into());
+        }
+    }
+
+    if update.next_sync_committee.is_some() && update.next_sync_committee_branch.is_some() {
+        let is_valid = is_next_committee_proof_valid(
+            &update.attested_header,
+            &mut update
+                .next_sync_committee
+                .clone()
+                .expect("we know that this is `Some`"),
+            &update
+                .next_sync_committee_branch
+                .clone()
+                .expect("we know that this is `Some`"),
+        );
+
+        if !is_valid {
+            return Err(ConsensusError::InvalidNextSyncCommitteeProof.into());
+        }
+    }
+
+    let sync_committee = if update_sig_period == store_period {
+        &store.current_sync_committee
+    } else {
+        store
+            .next_sync_committee
+            .as_ref()
+            .expect("we know that this is `Some` because we are in `valid_period`")
+    };
+
+    let pks = get_participating_keys(sync_committee, &update.sync_aggregate.sync_committee_bits)?;
+
+    let is_valid_sig = verify_sync_committee_signature(
+        &pks,
+        &update.attested_header,
+        &update.sync_aggregate.sync_committee_signature,
+        genesis_root,
+        fork_version,
+    );
+
+    if !is_valid_sig {
+        return Err(ConsensusError::InvalidSignature.into());
+    }
+
+    Ok(())
+}
+
+fn compute_committee_sign_root(
+    genesis_root: &[u8],
+    header: Bytes32,
+    fork_version: &[u8],
+) -> Result<Node> {
+    let genesis_root = genesis_root.to_vec().try_into()?;
+    let domain_type = &hex::decode("07000000")?[..];
+    let fork_version = Vector::from_iter(fork_version.to_vec());
+    let domain = compute_domain(domain_type, fork_version, genesis_root)?;
+    compute_signing_root(header, domain)
+}
+
 fn get_participating_keys(
     committee: &SyncCommittee,
     bitfield: &BitVector<typenum::U512>,
@@ -608,6 +618,32 @@ fn get_bits(bitfield: &BitVector<typenum::U512>) -> u64 {
     });
 
     count
+}
+
+fn verify_sync_committee_signature(
+    pks: &[PublicKey],
+    attested_header: &BeaconBlockHeader,
+    signature: &BlsSignature,
+    genesis_root: &[u8],
+    fork_version: &[u8],
+) -> bool {
+    let res: Result<bool> = (move || {
+        let pks: Vec<&PublicKey> = pks.iter().collect();
+        let header_root = bytes_to_bytes32(attested_header.tree_hash_root().as_slice());
+        let signing_root = compute_committee_sign_root(genesis_root, header_root, fork_version)?;
+
+        Ok(is_aggregate_valid(
+            signature,
+            signing_root.r#as_bytes(),
+            &pks,
+        ))
+    })();
+
+    if let Ok(is_valid) = res {
+        is_valid
+    } else {
+        false
+    }
 }
 
 fn is_finality_proof_valid(

--- a/light-client/src/consensus/consensus_client.rs
+++ b/light-client/src/consensus/consensus_client.rs
@@ -24,6 +24,7 @@ use ethportal_api::{
         bootstrap::CurrentSyncCommitteeProofLen,
         finality_update::LightClientFinalityUpdateDeneb,
         optimistic_update::LightClientOptimisticUpdateDeneb,
+        store::LightClientStore,
         update::{FinalizedRootProofLen, LightClientUpdateDeneb},
     },
     utils::bytes::hex_encode,
@@ -42,16 +43,6 @@ pub struct ConsensusLightClient<R: ConsensusRpc> {
     initial_checkpoint: Vec<u8>,
     pub last_checkpoint: Option<Vec<u8>>,
     pub config: Arc<Config>,
-}
-
-#[derive(Debug, Default)]
-struct LightClientStore {
-    finalized_header: BeaconBlockHeader,
-    current_sync_committee: SyncCommittee,
-    next_sync_committee: Option<SyncCommittee>,
-    optimistic_header: BeaconBlockHeader,
-    previous_max_active_participants: u64,
-    current_max_active_participants: u64,
 }
 
 impl<R: ConsensusRpc> ConsensusLightClient<R> {
@@ -97,6 +88,10 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
 
     pub fn get_finalized_header(&self) -> &BeaconBlockHeader {
         &self.store.finalized_header
+    }
+
+    pub fn get_light_client_store(&self) -> &LightClientStore {
+        &self.store
     }
 
     pub async fn sync(&mut self) -> Result<()> {

--- a/light-client/src/node.rs
+++ b/light-client/src/node.rs
@@ -1,12 +1,11 @@
 use std::{sync::Arc, time::Duration};
 
-use anyhow::{Error, Result};
-use ethportal_api::consensus::header::BeaconBlockHeader;
-
 use crate::{
     config::client_config::Config,
     consensus::{rpc::ConsensusRpc, ConsensusLightClient},
 };
+use anyhow::{Error, Result};
+use ethportal_api::{consensus::header::BeaconBlockHeader, light_client::store::LightClientStore};
 
 use crate::errors::NodeError;
 
@@ -79,6 +78,10 @@ impl<R: ConsensusRpc> Node<R> {
 
     pub fn get_finalized_header(&self) -> Result<BeaconBlockHeader> {
         Ok(self.consensus.get_finalized_header().clone())
+    }
+
+    pub fn get_light_client_store(&self) -> Result<LightClientStore> {
+        Ok(self.consensus.get_light_client_store().clone())
     }
 
     pub fn get_header(&self) -> Result<BeaconBlockHeader> {

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use ethportal_api::{
     consensus::header::BeaconBlockHeader,
+    light_client::store::LightClientStore,
     types::{
         enr::Enr,
         jsonrpc::{endpoints::BeaconEndpoint, request::BeaconJsonRpcRequest},
@@ -55,6 +56,12 @@ impl BeaconNetworkApiServer for BeaconNetworkApi {
     /// Delete Node ID from the overlay routing table.
     async fn delete_enr(&self, node_id: NodeId) -> RpcResult<bool> {
         let endpoint = BeaconEndpoint::DeleteEnr(node_id);
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
+    }
+
+    /// Returns the local store of the light client.
+    async fn light_client_store(&self) -> RpcResult<LightClientStore> {
+        let endpoint = BeaconEndpoint::LightClientStore;
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 

--- a/trin-beacon/src/network.rs
+++ b/trin-beacon/src/network.rs
@@ -48,7 +48,7 @@ impl BeaconNetwork {
         };
         let storage = Arc::new(PLRwLock::new(BeaconStorage::new(storage_config)?));
         let storage_clone = Arc::clone(&storage);
-        let validator = Arc::new(BeaconValidator { header_oracle });
+        let validator = Arc::new(BeaconValidator::new(header_oracle));
         let overlay = OverlayProtocol::new(
             config,
             discovery,


### PR DESCRIPTION
### What was wrong?
Fixes  #1406

This PR adds full light client content validation for `LightlClientUpdate`, `LightClientOptimisticUpdate`, and `LightClientFinalityUpdate` content on a protocol level. (before storing and gossiping the content to peers).

### How was it fixed?
- Add a new JSON-RPC endpoint to get the current `LIghtClientStore`  data.
- Refactor and expose the validation method as a public from the light client module. This allows us to use the same validation in` BeaconValidator` as the light client sync protocol.
- Add the validation steps in `BeaconValidator`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
