### PR TITLE
feat: add basic support for eth_call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6146,6 +6146,7 @@ dependencies = [
  "portalnet",
  "reth-ipc",
  "reth-rpc-types",
+ "revm",
  "serde",
  "serde_json",
  "strum",
@@ -6154,6 +6155,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "trin-execution",
  "trin-utils",
  "trin-validation",
 ]
@@ -8141,6 +8143,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "prometheus_exporter",
  "rayon",
+ "reth-rpc-types",
  "revm",
  "revm-inspectors",
  "revm-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ r2d2_sqlite = "0.24.0"
 rand = "0.8.5"
 reth-ipc = { tag = "v0.2.0-beta.5", git = "https://github.com/paradigmxyz/reth.git"}
 reth-rpc-types = { tag = "v1.0.6", git = "https://github.com/paradigmxyz/reth.git"}
-revm = { version = "14.0.1", default-features = false, features = ["std", "secp256k1", "serde-json", "optional_block_gas_limit"] }
+revm = { version = "14.0.1", default-features = false, features = ["std", "secp256k1", "serde-json"] }
 revm-primitives = { version = "9.0.1", default-features = false, features = ["std", "serde"] }
 rpc = { path = "rpc"}
 rstest = "0.18.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,8 +112,8 @@ r2d2_sqlite = "0.24.0"
 rand = "0.8.5"
 reth-ipc = { tag = "v0.2.0-beta.5", git = "https://github.com/paradigmxyz/reth.git"}
 reth-rpc-types = { tag = "v1.0.6", git = "https://github.com/paradigmxyz/reth.git"}
-revm = { version = "14.0.1", features = ["std", "secp256k1", "serde-json"], default-features = false }
-revm-primitives = { version = "9.0.1", features = ["std", "serde"], default-features = false }
+revm = { version = "14.0.1", default-features = false, features = ["std", "secp256k1", "serde-json", "optional_block_gas_limit"] }
+revm-primitives = { version = "9.0.1", default-features = false, features = ["std", "serde"] }
 rpc = { path = "rpc"}
 rstest = "0.18.2"
 rusqlite = { version = "0.31.0", features = ["bundled"] }

--- a/ethportal-api/src/eth.rs
+++ b/ethportal-api/src/eth.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{Address, Bytes, B256, U256};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_rpc_types::{Block, BlockId};
+use reth_rpc_types::{Block, BlockId, TransactionRequest};
 
 /// Web3 JSON-RPC endpoints
 #[rpc(client, server, namespace = "eth")]
@@ -24,4 +24,7 @@ pub trait EthApi {
     #[method(name = "getStorageAt")]
     async fn get_storage_at(&self, address: Address, slot: U256, block: BlockId)
         -> RpcResult<B256>;
+
+    #[method(name = "call")]
+    async fn call(&self, transaction: TransactionRequest, block: BlockId) -> RpcResult<Bytes>;
 }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -20,6 +20,7 @@ hyper.workspace = true
 portalnet.workspace = true
 reth-ipc.workspace = true
 reth-rpc-types.workspace = true
+revm.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
@@ -28,5 +29,6 @@ tokio.workspace = true
 tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4.4", features = ["full"] }
 tracing.workspace = true
+trin-execution.workspace = true
 trin-utils.workspace = true
 trin-validation.workspace = true

--- a/rpc/src/errors.rs
+++ b/rpc/src/errors.rs
@@ -53,12 +53,16 @@ impl RpcError {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum RpcServeError {
     /// A generic error with no data
+    #[error("Error: {0}")]
     Message(String),
     /// Method not available
+    #[error("Method not available: {0}")]
     MethodNotFound(String),
     /// ContentNotFound
+    #[error("Content not found: {message}")]
     ContentNotFound {
         message: String,
         trace: Option<Box<QueryTrace>>,

--- a/rpc/src/evm_state.rs
+++ b/rpc/src/evm_state.rs
@@ -1,0 +1,258 @@
+use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
+use alloy_rlp::Decodable;
+use eth_trie::{node::Node, TrieError};
+use ethportal_api::{
+    jsonrpsee::types::ErrorObjectOwned,
+    types::{
+        content_key::state::{AccountTrieNodeKey, ContractBytecodeKey, ContractStorageTrieNodeKey},
+        jsonrpc::{endpoints::StateEndpoint, request::StateJsonRpcRequest},
+        portal::ContentInfo,
+        state_trie::{
+            account_state::AccountState,
+            nibbles::Nibbles,
+            trie_traversal::{NodeTraversal, TraversalError, TraversalResult},
+        },
+    },
+    ContentValue, ContentValueError, Header, StateContentKey, StateContentValue,
+};
+use revm::primitives::{AccountInfo, Bytecode, KECCAK_EMPTY};
+use tokio::sync::mpsc;
+use trin_execution::evm::async_db::AsyncDatabase;
+
+use crate::{errors::RpcServeError, fetch::proxy_to_subnet};
+
+#[derive(Debug, PartialEq, thiserror::Error)]
+pub enum EvmStateError {
+    #[error("Received content value has unexpected type. key: {0} value: {0}")]
+    InvalidContentValueType(StateContentKey, StateContentValue),
+    #[error("Error decoding content value: {0}")]
+    DecodingContentValue(#[from] ContentValueError),
+    #[error("Error decoding trie node: {0}")]
+    DecodingTrieNode(#[from] TrieError),
+    #[error("Error RLP decoding trie value: {0}")]
+    DecodingTrieValue(#[from] alloy_rlp::Error),
+    #[error("Error traversing trie: {0}")]
+    TrieTraversal(#[from] TraversalError),
+    #[error("Storage value is invalid: {0}")]
+    InvalidStorageValue(Bytes),
+    #[error("Internal Error: {0}")]
+    InternalError(String),
+}
+
+impl From<EvmStateError> for RpcServeError {
+    fn from(value: EvmStateError) -> Self {
+        Self::Message(value.to_string())
+    }
+}
+
+impl From<EvmStateError> for ErrorObjectOwned {
+    fn from(value: EvmStateError) -> Self {
+        RpcServeError::from(value).into()
+    }
+}
+
+/// Provides access to the EVM state at the specific block
+pub struct EvmBlockState {
+    block_header: Header,
+    state_network: mpsc::UnboundedSender<StateJsonRpcRequest>,
+}
+
+impl EvmBlockState {
+    pub fn new(
+        block_header: Header,
+        state_network: mpsc::UnboundedSender<StateJsonRpcRequest>,
+    ) -> Self {
+        Self {
+            block_header,
+            state_network,
+        }
+    }
+
+    // Public functions
+
+    pub fn block_header(&self) -> &Header {
+        &self.block_header
+    }
+
+    pub async fn account_state(
+        &self,
+        address_hash: B256,
+    ) -> Result<Option<AccountState>, EvmStateError> {
+        self.traverse_trie(
+            self.block_header.state_root,
+            address_hash,
+            |path, node_hash| {
+                StateContentKey::AccountTrieNode(AccountTrieNodeKey { path, node_hash })
+            },
+        )
+        .await
+    }
+
+    pub async fn contract_storage_at_slot(
+        &self,
+        storage_root: B256,
+        address_hash: B256,
+        storage_slot: U256,
+    ) -> Result<B256, EvmStateError> {
+        let path = keccak256(storage_slot.to_be_bytes::<32>());
+        let value = self
+            .traverse_trie::<Bytes>(storage_root, path, |path, node_hash| {
+                StateContentKey::ContractStorageTrieNode(ContractStorageTrieNodeKey {
+                    address_hash,
+                    path,
+                    node_hash,
+                })
+            })
+            .await?
+            .unwrap_or_default();
+        if value.len() > B256::len_bytes() {
+            return Err(EvmStateError::InvalidStorageValue(value));
+        }
+
+        Ok(B256::left_padding_from(&value))
+    }
+
+    pub async fn contract_bytecode(
+        &self,
+        address_hash: B256,
+        code_hash: B256,
+    ) -> Result<Bytes, EvmStateError> {
+        let content_key = StateContentKey::ContractBytecode(ContractBytecodeKey {
+            address_hash,
+            code_hash,
+        });
+        let content_value = self.fetch_content(content_key.clone()).await?;
+        let StateContentValue::ContractBytecode(contract_bytecode) = content_value else {
+            return Err(EvmStateError::InvalidContentValueType(
+                content_key,
+                content_value,
+            ));
+        };
+        let bytes = Vec::from(contract_bytecode.code);
+        Ok(Bytes::from(bytes))
+    }
+
+    // Utility functions
+
+    async fn fetch_content(
+        &self,
+        content_key: StateContentKey,
+    ) -> Result<StateContentValue, EvmStateError> {
+        let endpoint = StateEndpoint::RecursiveFindContent(content_key.clone());
+        let response: ContentInfo = proxy_to_subnet(&self.state_network, endpoint)
+            .await
+            .map_err(|err| EvmStateError::InternalError(err.to_string()))?;
+        let ContentInfo::Content { content, .. } = response else {
+            return Err(EvmStateError::InternalError(format!(
+                "Invalid response variant: State RecursiveFindContent should contain content value; got {response:?}"
+            )));
+        };
+
+        let content_value = StateContentValue::decode(&content_key, &content)?;
+        Ok(content_value)
+    }
+
+    async fn fetch_trie_node(&self, content_key: StateContentKey) -> Result<Node, EvmStateError> {
+        let content_value = self.fetch_content(content_key.clone()).await?;
+        let StateContentValue::TrieNode(trie_node) = content_value else {
+            return Err(EvmStateError::InvalidContentValueType(
+                content_key,
+                content_value,
+            ));
+        };
+        Ok(trie_node.node.as_trie_node()?)
+    }
+
+    /// Utility function for fetching trie nodes and traversing the trie.
+    ///
+    /// This function works both with the account trie and the contract state trie.
+    async fn traverse_trie<T: Decodable>(
+        &self,
+        root: B256,
+        path: B256,
+        content_key_fn: impl Fn(Nibbles, B256) -> StateContentKey,
+    ) -> Result<Option<T>, EvmStateError> {
+        let path = Nibbles::unpack_nibbles(path.as_slice());
+
+        let mut node_hash = root;
+        let mut remaining_path = path.as_slice();
+
+        let value = loop {
+            let path_from_root = path
+                .strip_suffix(remaining_path)
+                .expect("Remaining path should be suffix of the path");
+
+            let content_key = content_key_fn(
+                Nibbles::try_from_unpacked_nibbles(path_from_root)
+                    .expect("we should be able to create Nibbles from path"),
+                node_hash,
+            );
+            let node = self.fetch_trie_node(content_key).await?;
+
+            match node.traverse(remaining_path) {
+                TraversalResult::Empty(_) => break None,
+                TraversalResult::Value(value) => break Some(value),
+                TraversalResult::Node(next_node) => {
+                    node_hash = next_node.hash;
+                    remaining_path = next_node.remaining_path;
+                }
+                TraversalResult::Error(err) => return Err(err.into()),
+            }
+        };
+
+        Ok(value
+            .map(|value| T::decode(&mut value.as_ref()))
+            .transpose()?)
+    }
+}
+
+impl AsyncDatabase for EvmBlockState {
+    type Error = EvmStateError;
+
+    async fn basic_async(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        let address_hash = keccak256(address);
+        let account_state = self.account_state(address_hash).await?;
+
+        let Some(account_state) = account_state else {
+            return Ok(None);
+        };
+
+        let code = if account_state.code_hash == KECCAK_EMPTY {
+            Bytecode::new()
+        } else {
+            let bytecode_raw = self
+                .contract_bytecode(address_hash, account_state.code_hash)
+                .await?;
+            Bytecode::new_raw(bytecode_raw)
+        };
+        Ok(Some(AccountInfo::new(
+            account_state.balance,
+            account_state.nonce,
+            account_state.code_hash,
+            code,
+        )))
+    }
+
+    async fn code_by_hash_async(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+        Err(EvmStateError::InternalError(
+            "The code_by_hash_async is not supported".to_string(),
+        ))
+    }
+
+    async fn storage_async(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        let address_hash = keccak256(address);
+        let account_state = self.account_state(address_hash).await?;
+        let Some(account_state) = account_state else {
+            return Ok(U256::ZERO);
+        };
+        self.contract_storage_at_slot(account_state.storage_root, address_hash, index)
+            .await
+            .map(|value| U256::from_be_bytes(value.0))
+    }
+
+    async fn block_hash_async(&mut self, _number: u64) -> Result<B256, Self::Error> {
+        Err(EvmStateError::InternalError(
+            "The block_hash_async is not supported".to_string(),
+        ))
+    }
+}

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -7,6 +7,7 @@ mod cors;
 mod discv5_rpc;
 mod errors;
 mod eth_rpc;
+mod evm_state;
 mod fetch;
 mod history_rpc;
 mod rpc_server;

--- a/trin-execution/Cargo.toml
+++ b/trin-execution/Cargo.toml
@@ -29,6 +29,7 @@ rayon = "1.10.0"
 revm.workspace = true
 revm-inspectors = "0.6"
 revm-primitives.workspace = true
+reth-rpc-types.workspace = true
 rocksdb = "0.22.0"
 serde = { workspace = true, features = ["rc"] }
 serde_json.workspace = true

--- a/trin-execution/src/evm/tx_env_modifier.rs
+++ b/trin-execution/src/evm/tx_env_modifier.rs
@@ -3,6 +3,7 @@ use ethportal_api::types::execution::transaction::{
     AccessListTransaction, BlobTransaction, EIP1559Transaction, LegacyTransaction, ToAddress,
     Transaction,
 };
+use reth_rpc_types::TransactionRequest;
 use revm_primitives::{AccessListItem, SpecId, TransactTo, TxEnv};
 
 use crate::era::types::TransactionsWithSender;
@@ -126,6 +127,42 @@ impl TxEnvModifier for BlobTransaction {
             .collect();
         tx_env.blob_hashes.clone_from(&self.blob_versioned_hashes);
         tx_env.max_fee_per_blob_gas = Some(U256::from(self.max_fee_per_blob_gas));
+    }
+}
+
+impl TxEnvModifier for TransactionRequest {
+    fn modify(&self, _block_number: u64, tx_env: &mut TxEnv) {
+        if let Some(from) = self.from {
+            tx_env.caller = from;
+        }
+        if let Some(to) = self.to {
+            tx_env.transact_to = to;
+        }
+        if let Some(gas_price) = self.gas_price {
+            tx_env.gas_price = U256::from(gas_price);
+        }
+        if let Some(max_fee_per_gas) = self.max_fee_per_gas {
+            tx_env.gas_price = U256::from(max_fee_per_gas);
+        }
+        tx_env.gas_priority_fee = self.max_priority_fee_per_gas.map(U256::from);
+        tx_env.max_fee_per_blob_gas = self.max_fee_per_blob_gas.map(U256::from);
+        if let Some(gas) = self.gas {
+            tx_env.gas_limit = gas as u64;
+        }
+        if let Some(value) = self.value {
+            tx_env.value = value;
+        }
+        if let Some(data) = self.input.input() {
+            tx_env.data.clone_from(data);
+        }
+        tx_env.nonce = self.nonce;
+        tx_env.chain_id = self.chain_id;
+        if let Some(access_list) = &self.access_list {
+            tx_env.access_list.clone_from(access_list);
+        }
+        if let Some(blob_versioned_hashes) = &self.blob_versioned_hashes {
+            tx_env.blob_hashes.clone_from(blob_versioned_hashes);
+        }
     }
 }
 


### PR DESCRIPTION
### What was wrong?

Trin doesn't support eth_call requests.

### How was it fixed?

- Refactored the rpc/src/eth_rpc.rs
    - `EvmBlockState` now takes care of fetching all state related content for a specific block
- Using async evm execution from `trin-execution` crate

I tested it locally, with one simple transaction (token balance), and it works.

### To-Do in future PRs

- Add caching to the `EvmBlockState`
    - this will speed up transaction execution as we wouldn't have to traverse entire trie for every piece of data
- Add support for fetching block_hash by block number
    - Until this is implemented in history network (https://github.com/ethereum/portal-network-specs/pull/334), we can fetch all blocks going backwards until we find the block that we need
    - low priority until lookup by block number is added
- Extract some common logic from `trin-execution/src/evm` into separate crate: e.g. `trin-evm`
