### PR TITLE
Credit first peer to return content

### DIFF
--- a/ethportal-peertest/src/utils.rs
+++ b/ethportal-peertest/src/utils.rs
@@ -105,7 +105,7 @@ fn read_history_content_key_value(
 /// Wrapper function for fixtures that directly returns the tuple.
 fn read_fixture(file_name: &str) -> (HistoryContentKey, HistoryContentValue) {
     read_history_content_key_value(file_name)
-        .unwrap_or_else(|err| panic!("Error reading fixture: {err}"))
+        .unwrap_or_else(|err| panic!("Error reading fixture in {file_name}: {err}"))
 }
 
 /// History HeaderWithProof content key & value

--- a/light-client/src/consensus/consensus_client.rs
+++ b/light-client/src/consensus/consensus_client.rs
@@ -523,11 +523,7 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
             ))
         })();
 
-        if let Ok(is_valid) = res {
-            is_valid
-        } else {
-            false
-        }
+        res.unwrap_or_default()
     }
 
     fn compute_committee_sign_root(&self, header: Bytes32, slot: u64) -> Result<Node> {

--- a/light-client/src/consensus/utils.rs
+++ b/light-client/src/consensus/utils.rs
@@ -37,11 +37,7 @@ pub fn is_proof_valid<L: TreeHash>(
         Ok(is_valid)
     })();
 
-    if let Ok(is_valid) = res {
-        is_valid
-    } else {
-        false
-    }
+    res.unwrap_or_default()
 }
 
 #[derive(SimpleSerialize, Default, Debug)]

--- a/portalnet/src/find/iterators/findcontent.rs
+++ b/portalnet/src/find/iterators/findcontent.rs
@@ -73,7 +73,7 @@ struct UtpAndPeerDetails<TNodeId> {
 }
 
 #[derive(Debug, Clone)]
-pub struct FindContentQuery<TNodeId> {
+pub struct FindContentQuery<TNodeId: std::fmt::Display> {
     /// The target key we are looking for
     target_key: Key<TNodeId>,
 
@@ -99,7 +99,7 @@ pub struct FindContentQuery<TNodeId> {
 
 impl<TNodeId> Query<TNodeId> for FindContentQuery<TNodeId>
 where
-    TNodeId: Into<Key<TNodeId>> + Eq + Clone,
+    TNodeId: Into<Key<TNodeId>> + Eq + Clone + std::fmt::Display,
 {
     type Response = FindContentQueryResponse<TNodeId>;
     type Result = FindContentQueryResult<TNodeId>;
@@ -361,7 +361,7 @@ where
 
 impl<TNodeId> FindContentQuery<TNodeId>
 where
-    TNodeId: Into<Key<TNodeId>> + Eq + Clone,
+    TNodeId: Into<Key<TNodeId>> + Eq + Clone + std::fmt::Display,
 {
     /// Creates a new query with the given configuration.
     pub fn with_config<I>(

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -650,7 +650,7 @@ where
                         let utp_processing = UtpProcessing::from(&*self);
                         tokio::spawn(async move {
                             Self::process_received_content(
-                                content.clone(),
+                                content,
                                 false,
                                 content_key,
                                 callback,

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -971,9 +971,9 @@ where
                     Ok(Content::ConnectionId(cid_send.to_be()))
                 }
             }
-            // If we don't have data to send back or can't obtain a permit, send the requester a
+            // If we can't obtain a permit or don't have data to send back, send the requester a
             // list of closer ENRs.
-            (Ok(Some(_)), _) | (Ok(None), _) => {
+            (Ok(_), None) | (Ok(None), _) => {
                 let mut enrs = self.find_nodes_close_to_content(content_key);
                 enrs.retain(|enr| source != &enr.node_id());
                 pop_while_ssz_bytes_len_gt(&mut enrs, MAX_PORTAL_CONTENT_PAYLOAD_SIZE);


### PR DESCRIPTION
### What was wrong?

While working on #1395, a number of cleanups accumulated. But there's enough going on in that PR that it's nice to separate out the stuff that can be. This is a mashup of those changes, with more info in each commit.

Most prominent, and the only change in functionality, is that when content arrives twice, we ignore the 2nd to arrive (instead of ignoring the first to arrive). We would like to give credit to the fastest peer to return the content.

### How was it fixed?

Just ignore additional content to come in. This of course continues to mean that if the first content to come in is invalid, then the whole query fails. #1395 is the next step toward improving that behavior.

Everything else is just:
- more logging lines, or info in the lines
- making Node ID loggable
- skip an unnecessary clone of content (which can be quite large)
- a new clippy warning on a recent nightly build of rust

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
