### PR TITLE
refactor: simplify TrinExecution

### DIFF
--- a/trin-execution/src/execution.rs
+++ b/trin-execution/src/execution.rs
@@ -1,16 +1,11 @@
-use alloy_primitives::{keccak256, Address, Bytes, B256};
-use alloy_rlp::Decodable;
-use anyhow::{anyhow, bail, ensure};
+use alloy_primitives::B256;
+use anyhow::ensure;
 use eth_trie::{RootWithTrieDiff, Trie};
-use ethportal_api::{types::state_trie::account_state::AccountState, Header};
-use std::{
-    collections::BTreeSet,
-    path::PathBuf,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use ethportal_api::{types::execution::transaction::Transaction, Header};
+use revm::inspectors::TracerEip3155;
+use std::{path::PathBuf, sync::Arc};
 use tokio::sync::Mutex;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{
     era::manager::EraManager,
@@ -23,7 +18,7 @@ use crate::{
     },
 };
 
-use super::{config::StateConfig, types::trie_proof::TrieProof, utils::address_to_nibble_path};
+use super::config::StateConfig;
 
 pub struct TrinExecution {
     pub database: EvmDB,
@@ -58,6 +53,14 @@ impl TrinExecution {
         })
     }
 
+    pub fn next_block_number(&self) -> u64 {
+        self.execution_position.next_block_number()
+    }
+
+    pub async fn process_next_block(&mut self) -> anyhow::Result<RootWithTrieDiff> {
+        self.process_range_of_blocks(self.next_block_number()).await
+    }
+
     /// Processes up to end block number (inclusive) and returns the root with trie diff
     /// If the state cache gets too big, we will commit the state to the database early and return
     /// the function early along with it
@@ -68,13 +71,10 @@ impl TrinExecution {
             "End block number {end} is less than start block number {start}",
         );
 
-        info!("Processing blocks from {} to {} (inclusive)", start, end);
-        let mut block_executor = BlockExecutor::new(
-            self.database.clone(),
-            self.config.block_to_trace.clone(),
-            self.node_data_directory.clone(),
-        );
-        let range_start = Instant::now();
+        info!("Processing blocks from {start} to {end} (inclusive)");
+
+        let mut block_executor = BlockExecutor::new(self.database.clone());
+
         let mut last_executed_block_header: Option<Header> = None;
         for block_number in start..=end {
             let timer = start_timer_vec(&BLOCK_PROCESSING_TIMES, &["fetching_block_from_era"]);
@@ -87,19 +87,14 @@ impl TrinExecution {
                 .clone();
             stop_timer(timer);
 
-            block_executor.execute_block(&block)?;
+            block_executor
+                .execute_block_with_tracer(&block, |tx| self.create_tracer(&block.header, tx))?;
+
             last_executed_block_header = Some(block.header);
 
-            // Commit the bundle if we have reached the limits, to prevent to much memory usage
+            // Commit early if we have reached the limits, to prevent too much memory usage.
             // We won't use this during the dos attack to avoid writing empty accounts to disk
-            if !(2_200_000..2_700_000).contains(&block_number)
-                && should_we_commit_block_execution_early(
-                    block_number - start,
-                    block_executor.bundle_size_hint() as u64,
-                    block_executor.cumulative_gas_used(),
-                    range_start.elapsed(),
-                )
-            {
+            if block_executor.should_commit() && !(2_200_000..2_700_000).contains(&block_number) {
                 break;
             }
         }
@@ -118,108 +113,35 @@ impl TrinExecution {
 
         let timer = start_timer_vec(&BLOCK_PROCESSING_TIMES, &["set_block_execution_number"]);
         self.execution_position
-            .update_position(self.database.db.clone(), last_executed_block_header)?;
+            .update_position(self.database.db.clone(), &last_executed_block_header)?;
         stop_timer(timer);
 
         Ok(root_with_trie_diff)
-    }
-
-    pub async fn process_next_block(&mut self) -> anyhow::Result<RootWithTrieDiff> {
-        self.process_range_of_blocks(self.next_block_number()).await
-    }
-
-    pub fn next_block_number(&self) -> u64 {
-        self.execution_position.next_block_number()
     }
 
     pub fn get_root(&mut self) -> anyhow::Result<B256> {
         Ok(self.database.trie.lock().root_hash()?)
     }
 
-    pub fn get_root_with_trie_diff(&mut self) -> anyhow::Result<RootWithTrieDiff> {
-        Ok(self.database.trie.lock().root_hash_with_changed_nodes()?)
+    fn create_tracer(&self, header: &Header, tx: &Transaction) -> Option<TracerEip3155> {
+        self.config
+            .block_to_trace
+            .create_trace_writer(self.node_data_directory.clone(), header, tx)
+            .unwrap_or_else(|err| {
+                warn!("Error while creating trace file: {err}. Skipping.");
+                None
+            })
+            .map(TracerEip3155::new)
     }
-
-    pub fn get_account_state(&self, account: &Address) -> anyhow::Result<AccountState> {
-        let account_state = self.database.db.get(keccak256(account))?;
-        match account_state {
-            Some(account) => {
-                let account = AccountState::decode(&mut account.as_slice())?;
-                Ok(account)
-            }
-            None => Ok(AccountState::default()),
-        }
-    }
-
-    pub fn get_proof(&mut self, address: Address) -> anyhow::Result<TrieProof> {
-        let proof: Vec<Bytes> = self
-            .database
-            .trie
-            .lock()
-            .get_proof(keccak256(address).as_slice())?
-            .into_iter()
-            .map(Bytes::from)
-            .collect();
-        let last_node = proof.last().ok_or(anyhow!("Missing proof!"))?;
-
-        let eth_trie::node::Node::Leaf(last_node) = eth_trie::decode_node(&mut last_node.as_ref())?
-        else {
-            bail!("Last node in the proof should be leaf!")
-        };
-        let mut last_node_nibbles = last_node.key.clone();
-        if last_node_nibbles.is_leaf() {
-            last_node_nibbles.pop();
-        } else {
-            bail!("Nibbles of the last node should have LEAF Marker")
-        }
-
-        let mut path = address_to_nibble_path(address);
-        if path.ends_with(last_node_nibbles.get_data()) {
-            path.truncate(path.len() - last_node_nibbles.len());
-        } else {
-            bail!("Path should have a suffix of last node's nibbles")
-        }
-
-        Ok(TrieProof { path, proof })
-    }
-
-    pub fn get_proofs(&mut self, accounts: &BTreeSet<Address>) -> anyhow::Result<Vec<TrieProof>> {
-        accounts
-            .iter()
-            .map(|account| self.get_proof(*account))
-            .collect()
-    }
-}
-
-/// This function is used to determine if we should commit the block execution early.
-/// We want this for a few reasons
-/// - To prevent memory usage from getting too high
-/// - To cap the amount of time it takes to commit everything to the database, the bigger the
-///   changes the more time it takes The various limits are arbitrary and can be adjusted as needed,
-///   but are based on the current state of the network and what we have seen so far
-pub fn should_we_commit_block_execution_early(
-    blocks_processed: u64,
-    pending_state_changes: u64,
-    cumulative_gas_used: u64,
-    elapsed: Duration,
-) -> bool {
-    blocks_processed >= 500_000
-        || pending_state_changes >= 5_000_000
-        || cumulative_gas_used >= 30_000_000 * 50_000
-        || elapsed >= Duration::from_secs(30 * 60)
 }
 
 #[cfg(test)]
 mod tests {
     use std::fs;
 
-    use crate::{
-        config::StateConfig, era::utils::process_era1_file, execution::TrinExecution,
-        storage::utils::setup_temp_dir,
-    };
+    use crate::{era::utils::process_era1_file, storage::utils::setup_temp_dir};
 
-    use alloy_primitives::Address;
-    use revm_primitives::hex::FromHex;
+    use super::*;
 
     #[tokio::test]
     async fn test_we_generate_the_correct_state_root_for_the_first_8192_blocks() {
@@ -236,22 +158,5 @@ mod tests {
             trin_execution.process_next_block().await.unwrap();
             assert_eq!(trin_execution.get_root().unwrap(), block.header.state_root);
         }
-    }
-
-    #[tokio::test]
-    async fn test_get_proof() {
-        let temp_directory = setup_temp_dir().unwrap();
-        let mut trin_execution = TrinExecution::new(
-            Some(temp_directory.path().to_path_buf()),
-            StateConfig::default(),
-        )
-        .await
-        .unwrap();
-        trin_execution.process_next_block().await.unwrap();
-        let valid_proof = trin_execution
-            .get_proof(Address::from_hex("0x001d14804b399c6ef80e64576f657660804fec0b").unwrap())
-            .unwrap();
-        assert_eq!(valid_proof.path, [5, 9, 2, 13]);
-        // the proof is already tested by eth-trie.rs
     }
 }

--- a/trin-execution/src/storage/execution_position.rs
+++ b/trin-execution/src/storage/execution_position.rs
@@ -47,7 +47,7 @@ impl ExecutionPosition {
         self.state_root
     }
 
-    pub fn update_position(&mut self, db: Arc<RocksDB>, header: Header) -> anyhow::Result<()> {
+    pub fn update_position(&mut self, db: Arc<RocksDB>, header: &Header) -> anyhow::Result<()> {
         self.next_block_number = header.number + 1;
         self.state_root = header.state_root;
         db.put(EXECUTION_POSITION_DB_KEY, alloy_rlp::encode(self))?;

--- a/trin-execution/src/subcommands/era2/import.rs
+++ b/trin-execution/src/subcommands/era2/import.rs
@@ -113,7 +113,7 @@ impl StateImporter {
         // Save execution position
         self.trin_execution
             .execution_position
-            .update_position(self.trin_execution.database.db.clone(), era2.header.header)?;
+            .update_position(self.trin_execution.database.db.clone(), &era2.header.header)?;
 
         info!("Done importing State from .era2 file");
 

--- a/trin-execution/src/types/block_to_trace.rs
+++ b/trin-execution/src/types/block_to_trace.rs
@@ -1,4 +1,11 @@
-use std::str::FromStr;
+use std::{
+    fs::{self, File},
+    io::{BufWriter, Write},
+    path::PathBuf,
+    str::FromStr,
+};
+
+use ethportal_api::{types::execution::transaction::Transaction, Header};
 
 #[derive(Clone, Debug, PartialEq, Default, Eq)]
 pub enum BlockToTrace {
@@ -14,6 +21,28 @@ impl BlockToTrace {
             BlockToTrace::None => false,
             BlockToTrace::All => true,
             BlockToTrace::Block(b) => *b == block_number,
+        }
+    }
+
+    /// Creates file writer for tracing given transaction.
+    ///
+    /// Returns None if transaction shouldn't be traced.
+    pub fn create_trace_writer(
+        &self,
+        root_dir: PathBuf,
+        header: &Header,
+        tx: &Transaction,
+    ) -> std::io::Result<Option<Box<dyn Write>>> {
+        let block_number = header.number;
+        if self.should_trace(block_number) {
+            let output_dir = root_dir
+                .join("evm_traces")
+                .join(format!("block_{block_number}"));
+            fs::create_dir_all(&output_dir)?;
+            let output_file = File::create(output_dir.join(format!("tx_{}.json", tx.hash())))?;
+            Ok(Some(Box::new(BufWriter::new(output_file))))
+        } else {
+            Ok(None)
         }
     }
 }


### PR DESCRIPTION
### What was wrong?

TrinExecution has quite of bit responsibility, which I feel it shouldn't have. It also has some functionality that is no longer used.

### How was it fixed?

- "should commit early" is suited much better in BlockExecutor 
- proof generation is no longer used (removed)
- transaction tracing: I feel that this belongs in TrinExecution more than it does in BlockExecution
    - BlockToTrace now creates folders and writer, if tracing is enabled
    - BlockExecution accepts function that creates optional tracer

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
