### PR TITLE
chore: update windows  ci from `cargo check` -> `cargo build`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,9 +186,9 @@ jobs:
           name: Build Trin workspace
           command: cargo build --workspace
       - save-sccache-cache
-  check-windows:
+  build-windows:
     description: |
-      Check the crate on Windows (Check will tell us if we can build on Windows without the need to codegen (which is the time consuming part)).
+      Build's Trin workspace on Windows
     executor:
       name: win/default
       size: xlarge
@@ -198,13 +198,13 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Check Trin workspace
+          name: Build Trin workspace
           # We are running all these together because this version of circleci windows has an environment variable bug
           # https://discuss.circleci.com/t/march-2022-beta-support-for-new-operating-system-for-windows-executors-windows-server-2022/43198/44
           command: |
             choco uninstall rust
             choco install rust-ms llvm -y
-            cargo check --workspace
+            cargo build --workspace
   test:
     description: |
       Run tests.
@@ -330,6 +330,6 @@ workflows:
       - cargo-clippy
       - build
       - test
-      - check-windows
+      - build-windows
       - utp-test
       - check-workspace-crates

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ The Portal Network is still in the research phase, and this client is experiment
 
 **Do not rely on Trin in a production setting.**
 
-**NOTE: Unix-only**
-
-Trin currently only runs on Unix-based platforms (Linux, macOS). We plan to eventually implement support for Windows, but until then do not expect any support for issues on Windows.
 
 ## How to use Trin
 


### PR DESCRIPTION
### What was wrong?
resolve concern gave here https://github.com/ethereum/trin/pull/1426#issuecomment-2333431869

TL:DR, `cargo check` doesn't fully verify an application can be compiled 

### How was it fixed?
Change Window's CI from doing `cargo check` to `cargo build` the reason for this is `cargo check` doesn't verify there isn't any linker error's
