### PR TITLE
refactor: add logging for investigating #1390

### DIFF
--- a/portalnet/src/gossip.rs
+++ b/portalnet/src/gossip.rs
@@ -70,7 +70,7 @@ pub fn propagate_gossip_cross_thread<TContentKey: OverlayContentKey>(
         .collect();
 
     debug!(
-        "propagating validated content: found {} nodes",
+        "propagating validated content: found {} nodes (#1390)",
         all_nodes.len()
     );
     if all_nodes.is_empty() {
@@ -97,7 +97,7 @@ pub fn propagate_gossip_cross_thread<TContentKey: OverlayContentKey>(
     }
 
     let num_propagated_peers = enrs_and_content.len();
-    debug!("propagating validated content to {num_propagated_peers} peers");
+    debug!("propagating validated content to {num_propagated_peers} peers (#1390)");
 
     // Create and send OFFER overlay request to the interested nodes
     for (enr_string, mut interested_content) in enrs_and_content.into_iter() {
@@ -154,7 +154,7 @@ pub fn propagate_gossip_cross_thread<TContentKey: OverlayContentKey>(
         }
     }
 
-    debug!("finished propagating validated content");
+    debug!("finished propagating validated content (#1390)");
     num_propagated_peers
 }
 

--- a/portalnet/src/overlay/protocol.rs
+++ b/portalnet/src/overlay/protocol.rs
@@ -207,6 +207,9 @@ where
     /// Propagate gossip accepted content via OFFER/ACCEPT, return number of peers propagated
     pub fn propagate_gossip(&self, content: Vec<(TContentKey, Vec<u8>)>) -> usize {
         let kbuckets = Arc::clone(&self.kbuckets);
+        debug!(
+            "calling propagate_gossip_cross_thread from OverlayProtocol::propagate_gossip (#1390)"
+        );
         propagate_gossip_cross_thread(content, kbuckets, self.command_tx.clone(), None)
     }
 

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -1221,6 +1221,9 @@ where
                 })
                 .flatten()
                 .collect();
+            debug!(
+                "calling propagate_gossip_cross_thread from OverlayService::handle_offer (#1390)"
+            );
             propagate_gossip_cross_thread(
                 validated_content,
                 utp_processing.kbuckets,
@@ -1705,6 +1708,7 @@ where
             }
         };
 
+        debug!("calling propagate_gossip_cross_thread from OverlayService::fallback_find_content (#1390)");
         propagate_gossip_cross_thread(
             validated_content,
             utp_processing.kbuckets,
@@ -1896,6 +1900,7 @@ where
                             );
                             content_to_propagate.extend(dropped_content.clone());
                         }
+                        debug!("calling propagate_gossip_cross_thread from OverlayService::process_received_content (#1390)");
                         propagate_gossip_cross_thread(
                             content_to_propagate,
                             utp_processing.kbuckets.clone(),


### PR DESCRIPTION
### What was wrong?

I was checking `state` nodes and figured out that they all deadlocked (at least all that I checked ~10 of them).
They all had the same last message, related to #1390 .

I investigated the issue by looking at the code, but I couldn't figure out that issue.

### How was it fixed?

This is an attempt to narrow down the issue, by adding more logs.

I also added "(#1390)" to logs that were already added in #1391 (so we can easily track them down and remove afterwards).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
