### PR TITLE
refactor: add from bytes trait to content key

### DIFF
--- a/ethportal-api/src/types/content_key/history.rs
+++ b/ethportal-api/src/types/content_key/history.rs
@@ -87,6 +87,12 @@ pub struct BlockHeaderByHashKey {
     pub block_hash: [u8; 32],
 }
 
+impl From<[u8; 32]> for BlockHeaderByHashKey {
+    fn from(block_hash: [u8; 32]) -> Self {
+        Self { block_hash }
+    }
+}
+
 impl From<B256> for BlockHeaderByHashKey {
     fn from(block_hash: B256) -> Self {
         Self {
@@ -115,6 +121,12 @@ pub struct BlockBodyKey {
     pub block_hash: [u8; 32],
 }
 
+impl From<[u8; 32]> for BlockBodyKey {
+    fn from(block_hash: [u8; 32]) -> Self {
+        Self { block_hash }
+    }
+}
+
 impl From<B256> for BlockBodyKey {
     fn from(block_hash: B256) -> Self {
         Self {
@@ -128,6 +140,12 @@ impl From<B256> for BlockBodyKey {
 pub struct BlockReceiptsKey {
     /// Hash of the block.
     pub block_hash: [u8; 32],
+}
+
+impl From<[u8; 32]> for BlockReceiptsKey {
+    fn from(block_hash: [u8; 32]) -> Self {
+        Self { block_hash }
+    }
 }
 
 impl TryFrom<RawContentKey> for HistoryContentKey {
@@ -394,9 +412,7 @@ mod test {
     fn ser_de_block_body() {
         let content_key_json =
             "\"0x01d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d\"";
-        let expected_content_key = HistoryContentKey::BlockBody(BlockBodyKey {
-            block_hash: BLOCK_HASH,
-        });
+        let expected_content_key = HistoryContentKey::BlockBody(BLOCK_HASH.into());
 
         let content_key: HistoryContentKey = serde_json::from_str(content_key_json).unwrap();
 
@@ -411,9 +427,7 @@ mod test {
     fn ser_de_block_receipts() {
         let content_key_json =
             "\"0x02d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d\"";
-        let expected_content_key = HistoryContentKey::BlockReceipts(BlockReceiptsKey {
-            block_hash: BLOCK_HASH,
-        });
+        let expected_content_key = HistoryContentKey::BlockReceipts(BLOCK_HASH.into());
 
         let content_key: HistoryContentKey = serde_json::from_str(content_key_json).unwrap();
 

--- a/ethportal-api/src/types/content_key/history.rs
+++ b/ethportal-api/src/types/content_key/history.rs
@@ -1,4 +1,3 @@
-use alloy_primitives::B256;
 use rand::{seq::SliceRandom, RngCore};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest as Sha2Digest, Sha256};
@@ -53,6 +52,28 @@ impl HistoryContentKey {
         let random_bytes: RawContentKey = random_bytes.into();
         Self::try_from(random_bytes).map_err(anyhow::Error::msg)
     }
+
+    pub fn new_block_header_by_hash(block_hash: impl Into<[u8; 32]>) -> Self {
+        Self::BlockHeaderByHash(BlockHeaderByHashKey {
+            block_hash: block_hash.into(),
+        })
+    }
+
+    pub fn new_block_header_by_number(block_number: u64) -> Self {
+        Self::BlockHeaderByNumber(BlockHeaderByNumberKey { block_number })
+    }
+
+    pub fn new_block_body(block_hash: impl Into<[u8; 32]>) -> Self {
+        Self::BlockBody(BlockBodyKey {
+            block_hash: block_hash.into(),
+        })
+    }
+
+    pub fn new_block_receipts(block_hash: impl Into<[u8; 32]>) -> Self {
+        Self::BlockReceipts(BlockReceiptsKey {
+            block_hash: block_hash.into(),
+        })
+    }
 }
 
 impl Hash for HistoryContentKey {
@@ -87,31 +108,11 @@ pub struct BlockHeaderByHashKey {
     pub block_hash: [u8; 32],
 }
 
-impl From<[u8; 32]> for BlockHeaderByHashKey {
-    fn from(block_hash: [u8; 32]) -> Self {
-        Self { block_hash }
-    }
-}
-
-impl From<B256> for BlockHeaderByHashKey {
-    fn from(block_hash: B256) -> Self {
-        Self {
-            block_hash: block_hash.0,
-        }
-    }
-}
-
 /// A key for a block header by number.
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, Default)]
 pub struct BlockHeaderByNumberKey {
     /// Number of the block.
     pub block_number: u64,
-}
-
-impl From<u64> for BlockHeaderByNumberKey {
-    fn from(block_number: u64) -> Self {
-        Self { block_number }
-    }
 }
 
 /// A key for a block body.
@@ -121,31 +122,11 @@ pub struct BlockBodyKey {
     pub block_hash: [u8; 32],
 }
 
-impl From<[u8; 32]> for BlockBodyKey {
-    fn from(block_hash: [u8; 32]) -> Self {
-        Self { block_hash }
-    }
-}
-
-impl From<B256> for BlockBodyKey {
-    fn from(block_hash: B256) -> Self {
-        Self {
-            block_hash: block_hash.0,
-        }
-    }
-}
-
 /// A key for the transaction receipts for a block.
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
 pub struct BlockReceiptsKey {
     /// Hash of the block.
     pub block_hash: [u8; 32],
-}
-
-impl From<[u8; 32]> for BlockReceiptsKey {
-    fn from(block_hash: [u8; 32]) -> Self {
-        Self { block_hash }
-    }
 }
 
 impl TryFrom<RawContentKey> for HistoryContentKey {
@@ -412,7 +393,7 @@ mod test {
     fn ser_de_block_body() {
         let content_key_json =
             "\"0x01d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d\"";
-        let expected_content_key = HistoryContentKey::BlockBody(BLOCK_HASH.into());
+        let expected_content_key = HistoryContentKey::new_block_body(BLOCK_HASH);
 
         let content_key: HistoryContentKey = serde_json::from_str(content_key_json).unwrap();
 
@@ -427,7 +408,7 @@ mod test {
     fn ser_de_block_receipts() {
         let content_key_json =
             "\"0x02d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d\"";
-        let expected_content_key = HistoryContentKey::BlockReceipts(BLOCK_HASH.into());
+        let expected_content_key = HistoryContentKey::new_block_receipts(BLOCK_HASH);
 
         let content_key: HistoryContentKey = serde_json::from_str(content_key_json).unwrap();
 

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -1,9 +1,7 @@
 use crate::{utils::fixture_header_by_hash, Peertest, PeertestNode};
 use alloy_primitives::{B256, U256};
 use ethportal_api::{
-    types::{
-        content_key::history::BlockHeaderByHashKey, distance::Distance, portal_wire::ProtocolId,
-    },
+    types::{distance::Distance, portal_wire::ProtocolId},
     BeaconNetworkApiClient, ContentValue, Discv5ApiClient, HistoryContentKey,
     HistoryNetworkApiClient, StateNetworkApiClient, Web3ApiClient,
 };
@@ -186,9 +184,7 @@ pub async fn test_history_store(target: &Client) {
 
 pub async fn test_history_local_content_absent(target: &Client) {
     info!("Testing portal_historyLocalContent absent");
-    let content_key = HistoryContentKey::BlockHeaderByHash(BlockHeaderByHashKey {
-        block_hash: B256::random().into(),
-    });
+    let content_key = HistoryContentKey::BlockHeaderByHash(B256::random().into());
     let error = HistoryNetworkApiClient::local_content(target, content_key)
         .await
         .unwrap_err();

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -184,7 +184,7 @@ pub async fn test_history_store(target: &Client) {
 
 pub async fn test_history_local_content_absent(target: &Client) {
     info!("Testing portal_historyLocalContent absent");
-    let content_key = HistoryContentKey::BlockHeaderByHash(B256::random().into());
+    let content_key = HistoryContentKey::new_block_header_by_hash(B256::random());
     let error = HistoryNetworkApiClient::local_content(target, content_key)
         .await
         .unwrap_err();

--- a/ethportal-peertest/src/scenarios/paginate.rs
+++ b/ethportal-peertest/src/scenarios/paginate.rs
@@ -1,7 +1,4 @@
-use ethportal_api::{
-    types::content_key::history::BlockHeaderByHashKey, ContentValue, HistoryContentKey,
-    HistoryNetworkApiClient,
-};
+use ethportal_api::{ContentValue, HistoryContentKey, HistoryNetworkApiClient};
 
 use crate::{utils::fixture_header_by_hash, Peertest};
 
@@ -15,9 +12,7 @@ pub async fn test_paginate_local_storage(peertest: &Peertest) {
     let mut content_keys: Vec<String> = (0..20_u8)
         .map(|_| {
             serde_json::to_string(&HistoryContentKey::BlockHeaderByHash(
-                BlockHeaderByHashKey {
-                    block_hash: rand::random(),
-                },
+                rand::random::<alloy_primitives::B256>().into(),
             ))
             .unwrap()
         })

--- a/ethportal-peertest/src/scenarios/paginate.rs
+++ b/ethportal-peertest/src/scenarios/paginate.rs
@@ -11,8 +11,8 @@ pub async fn test_paginate_local_storage(peertest: &Peertest) {
 
     let mut content_keys: Vec<String> = (0..20_u8)
         .map(|_| {
-            serde_json::to_string(&HistoryContentKey::BlockHeaderByHash(
-                rand::random::<alloy_primitives::B256>().into(),
+            serde_json::to_string(&HistoryContentKey::new_block_header_by_hash(
+                rand::random::<alloy_primitives::B256>(),
             ))
             .unwrap()
         })

--- a/ethportal-peertest/src/scenarios/state.rs
+++ b/ethportal-peertest/src/scenarios/state.rs
@@ -46,7 +46,7 @@ pub async fn test_state_gossip_contract_bytecode(peertest: &Peertest, target: &C
 async fn test_state_offer(fixture: &StateFixture, target: &Client, peer: &PeertestNode) {
     // Make sure that peer has block header
     let history_content_key =
-        HistoryContentKey::BlockHeaderByHash(fixture.block_header.hash().into());
+        HistoryContentKey::new_block_header_by_hash(fixture.block_header.hash());
     let history_content_value = HistoryContentValue::BlockHeaderWithProof(HeaderWithProof {
         header: fixture.block_header.clone(),
         proof: BlockHeaderProof::None(SszNone::default()),

--- a/ethportal-peertest/src/scenarios/validation.rs
+++ b/ethportal-peertest/src/scenarios/validation.rs
@@ -7,7 +7,7 @@ use crate::{
 use alloy_primitives::B256;
 use ethportal_api::{
     jsonrpsee::async_client::Client,
-    types::{content_key::history::BlockHeaderByHashKey, enr::Enr, portal::ContentInfo},
+    types::{enr::Enr, portal::ContentInfo},
     ContentValue, HistoryContentKey, HistoryNetworkApiClient,
 };
 use std::str::FromStr;
@@ -90,9 +90,7 @@ pub async fn test_invalidate_header_by_hash(peertest: &Peertest, target: &Client
 
     // store header_with_proof - doesn't perform validation
     let (_, content_value) = fixture_header_by_hash();
-    let invalid_content_key = HistoryContentKey::BlockHeaderByHash(BlockHeaderByHashKey {
-        block_hash: B256::random().into(),
-    });
+    let invalid_content_key = HistoryContentKey::BlockHeaderByHash(B256::random().into());
 
     let store_result = peertest
         .bootnode

--- a/ethportal-peertest/src/scenarios/validation.rs
+++ b/ethportal-peertest/src/scenarios/validation.rs
@@ -90,7 +90,7 @@ pub async fn test_invalidate_header_by_hash(peertest: &Peertest, target: &Client
 
     // store header_with_proof - doesn't perform validation
     let (_, content_value) = fixture_header_by_hash();
-    let invalid_content_key = HistoryContentKey::BlockHeaderByHash(B256::random().into());
+    let invalid_content_key = HistoryContentKey::new_block_header_by_hash(B256::random());
 
     let store_result = peertest
         .bootnode

--- a/portal-bridge/src/api/execution.rs
+++ b/portal-bridge/src/api/execution.rs
@@ -104,10 +104,10 @@ impl ExecutionApi {
         };
         // Construct header by hash content key / value pair.
         let header_by_hash_content_key =
-            HistoryContentKey::BlockHeaderByHash(full_header.header.hash().0.into());
+            HistoryContentKey::new_block_header_by_hash(full_header.header.hash());
         // Construct header by number content key / value pair.
         let header_by_number_content_key =
-            HistoryContentKey::BlockHeaderByNumber(full_header.header.number.into());
+            HistoryContentKey::new_block_header_by_number(full_header.header.number);
         let content_value = match &full_header.epoch_acc {
             Some(epoch_acc) => {
                 // Construct HeaderWithProof
@@ -141,7 +141,7 @@ impl ExecutionApi {
     ) -> anyhow::Result<(HistoryContentKey, HistoryContentValue)> {
         let block_body = self.get_trusted_block_body(full_header).await?;
         block_body.validate_against_header(&full_header.header)?;
-        let content_key = HistoryContentKey::BlockBody(full_header.header.hash().0.into());
+        let content_key = HistoryContentKey::new_block_body(full_header.header.hash());
         let content_value = HistoryContentValue::BlockBody(block_body);
         Ok((content_key, content_value))
     }
@@ -219,7 +219,7 @@ impl ExecutionApi {
                 full_header.header.receipts_root
             );
         }
-        let content_key = HistoryContentKey::BlockReceipts(full_header.header.hash().0.into());
+        let content_key = HistoryContentKey::new_block_receipts(full_header.header.hash());
         let content_value = HistoryContentValue::Receipts(receipts);
         Ok((content_key, content_value))
     }

--- a/portal-bridge/src/api/execution.rs
+++ b/portal-bridge/src/api/execution.rs
@@ -4,7 +4,6 @@ use alloy_primitives::B256;
 use anyhow::{anyhow, bail};
 use ethportal_api::{
     types::{
-        content_key::history::{BlockHeaderByHashKey, BlockHeaderByNumberKey},
         execution::{
             accumulator::EpochAccumulator,
             block_body::{
@@ -18,7 +17,7 @@ use ethportal_api::{
         jsonrpc::{params::Params, request::JsonRequest},
     },
     utils::bytes::{hex_decode, hex_encode},
-    BlockBodyKey, BlockReceiptsKey, Header, HistoryContentKey, HistoryContentValue, Receipts,
+    Header, HistoryContentKey, HistoryContentValue, Receipts,
 };
 use futures::future::join_all;
 use serde_json::{json, Value};
@@ -105,14 +104,10 @@ impl ExecutionApi {
         };
         // Construct header by hash content key / value pair.
         let header_by_hash_content_key =
-            HistoryContentKey::BlockHeaderByHash(BlockHeaderByHashKey {
-                block_hash: full_header.header.hash().0,
-            });
+            HistoryContentKey::BlockHeaderByHash(full_header.header.hash().0.into());
         // Construct header by number content key / value pair.
         let header_by_number_content_key =
-            HistoryContentKey::BlockHeaderByNumber(BlockHeaderByNumberKey {
-                block_number: full_header.header.number,
-            });
+            HistoryContentKey::BlockHeaderByNumber(full_header.header.number.into());
         let content_value = match &full_header.epoch_acc {
             Some(epoch_acc) => {
                 // Construct HeaderWithProof
@@ -146,9 +141,7 @@ impl ExecutionApi {
     ) -> anyhow::Result<(HistoryContentKey, HistoryContentValue)> {
         let block_body = self.get_trusted_block_body(full_header).await?;
         block_body.validate_against_header(&full_header.header)?;
-        let content_key = HistoryContentKey::BlockBody(BlockBodyKey {
-            block_hash: full_header.header.hash().0,
-        });
+        let content_key = HistoryContentKey::BlockBody(full_header.header.hash().0.into());
         let content_value = HistoryContentValue::BlockBody(block_body);
         Ok((content_key, content_value))
     }
@@ -226,9 +219,7 @@ impl ExecutionApi {
                 full_header.header.receipts_root
             );
         }
-        let content_key = HistoryContentKey::BlockReceipts(BlockReceiptsKey {
-            block_hash: full_header.header.hash().0,
-        });
+        let content_key = HistoryContentKey::BlockReceipts(full_header.header.hash().0.into());
         let content_value = HistoryContentValue::Receipts(receipts);
         Ok((content_key, content_value))
     }

--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -148,10 +148,10 @@ impl Era1Bridge {
                 .into_iter()
                 .map(|(hash, number)| {
                     (
-                        HistoryContentKey::BlockHeaderByHash(hash.0.into()),
-                        HistoryContentKey::BlockHeaderByNumber(number.into()),
-                        HistoryContentKey::BlockBody(hash.0.into()),
-                        HistoryContentKey::BlockReceipts(hash.0.into()),
+                        HistoryContentKey::new_block_header_by_hash(hash),
+                        HistoryContentKey::new_block_header_by_number(number),
+                        HistoryContentKey::new_block_body(hash),
+                        HistoryContentKey::new_block_receipts(hash),
                     )
                 })
                 .collect::<Vec<(
@@ -369,7 +369,7 @@ impl Era1Bridge {
         let mut gossip_header_by_hash = true;
         if hunt {
             let header_hash = block_tuple.header.header.hash();
-            let header_content_key = HistoryContentKey::BlockHeaderByHash(header_hash.0.into());
+            let header_content_key = HistoryContentKey::new_block_header_by_hash(header_hash);
             let header_content_info = portal_client
                 .recursive_find_content(header_content_key.clone())
                 .await;
@@ -422,7 +422,7 @@ impl Era1Bridge {
         let mut gossip_header_by_number = true;
         if hunt {
             let header_content_key =
-                HistoryContentKey::BlockHeaderByNumber(block_tuple.header.header.number.into());
+                HistoryContentKey::new_block_header_by_number(block_tuple.header.header.number);
             let header_content_info = portal_client
                 .recursive_find_content(header_content_key.clone())
                 .await;
@@ -465,7 +465,7 @@ impl Era1Bridge {
         let mut gossip_body = true;
         if hunt {
             let body_hash = block_tuple.header.header.hash();
-            let body_content_key = HistoryContentKey::BlockBody(body_hash.0.into());
+            let body_content_key = HistoryContentKey::new_block_body(body_hash);
             let body_content_info = portal_client
                 .recursive_find_content(body_content_key.clone())
                 .await;
@@ -506,7 +506,7 @@ impl Era1Bridge {
         let mut gossip_receipts = true;
         if hunt {
             let receipts_hash = block_tuple.header.header.hash();
-            let receipts_content_key = HistoryContentKey::BlockReceipts(receipts_hash.0.into());
+            let receipts_content_key = HistoryContentKey::new_block_receipts(receipts_hash);
             let receipts_content_info = portal_client
                 .recursive_find_content(receipts_content_key.clone())
                 .await;
@@ -580,7 +580,7 @@ impl Era1Bridge {
         // Construct HistoryContentValue
         let content_value = HistoryContentValue::BlockHeaderWithProof(header_with_proof);
         // Construct HistoryContentKey for block header by hash and gossip it
-        let content_key = HistoryContentKey::BlockHeaderByHash(header.hash().0.into());
+        let content_key = HistoryContentKey::new_block_header_by_hash(header.hash());
         gossip_history_content(portal_client, content_key, content_value, block_stats).await?;
 
         Ok(())
@@ -619,7 +619,7 @@ impl Era1Bridge {
         // Construct HistoryContentValue
         let content_value = HistoryContentValue::BlockHeaderWithProof(header_with_proof);
         // Construct HistoryContentKey for block header by number and gossip it
-        let content_key = HistoryContentKey::BlockHeaderByNumber(header.number.into());
+        let content_key = HistoryContentKey::new_block_header_by_number(header.number);
         gossip_history_content(portal_client, content_key, content_value, block_stats).await?;
 
         Ok(())
@@ -636,7 +636,7 @@ impl Era1Bridge {
         );
         let header = block_tuple.header.header;
         // Construct HistoryContentKey
-        let content_key = HistoryContentKey::BlockBody(header.hash().0.into());
+        let content_key = HistoryContentKey::new_block_body(header.hash());
         // Construct HistoryContentValue
         let content_value = HistoryContentValue::BlockBody(block_tuple.body.body);
         gossip_history_content(portal_client, content_key, content_value, block_stats).await
@@ -653,7 +653,7 @@ impl Era1Bridge {
         );
         let header = block_tuple.header.header;
         // Construct HistoryContentKey
-        let content_key = HistoryContentKey::BlockReceipts(header.hash().0.into());
+        let content_key = HistoryContentKey::new_block_receipts(header.hash());
         // Construct HistoryContentValue
         let content_value = HistoryContentValue::Receipts(block_tuple.receipts.receipts);
         gossip_history_content(portal_client, content_key, content_value, block_stats).await

--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -36,13 +36,8 @@ use crate::{
 };
 use ethportal_api::{
     jsonrpsee::http_client::HttpClient,
-    types::{
-        content_key::history::{BlockHeaderByHashKey, BlockHeaderByNumberKey},
-        execution::accumulator::EpochAccumulator,
-        portal::ContentInfo,
-    },
-    BlockBodyKey, BlockReceiptsKey, HistoryContentKey, HistoryContentValue,
-    HistoryNetworkApiClient,
+    types::{execution::accumulator::EpochAccumulator, portal::ContentInfo},
+    HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
 };
 use trin_validation::{
     constants::EPOCH_SIZE, header_validator::HeaderValidator, oracle::HeaderOracle,
@@ -144,27 +139,38 @@ impl Era1Bridge {
             let blocks_to_sample = block_range.clone().collect::<Vec<u64>>();
             let blocks_to_sample =
                 blocks_to_sample.choose_multiple(&mut thread_rng(), sample_size as usize);
-            let mut hashes_to_sample: Vec<B256> = vec![];
+            let mut hashes_to_sample: Vec<(B256, u64)> = vec![];
             for block_number in blocks_to_sample {
                 let block_hash = self.execution_api.get_block_hash(*block_number).await?;
-                hashes_to_sample.push(block_hash);
+                hashes_to_sample.push((block_hash, *block_number));
             }
             let content_keys_to_sample = hashes_to_sample
-                .iter()
-                .map(|hash| {
+                .into_iter()
+                .map(|(hash, number)| {
                     (
-                        HistoryContentKey::BlockHeaderByHash(BlockHeaderByHashKey {
-                            block_hash: hash.0,
-                        }),
-                        HistoryContentKey::BlockBody(BlockBodyKey { block_hash: hash.0 }),
-                        HistoryContentKey::BlockReceipts(BlockReceiptsKey { block_hash: hash.0 }),
+                        HistoryContentKey::BlockHeaderByHash(hash.0.into()),
+                        HistoryContentKey::BlockHeaderByNumber(number.into()),
+                        HistoryContentKey::BlockBody(hash.0.into()),
+                        HistoryContentKey::BlockReceipts(hash.0.into()),
                     )
                 })
-                .collect::<Vec<(HistoryContentKey, HistoryContentKey, HistoryContentKey)>>()
+                .collect::<Vec<(
+                    HistoryContentKey,
+                    HistoryContentKey,
+                    HistoryContentKey,
+                    HistoryContentKey,
+                )>>()
                 .iter()
-                .flat_map(|(header_key, body_key, receipts_key)| {
-                    vec![header_key.clone(), body_key.clone(), receipts_key.clone()]
-                })
+                .flat_map(
+                    |(header_by_hash_key, header_by_number_key, body_key, receipts_key)| {
+                        vec![
+                            header_by_hash_key.clone(),
+                            header_by_number_key.clone(),
+                            body_key.clone(),
+                            receipts_key.clone(),
+                        ]
+                    },
+                )
                 .collect::<Vec<HistoryContentKey>>();
             let mut found = 0;
             let hunter_threshold = (content_keys_to_sample.len() as u64 * threshold / 100) as usize;
@@ -360,46 +366,43 @@ impl Era1Bridge {
             "Serving block tuple at height: {}",
             block_tuple.header.header.number
         );
-        let mut gossip_header = true;
+        let mut gossip_header_by_hash = true;
         if hunt {
             let header_hash = block_tuple.header.header.hash();
-            let header_by_hash_key = BlockHeaderByHashKey {
-                block_hash: header_hash.0,
-            };
-            let header_content_key = HistoryContentKey::BlockHeaderByHash(header_by_hash_key);
+            let header_content_key = HistoryContentKey::BlockHeaderByHash(header_hash.0.into());
             let header_content_info = portal_client
                 .recursive_find_content(header_content_key.clone())
                 .await;
             if let Ok(ContentInfo::Content { .. }) = header_content_info {
                 info!(
-                    "Skipping header at height: {} as header already found",
+                    "Skipping header by hash at height: {} as header already found",
                     block_tuple.header.header.number
                 );
-                gossip_header = false;
+                gossip_header_by_hash = false;
             }
         }
-        if gossip_header {
-            let timer = metrics.start_process_timer("construct_and_gossip_header");
-            match Self::construct_and_gossip_header(
+        if gossip_header_by_hash {
+            let timer = metrics.start_process_timer("construct_and_gossip_header_by_hash");
+            match Self::construct_and_gossip_header_by_hash(
                 portal_client.clone(),
                 block_tuple.clone(),
-                epoch_acc,
-                header_validator,
+                epoch_acc.clone(),
+                header_validator.clone(),
                 block_stats.clone(),
             )
             .await
             {
                 Ok(_) => {
-                    metrics.report_gossip_success(true, "header");
+                    metrics.report_gossip_success(true, "header_by_hash");
                     info!(
-                        "Successfully served block tuple header at height: {:?}",
+                        "Successfully served block tuple header by hash at height: {:?}",
                         block_tuple.header.header.number
                     )
                 }
                 Err(msg) => {
-                    metrics.report_gossip_success(false, "header");
+                    metrics.report_gossip_success(false, "header_by_hash");
                     warn!(
-                        "Error serving block tuple header at height, will not gossip remaining block content: {:?} - {:?}",
+                        "Error serving block tuple header by hash at height, will not gossip remaining block content: {:?} - {:?}",
                         block_tuple.header.header.number, msg
                     );
                     // We actually do want to cut off the gossip for body / receipts if header
@@ -416,13 +419,53 @@ impl Era1Bridge {
             // since they must be available for body / receipt validation.
             sleep(Duration::from_secs(HEADER_SATURATION_DELAY)).await;
         }
+        let mut gossip_header_by_number = true;
+        if hunt {
+            let header_content_key =
+                HistoryContentKey::BlockHeaderByNumber(block_tuple.header.header.number.into());
+            let header_content_info = portal_client
+                .recursive_find_content(header_content_key.clone())
+                .await;
+            if let Ok(ContentInfo::Content { .. }) = header_content_info {
+                info!(
+                    "Skipping header by number at height: {} as header already found",
+                    block_tuple.header.header.number
+                );
+                gossip_header_by_number = false;
+            }
+        }
+        if gossip_header_by_number {
+            let timer = metrics.start_process_timer("construct_and_gossip_header_by_number");
+            match Self::construct_and_gossip_header_by_number(
+                portal_client.clone(),
+                block_tuple.clone(),
+                epoch_acc,
+                header_validator,
+                block_stats.clone(),
+            )
+            .await
+            {
+                Ok(_) => {
+                    metrics.report_gossip_success(true, "header_by_number");
+                    info!(
+                        "Successfully served block tuple header by number at height: {:?}",
+                        block_tuple.header.header.number
+                    )
+                }
+                Err(msg) => {
+                    metrics.report_gossip_success(false, "header_by_number");
+                    warn!(
+                        "Error serving block tuple header by number at height, will not gossip remaining block content: {:?} - {:?}",
+                        block_tuple.header.header.number, msg
+                    );
+                }
+            }
+            metrics.stop_process_timer(timer);
+        }
         let mut gossip_body = true;
         if hunt {
             let body_hash = block_tuple.header.header.hash();
-            let body_key = BlockBodyKey {
-                block_hash: body_hash.0,
-            };
-            let body_content_key = HistoryContentKey::BlockBody(body_key);
+            let body_content_key = HistoryContentKey::BlockBody(body_hash.0.into());
             let body_content_info = portal_client
                 .recursive_find_content(body_content_key.clone())
                 .await;
@@ -463,10 +506,7 @@ impl Era1Bridge {
         let mut gossip_receipts = true;
         if hunt {
             let receipts_hash = block_tuple.header.header.hash();
-            let receipts_key = BlockReceiptsKey {
-                block_hash: receipts_hash.0,
-            };
-            let receipts_content_key = HistoryContentKey::BlockReceipts(receipts_key);
+            let receipts_content_key = HistoryContentKey::BlockReceipts(receipts_hash.0.into());
             let receipts_content_info = portal_client
                 .recursive_find_content(receipts_content_key.clone())
                 .await;
@@ -507,7 +547,7 @@ impl Era1Bridge {
         Ok(())
     }
 
-    async fn construct_and_gossip_header(
+    async fn construct_and_gossip_header_by_hash(
         portal_client: HttpClient,
         block_tuple: BlockTuple,
         epoch_acc: Arc<EpochAccumulator>,
@@ -539,25 +579,47 @@ impl Era1Bridge {
         header_validator.validate_header_with_proof(&header_with_proof)?;
         // Construct HistoryContentValue
         let content_value = HistoryContentValue::BlockHeaderWithProof(header_with_proof);
-
         // Construct HistoryContentKey for block header by hash and gossip it
-        let content_key = HistoryContentKey::BlockHeaderByHash(BlockHeaderByHashKey {
-            block_hash: header.hash().0,
-        });
+        let content_key = HistoryContentKey::BlockHeaderByHash(header.hash().0.into());
+        gossip_history_content(portal_client, content_key, content_value, block_stats).await?;
 
-        gossip_history_content(
-            portal_client.clone(),
-            content_key,
-            content_value.clone(),
-            block_stats.clone(),
-        )
-        .await?;
+        Ok(())
+    }
 
+    async fn construct_and_gossip_header_by_number(
+        portal_client: HttpClient,
+        block_tuple: BlockTuple,
+        epoch_acc: Arc<EpochAccumulator>,
+        header_validator: Arc<HeaderValidator>,
+        block_stats: Arc<Mutex<HistoryBlockStats>>,
+    ) -> anyhow::Result<()> {
+        debug!(
+            "Serving block header by number at height: {}",
+            block_tuple.header.header.number
+        );
+        let header = block_tuple.header.header;
+        // Fetch HeaderRecord from EpochAccumulator for validation
+        let header_index = header.number % EPOCH_SIZE;
+        let header_record = &epoch_acc[header_index as usize];
+
+        // Validate Header
+        let actual_header_hash = header.hash();
+
+        ensure!(
+            header_record.block_hash == actual_header_hash,
+            "Header hash doesn't match record in local accumulator: {:?} - {:?}",
+            actual_header_hash,
+            header_record.block_hash
+        );
+
+        // Construct HeaderWithProof
+        let header_with_proof = construct_proof(header.clone(), &epoch_acc).await?;
+        // Double check that the proof is valid
+        header_validator.validate_header_with_proof(&header_with_proof)?;
+        // Construct HistoryContentValue
+        let content_value = HistoryContentValue::BlockHeaderWithProof(header_with_proof);
         // Construct HistoryContentKey for block header by number and gossip it
-        let content_key = HistoryContentKey::BlockHeaderByNumber(BlockHeaderByNumberKey {
-            block_number: header.number,
-        });
-
+        let content_key = HistoryContentKey::BlockHeaderByNumber(header.number.into());
         gossip_history_content(portal_client, content_key, content_value, block_stats).await?;
 
         Ok(())
@@ -574,9 +636,7 @@ impl Era1Bridge {
         );
         let header = block_tuple.header.header;
         // Construct HistoryContentKey
-        let content_key = HistoryContentKey::BlockBody(BlockBodyKey {
-            block_hash: header.hash().0,
-        });
+        let content_key = HistoryContentKey::BlockBody(header.hash().0.into());
         // Construct HistoryContentValue
         let content_value = HistoryContentValue::BlockBody(block_tuple.body.body);
         gossip_history_content(portal_client, content_key, content_value, block_stats).await
@@ -593,9 +653,7 @@ impl Era1Bridge {
         );
         let header = block_tuple.header.header;
         // Construct HistoryContentKey
-        let content_key = HistoryContentKey::BlockReceipts(BlockReceiptsKey {
-            block_hash: header.hash().0,
-        });
+        let content_key = HistoryContentKey::BlockReceipts(header.hash().0.into());
         // Construct HistoryContentValue
         let content_value = HistoryContentValue::Receipts(block_tuple.receipts.receipts);
         gossip_history_content(portal_client, content_key, content_value, block_stats).await

--- a/rpc/src/eth_rpc.rs
+++ b/rpc/src/eth_rpc.rs
@@ -170,7 +170,7 @@ impl EthApi {
 
     async fn fetch_header_by_hash(&self, block_hash: B256) -> Result<Header, RpcServeError> {
         let content_value = self
-            .fetch_history_content(HistoryContentKey::BlockHeaderByHash(block_hash.into()))
+            .fetch_history_content(HistoryContentKey::new_block_header_by_hash(block_hash))
             .await?;
         let HistoryContentValue::BlockHeaderWithProof(header_with_proof) = content_value else {
             return Err(RpcServeError::Message(format!(
@@ -182,7 +182,7 @@ impl EthApi {
 
     async fn fetch_block_body(&self, block_hash: B256) -> Result<BlockBody, RpcServeError> {
         let content_value = self
-            .fetch_history_content(HistoryContentKey::BlockBody(block_hash.into()))
+            .fetch_history_content(HistoryContentKey::new_block_body(block_hash))
             .await?;
         let HistoryContentValue::BlockBody(block_body) = content_value else {
             return Err(RpcServeError::Message(format!(

--- a/src/bin/poll_latest.rs
+++ b/src/bin/poll_latest.rs
@@ -141,28 +141,28 @@ async fn audit_block(
 ) -> Result<()> {
     metrics.lock().unwrap().active_audit_count += 3;
     let header_by_hash_handle = tokio::spawn(audit_content_key(
-        HistoryContentKey::BlockHeaderByHash(hash.0.into()),
+        HistoryContentKey::new_block_header_by_hash(hash),
         timestamp,
         timeout,
         backoff,
         client.clone(),
     ));
     let header_by_number_handle = tokio::spawn(audit_content_key(
-        HistoryContentKey::BlockHeaderByNumber(block_number.into()),
+        HistoryContentKey::new_block_header_by_number(block_number),
         timestamp,
         timeout,
         backoff,
         client.clone(),
     ));
     let block_body_handle = tokio::spawn(audit_content_key(
-        HistoryContentKey::BlockBody(hash.0.into()),
+        HistoryContentKey::new_block_body(hash),
         timestamp,
         timeout,
         backoff,
         client.clone(),
     ));
     let receipts_handle = tokio::spawn(audit_content_key(
-        HistoryContentKey::BlockReceipts(hash.0.into()),
+        HistoryContentKey::new_block_receipts(hash),
         timestamp,
         timeout,
         backoff,

--- a/src/bin/sample_range.rs
+++ b/src/bin/sample_range.rs
@@ -138,10 +138,10 @@ async fn audit_block(
     metrics: Arc<Mutex<Metrics>>,
     client: HttpClient,
 ) -> anyhow::Result<()> {
-    let header_by_hash_ck = HistoryContentKey::BlockHeaderByHash(hash.0.into());
-    let header_by_number_ck = HistoryContentKey::BlockHeaderByNumber(block_number.into());
-    let body_ck = HistoryContentKey::BlockBody(hash.0.into());
-    let receipts_ck = HistoryContentKey::BlockReceipts(hash.0.into());
+    let header_by_hash_ck = HistoryContentKey::new_block_header_by_hash(hash);
+    let header_by_number_ck = HistoryContentKey::new_block_header_by_number(block_number);
+    let body_ck = HistoryContentKey::new_block_body(hash);
+    let receipts_ck = HistoryContentKey::new_block_receipts(hash);
     match client.recursive_find_content(header_by_hash_ck).await {
         Ok(_) => {
             metrics.lock().unwrap().header_by_hash.success_count += 1;

--- a/tests/rpc_server.rs
+++ b/tests/rpc_server.rs
@@ -125,7 +125,7 @@ async fn test_eth_get_block_by_hash() {
     };
 
     // Store header with proof in server
-    let content_key = HistoryContentKey::BlockHeaderByHash(block_hash.into());
+    let content_key = HistoryContentKey::new_block_header_by_hash(block_hash);
     let content_value = HistoryContentValue::BlockHeaderWithProof(hwp);
     let result = native_client
         .store(content_key, content_value.encode())
@@ -134,7 +134,7 @@ async fn test_eth_get_block_by_hash() {
     assert!(result);
 
     // Store block in server
-    let content_key = HistoryContentKey::BlockBody(block_hash.into());
+    let content_key = HistoryContentKey::new_block_body(block_hash);
     let content_value = HistoryContentValue::BlockBody(body);
     let result = native_client
         .store(content_key, content_value.encode())

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -130,10 +130,7 @@ mod tests {
     use serde_json::Value;
     use ssz::Encode;
 
-    use ethportal_api::{
-        types::content_key::history::{BlockHeaderByHashKey, BlockHeaderByNumberKey},
-        utils::bytes::hex_decode,
-    };
+    use ethportal_api::utils::bytes::hex_decode;
 
     fn get_header_with_proof_ssz() -> Vec<u8> {
         let file =
@@ -153,9 +150,8 @@ mod tests {
             HeaderWithProof::from_ssz_bytes(&header_with_proof_ssz).expect("error decoding header");
         let header_oracle = default_header_oracle();
         let chain_history_validator = ChainHistoryValidator { header_oracle };
-        let content_key = HistoryContentKey::BlockHeaderByHash(BlockHeaderByHashKey {
-            block_hash: header_with_proof.header.hash().0,
-        });
+        let content_key =
+            HistoryContentKey::BlockHeaderByHash(header_with_proof.header.hash().0.into());
         chain_history_validator
             .validate_content(&content_key, &header_with_proof_ssz)
             .await
@@ -175,9 +171,7 @@ mod tests {
         let content_value = header.as_ssz_bytes();
         let header_oracle = default_header_oracle();
         let chain_history_validator = ChainHistoryValidator { header_oracle };
-        let content_key = HistoryContentKey::BlockHeaderByHash(BlockHeaderByHashKey {
-            block_hash: header.header.hash().0,
-        });
+        let content_key = HistoryContentKey::BlockHeaderByHash(header.header.hash().0.into());
         chain_history_validator
             .validate_content(&content_key, &content_value)
             .await
@@ -198,9 +192,7 @@ mod tests {
         let content_value = header.as_ssz_bytes();
         let header_oracle = default_header_oracle();
         let chain_history_validator = ChainHistoryValidator { header_oracle };
-        let content_key = HistoryContentKey::BlockHeaderByHash(BlockHeaderByHashKey {
-            block_hash: header.header.hash().0,
-        });
+        let content_key = HistoryContentKey::BlockHeaderByHash(header.header.hash().0.into());
         chain_history_validator
             .validate_content(&content_key, &content_value)
             .await
@@ -214,9 +206,8 @@ mod tests {
             HeaderWithProof::from_ssz_bytes(&header_with_proof_ssz).expect("error decoding header");
         let header_oracle = default_header_oracle();
         let chain_history_validator = ChainHistoryValidator { header_oracle };
-        let content_key = HistoryContentKey::BlockHeaderByNumber(BlockHeaderByNumberKey {
-            block_number: header_with_proof.header.number,
-        });
+        let content_key =
+            HistoryContentKey::BlockHeaderByNumber(header_with_proof.header.number.into());
         chain_history_validator
             .validate_content(&content_key, &header_with_proof_ssz)
             .await
@@ -236,9 +227,7 @@ mod tests {
         let content_value = header.as_ssz_bytes();
         let header_oracle = default_header_oracle();
         let chain_history_validator = ChainHistoryValidator { header_oracle };
-        let content_key = HistoryContentKey::BlockHeaderByNumber(BlockHeaderByNumberKey {
-            block_number: header.header.number,
-        });
+        let content_key = HistoryContentKey::BlockHeaderByNumber(header.header.number.into());
         chain_history_validator
             .validate_content(&content_key, &content_value)
             .await
@@ -259,9 +248,7 @@ mod tests {
         let content_value = header.as_ssz_bytes();
         let header_oracle = default_header_oracle();
         let chain_history_validator = ChainHistoryValidator { header_oracle };
-        let content_key = HistoryContentKey::BlockHeaderByNumber(BlockHeaderByNumberKey {
-            block_number: header.header.number,
-        });
+        let content_key = HistoryContentKey::BlockHeaderByNumber(header.header.number.into());
         chain_history_validator
             .validate_content(&content_key, &content_value)
             .await

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -151,7 +151,7 @@ mod tests {
         let header_oracle = default_header_oracle();
         let chain_history_validator = ChainHistoryValidator { header_oracle };
         let content_key =
-            HistoryContentKey::BlockHeaderByHash(header_with_proof.header.hash().0.into());
+            HistoryContentKey::new_block_header_by_hash(header_with_proof.header.hash());
         chain_history_validator
             .validate_content(&content_key, &header_with_proof_ssz)
             .await
@@ -171,7 +171,7 @@ mod tests {
         let content_value = header.as_ssz_bytes();
         let header_oracle = default_header_oracle();
         let chain_history_validator = ChainHistoryValidator { header_oracle };
-        let content_key = HistoryContentKey::BlockHeaderByHash(header.header.hash().0.into());
+        let content_key = HistoryContentKey::new_block_header_by_hash(header.header.hash());
         chain_history_validator
             .validate_content(&content_key, &content_value)
             .await
@@ -192,7 +192,7 @@ mod tests {
         let content_value = header.as_ssz_bytes();
         let header_oracle = default_header_oracle();
         let chain_history_validator = ChainHistoryValidator { header_oracle };
-        let content_key = HistoryContentKey::BlockHeaderByHash(header.header.hash().0.into());
+        let content_key = HistoryContentKey::new_block_header_by_hash(header.header.hash());
         chain_history_validator
             .validate_content(&content_key, &content_value)
             .await
@@ -207,7 +207,7 @@ mod tests {
         let header_oracle = default_header_oracle();
         let chain_history_validator = ChainHistoryValidator { header_oracle };
         let content_key =
-            HistoryContentKey::BlockHeaderByNumber(header_with_proof.header.number.into());
+            HistoryContentKey::new_block_header_by_number(header_with_proof.header.number);
         chain_history_validator
             .validate_content(&content_key, &header_with_proof_ssz)
             .await
@@ -227,7 +227,7 @@ mod tests {
         let content_value = header.as_ssz_bytes();
         let header_oracle = default_header_oracle();
         let chain_history_validator = ChainHistoryValidator { header_oracle };
-        let content_key = HistoryContentKey::BlockHeaderByNumber(header.header.number.into());
+        let content_key = HistoryContentKey::new_block_header_by_number(header.header.number);
         chain_history_validator
             .validate_content(&content_key, &content_value)
             .await
@@ -248,7 +248,7 @@ mod tests {
         let content_value = header.as_ssz_bytes();
         let header_oracle = default_header_oracle();
         let chain_history_validator = ChainHistoryValidator { header_oracle };
-        let content_key = HistoryContentKey::BlockHeaderByNumber(header.header.number.into());
+        let content_key = HistoryContentKey::new_block_header_by_number(header.header.number);
         chain_history_validator
             .validate_content(&content_key, &content_value)
             .await

--- a/trin-state/src/validation/validator.rs
+++ b/trin-state/src/validation/validator.rs
@@ -186,8 +186,8 @@ mod tests {
         });
         let history_jsonrpc_tx = MockJsonRpcBuilder::new()
             .with_response(
-                HistoryEndpoint::RecursiveFindContent(HistoryContentKey::BlockHeaderByHash(
-                    header.hash().into(),
+                HistoryEndpoint::RecursiveFindContent(HistoryContentKey::new_block_header_by_hash(
+                    header.hash(),
                 )),
                 ContentInfo::Content {
                     content: history_content_value.encode(),

--- a/trin-validation/src/oracle.rs
+++ b/trin-validation/src/oracle.rs
@@ -55,7 +55,7 @@ impl HeaderOracle {
         &self,
         block_hash: B256,
     ) -> anyhow::Result<HeaderWithProof> {
-        let content_key = HistoryContentKey::BlockHeaderByHash(block_hash.0.into());
+        let content_key = HistoryContentKey::new_block_header_by_hash(block_hash);
         let endpoint = HistoryEndpoint::RecursiveFindContent(content_key.clone());
         let (resp, mut resp_rx) = mpsc::unbounded_channel::<Result<Value, String>>();
         let request = HistoryJsonRpcRequest { endpoint, resp };

--- a/trin-validation/src/oracle.rs
+++ b/trin-validation/src/oracle.rs
@@ -9,7 +9,6 @@ use ethportal_api::{
     consensus::header::BeaconBlockHeader,
     light_client::store::LightClientStore,
     types::{
-        content_key::history::BlockHeaderByHashKey,
         execution::header_with_proof::HeaderWithProof,
         jsonrpc::{
             endpoints::{BeaconEndpoint, HistoryEndpoint, StateEndpoint},
@@ -56,9 +55,7 @@ impl HeaderOracle {
         &self,
         block_hash: B256,
     ) -> anyhow::Result<HeaderWithProof> {
-        let content_key = HistoryContentKey::BlockHeaderByHash(BlockHeaderByHashKey {
-            block_hash: block_hash.0,
-        });
+        let content_key = HistoryContentKey::BlockHeaderByHash(block_hash.0.into());
         let endpoint = HistoryEndpoint::RecursiveFindContent(content_key.clone());
         let (resp, mut resp_rx) = mpsc::unbounded_channel::<Result<Value, String>>();
         let request = HistoryJsonRpcRequest { endpoint, resp };


### PR DESCRIPTION
### What was wrong?
Minor refactor to content keys

### How was it fixed?
Added `From` trait to simplify construction

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
