### PR TITLE
fix: use default angelfood bootnodes if network is selected

### DIFF
--- a/ethportal-api/src/types/bootnodes.rs
+++ b/ethportal-api/src/types/bootnodes.rs
@@ -12,19 +12,13 @@ pub struct Bootnode {
 
 impl From<Enr> for Bootnode {
     fn from(enr: Enr) -> Self {
-        let all_bootnodes = DEFAULT_BOOTNODES
-            .clone()
-            .into_iter()
-            .chain(ANGELFOOD_BOOTNODES.clone());
-        for bootnode in all_bootnodes {
-            if bootnode.enr == enr {
-                return bootnode;
-            }
-        }
-        Bootnode {
-            enr,
-            alias: "custom".to_string(),
-        }
+        Iterator::chain(DEFAULT_BOOTNODES.iter(), ANGELFOOD_BOOTNODES.iter())
+            .find(|bootnode| bootnode.enr == enr)
+            .cloned()
+            .unwrap_or_else(|| Self {
+                enr,
+                alias: "custom".to_string(),
+            })
     }
 }
 

--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -259,7 +259,7 @@ impl TrinConfig {
         I: Iterator<Item = T>,
         T: Into<OsString> + Clone,
     {
-        let mut config = Self::try_parse_from(args)?;
+        let config = Self::try_parse_from(args)?;
 
         if let Some(TrinConfigCommands::CreateDashboard(dashboard_config)) = config.command {
             if let Err(err) = create_dashboard(dashboard_config) {
@@ -310,14 +310,6 @@ impl TrinConfig {
                 ErrorKind::ValueValidation,
                 "State subnetwork can only be enabled together with history.",
             ));
-        }
-
-        // change to default angelfood bootnodes if angelfood is selected,
-        // and default mainnet bootnodes are being used
-        if config.network.get_network_name() == "angelfood"
-            && config.bootnodes == Bootnodes::Default
-        {
-            config.bootnodes = Bootnodes::Angelfood;
         }
 
         Ok(config)

--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -259,7 +259,7 @@ impl TrinConfig {
         I: Iterator<Item = T>,
         T: Into<OsString> + Clone,
     {
-        let config = Self::try_parse_from(args)?;
+        let mut config = Self::try_parse_from(args)?;
 
         if let Some(TrinConfigCommands::CreateDashboard(dashboard_config)) = config.command {
             if let Err(err) = create_dashboard(dashboard_config) {
@@ -310,6 +310,14 @@ impl TrinConfig {
                 ErrorKind::ValueValidation,
                 "State subnetwork can only be enabled together with history.",
             ));
+        }
+
+        // change to default angelfood bootnodes if angelfood is selected,
+        // and default mainnet bootnodes are being used
+        if config.network.get_network_name() == "angelfood"
+            && config.bootnodes == Bootnodes::Default
+        {
+            config.bootnodes = Bootnodes::Angelfood;
         }
 
         Ok(config)

--- a/portalnet/src/config.rs
+++ b/portalnet/src/config.rs
@@ -19,7 +19,6 @@ pub struct PortalnetConfig {
     pub private_key: B256,
     pub listen_port: u16,
     pub bootnodes: Vec<Enr>,
-    pub internal_ip: bool,
     pub no_stun: bool,
     pub no_upnp: bool,
     pub node_addr_cache_capacity: usize,
@@ -29,6 +28,7 @@ pub struct PortalnetConfig {
     pub utp_transfer_limit: usize,
 }
 
+// to be used inside test code only
 impl Default for PortalnetConfig {
     fn default() -> Self {
         Self {
@@ -36,7 +36,6 @@ impl Default for PortalnetConfig {
             private_key: B256::random(),
             listen_port: 4242,
             bootnodes: Bootnodes::default().to_enrs(Network::Mainnet),
-            internal_ip: false,
             no_stun: false,
             no_upnp: false,
             node_addr_cache_capacity: NODE_ADDR_CACHE_CAPACITY,
@@ -53,13 +52,13 @@ impl PortalnetConfig {
             external_addr: trin_config.external_addr,
             private_key,
             listen_port: trin_config.discovery_port,
+            bootnodes: trin_config.bootnodes.to_enrs(trin_config.network.network()),
             no_stun: trin_config.no_stun,
             no_upnp: trin_config.no_upnp,
-            bootnodes: trin_config.bootnodes.to_enrs(trin_config.network.network()),
+            node_addr_cache_capacity: NODE_ADDR_CACHE_CAPACITY,
             disable_poke: trin_config.disable_poke,
             trusted_block_root: trin_config.trusted_block_root,
             utp_transfer_limit: trin_config.utp_transfer_limit,
-            ..Default::default()
         }
     }
 }

--- a/portalnet/src/config.rs
+++ b/portalnet/src/config.rs
@@ -4,6 +4,8 @@ use alloy_primitives::B256;
 use ethportal_api::types::{
     bootnodes::Bootnodes,
     cli::{TrinConfig, DEFAULT_UTP_TRANSFER_LIMIT},
+    enr::Enr,
+    network::Network,
 };
 
 /// Capacity of the cache for observed `NodeAddress` values.
@@ -16,7 +18,7 @@ pub struct PortalnetConfig {
     pub external_addr: Option<SocketAddr>,
     pub private_key: B256,
     pub listen_port: u16,
-    pub bootnodes: Bootnodes,
+    pub bootnodes: Vec<Enr>,
     pub internal_ip: bool,
     pub no_stun: bool,
     pub no_upnp: bool,
@@ -33,7 +35,7 @@ impl Default for PortalnetConfig {
             external_addr: None,
             private_key: B256::random(),
             listen_port: 4242,
-            bootnodes: Bootnodes::default(),
+            bootnodes: Bootnodes::default().to_enrs(Network::Mainnet),
             internal_ip: false,
             no_stun: false,
             no_upnp: false,
@@ -53,7 +55,7 @@ impl PortalnetConfig {
             listen_port: trin_config.discovery_port,
             no_stun: trin_config.no_stun,
             no_upnp: trin_config.no_upnp,
-            bootnodes: trin_config.bootnodes.clone(),
+            bootnodes: trin_config.bootnodes.to_enrs(trin_config.network.network()),
             disable_poke: trin_config.disable_poke,
             trusted_block_root: trin_config.trusted_block_root,
             utp_transfer_limit: trin_config.utp_transfer_limit,

--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -181,8 +181,7 @@ impl Discovery {
         let discv5 = Discv5::new(enr, enr_key, discv5_config)
             .map_err(|e| format!("Failed to create discv5 instance: {e}"))?;
 
-        let bootnode_enrs: Vec<Enr> = portal_config.bootnodes.into();
-        for enr in bootnode_enrs {
+        for enr in portal_config.bootnodes {
             if enr.node_id() == discv5.local_enr().node_id() {
                 warn!("Bootnode ENR is the same as the local ENR. Skipping.");
                 continue;
@@ -523,7 +522,7 @@ impl AsyncUdpSocket<UtpEnr> for Discv5UdpSocket {
 mod tests {
     use super::*;
     use crate::utils::db::configure_node_data_dir;
-    use ethportal_api::types::{bootnodes::Bootnodes, portal_wire::MAINNET};
+    use ethportal_api::types::portal_wire::MAINNET;
     use trin_utils::dir::create_temp_test_dir;
 
     #[test]
@@ -537,7 +536,7 @@ mod tests {
 
         let mut portalnet_config = PortalnetConfig {
             private_key,
-            bootnodes: Bootnodes::None,
+            bootnodes: vec![],
             ..Default::default()
         };
 

--- a/trin-beacon/src/lib.rs
+++ b/trin-beacon/src/lib.rs
@@ -20,7 +20,7 @@ use tracing::info;
 use utp_rs::socket::UtpSocket;
 
 use crate::{events::BeaconEvents, jsonrpc::BeaconRequestHandler, network::BeaconNetwork};
-use ethportal_api::types::{enr::Enr, jsonrpc::request::BeaconJsonRpcRequest};
+use ethportal_api::types::jsonrpc::request::BeaconJsonRpcRequest;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
@@ -82,10 +82,9 @@ pub fn spawn_beacon_network(
     portalnet_config: PortalnetConfig,
     beacon_message_rx: mpsc::UnboundedReceiver<OverlayRequest>,
 ) -> JoinHandle<()> {
-    let bootnode_enrs: Vec<Enr> = portalnet_config.bootnodes.into();
     info!(
         "About to spawn Beacon Network with {} boot nodes.",
-        bootnode_enrs.len()
+        portalnet_config.bootnodes.len()
     );
 
     tokio::spawn(async move {

--- a/trin-beacon/src/network.rs
+++ b/trin-beacon/src/network.rs
@@ -7,7 +7,7 @@ use utp_rs::socket::UtpSocket;
 
 use crate::{storage::BeaconStorage, sync::BeaconSync, validation::BeaconValidator};
 use ethportal_api::{
-    types::{distance::XorMetric, enr::Enr, network::Subnetwork},
+    types::{distance::XorMetric, network::Subnetwork},
     BeaconContentKey,
 };
 use light_client::{consensus::rpc::portal_rpc::PortalRpc, database::FileDB, Client};
@@ -39,9 +39,8 @@ impl BeaconNetwork {
         portal_config: PortalnetConfig,
         header_oracle: Arc<RwLock<HeaderOracle>>,
     ) -> anyhow::Result<Self> {
-        let bootnode_enrs: Vec<Enr> = portal_config.bootnodes.into();
         let config = OverlayConfig {
-            bootnode_enrs,
+            bootnode_enrs: portal_config.bootnodes,
             utp_transfer_limit: portal_config.utp_transfer_limit,
             gossip_dropped: GOSSIP_DROPPED,
             ..Default::default()

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -20,7 +20,7 @@ use tracing::info;
 use utp_rs::socket::UtpSocket;
 
 use crate::{events::HistoryEvents, jsonrpc::HistoryRequestHandler};
-use ethportal_api::types::{enr::Enr, jsonrpc::request::HistoryJsonRpcRequest};
+use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
@@ -83,10 +83,9 @@ pub fn spawn_history_network(
     portalnet_config: PortalnetConfig,
     history_message_rx: mpsc::UnboundedReceiver<OverlayRequest>,
 ) -> JoinHandle<()> {
-    let bootnode_enrs: Vec<Enr> = portalnet_config.bootnodes.into();
     info!(
         "About to spawn History Network with {} boot nodes",
-        bootnode_enrs.len()
+        portalnet_config.bootnodes.len()
     );
 
     tokio::spawn(async move {

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -6,7 +6,7 @@ use utp_rs::socket::UtpSocket;
 
 use crate::storage::HistoryStorage;
 use ethportal_api::{
-    types::{distance::XorMetric, enr::Enr, network::Subnetwork},
+    types::{distance::XorMetric, network::Subnetwork},
     HistoryContentKey,
 };
 use portalnet::{
@@ -39,9 +39,8 @@ impl HistoryNetwork {
         portal_config: PortalnetConfig,
         header_oracle: Arc<RwLock<HeaderOracle>>,
     ) -> anyhow::Result<Self> {
-        let bootnode_enrs: Vec<Enr> = portal_config.bootnodes.into();
         let config = OverlayConfig {
-            bootnode_enrs,
+            bootnode_enrs: portal_config.bootnodes,
             disable_poke: portal_config.disable_poke,
             gossip_dropped: GOSSIP_DROPPED,
             utp_transfer_limit: portal_config.utp_transfer_limit,

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -13,7 +13,7 @@ use tracing::info;
 use utp_rs::socket::UtpSocket;
 
 use crate::{events::StateEvents, jsonrpc::StateRequestHandler};
-use ethportal_api::types::{enr::Enr, jsonrpc::request::StateJsonRpcRequest};
+use ethportal_api::types::jsonrpc::request::StateJsonRpcRequest;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
@@ -85,10 +85,9 @@ pub fn spawn_state_network(
     portalnet_config: PortalnetConfig,
     state_message_rx: mpsc::UnboundedReceiver<OverlayRequest>,
 ) -> JoinHandle<()> {
-    let bootnode_enrs: Vec<Enr> = portalnet_config.bootnodes.into();
     info!(
         "About to spawn State Network with {} boot nodes.",
-        bootnode_enrs.len()
+        portalnet_config.bootnodes.len()
     );
 
     tokio::spawn(async move {

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -45,7 +45,7 @@ impl StateNetwork {
             debug!("Poke is not supported by the State Network")
         }
         let config = OverlayConfig {
-            bootnode_enrs: portal_config.bootnodes.into(),
+            bootnode_enrs: portal_config.bootnodes,
             disable_poke: DISABLE_POKE,
             gossip_dropped: GOSSIP_DROPPED,
             utp_transfer_limit: portal_config.utp_transfer_limit,


### PR DESCRIPTION
### What was wrong?
fixes #1460

### How was it fixed?
Added angelfood bootnodes and logic to handle the correct bootnodes depending on what network's selected.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
