### PR TITLE
feat: unify data directory cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4395,7 +4395,6 @@ dependencies = [
  "bytes",
  "crossbeam-channel",
  "delay_map 0.4.0",
- "directories",
  "discv5",
  "env_logger 0.9.3",
  "ethereum_ssz",
@@ -4418,7 +4417,6 @@ dependencies = [
  "smallvec",
  "ssz_types",
  "stunclient",
- "tempfile",
  "test-log",
  "thiserror",
  "tokio",
@@ -6862,7 +6860,6 @@ dependencies = [
  "alloy-rpc-types-engine",
  "anyhow",
  "clap",
- "directories",
  "e2store",
  "eth_trie",
  "ethportal-api",
@@ -6879,7 +6876,6 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
- "tempfile",
  "test-log",
  "thiserror",
  "tokio",
@@ -6985,7 +6981,10 @@ version = "0.1.1-alpha.1"
 dependencies = [
  "ansi_term",
  "atty",
+ "directories",
  "shadow-rs",
+ "tempfile",
+ "tracing",
  "tracing-subscriber 0.3.18",
 ]
 

--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -146,7 +146,7 @@ pub struct TrinConfig {
     pub trusted_block_root: Option<B256>,
 
     #[arg(
-    long = "portal-subnetworks",
+        long = "portal-subnetworks",
         help = "Comma-separated list of which portal subnetworks to activate",
         default_value = DEFAULT_SUBNETWORKS,
         value_parser = subnetwork_parser,
@@ -155,10 +155,10 @@ pub struct TrinConfig {
 
     #[arg(
         long = "network",
-            help = "Choose mainnet or angelfood",
-            default_value = DEFAULT_NETWORK,
-            value_parser = network_parser
-        )]
+        help = "Choose mainnet or angelfood",
+        default_value = DEFAULT_NETWORK,
+        value_parser = network_parser
+    )]
     pub network: Arc<NetworkSpec>,
 
     /// Storage capacity specified in megabytes.
@@ -176,9 +176,15 @@ pub struct TrinConfig {
     pub enable_metrics_with_url: Option<SocketAddr>,
 
     #[arg(
-        short = 'e',
-        long = "ephemeral",
-        help = "Use temporary data storage that is deleted on exit."
+        long,
+        help = "The directory for storing application data. If used together with --ephemeral, new child directory will be created. Can be alternatively set via TRIN_DATA_PATH env variable."
+    )]
+    pub data_dir: Option<PathBuf>,
+
+    #[arg(
+        long,
+        short,
+        help = "Use new data directory, located in OS temporary directory. If used together with --data-dir, new directory will be created there instead."
     )]
     pub ephemeral: bool,
 
@@ -237,6 +243,7 @@ impl Default for TrinConfig {
                 .parse()
                 .expect("Parsing static DEFAULT_STORAGE_CAPACITY_MB to work"),
             enable_metrics_with_url: None,
+            data_dir: None,
             ephemeral: false,
             disable_poke: false,
             ws: false,

--- a/ethportal-api/src/types/portal_wire.rs
+++ b/ethportal-api/src/types/portal_wire.rs
@@ -185,8 +185,8 @@ pub struct NetworkSpec {
 }
 
 impl NetworkSpec {
-    pub fn get_network_name(&self) -> String {
-        self.network.to_string()
+    pub fn network(&self) -> Network {
+        self.network
     }
 
     pub fn get_protocol_id_from_hex(&self, hex: &str) -> Result<ProtocolId, ProtocolIdError> {

--- a/portal-bridge/src/bridge/state.rs
+++ b/portal-bridge/src/bridge/state.rs
@@ -22,12 +22,12 @@ use trin_execution::{
     },
     evm::spec_id::get_spec_block_number,
     execution::TrinExecution,
-    storage::utils::setup_temp_dir,
     trie_walker::TrieWalker,
     types::{block_to_trace::BlockToTrace, trie_proof::TrieProof},
     utils::full_nibble_path_to_address_hash,
 };
 use trin_metrics::bridge::BridgeMetricsReporter;
+use trin_utils::dir::create_temp_dir;
 
 use crate::{
     bridge::history::SERVE_BLOCK_TIMEOUT,
@@ -85,15 +85,14 @@ impl StateBridge {
 
     async fn launch_state(&self, last_block: u64) -> anyhow::Result<()> {
         info!("Gossiping state data from block 0 to {last_block}");
-        let temp_directory = setup_temp_dir()?;
+        let temp_directory = create_temp_dir("trin-bridge-state", None)?;
 
         // Enable contract storage changes caching required for gossiping the storage trie
         let state_config = StateConfig {
             cache_contract_storage_changes: true,
             block_to_trace: BlockToTrace::None,
         };
-        let mut trin_execution =
-            TrinExecution::new(Some(temp_directory.path().to_path_buf()), state_config).await?;
+        let mut trin_execution = TrinExecution::new(temp_directory.path(), state_config).await?;
         for block_number in 0..=last_block {
             info!("Gossipping state for block at height: {block_number}");
 
@@ -178,6 +177,7 @@ impl StateBridge {
             // This is used for gossiping storage trie diffs
             trin_execution.database.storage_cache.clear();
         }
+        temp_directory.close()?;
         Ok(())
     }
 

--- a/portal-bridge/src/handle.rs
+++ b/portal-bridge/src/handle.rs
@@ -23,7 +23,7 @@ pub fn build_trin(bridge_config: &BridgeConfig) -> anyhow::Result<Child> {
         .args(["--no-upnp"])
         .args(["--mb", "0"])
         .args(["--web3-transport", "http"])
-        .args(["--network", &bridge_config.network.get_network_name()])
+        .args(["--network", &bridge_config.network.network().to_string()])
         .args(["--portal-subnetworks", &subnetworks_flag(bridge_config)])
         .args(["--unsafe-private-key", &private_key])
         .args([

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -17,7 +17,6 @@ async-trait.workspace = true
 bytes.workspace = true
 crossbeam-channel = "0.5.13"
 delay_map.workspace = true
-directories.workspace = true
 discv5.workspace = true
 ethereum_ssz.workspace = true
 ethportal-api.workspace = true
@@ -36,7 +35,6 @@ serde.workspace = true
 smallvec = "1.8.0"
 ssz_types.workspace = true
 stunclient = "0.4.1"
-tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream = { version = "0.1.14", features = ["sync"] }

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -2754,12 +2754,12 @@ mod tests {
         time::timeout,
     };
     use tokio_test::{assert_pending, assert_ready, task};
+    use trin_utils::dir::create_temp_test_dir;
 
     use crate::{
         config::PortalnetConfig,
         discovery::{Discovery, NodeAddress},
         overlay::config::OverlayConfig,
-        utils::db::setup_temp_dir,
     };
     use ethportal_api::types::{
         cli::{DEFAULT_DISCOVERY_PORT, DEFAULT_UTP_TRANSFER_LIMIT},
@@ -2785,8 +2785,9 @@ mod tests {
             no_upnp: true,
             ..Default::default()
         };
-        let temp_dir = setup_temp_dir().unwrap().into_path();
-        let discovery = Arc::new(Discovery::new(portal_config, temp_dir, MAINNET.clone()).unwrap());
+        let temp_dir = create_temp_test_dir().unwrap().into_path();
+        let discovery =
+            Arc::new(Discovery::new(portal_config, &temp_dir, MAINNET.clone()).unwrap());
 
         let header_oracle = HeaderOracle::default();
         let header_oracle = Arc::new(TokioRwLock::new(header_oracle));

--- a/rpc/src/rpc_server.rs
+++ b/rpc/src/rpc_server.rs
@@ -616,8 +616,9 @@ mod tests {
     use super::*;
     use crate::{builder::RpcModuleSelection, PortalRpcModule, RpcModuleBuilder};
     use ethportal_api::types::portal_wire::MAINNET;
-    use portalnet::{discovery::Discovery, utils::db::setup_temp_dir};
+    use portalnet::discovery::Discovery;
     use std::{io, sync::Arc};
+    use trin_utils::dir::create_temp_test_dir;
 
     /// Localhost with port 0 so a free port is used.
     pub fn test_address() -> SocketAddr {
@@ -637,9 +638,9 @@ mod tests {
     pub fn test_rpc_builder() -> RpcModuleBuilder {
         let (history_tx, _) = tokio::sync::mpsc::unbounded_channel();
         let (beacon_tx, _) = tokio::sync::mpsc::unbounded_channel();
-        let temp_dir = setup_temp_dir().unwrap().into_path();
+        let temp_dir = create_temp_test_dir().unwrap().into_path();
         let discv5 =
-            Arc::new(Discovery::new(Default::default(), temp_dir, MAINNET.clone()).unwrap());
+            Arc::new(Discovery::new(Default::default(), &temp_dir, MAINNET.clone()).unwrap());
         RpcModuleBuilder::new(discv5)
             .with_history(history_tx)
             .with_beacon(beacon_tx)

--- a/src/bin/purge_invalid_history_content.rs
+++ b/src/bin/purge_invalid_history_content.rs
@@ -4,7 +4,10 @@ use clap::Parser;
 use discv5::enr::{CombinedKey, Enr};
 use tracing::info;
 
-use ethportal_api::types::{network::Subnetwork, portal_wire::ProtocolId};
+use ethportal_api::types::{
+    network::{Network, Subnetwork},
+    portal_wire::ProtocolId,
+};
 use portalnet::utils::db::{configure_node_data_dir, configure_trin_data_dir};
 use trin_storage::{
     versioned::{ContentType, IdIndexedV1StoreConfig},
@@ -17,12 +20,10 @@ pub fn main() -> Result<()> {
     init_tracing_logger();
     let script_config = PurgeConfig::parse();
 
-    let trin_data_dir = configure_trin_data_dir(false /* ephemeral */)?;
-    let (node_data_dir, mut private_key) = configure_node_data_dir(
-        trin_data_dir,
-        script_config.private_key,
-        "mainnet".to_string(),
-    )?;
+    let trin_data_dir =
+        configure_trin_data_dir(None /* data_dir */, false /* ephemeral */)?;
+    let (node_data_dir, mut private_key) =
+        configure_node_data_dir(&trin_data_dir, script_config.private_key, Network::Mainnet)?;
     let enr_key = CombinedKey::secp256k1_from_bytes(private_key.as_mut_slice())
         .expect("Failed to create ENR key");
     let enr = Enr::empty(&enr_key).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,13 +42,14 @@ pub async fn run_trin(
     info!(config = %trin_config, "With:");
 
     // Setup temp trin data directory if we're in ephemeral mode
-    let trin_data_dir = configure_trin_data_dir(trin_config.ephemeral)?;
+    let trin_data_dir =
+        configure_trin_data_dir(trin_config.data_dir.clone(), trin_config.ephemeral)?;
 
     // Configure node data dir based on the provided private key
     let (node_data_dir, private_key) = configure_node_data_dir(
-        trin_data_dir,
+        &trin_data_dir,
         trin_config.private_key,
-        trin_config.network.get_network_name().to_string(),
+        trin_config.network.network(),
     )?;
 
     let portalnet_config = PortalnetConfig::new(&trin_config, private_key);
@@ -56,7 +57,7 @@ pub async fn run_trin(
     // Initialize base discovery protocol
     let mut discovery = Discovery::new(
         portalnet_config.clone(),
-        node_data_dir.clone(),
+        &node_data_dir,
         trin_config.network.clone(),
     )?;
     let talk_req_rx = discovery.start().await?;

--- a/trin-execution/Cargo.toml
+++ b/trin-execution/Cargo.toml
@@ -19,7 +19,6 @@ alloy-rpc-types.workspace = true
 alloy-rpc-types-engine = "0.3.6"
 anyhow.workspace = true
 clap.workspace = true
-directories.workspace = true
 ethportal-api.workspace = true
 e2store.workspace = true
 eth_trie.workspace = true
@@ -36,7 +35,6 @@ revm-primitives.workspace = true
 rocksdb = "0.22.0"
 serde = { workspace = true, features = ["rc"] }
 serde_json.workspace = true
-tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/trin-execution/src/cli.rs
+++ b/trin-execution/src/cli.rs
@@ -8,9 +8,15 @@ use crate::types::block_to_trace::BlockToTrace;
 #[command(name = "Trin Execution", about = "Executing blocks with no devp2p")]
 pub struct TrinExecutionConfig {
     #[arg(
-        short = 'e',
-        long = "ephemeral",
-        help = "Use temporary data storage that is deleted on exit."
+        long,
+        help = "The directory for storing application data. If used together with --ephemeral, new child directory will be created."
+    )]
+    pub data_dir: Option<PathBuf>,
+
+    #[arg(
+        long,
+        short,
+        help = "Use new data directory, located in OS temporary directory. If used together with --data-dir, new directory will be created there instead."
     )]
     pub ephemeral: bool,
 
@@ -22,7 +28,7 @@ pub struct TrinExecutionConfig {
     pub block_to_trace: BlockToTrace,
 
     #[arg(
-        long = "enable-metrics-with-url",
+        long,
         help = "Enable prometheus metrics reporting (provide local IP/Port from which your Prometheus server is configured to fetch metrics)"
     )]
     pub enable_metrics_with_url: Option<SocketAddr>,
@@ -42,18 +48,12 @@ pub enum TrinExecutionSubCommands {
 
 #[derive(Args, Debug, Default, Clone, PartialEq)]
 pub struct ImportStateConfig {
-    #[arg(
-        long = "path-to-era2",
-        help = "path to where the era2 state snapshot is located"
-    )]
+    #[arg(long, help = "path to where the era2 state snapshot is located")]
     pub path_to_era2: PathBuf,
 }
 
 #[derive(Args, Debug, Default, Clone, PartialEq)]
 pub struct ExportStateConfig {
-    #[arg(
-        long = "path-to-era2",
-        help = "path to where the era2 state snapshot is located"
-    )]
+    #[arg(long, help = "path to where the era2 state snapshot is located")]
     pub path_to_era2: PathBuf,
 }

--- a/trin-execution/src/main.rs
+++ b/trin-execution/src/main.rs
@@ -6,10 +6,11 @@ use trin_execution::{
     era::manager::EraManager,
     evm::spec_id::get_spec_block_number,
     execution::TrinExecution,
-    storage::utils::setup_temp_dir,
     subcommands::era2::{export::StateExporter, import::StateImporter},
 };
-use trin_utils::log::init_tracing_logger;
+use trin_utils::{dir::setup_data_dir, log::init_tracing_logger};
+
+const APP_NAME: &str = "trin-execution";
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -22,16 +23,14 @@ async fn main() -> anyhow::Result<()> {
         prometheus_exporter::start(addr)?;
     }
 
-    let directory = match trin_execution_config.ephemeral {
-        false => None,
-        true => Some(setup_temp_dir()?),
-    };
+    let data_dir = setup_data_dir(
+        APP_NAME,
+        trin_execution_config.data_dir.clone(),
+        trin_execution_config.ephemeral,
+    )?;
 
-    let mut trin_execution = TrinExecution::new(
-        directory.map(|temp_directory| temp_directory.path().to_path_buf()),
-        trin_execution_config.clone().into(),
-    )
-    .await?;
+    let mut trin_execution =
+        TrinExecution::new(&data_dir, trin_execution_config.clone().into()).await?;
 
     if let Some(command) = trin_execution_config.command {
         match command {

--- a/trin-execution/src/storage/account_db.rs
+++ b/trin-execution/src/storage/account_db.rs
@@ -61,14 +61,16 @@ impl DB for AccountDB {
 #[cfg(test)]
 mod test_account_db {
 
-    use crate::storage::utils::{setup_rocksdb, setup_temp_dir};
+    use crate::storage::utils::setup_rocksdb;
 
     use super::*;
     use eth_trie::DB;
+    use trin_utils::dir::create_temp_test_dir;
 
     #[test]
     fn test_account_db_get() {
-        let rocksdb = setup_rocksdb(setup_temp_dir().unwrap().into_path()).unwrap();
+        let temp_directory = create_temp_test_dir().unwrap();
+        let rocksdb = setup_rocksdb(temp_directory.path()).unwrap();
         let accdb = AccountDB::new(B256::ZERO, Arc::new(rocksdb));
         accdb
             .insert(keccak256(b"test-key").as_slice(), b"test-value".to_vec())
@@ -77,18 +79,21 @@ mod test_account_db {
             .get(keccak256(b"test-key").as_slice())
             .unwrap()
             .unwrap();
-        assert_eq!(v, b"test-value")
+        assert_eq!(v, b"test-value");
+        temp_directory.close().unwrap();
     }
 
     #[test]
     fn test_account_db_remove() {
-        let rocksdb = setup_rocksdb(setup_temp_dir().unwrap().into_path()).unwrap();
+        let temp_directory = create_temp_test_dir().unwrap();
+        let rocksdb = setup_rocksdb(temp_directory.path()).unwrap();
         let accdb = AccountDB::new(B256::ZERO, Arc::new(rocksdb));
         accdb
             .insert(keccak256(b"test").as_slice(), b"test".to_vec())
             .unwrap();
         accdb.remove(keccak256(b"test").as_slice()).unwrap();
         let contains = accdb.get(keccak256(b"test").as_slice()).unwrap();
-        assert_eq!(contains, None)
+        assert_eq!(contains, None);
+        temp_directory.close().unwrap();
     }
 }

--- a/trin-execution/src/storage/utils.rs
+++ b/trin-execution/src/storage/utils.rs
@@ -1,15 +1,10 @@
-use std::{env, fs, path::PathBuf};
+use std::path::Path;
 
-use anyhow::anyhow;
-use directories::ProjectDirs;
 use rocksdb::{Options, DB as RocksDB};
-use tempfile::TempDir;
-use tracing::{debug, info};
-
-const TRIN_EXECUTION_DATA_DIR: &str = "trin-execution";
+use tracing::info;
 
 /// Helper function for opening a RocksDB connection for the radius-constrained db.
-pub fn setup_rocksdb(path: PathBuf) -> anyhow::Result<RocksDB> {
+pub fn setup_rocksdb(path: &Path) -> anyhow::Result<RocksDB> {
     let rocksdb_path = path.join("rocksdb");
     info!(path = %rocksdb_path.display(), "Setting up RocksDB");
 
@@ -26,29 +21,4 @@ pub fn setup_rocksdb(path: PathBuf) -> anyhow::Result<RocksDB> {
     // process. This limit prevents issues with the OS running out of file descriptors.
     db_opts.set_max_open_files(150);
     Ok(RocksDB::open(&db_opts, rocksdb_path)?)
-}
-
-/// Create a directory on the file system that is deleted once it goes out of scope
-pub fn setup_temp_dir() -> anyhow::Result<TempDir> {
-    let mut os_temp = env::temp_dir();
-    os_temp.push(TRIN_EXECUTION_DATA_DIR);
-    debug!("Creating temp dir: {os_temp:?}");
-    fs::create_dir_all(&os_temp)?;
-
-    let temp_dir = TempDir::new_in(&os_temp)?;
-
-    Ok(temp_dir)
-}
-
-pub fn get_default_data_dir() -> anyhow::Result<PathBuf> {
-    // Windows: C:\Users\Username\AppData\Roaming\$TRIN_EXECUTION_DATA_DIR
-    // macOS: ~/Library/Application Support/$TRIN_EXECUTION_DATA_DIR
-    // Unix-like: $HOME/.local/share/$TRIN_EXECUTION_DATA_DIR
-    match ProjectDirs::from("", "", TRIN_EXECUTION_DATA_DIR) {
-        Some(proj_dirs) => match proj_dirs.data_local_dir().to_str() {
-            Some(val) => Ok(PathBuf::from(val)),
-            None => Err(anyhow!("Unable to find default data directory")),
-        },
-        None => Err(anyhow!("Unable to find default data directory")),
-    }
 }

--- a/trin-execution/src/trie_walker.rs
+++ b/trin-execution/src/trie_walker.rs
@@ -163,21 +163,16 @@ mod tests {
 
     use alloy_primitives::{keccak256, Address, Bytes};
     use eth_trie::{RootWithTrieDiff, Trie};
+    use trin_utils::dir::create_temp_test_dir;
 
-    use crate::{
-        config::StateConfig, execution::TrinExecution, storage::utils::setup_temp_dir,
-        trie_walker::TrieWalker,
-    };
+    use crate::{config::StateConfig, execution::TrinExecution, trie_walker::TrieWalker};
 
     #[tokio::test]
     async fn test_trie_walker_builds_valid_proof() {
-        let temp_directory = setup_temp_dir().unwrap();
-        let mut trin_execution = TrinExecution::new(
-            Some(temp_directory.path().to_path_buf()),
-            StateConfig::default(),
-        )
-        .await
-        .unwrap();
+        let temp_directory = create_temp_test_dir().unwrap();
+        let mut trin_execution = TrinExecution::new(temp_directory.path(), StateConfig::default())
+            .await
+            .unwrap();
         let RootWithTrieDiff { trie_diff, .. } = trin_execution.process_next_block().await.unwrap();
         let root_hash = trin_execution.get_root().unwrap();
         let walk_diff = TrieWalker::new(root_hash, trie_diff);
@@ -198,5 +193,7 @@ mod tests {
 
         assert_eq!(account_proof.path, [5, 9, 2, 13]);
         assert_eq!(account_proof.proof, valid_proof);
+
+        temp_directory.close().unwrap();
     }
 }

--- a/trin-execution/src/types/block_to_trace.rs
+++ b/trin-execution/src/types/block_to_trace.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::{self, File},
     io::{BufWriter, Write},
-    path::PathBuf,
+    path::Path,
     str::FromStr,
 };
 
@@ -29,7 +29,7 @@ impl BlockToTrace {
     /// Returns None if transaction shouldn't be traced.
     pub fn create_trace_writer(
         &self,
-        root_dir: PathBuf,
+        root_dir: &Path,
         header: &Header,
         tx: &Transaction,
     ) -> std::io::Result<Option<Box<dyn Write>>> {

--- a/trin-execution/tests/content_generation.rs
+++ b/trin-execution/tests/content_generation.rs
@@ -12,11 +12,11 @@ use trin_execution::{
         create_contract_content_value, create_storage_content_key, create_storage_content_value,
     },
     execution::TrinExecution,
-    storage::utils::setup_temp_dir,
     trie_walker::TrieWalker,
     types::block_to_trace::BlockToTrace,
     utils::full_nibble_path_to_address_hash,
 };
+use trin_utils::dir::create_temp_test_dir;
 
 /// Tests that we can execute and generate content up to a specified block.
 ///
@@ -34,10 +34,10 @@ async fn test_we_can_generate_content_key_values_up_to_x() -> Result<()> {
     // set last block to test for
     let blocks = 1_000_000;
 
-    let temp_directory = setup_temp_dir()?;
+    let temp_directory = create_temp_test_dir()?;
 
     let mut trin_execution = TrinExecution::new(
-        Some(temp_directory.path().to_path_buf()),
+        temp_directory.path(),
         StateConfig {
             cache_contract_storage_changes: true,
             block_to_trace: BlockToTrace::None,
@@ -124,5 +124,6 @@ async fn test_we_can_generate_content_key_values_up_to_x() -> Result<()> {
         trin_execution.database.storage_cache.clear();
         println!("Block {block_number} finished. Total content key/value pairs: {content_pairs}");
     }
+    temp_directory.close()?;
     Ok(())
 }

--- a/trin-utils/Cargo.toml
+++ b/trin-utils/Cargo.toml
@@ -12,7 +12,10 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 build = "build.rs"
 
 [dependencies]
+directories.workspace = true
 shadow-rs = "0.27"
+tempfile.workspace = true
+tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [build-dependencies]

--- a/trin-utils/src/dir.rs
+++ b/trin-utils/src/dir.rs
@@ -1,0 +1,59 @@
+use std::{env, fs, io, path::PathBuf};
+
+use directories::ProjectDirs;
+use tempfile::TempDir;
+use tracing::debug;
+
+/// Setup applications data directory.
+///
+/// - If `ephemeral` is set, it will create temporary directory, either in `data_dir` (if provided)
+///   or in operating system temp directory.
+/// - Otherwise, it uses `data_dir` if set.
+/// - Lastly, if neither are set, it will use operating system default application local data
+///   directory.
+pub fn setup_data_dir(
+    app_name: &str,
+    data_dir: Option<PathBuf>,
+    ephemeral: bool,
+) -> io::Result<PathBuf> {
+    if ephemeral {
+        return create_temp_dir(app_name, data_dir).map(TempDir::into_path);
+    }
+    let data_dir = match data_dir {
+        Some(data_dir) => data_dir,
+        None => get_default_data_dir_path(app_name)
+            .ok_or_else(|| io::Error::other("No valid default directory."))?,
+    };
+    fs::create_dir_all(&data_dir)?;
+    Ok(data_dir)
+}
+
+/// Returns default data directory.
+///
+/// - Windows: `C:\Users\Username\AppData\Roaming\{app_name}`
+/// - macOS: `~/Library/Application Support/{app_name}`
+/// - Unix-like: `$HOME/.local/share/{app_name}`
+///
+/// It returns `None` if no valid home directory path could be retrieved from the operating system.
+pub fn get_default_data_dir_path(app_name: &str) -> Option<PathBuf> {
+    ProjectDirs::from("", "", app_name).map(|proj_dirs| proj_dirs.data_local_dir().to_path_buf())
+}
+
+/// Create temporary test directory for the purpose of testing.
+pub fn create_temp_test_dir() -> io::Result<TempDir> {
+    create_temp_dir("trin-tests", None)
+}
+
+/// Create a random named directory that is deleted once it goes out of scope.
+///
+/// The location of the directory can be controlled by `dir` param:
+///
+/// - if `None`, it will be located under OS's temporary directory, e.g. on Linux:
+///   `/tmp/{app_name}/{random_name}`
+/// - if `Some(root)`, it will be `{root}/{app_name}/{random_name}`
+pub fn create_temp_dir(app_name: &str, root: Option<PathBuf>) -> io::Result<TempDir> {
+    let temp_dir = root.unwrap_or_else(env::temp_dir).join(app_name);
+    debug!("Creating temp dir: {temp_dir:?}");
+    fs::create_dir_all(&temp_dir)?;
+    TempDir::new_in(&temp_dir)
+}

--- a/trin-utils/src/lib.rs
+++ b/trin-utils/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::unwrap_used)]
 #![warn(clippy::uninlined_format_args)]
 
+pub mod dir;
 pub mod log;
 pub mod submodules;
 pub mod version;

--- a/utp-testing/src/lib.rs
+++ b/utp-testing/src/lib.rs
@@ -22,13 +22,13 @@ use jsonrpsee::{
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
-    utils::db::setup_temp_dir,
 };
 use std::{io::ErrorKind, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 use tokio::sync::{
     mpsc::{self, Receiver},
     RwLock,
 };
+use trin_utils::dir::create_temp_test_dir;
 use trin_validation::oracle::HeaderOracle;
 use utp_rs::{conn::ConnectionConfig, socket::UtpSocket};
 
@@ -170,8 +170,8 @@ pub async fn run_test_app(
         ..Default::default()
     };
 
-    let temp_dir = setup_temp_dir().unwrap().into_path();
-    let mut discovery = Discovery::new(config, temp_dir, MAINNET.clone()).unwrap();
+    let temp_dir = create_temp_test_dir()?.into_path();
+    let mut discovery = Discovery::new(config, &temp_dir, MAINNET.clone()).unwrap();
     let talk_req_rx = discovery.start().await.unwrap();
     let enr = discovery.local_enr();
     let discovery = Arc::new(discovery);


### PR DESCRIPTION
### What was wrong?

Currently, `trin-execution` binary doesn't support setting custom directory and `trin` supports it only via env variable. Also the code initializes directory is split.

### How was it fixed?

Added `data-dir` command line flag to both `trin` and `trin-execution`, and extracted common logic into `trin-utils` crate.

- if neither `data-dir` nor `ephemeral` flags are set, we use OS's default local data directory (same as now)
- if only `data-dir` is set, we use that folder instead
- if only `ephemeral` is set, we use OS's temporary directory, and create `trin`/`trin-execution` subfolder inside (same as now)
- if both flags are set, it behaves the same as with `ephemeral`, but it uses provided directory instead of OS's temp directory

In the case of trin, I left an option for env variable (`TRIN_DATA_PATH`) to be used. It behaves the same as `--data-dir` was set. If both are set, we will throw error.

Other smaller refactorings:

- convert to use `&Path` instead of `PathBuf` in several existing functions
- created `create_temp_test_dir` function that unifies how temporary directories are created for test purposes
    - they are more use cases that I didn't catch in this PR, as this wasn't the primary purpose of this PR


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
