### PR TITLE
feat(trin-execution): add JSON-RPC trait's required for the Engine API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,43 +456,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types-admin"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fefd12e99dd6b7de387ed13ad047ce2c90d8950ca62fc48b8a457ebb8f936c61"
-dependencies = [
- "alloy-genesis",
- "alloy-primitives",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-rpc-types-anvil"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25cb45ad7c0930dd62eecf164d2afe4c3d2dd2c82af85680ad1f118e1e5cb83"
-dependencies = [
- "alloy-primitives",
- "alloy-serde",
- "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-beacon"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7081d2206dca51ce23a06338d78d9b536931cc3f15134fc1c6535eb2b77f18"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "serde",
- "serde_with",
- "thiserror",
-]
-
-[[package]]
 name = "alloy-rpc-types-engine"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,7 +467,8 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "derive_more 1.0.0",
- "jsonrpsee-types 0.24.4",
+ "jsonwebtoken",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -525,20 +489,6 @@ dependencies = [
  "derive_more 1.0.0",
  "hashbrown 0.14.5",
  "itertools 0.13.0",
- "jsonrpsee-types 0.24.4",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-rpc-types-mev"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922d92389e5022650c4c60ffd2f9b2467c3f853764f0f74ff16a23106f9017d5"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
  "serde",
  "serde_json",
 ]
@@ -555,18 +505,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "alloy-rpc-types-txpool"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bac37082c3b21283b3faf5cc0e08974272aee2f756ce1adeb26db56a5fce0d5"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "serde",
 ]
 
 [[package]]
@@ -1388,7 +1326,6 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -1809,7 +1746,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -2235,6 +2171,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types",
  "anyhow",
  "base64 0.13.1",
  "bimap",
@@ -2257,7 +2194,6 @@ dependencies = [
  "once_cell",
  "quickcheck",
  "rand 0.8.5",
- "reth-rpc-types",
  "rlp",
  "rs_merkle",
  "rstest",
@@ -3153,7 +3089,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -3164,7 +3099,6 @@ checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
- "serde",
 ]
 
 [[package]]
@@ -3290,7 +3224,7 @@ dependencies = [
  "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
- "jsonrpsee-types 0.20.4",
+ "jsonrpsee-types",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "tokio",
@@ -3333,7 +3267,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hyper 0.14.30",
- "jsonrpsee-types 0.20.4",
+ "jsonrpsee-types",
  "parking_lot 0.12.3",
  "rand 0.8.5",
  "rustc-hash",
@@ -3356,7 +3290,7 @@ dependencies = [
  "hyper 0.14.30",
  "hyper-rustls 0.24.2",
  "jsonrpsee-core",
- "jsonrpsee-types 0.20.4",
+ "jsonrpsee-types",
  "serde",
  "serde_json",
  "thiserror",
@@ -3389,7 +3323,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.30",
  "jsonrpsee-core",
- "jsonrpsee-types 0.20.4",
+ "jsonrpsee-types",
  "route-recognizer",
  "serde",
  "serde_json",
@@ -3417,18 +3351,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-types"
-version = "0.24.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531e386460425e49679587871a056f2895a47dade21457324ad1262cd78ef6d9"
-dependencies = [
- "http 1.1.0",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "jsonrpsee-wasm-client"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,7 +3358,7 @@ checksum = "9437dd0e8728897d0aa5a0075b8710266300e55ced07101ca0930fac4a611384"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
- "jsonrpsee-types 0.20.4",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -3448,8 +3370,23 @@ dependencies = [
  "http 0.2.12",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
- "jsonrpsee-types 0.20.4",
+ "jsonrpsee-types",
  "url",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+dependencies = [
+ "base64 0.21.7",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -4030,88 +3967,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "op-alloy-consensus"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21aad1fbf80d2bcd7406880efc7ba109365f44bbb72896758ddcbfa46bf1592c"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more 1.0.0",
- "serde",
- "spin",
-]
-
-[[package]]
-name = "op-alloy-genesis"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1b8a9b70da0e027242ec1762f0f3a386278b6291d00d12ff5a64929dc19f68"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-sol-types",
- "serde",
- "serde_repr",
-]
-
-[[package]]
-name = "op-alloy-protocol"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf300a82ae2d30e2255bfea87a2259da49f63a25a44db561ae64cc9e3084139f"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "hashbrown 0.14.5",
- "op-alloy-consensus",
- "op-alloy-genesis",
- "serde",
-]
-
-[[package]]
-name = "op-alloy-rpc-types"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e281fbfc2198b7c0c16457d6524f83d192662bc9f3df70f24c3038d4521616df"
-dependencies = [
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "cfg-if",
- "hashbrown 0.14.5",
- "op-alloy-consensus",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "op-alloy-rpc-types-engine"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2947272a81ebf988f4804b6f0f6a7c0b2f6f89a908cb410e36f8f3828f81c778"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "alloy-serde",
- "derive_more 1.0.0",
- "op-alloy-consensus",
- "op-alloy-genesis",
- "op-alloy-protocol",
- "serde",
-]
-
-[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4298,6 +4153,16 @@ dependencies = [
  "proc-macro2-diagnostics",
  "quote",
  "syn 2.0.77",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
 ]
 
 [[package]]
@@ -5076,26 +4941,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-rpc-types"
-version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.6#c228fe15808c3acbf18dc3af1a03ef5cbdcda07a"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types",
- "alloy-rpc-types-admin",
- "alloy-rpc-types-anvil",
- "alloy-rpc-types-beacon",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-mev",
- "alloy-rpc-types-trace",
- "alloy-rpc-types-txpool",
- "alloy-serde",
- "jsonrpsee-types 0.24.4",
- "op-alloy-rpc-types",
- "op-alloy-rpc-types-engine",
-]
-
-[[package]]
 name = "retry-policies"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5250,13 +5095,13 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types",
  "discv5",
  "eth_trie",
  "ethportal-api",
  "hyper 0.14.30",
  "portalnet",
  "reth-ipc",
- "reth-rpc-types",
  "revm",
  "serde",
  "serde_json",
@@ -5783,17 +5628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5812,36 +5646,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.5.0",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
-dependencies = [
- "darling 0.20.10",
- "proc-macro2",
- "quote",
- "syn 2.0.77",
 ]
 
 [[package]]
@@ -6016,6 +5820,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6107,9 +5923,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spki"
@@ -7035,6 +6848,8 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types",
+ "alloy-rpc-types-engine",
  "anyhow",
  "clap",
  "directories",
@@ -7042,12 +6857,12 @@ dependencies = [
  "eth_trie",
  "ethportal-api",
  "hashbrown 0.14.5",
+ "jsonrpsee",
  "lazy_static",
  "parking_lot 0.11.2",
  "prometheus_exporter",
  "rayon",
  "reqwest",
- "reth-rpc-types",
  "revm",
  "revm-inspectors",
  "revm-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ members = [
 alloy-consensus = "0.3.6"
 alloy-primitives = "0.8.3" 
 alloy-rlp = "0.3.8"
+alloy-rpc-types = "0.3.6"
 anyhow = "1.0.68"
 async-trait = "0.1.68"
 bytes = "1.3.0"
@@ -110,7 +111,6 @@ r2d2_sqlite = "0.24.0"
 rand = "0.8.5"
 reqwest = { version = "0.12.7", features = ["native-tls-vendored", "json"] }
 reth-ipc = { tag = "v0.2.0-beta.5", git = "https://github.com/paradigmxyz/reth.git"}
-reth-rpc-types = { tag = "v1.0.6", git = "https://github.com/paradigmxyz/reth.git"}
 revm = { version = "14.0.2", default-features = false, features = ["std", "secp256k1", "serde-json"] }
 revm-primitives = { version = "9.0.2", default-features = false, features = ["std", "serde"] }
 rpc = { path = "rpc"}

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -14,6 +14,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
+alloy-rpc-types.workspace = true
 anyhow.workspace = true
 base64 = "0.13.0"
 bimap = "0.6.3"
@@ -35,7 +36,6 @@ nanotemplate = "0.3.0"
 once_cell = "1.17"
 quickcheck.workspace = true
 rand.workspace = true
-reth-rpc-types.workspace = true
 rlp = "0.5.0"
 rs_merkle = "1.4.2"
 secp256k1 = { version = "0.29.0", features = ["global-context", "recovery", "rand"] }

--- a/ethportal-api/src/eth.rs
+++ b/ethportal-api/src/eth.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{Address, Bytes, B256, U256};
+use alloy_rpc_types::{Block, BlockId, TransactionRequest};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_rpc_types::{Block, BlockId, TransactionRequest};
 
 /// Web3 JSON-RPC endpoints
 #[rpc(client, server, namespace = "eth")]

--- a/ethportal-api/src/types/execution/header.rs
+++ b/ethportal-api/src/types/execution/header.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{keccak256, Address, Bloom, Bytes, B256, B64, U256, U64};
 use alloy_rlp::{Decodable, Encodable, Header as RlpHeader};
-use reth_rpc_types::Header as RpcHeader;
+use alloy_rpc_types::Header as RpcHeader;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::utils::bytes::{hex_decode, hex_encode};

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -11,7 +11,7 @@ description = "Testing utilities for trin"
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy-primitives = { workspace = true, features = ["getrandom"] }
 alloy-rlp.workspace = true
 anyhow.workspace = true
 discv5.workspace = true

--- a/ethportal-peertest/src/scenarios/paginate.rs
+++ b/ethportal-peertest/src/scenarios/paginate.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::B256;
 use ethportal_api::{ContentValue, HistoryContentKey, HistoryNetworkApiClient};
 
 use crate::{utils::fixture_header_by_hash, Peertest};
@@ -11,10 +12,8 @@ pub async fn test_paginate_local_storage(peertest: &Peertest) {
 
     let mut content_keys: Vec<String> = (0..20_u8)
         .map(|_| {
-            serde_json::to_string(&HistoryContentKey::new_block_header_by_hash(
-                rand::random::<alloy_primitives::B256>(),
-            ))
-            .unwrap()
+            serde_json::to_string(&HistoryContentKey::new_block_header_by_hash(B256::random()))
+                .unwrap()
         })
         .collect();
     let (_, content_value) = fixture_header_by_hash();

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -13,13 +13,13 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
+alloy-rpc-types.workspace = true
 discv5.workspace = true
 eth_trie.workspace = true
 ethportal-api.workspace = true
 hyper.workspace = true
 portalnet.workspace = true
 reth-ipc.workspace = true
-reth-rpc-types.workspace = true
 revm.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/rpc/src/eth_rpc.rs
+++ b/rpc/src/eth_rpc.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Address, Bytes, B256, U256};
-use reth_rpc_types::{Block, BlockId, BlockTransactions, TransactionRequest};
+use alloy_rpc_types::{Block, BlockId, BlockTransactions, TransactionRequest};
 use tokio::sync::mpsc;
 
 use ethportal_api::{

--- a/trin-execution/Cargo.toml
+++ b/trin-execution/Cargo.toml
@@ -15,6 +15,8 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
+alloy-rpc-types.workspace = true
+alloy-rpc-types-engine = "0.3.6"
 anyhow.workspace = true
 clap.workspace = true
 directories.workspace = true
@@ -22,6 +24,7 @@ ethportal-api.workspace = true
 e2store.workspace = true
 eth_trie.workspace = true
 hashbrown = "0.14.0"
+jsonrpsee = { workspace = true, features = ["async-client", "client", "macros", "server"]}
 lazy_static.workspace = true
 parking_lot.workspace = true
 prometheus_exporter.workspace = true
@@ -30,7 +33,6 @@ reqwest.workspace = true
 revm.workspace = true
 revm-inspectors = "0.7.4"
 revm-primitives.workspace = true
-reth-rpc-types.workspace = true
 rocksdb = "0.22.0"
 serde = { workspace = true, features = ["rc"] }
 serde_json.workspace = true

--- a/trin-execution/src/engine/mod.rs
+++ b/trin-execution/src/engine/mod.rs
@@ -1,0 +1,1 @@
+pub mod rpc;

--- a/trin-execution/src/engine/rpc.rs
+++ b/trin-execution/src/engine/rpc.rs
@@ -1,0 +1,146 @@
+use alloy_rlp::Bytes;
+use alloy_rpc_types::{Block, BlockId, Filter, Log, SyncStatus, TransactionRequest};
+use alloy_rpc_types_engine::{
+    ExecutionPayloadBodiesV1, ExecutionPayloadBodiesV2, ExecutionPayloadInputV2,
+    ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3, ExecutionPayloadV4,
+    ForkchoiceState, ForkchoiceUpdated, PayloadAttributes, PayloadId, PayloadStatus,
+    TransitionConfiguration,
+};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use revm_primitives::{Address, B256, U256};
+
+/// Engine Api JSON-RPC endpoints
+#[rpc(client, server, namespace = "engine")]
+pub trait EngineApi {
+    #[method(name = "exchangeCapabilities")]
+    async fn exchange_capabilities(
+        &self,
+        supported_capabilities: Vec<String>,
+    ) -> RpcResult<Vec<String>>;
+
+    #[method(name = "exchangeTransitionConfigurationV1")]
+    async fn exchange_transition_configuration_v1(
+        &self,
+        transition_configuration: TransitionConfiguration,
+    ) -> RpcResult<TransitionConfiguration>;
+
+    #[method(name = "forkchoiceUpdatedV1")]
+    async fn fork_choice_updated_v1(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<PayloadAttributes>,
+    ) -> RpcResult<ForkchoiceUpdated>;
+
+    #[method(name = "forkchoiceUpdatedV2")]
+    async fn fork_choice_updated_v2(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<PayloadAttributes>,
+    ) -> RpcResult<ForkchoiceUpdated>;
+
+    #[method(name = "forkchoiceUpdatedV3")]
+    async fn fork_choice_updated_v3(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<PayloadAttributes>,
+    ) -> RpcResult<ForkchoiceUpdated>;
+
+    #[method(name = "getPayloadBodiesByHashV1")]
+    async fn get_payload_bodies_by_hash_v1(
+        &self,
+        block_hashes: Vec<B256>,
+    ) -> RpcResult<ExecutionPayloadBodiesV1>;
+
+    #[method(name = "getPayloadBodiesByHashV2")]
+    async fn get_payload_bodies_by_hash_v2(
+        &self,
+        block_hashes: Vec<B256>,
+    ) -> RpcResult<ExecutionPayloadBodiesV2>;
+
+    #[method(name = "getPayloadBodiesByRangeV1")]
+    async fn get_payload_bodies_by_range_v1(
+        &self,
+        start: u64,
+        count: u64,
+    ) -> RpcResult<ExecutionPayloadBodiesV1>;
+
+    #[method(name = "getPayloadBodiesByRangeV2")]
+    async fn get_payload_bodies_by_range_v2(
+        &self,
+        start: u64,
+        count: u64,
+    ) -> RpcResult<ExecutionPayloadBodiesV2>;
+
+    #[method(name = "getPayloadV1")]
+    async fn get_payload_v1(&self, payload_id: PayloadId) -> RpcResult<ExecutionPayloadV1>;
+
+    #[method(name = "getPayloadV2")]
+    async fn get_payload_v2(&self, payload_id: PayloadId) -> RpcResult<ExecutionPayloadV2>;
+
+    #[method(name = "getPayloadV3")]
+    async fn get_payload_v3(&self, payload_id: PayloadId) -> RpcResult<ExecutionPayloadV3>;
+
+    #[method(name = "getPayloadV4")]
+    async fn get_payload_v4(&self, payload_id: PayloadId) -> RpcResult<ExecutionPayloadV4>;
+
+    #[method(name = "newPayloadV1")]
+    async fn new_payload_v1(&self, payload: ExecutionPayloadV1) -> RpcResult<PayloadStatus>;
+
+    #[method(name = "newPayloadV2")]
+    async fn new_payload_v2(&self, payload: ExecutionPayloadInputV2) -> RpcResult<PayloadStatus>;
+
+    #[method(name = "newPayloadV3")]
+    async fn new_payload_v3(
+        &self,
+        payload: ExecutionPayloadV3,
+        versioned_hashes: Vec<B256>,
+        parent_beacon_block_root: B256,
+    ) -> RpcResult<PayloadStatus>;
+
+    #[method(name = "newPayloadV4")]
+    async fn new_payload_v4(
+        &self,
+        payload: ExecutionPayloadV4,
+        versioned_hashes: Vec<B256>,
+        parent_beacon_block_root: B256,
+    ) -> RpcResult<PayloadStatus>;
+}
+
+/// A subset of Eth JSON-RPC endpoints under the Engine Api's JWT authentication
+#[rpc(client, server, namespace = "eth")]
+pub trait EngineEthApi {
+    #[method(name = "blockNumber")]
+    async fn block_number(&self) -> RpcResult<String>;
+
+    #[method(name = "call")]
+    async fn call(&self, transaction: TransactionRequest, block: BlockId) -> RpcResult<Bytes>;
+
+    #[method(name = "chainId")]
+    async fn chain_id(&self) -> RpcResult<U256>;
+
+    #[method(name = "getBlockByHash")]
+    async fn get_block_by_hash(
+        &self,
+        block_hash: B256,
+        hydrated_transactions: bool,
+    ) -> RpcResult<Block>;
+
+    #[method(name = "getBlockByNumber")]
+    async fn get_block_by_number(
+        &self,
+        block_number: u64,
+        hydrated_transactions: bool,
+    ) -> RpcResult<Block>;
+
+    #[method(name = "getCode")]
+    async fn get_code(&self, address: Address, block: BlockId) -> RpcResult<Bytes>;
+
+    #[method(name = "getLogs")]
+    async fn get_logs(&self, filter: Filter) -> RpcResult<Vec<Log>>;
+
+    #[method(name = "sendRawTransaction")]
+    async fn send_raw_transaction(&self, bytes: Bytes) -> RpcResult<B256>;
+
+    #[method(name = "syncing")]
+    async fn syncing(&self) -> RpcResult<SyncStatus>;
+}

--- a/trin-execution/src/evm/tx_env_modifier.rs
+++ b/trin-execution/src/evm/tx_env_modifier.rs
@@ -1,9 +1,9 @@
 use alloy_primitives::U256;
+use alloy_rpc_types::TransactionRequest;
 use ethportal_api::types::execution::transaction::{
     AccessListTransaction, BlobTransaction, EIP1559Transaction, LegacyTransaction, ToAddress,
     Transaction,
 };
-use reth_rpc_types::TransactionRequest;
 use revm_primitives::{AccessListItem, SpecId, TransactTo, TxEnv};
 
 use crate::era::types::TransactionsWithSender;

--- a/trin-execution/src/lib.rs
+++ b/trin-execution/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cli;
 pub mod config;
 pub mod content;
+pub mod engine;
 pub mod era;
 pub mod evm;
 pub mod execution;


### PR DESCRIPTION
### What was wrong?
We don't implement the engine api. The first step to do this is by adding the jsonrpcee trait outline.

The engine api, exposes the `engine` namespace and also a subset of the `eth` namespace, both under JWT authentication.

I made a PR first just adding the trait to make the changes easier to review, my follow up PR's will be implementing the rest of the Engine API I am not sure how many PR's it will end up being, but I will try to make them all easily review-able sizes
### How was it fixed?

Implementing the jsonrpcee trait which outlines both the `engine` and `eth` (subset) namespaces which is required to support the engine API
