### PR TITLE
fix(docker): add trin-evm directory to docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,13 +18,14 @@ COPY ./Cargo.toml ./Cargo.toml
 COPY ./e2store ./e2store
 COPY ./ethportal-api ./ethportal-api
 COPY ./ethportal-peertest ./ethportal-peertest
-COPY ./portalnet ./portalnet
 COPY ./light-client ./light-client
+COPY ./portalnet ./portalnet
+COPY ./portal-bridge ./portal-bridge
 COPY ./rpc ./rpc
 COPY ./src ./src 
 COPY ./trin-beacon ./trin-beacon
+COPY ./trin-evm ./trin-evm
 COPY ./trin-execution ./trin-execution
-COPY ./portal-bridge ./portal-bridge
 COPY ./trin-history ./trin-history
 COPY ./trin-metrics ./trin-metrics
 COPY ./trin-state ./trin-state

--- a/docker/Dockerfile.bridge
+++ b/docker/Dockerfile.bridge
@@ -26,23 +26,24 @@ RUN apt-get update && apt-get install clang -y
 # copy over manifests and source to build image
 COPY ./Cargo.lock ./Cargo.lock
 COPY ./Cargo.toml ./Cargo.toml
-COPY ./portalnet ./portalnet
+COPY ./e2store ./e2store
+COPY ./ethportal-api ./ethportal-api
+COPY ./ethportal-peertest ./ethportal-peertest
 COPY ./light-client ./light-client
+COPY ./portalnet ./portalnet
+COPY ./portal-bridge ./portal-bridge
+COPY ./rpc ./rpc
 COPY ./src ./src 
 COPY ./trin-beacon ./trin-beacon
-COPY ./portal-bridge ./portal-bridge
+COPY ./trin-evm ./trin-evm
 COPY ./trin-execution ./trin-execution
 COPY ./trin-history ./trin-history
 COPY ./trin-metrics ./trin-metrics
 COPY ./trin-state ./trin-state
 COPY ./trin-storage ./trin-storage
 COPY ./trin-utils ./trin-utils
-COPY ./trin-validation ./trin-validation
-COPY ./e2store ./e2store
-COPY ./ethportal-peertest ./ethportal-peertest 
+COPY ./trin-validation ./trin-validation 
 COPY ./utp-testing ./utp-testing
-COPY ./ethportal-api ./ethportal-api
-COPY ./rpc ./rpc
 
 # build for release
 RUN cargo build -p trin -p portal-bridge --release


### PR DESCRIPTION
### What was wrong?

I forgot to add `trin-evm` to docker files (should have been part of #1470)

### How was it fixed?

I added `trin-evm` and sorted folders by name.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
