### PR TITLE
fix: unable to execute to Cancun due to bug in post_block_beneficiaries

### DIFF
--- a/trin-execution/src/evm/post_block_beneficiaries.rs
+++ b/trin-execution/src/evm/post_block_beneficiaries.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use alloy_consensus::constants::ETH_TO_WEI;
+use alloy_consensus::constants::{ETH_TO_WEI, GWEI_TO_WEI};
 use alloy_primitives::Address;
 use revm::{db::State, Evm};
 use revm_primitives::SpecId;
@@ -42,7 +42,8 @@ pub fn process_withdrawals(block: &ProcessedBlock, beneficiaries: &mut HashMap<A
             if withdrawal.amount == 0 {
                 continue;
             }
-            *beneficiaries.entry(withdrawal.address).or_default() += withdrawal.amount as u128;
+            *beneficiaries.entry(withdrawal.address).or_default() +=
+                withdrawal.amount as u128 * GWEI_TO_WEI as u128;
         }
     }
 }

--- a/trin-execution/src/main.rs
+++ b/trin-execution/src/main.rs
@@ -63,7 +63,7 @@ async fn main() -> anyhow::Result<()> {
         tx.send(()).expect("signal ctrl_c should never fail");
     });
 
-    let end_block = get_spec_block_number(SpecId::SHANGHAI);
+    let end_block = get_spec_block_number(SpecId::CANCUN);
     trin_execution
         .process_range_of_blocks(end_block, Some(rx))
         .await?;


### PR DESCRIPTION
### What was wrong?
When executing 17034871 we are generating the wrong state root
### How was it fixed?
I found the issue was we had to convert the amount in the withdrawal to the amount in the denomination of WEI. We do the same thing for block rewards.

With this fix we can now execute to Cancun 

