### PR TITLE
refactor: swap ProtocolId with Subnetwork type

### DIFF
--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -353,6 +353,12 @@ pub fn subnetwork_parser(subnetwork_string: &str) -> Result<Arc<Vec<Subnetwork>>
         return Err("At least one subnetwork must be enabled".to_owned());
     }
 
+    for subnetwork in &subnetworks {
+        if !subnetwork.is_active() {
+            return Err("{subnetwork} subnetwork has not yet been activated".to_owned());
+        }
+    }
+
     Ok(Arc::new(subnetworks))
 }
 

--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -346,7 +346,7 @@ pub fn network_parser(network_string: &str) -> Result<Arc<NetworkSpec>, String> 
 pub fn subnetwork_parser(subnetwork_string: &str) -> Result<Arc<Vec<Subnetwork>>, String> {
     let subnetworks = subnetwork_string
         .split(',')
-        .map(Subnetwork::from_str)
+        .map(Subnetwork::from_cli_arg)
         .collect::<Result<Vec<Subnetwork>, String>>()?;
 
     if subnetworks.is_empty() {

--- a/ethportal-api/src/types/content_value/error.rs
+++ b/ethportal-api/src/types/content_value/error.rs
@@ -9,7 +9,7 @@ pub enum ContentValueError {
         decode_error: ssz::DecodeError,
         input: String,
     },
-    #[error("could not determine content type of {bytes} from {subnetwork} subnetwork")]
+    #[error("could not determine content type of {bytes} from {subnetwork:?} subnetwork")]
     UnknownContent {
         bytes: String,
         subnetwork: Subnetwork,
@@ -25,12 +25,12 @@ pub enum ContentValueError {
     /// This error implies that handling of the "content absent" response was skipped.
     #[error("attempted to decode the '0x' absent content message")]
     DecodeAbsentContent,
-    #[error("could not determine fork digest of {bytes} from {subnetwork} subnetwork")]
+    #[error("could not determine fork digest of {bytes} from {subnetwork:?} subnetwork")]
     UnknownForkDigest {
         bytes: String,
         subnetwork: Subnetwork,
     },
-    #[error("could not determine fork name of {bytes} from {subnetwork} subnetwork")]
+    #[error("could not determine fork name of {bytes} from {subnetwork:?} subnetwork")]
     UnknownForkName {
         bytes: String,
         subnetwork: Subnetwork,

--- a/ethportal-api/src/types/content_value/history.rs
+++ b/ethportal-api/src/types/content_value/history.rs
@@ -101,7 +101,7 @@ mod test {
         // Test the error Display representation.
         assert_eq!(
             error.to_string(),
-            "could not determine content type of 0x010203040506070809 from history subnetwork"
+            "could not determine content type of 0x010203040506070809 from History subnetwork"
         );
     }
 }

--- a/ethportal-api/src/types/network.rs
+++ b/ethportal-api/src/types/network.rs
@@ -81,4 +81,17 @@ impl Subnetwork {
             Subnetwork::Utp => "utp".to_string(),
         }
     }
+
+    /// Returns true if the subnetwork has been "fully" activated.
+    pub fn is_active(&self) -> bool {
+        match self {
+            Subnetwork::Beacon => true,
+            Subnetwork::History => true,
+            Subnetwork::State => true,
+            Subnetwork::CanonicalIndices => false,
+            Subnetwork::VerkleState => false,
+            Subnetwork::TransactionGossip => false,
+            Subnetwork::Utp => false,
+        }
+    }
 }

--- a/ethportal-api/src/types/network.rs
+++ b/ethportal-api/src/types/network.rs
@@ -29,32 +29,56 @@ impl std::str::FromStr for Network {
 }
 
 /// Enum for various different portal subnetworks in a "core" network.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Subnetwork {
     Beacon,
     History,
     State,
+    CanonicalIndices,
+    VerkleState,
+    TransactionGossip,
+    Utp,
 }
 
+// Pretty printed version of the subnetwork enum, used in metrics labels.
 impl fmt::Display for Subnetwork {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Subnetwork::Beacon => write!(f, "beacon"),
-            Subnetwork::History => write!(f, "history"),
-            Subnetwork::State => write!(f, "state"),
+            Subnetwork::Beacon => write!(f, "Beacon"),
+            Subnetwork::History => write!(f, "History"),
+            Subnetwork::State => write!(f, "State"),
+            Subnetwork::CanonicalIndices => write!(f, "Canonical Indices"),
+            Subnetwork::VerkleState => write!(f, "Verkle State"),
+            Subnetwork::TransactionGossip => write!(f, "Transaction Gossip"),
+            Subnetwork::Utp => write!(f, "uTP"),
         }
     }
 }
 
-impl std::str::FromStr for Subnetwork {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+// Convert camel_case cli args to/from the Subnetwork enum.
+impl Subnetwork {
+    pub fn from_cli_arg(s: &str) -> Result<Self, String> {
         match s {
             "beacon" => Ok(Subnetwork::Beacon),
             "history" => Ok(Subnetwork::History),
             "state" => Ok(Subnetwork::State),
+            "canonical_indices" => Ok(Subnetwork::CanonicalIndices),
+            "verkle_state" => Ok(Subnetwork::VerkleState),
+            "transaction_gossip" => Ok(Subnetwork::TransactionGossip),
+            "utp" => Ok(Subnetwork::Utp),
             _ => Err(format!("Unknown subnetwork: {s}")),
+        }
+    }
+
+    pub fn to_cli_arg(&self) -> String {
+        match self {
+            Subnetwork::Beacon => "beacon".to_string(),
+            Subnetwork::History => "history".to_string(),
+            Subnetwork::State => "state".to_string(),
+            Subnetwork::CanonicalIndices => "canonical_indices".to_string(),
+            Subnetwork::VerkleState => "verkle_state".to_string(),
+            Subnetwork::TransactionGossip => "transaction_gossip".to_string(),
+            Subnetwork::Utp => "utp".to_string(),
         }
     }
 }

--- a/ethportal-peertest/src/lib.rs
+++ b/ethportal-peertest/src/lib.rs
@@ -84,7 +84,7 @@ fn generate_trin_config(
     let private_key = hex_encode(private_key);
     let subnetworks = subnetworks
         .iter()
-        .map(|sn| sn.to_string())
+        .map(|sn| sn.to_cli_arg())
         .collect::<Vec<String>>()
         .join(",");
     let network = network.to_string();

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -1,7 +1,7 @@
 use crate::{utils::fixture_header_by_hash, Peertest, PeertestNode};
 use alloy_primitives::{B256, U256};
 use ethportal_api::{
-    types::{distance::Distance, portal_wire::ProtocolId},
+    types::{distance::Distance, network::Subnetwork},
     BeaconNetworkApiClient, ContentValue, Discv5ApiClient, HistoryContentKey,
     HistoryNetworkApiClient, StateNetworkApiClient, Web3ApiClient,
 };
@@ -29,26 +29,26 @@ pub async fn test_discv5_routing_table_info(target: &Client) {
     assert!(result.local_node_id.starts_with("0x"));
 }
 
-pub async fn test_routing_table_info(protocol: ProtocolId, target: &Client) {
-    info!("Testing routing_table_info for {protocol}");
-    let result = match protocol {
-        ProtocolId::Beacon => BeaconNetworkApiClient::routing_table_info(target),
-        ProtocolId::History => HistoryNetworkApiClient::routing_table_info(target),
-        ProtocolId::State => StateNetworkApiClient::routing_table_info(target),
-        _ => panic!("Unexpected protocol: {protocol}"),
+pub async fn test_routing_table_info(subnetwork: Subnetwork, target: &Client) {
+    info!("Testing routing_table_info for {subnetwork}");
+    let result = match subnetwork {
+        Subnetwork::Beacon => BeaconNetworkApiClient::routing_table_info(target),
+        Subnetwork::History => HistoryNetworkApiClient::routing_table_info(target),
+        Subnetwork::State => StateNetworkApiClient::routing_table_info(target),
+        _ => panic!("Unexpected subnetwork: {subnetwork}"),
     }
     .await
     .unwrap();
     assert!(result.local_node_id.starts_with("0x"));
 }
 
-pub async fn test_radius(protocol: ProtocolId, target: &Client) {
-    info!("Testing radius for {protocol}");
-    let result = match protocol {
-        ProtocolId::Beacon => BeaconNetworkApiClient::radius(target),
-        ProtocolId::History => HistoryNetworkApiClient::radius(target),
-        ProtocolId::State => StateNetworkApiClient::radius(target),
-        _ => panic!("Unexpected protocol: {protocol}"),
+pub async fn test_radius(subnetwork: Subnetwork, target: &Client) {
+    info!("Testing radius for {subnetwork}");
+    let result = match subnetwork {
+        Subnetwork::Beacon => BeaconNetworkApiClient::radius(target),
+        Subnetwork::History => HistoryNetworkApiClient::radius(target),
+        Subnetwork::State => StateNetworkApiClient::radius(target),
+        _ => panic!("Unexpected subnetwork: {subnetwork}"),
     }
     .await
     .unwrap();
@@ -58,71 +58,71 @@ pub async fn test_radius(protocol: ProtocolId, target: &Client) {
     );
 }
 
-pub async fn test_add_enr(protocol: ProtocolId, target: &Client, peertest: &Peertest) {
-    info!("Testing add_enr for {protocol}");
+pub async fn test_add_enr(subnetwork: Subnetwork, target: &Client, peertest: &Peertest) {
+    info!("Testing add_enr for {subnetwork}");
     let bootnode_enr = peertest.bootnode.enr.clone();
-    let result = match protocol {
-        ProtocolId::Beacon => BeaconNetworkApiClient::add_enr(target, bootnode_enr),
-        ProtocolId::History => HistoryNetworkApiClient::add_enr(target, bootnode_enr),
-        ProtocolId::State => StateNetworkApiClient::add_enr(target, bootnode_enr),
-        _ => panic!("Unexpected protocol: {protocol}"),
+    let result = match subnetwork {
+        Subnetwork::Beacon => BeaconNetworkApiClient::add_enr(target, bootnode_enr),
+        Subnetwork::History => HistoryNetworkApiClient::add_enr(target, bootnode_enr),
+        Subnetwork::State => StateNetworkApiClient::add_enr(target, bootnode_enr),
+        _ => panic!("Unexpected subnetwork: {subnetwork}"),
     }
     .await
     .unwrap();
     assert!(result);
 }
 
-pub async fn test_get_enr(protocol: ProtocolId, target: &Client, peertest: &Peertest) {
-    info!("Testing get_enr for {protocol}");
+pub async fn test_get_enr(subnetwork: Subnetwork, target: &Client, peertest: &Peertest) {
+    info!("Testing get_enr for {subnetwork}");
     let node_id = peertest.bootnode.enr.node_id();
-    let result = match protocol {
-        ProtocolId::Beacon => BeaconNetworkApiClient::get_enr(target, node_id),
-        ProtocolId::History => HistoryNetworkApiClient::get_enr(target, node_id),
-        ProtocolId::State => StateNetworkApiClient::get_enr(target, node_id),
-        _ => panic!("Unexpected protocol: {protocol}"),
+    let result = match subnetwork {
+        Subnetwork::Beacon => BeaconNetworkApiClient::get_enr(target, node_id),
+        Subnetwork::History => HistoryNetworkApiClient::get_enr(target, node_id),
+        Subnetwork::State => StateNetworkApiClient::get_enr(target, node_id),
+        _ => panic!("Unexpected subnetwork: {subnetwork}"),
     }
     .await
     .unwrap();
     assert_eq!(result, peertest.bootnode.enr);
 }
 
-pub async fn test_delete_enr(protocol: ProtocolId, target: &Client, peertest: &Peertest) {
-    info!("Testing delete_enr for {protocol}");
+pub async fn test_delete_enr(subnetwork: Subnetwork, target: &Client, peertest: &Peertest) {
+    info!("Testing delete_enr for {subnetwork}");
     let node_id = peertest.bootnode.enr.node_id();
-    let result = match protocol {
-        ProtocolId::Beacon => BeaconNetworkApiClient::delete_enr(target, node_id),
-        ProtocolId::History => HistoryNetworkApiClient::delete_enr(target, node_id),
-        ProtocolId::State => StateNetworkApiClient::delete_enr(target, node_id),
-        _ => panic!("Unexpected protocol: {protocol}"),
+    let result = match subnetwork {
+        Subnetwork::Beacon => BeaconNetworkApiClient::delete_enr(target, node_id),
+        Subnetwork::History => HistoryNetworkApiClient::delete_enr(target, node_id),
+        Subnetwork::State => StateNetworkApiClient::delete_enr(target, node_id),
+        _ => panic!("Unexpected subnetwork: {subnetwork}"),
     }
     .await
     .unwrap();
     assert!(result);
 }
 
-pub async fn test_lookup_enr(protocol: ProtocolId, peertest: &Peertest) {
-    info!("Testing lookup_enr for {protocol}");
+pub async fn test_lookup_enr(subnetwork: Subnetwork, peertest: &Peertest) {
+    info!("Testing lookup_enr for {subnetwork}");
     let target = &peertest.bootnode.ipc_client;
     let node_id = peertest.nodes[0].enr.node_id();
-    let result = match protocol {
-        ProtocolId::Beacon => BeaconNetworkApiClient::lookup_enr(target, node_id),
-        ProtocolId::History => HistoryNetworkApiClient::lookup_enr(target, node_id),
-        ProtocolId::State => StateNetworkApiClient::lookup_enr(target, node_id),
-        _ => panic!("Unexpected protocol: {protocol}"),
+    let result = match subnetwork {
+        Subnetwork::Beacon => BeaconNetworkApiClient::lookup_enr(target, node_id),
+        Subnetwork::History => HistoryNetworkApiClient::lookup_enr(target, node_id),
+        Subnetwork::State => StateNetworkApiClient::lookup_enr(target, node_id),
+        _ => panic!("Unexpected subnetwork: {subnetwork}"),
     }
     .await
     .unwrap();
     assert_eq!(result, peertest.nodes[0].enr);
 }
 
-pub async fn test_ping(protocol: ProtocolId, target: &Client, peertest: &Peertest) {
-    info!("Testing ping for {protocol}");
+pub async fn test_ping(subnetwork: Subnetwork, target: &Client, peertest: &Peertest) {
+    info!("Testing ping for {subnetwork}");
     let bootnode_enr = peertest.bootnode.enr.clone();
-    let result = match protocol {
-        ProtocolId::Beacon => BeaconNetworkApiClient::ping(target, bootnode_enr),
-        ProtocolId::History => HistoryNetworkApiClient::ping(target, bootnode_enr),
-        ProtocolId::State => StateNetworkApiClient::ping(target, bootnode_enr),
-        _ => panic!("Unexpected protocol: {protocol}"),
+    let result = match subnetwork {
+        Subnetwork::Beacon => BeaconNetworkApiClient::ping(target, bootnode_enr),
+        Subnetwork::History => HistoryNetworkApiClient::ping(target, bootnode_enr),
+        Subnetwork::State => StateNetworkApiClient::ping(target, bootnode_enr),
+        _ => panic!("Unexpected subnetwork: {subnetwork}"),
     }
     .await
     .unwrap();
@@ -141,14 +141,14 @@ pub async fn test_ping_cross_network(mainnet_target: &Client, angelfood_node: &P
     };
 }
 
-pub async fn test_find_nodes(protocol: ProtocolId, target: &Client, peertest: &Peertest) {
-    info!("Testing find_nodes for {protocol}");
+pub async fn test_find_nodes(subnetwork: Subnetwork, target: &Client, peertest: &Peertest) {
+    info!("Testing find_nodes for {subnetwork}");
     let bootnode_enr = peertest.bootnode.enr.clone();
-    let result = match protocol {
-        ProtocolId::Beacon => BeaconNetworkApiClient::find_nodes(target, bootnode_enr, vec![256]),
-        ProtocolId::History => HistoryNetworkApiClient::find_nodes(target, bootnode_enr, vec![256]),
-        ProtocolId::State => StateNetworkApiClient::find_nodes(target, bootnode_enr, vec![256]),
-        _ => panic!("Unexpected protocol: {protocol}"),
+    let result = match subnetwork {
+        Subnetwork::Beacon => BeaconNetworkApiClient::find_nodes(target, bootnode_enr, vec![256]),
+        Subnetwork::History => HistoryNetworkApiClient::find_nodes(target, bootnode_enr, vec![256]),
+        Subnetwork::State => StateNetworkApiClient::find_nodes(target, bootnode_enr, vec![256]),
+        _ => panic!("Unexpected subnetwork: {subnetwork}"),
     }
     .await
     .unwrap();
@@ -156,17 +156,17 @@ pub async fn test_find_nodes(protocol: ProtocolId, target: &Client, peertest: &P
 }
 
 pub async fn test_find_nodes_zero_distance(
-    protocol: ProtocolId,
+    subnetwork: Subnetwork,
     target: &Client,
     peertest: &Peertest,
 ) {
-    info!("Testing find_nodes with zero distance for {protocol}");
+    info!("Testing find_nodes with zero distance for {subnetwork}");
     let bootnode_enr = peertest.bootnode.enr.clone();
-    let result = match protocol {
-        ProtocolId::Beacon => BeaconNetworkApiClient::find_nodes(target, bootnode_enr, vec![0]),
-        ProtocolId::History => HistoryNetworkApiClient::find_nodes(target, bootnode_enr, vec![0]),
-        ProtocolId::State => StateNetworkApiClient::find_nodes(target, bootnode_enr, vec![0]),
-        _ => panic!("Unexpected protocol: {protocol}"),
+    let result = match subnetwork {
+        Subnetwork::Beacon => BeaconNetworkApiClient::find_nodes(target, bootnode_enr, vec![0]),
+        Subnetwork::History => HistoryNetworkApiClient::find_nodes(target, bootnode_enr, vec![0]),
+        Subnetwork::State => StateNetworkApiClient::find_nodes(target, bootnode_enr, vec![0]),
+        _ => panic!("Unexpected subnetwork: {subnetwork}"),
     }
     .await
     .unwrap();

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -6,39 +6,39 @@ use tracing::info;
 
 use crate::{utils::fixture_header_by_hash, Peertest};
 use ethportal_api::{
-    types::{portal::ContentInfo, portal_wire::ProtocolId},
+    types::{network::Subnetwork, portal::ContentInfo},
     utils::bytes::hex_decode,
     BeaconNetworkApiClient, ContentValue, Enr, HistoryNetworkApiClient, OverlayContentKey,
     StateNetworkApiClient,
 };
 
-pub async fn test_recursive_find_nodes_self(protocol: ProtocolId, peertest: &Peertest) {
-    info!("Testing recursive find nodes self for {protocol}");
+pub async fn test_recursive_find_nodes_self(subnetwork: Subnetwork, peertest: &Peertest) {
+    info!("Testing recursive find nodes self for {subnetwork}");
     let target_enr = peertest.bootnode.enr.clone();
     let target_node_id = NodeId::from(target_enr.node_id().raw());
     let result =
-        call_recursive_find_nodes(protocol, &peertest.bootnode.ipc_client, target_node_id).await;
+        call_recursive_find_nodes(subnetwork, &peertest.bootnode.ipc_client, target_node_id).await;
     assert_eq!(result, vec![target_enr]);
 }
 
-pub async fn test_recursive_find_nodes_peer(protocol: ProtocolId, peertest: &Peertest) {
-    info!("Testing recursive find nodes peer for {protocol}");
+pub async fn test_recursive_find_nodes_peer(subnetwork: Subnetwork, peertest: &Peertest) {
+    info!("Testing recursive find nodes peer for {subnetwork}");
     let target_enr = peertest.nodes[0].enr.clone();
     let target_node_id = NodeId::from(target_enr.node_id().raw());
     let result =
-        call_recursive_find_nodes(protocol, &peertest.bootnode.ipc_client, target_node_id).await;
+        call_recursive_find_nodes(subnetwork, &peertest.bootnode.ipc_client, target_node_id).await;
     assert_eq!(result, vec![target_enr]);
 }
 
-pub async fn test_recursive_find_nodes_random(protocol: ProtocolId, peertest: &Peertest) {
-    info!("Testing recursive find nodes random for {protocol}");
+pub async fn test_recursive_find_nodes_random(subnetwork: Subnetwork, peertest: &Peertest) {
+    info!("Testing recursive find nodes random for {subnetwork}");
     let mut bytes = [0u8; 32];
     let random_node_id =
         hex_decode("0xcac75e7e776d84fba55a3104bdccfd716537bca3ad8465113f67f04d62694183").unwrap();
     bytes.copy_from_slice(&random_node_id);
     let target_node_id = NodeId::from(bytes);
     let result =
-        call_recursive_find_nodes(protocol, &peertest.bootnode.ipc_client, target_node_id).await;
+        call_recursive_find_nodes(subnetwork, &peertest.bootnode.ipc_client, target_node_id).await;
     assert_eq!(result.len(), 2);
 }
 
@@ -180,15 +180,15 @@ pub async fn test_trace_recursive_find_content_local_db(peertest: &Peertest) {
 }
 
 async fn call_recursive_find_nodes(
-    protocol: ProtocolId,
+    subnetwork: Subnetwork,
     client: &Client,
     node_id: NodeId,
 ) -> Vec<Enr> {
-    match protocol {
-        ProtocolId::Beacon => BeaconNetworkApiClient::recursive_find_nodes(client, node_id),
-        ProtocolId::History => HistoryNetworkApiClient::recursive_find_nodes(client, node_id),
-        ProtocolId::State => StateNetworkApiClient::recursive_find_nodes(client, node_id),
-        _ => panic!("Unexpected protocol: {protocol}"),
+    match subnetwork {
+        Subnetwork::Beacon => BeaconNetworkApiClient::recursive_find_nodes(client, node_id),
+        Subnetwork::History => HistoryNetworkApiClient::recursive_find_nodes(client, node_id),
+        Subnetwork::State => StateNetworkApiClient::recursive_find_nodes(client, node_id),
+        _ => panic!("Unexpected subnetwork: {subnetwork}"),
     }
     .await
     .unwrap()

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -1,4 +1,4 @@
-use std::{env, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
+use std::{env, net::SocketAddr, path::PathBuf, sync::Arc};
 
 use alloy_primitives::B256;
 use clap::Parser;
@@ -240,7 +240,7 @@ impl ClientWithBaseUrl {
 fn subnetwork_parser(subnetwork_string: &str) -> Result<Arc<Vec<Subnetwork>>, String> {
     let active_subnetworks: Vec<Subnetwork> = subnetwork_string
         .split(',')
-        .map(Subnetwork::from_str)
+        .map(Subnetwork::from_cli_arg)
         .collect::<Result<Vec<Subnetwork>, String>>()?;
     if active_subnetworks.contains(&Subnetwork::State) && active_subnetworks.len() > 1 {
         return Err("The State network doesn't support being ran with other subnetwork bridges at the same time".to_string());

--- a/portal-bridge/src/handle.rs
+++ b/portal-bridge/src/handle.rs
@@ -65,8 +65,9 @@ pub fn subnetworks_flag(bridge_config: &BridgeConfig) -> String {
             Subnetwork::History => vec![Subnetwork::History],
             // State requires both history and state
             Subnetwork::State => vec![Subnetwork::History, Subnetwork::State],
+            _ => panic!("Unsupported subnetwork: {subnetwork:?}"),
         })
-        .map(|network_kind| network_kind.to_string())
+        .map(|network_kind| network_kind.to_cli_arg())
         .collect::<HashSet<_>>();
     Vec::from_iter(subnetworks).join(",")
 }

--- a/portalnet/src/overlay/protocol.rs
+++ b/portalnet/src/overlay/protocol.rs
@@ -41,9 +41,10 @@ use ethportal_api::{
         discv5::RoutingTableInfo,
         distance::{Distance, Metric},
         enr::Enr,
+        network::Subnetwork,
         portal_wire::{
             Accept, Content, CustomPayload, FindContent, FindNodes, Message, Nodes, Ping, Pong,
-            PopulatedOffer, PopulatedOfferWithResult, ProtocolId, Request, Response,
+            PopulatedOffer, PopulatedOfferWithResult, Request, Response,
         },
     },
     utils::bytes::hex_encode,
@@ -70,7 +71,7 @@ pub struct OverlayProtocol<TContentKey, TMetric, TValidator, TStore> {
     /// The overlay routing table of the local node.
     kbuckets: Arc<RwLock<KBucketsTable<NodeId, Node>>>,
     /// The subnetwork protocol of the overlay.
-    protocol: ProtocolId,
+    protocol: Subnetwork,
     /// A sender to send commands to the OverlayService.
     pub command_tx: UnboundedSender<OverlayCommand<TContentKey>>,
     /// uTP controller.
@@ -101,7 +102,7 @@ where
         discovery: Arc<Discovery>,
         utp_socket: Arc<UtpSocket<UtpEnr>>,
         store: Arc<RwLock<TStore>>,
-        protocol: ProtocolId,
+        protocol: Subnetwork,
         validator: Arc<TValidator>,
     ) -> Self {
         let kbuckets = Arc::new(RwLock::new(KBucketsTable::new(
@@ -156,7 +157,7 @@ where
     }
 
     /// Returns the subnetwork protocol of the overlay protocol.
-    pub fn protocol(&self) -> &ProtocolId {
+    pub fn protocol(&self) -> &Subnetwork {
         &self.protocol
     }
 

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -70,9 +70,10 @@ use ethportal_api::{
     types::{
         distance::{Distance, Metric},
         enr::{Enr, SszEnr},
+        network::Subnetwork,
         portal_wire::{
             Accept, Content, CustomPayload, FindContent, FindNodes, Message, Nodes, Offer, Ping,
-            Pong, PopulatedOffer, ProtocolId, Request, Response, MAX_PORTAL_CONTENT_PAYLOAD_SIZE,
+            Pong, PopulatedOffer, Request, Response, MAX_PORTAL_CONTENT_PAYLOAD_SIZE,
             MAX_PORTAL_NODES_ENRS_SIZE,
         },
         query_trace::QueryTrace,
@@ -112,7 +113,7 @@ where
     /// The routing table of the local node.
     kbuckets: Arc<RwLock<KBucketsTable<NodeId, Node>>>,
     /// The protocol identifier.
-    protocol: ProtocolId,
+    protocol: Subnetwork,
     /// A queue of peers that require regular ping to check connectivity.
     /// Inserted entries expire after a fixed time. Nodes to be pinged are inserted with a timeout
     /// duration equal to some ping interval, and we continuously poll the queue to check for
@@ -183,7 +184,7 @@ where
         kbuckets: Arc<RwLock<KBucketsTable<NodeId, Node>>>,
         bootnode_enrs: Vec<Enr>,
         ping_queue_interval: Option<Duration>,
-        protocol: ProtocolId,
+        protocol: Subnetwork,
         utp_controller: Arc<UtpController>,
         metrics: OverlayMetricsReporter,
         validator: Arc<TValidator>,
@@ -464,7 +465,7 @@ where
     /// result is recorded when a pending bucket entry replaces a disconnected entry in the
     /// respective bucket.
     async fn bucket_maintenance_poll(
-        protocol: ProtocolId,
+        protocol: Subnetwork,
         kbuckets: &Arc<RwLock<KBucketsTable<NodeId, Node>>>,
     ) {
         future::poll_fn(move |_cx| {
@@ -2620,7 +2621,7 @@ where
 
     /// Send `OverlayEvent` to the event stream.
     #[allow(dead_code)] // TODO: remove when used
-    fn send_event(&self, event: OverlayEvent, to: Option<Vec<ProtocolId>>) {
+    fn send_event(&self, event: OverlayEvent, to: Option<Vec<Subnetwork>>) {
         trace!(
             "Sending event={:?} to event-stream from protocol {}",
             event,
@@ -2823,7 +2824,7 @@ mod tests {
             overlay_config.bucket_filter,
         )));
 
-        let protocol = ProtocolId::History;
+        let protocol = Subnetwork::History;
         let active_outgoing_requests = Arc::new(RwLock::new(HashMap::new()));
         let peers_to_ping = HashSetDelay::default();
         let (command_tx, command_rx) = mpsc::unbounded_channel();

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -61,6 +61,7 @@ pub async fn launch_jsonrpc_server(
             }
             Subnetwork::State => modules.push(PortalRpcModule::State),
             Subnetwork::Beacon => modules.push(PortalRpcModule::Beacon),
+            _ => return Err(RpcError::Custom("Unsupported subnetwork".to_string())),
         }
     }
 

--- a/src/bin/purge_invalid_history_content.rs
+++ b/src/bin/purge_invalid_history_content.rs
@@ -4,10 +4,7 @@ use clap::Parser;
 use discv5::enr::{CombinedKey, Enr};
 use tracing::info;
 
-use ethportal_api::types::{
-    network::{Network, Subnetwork},
-    portal_wire::ProtocolId,
-};
+use ethportal_api::types::network::{Network, Subnetwork};
 use portalnet::utils::db::{configure_node_data_dir, configure_trin_data_dir};
 use trin_storage::{
     versioned::{ContentType, IdIndexedV1StoreConfig},
@@ -39,7 +36,7 @@ pub fn main() -> Result<()> {
     )
     .unwrap()
     .create(&Subnetwork::History);
-    let config = IdIndexedV1StoreConfig::new(ContentType::History, ProtocolId::History, config);
+    let config = IdIndexedV1StoreConfig::new(ContentType::History, Subnetwork::History, config);
     let sql_connection_pool = config.sql_connection_pool.clone();
     let total_count = sql_connection_pool
         .get()

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -8,7 +8,6 @@ use std::{
 use ethportal_api::types::{
     cli::{TrinConfig, DEFAULT_WEB3_HTTP_ADDRESS, DEFAULT_WEB3_IPC_PATH},
     network::{Network, Subnetwork},
-    portal_wire::ProtocolId,
 };
 use ethportal_peertest as peertest;
 use ethportal_peertest::Peertest;
@@ -39,20 +38,20 @@ async fn peertest_stateless() {
     peertest::scenarios::basic::test_discv5_routing_table_info(&target).await;
     peertest::scenarios::eth_rpc::test_eth_chain_id(&peertest).await;
 
-    for protocol in [ProtocolId::History, ProtocolId::Beacon, ProtocolId::State] {
-        peertest::scenarios::basic::test_routing_table_info(protocol, &target).await;
-        peertest::scenarios::basic::test_radius(protocol, &target).await;
-        peertest::scenarios::basic::test_add_enr(protocol, &target, &peertest).await;
-        peertest::scenarios::basic::test_get_enr(protocol, &target, &peertest).await;
-        peertest::scenarios::basic::test_delete_enr(protocol, &target, &peertest).await;
-        peertest::scenarios::basic::test_lookup_enr(protocol, &peertest).await;
-        peertest::scenarios::basic::test_ping(protocol, &target, &peertest).await;
-        peertest::scenarios::basic::test_find_nodes(protocol, &target, &peertest).await;
-        peertest::scenarios::basic::test_find_nodes_zero_distance(protocol, &target, &peertest)
+    for subnetwork in [Subnetwork::History, Subnetwork::Beacon, Subnetwork::State] {
+        peertest::scenarios::basic::test_routing_table_info(subnetwork, &target).await;
+        peertest::scenarios::basic::test_radius(subnetwork, &target).await;
+        peertest::scenarios::basic::test_add_enr(subnetwork, &target, &peertest).await;
+        peertest::scenarios::basic::test_get_enr(subnetwork, &target, &peertest).await;
+        peertest::scenarios::basic::test_delete_enr(subnetwork, &target, &peertest).await;
+        peertest::scenarios::basic::test_lookup_enr(subnetwork, &peertest).await;
+        peertest::scenarios::basic::test_ping(subnetwork, &target, &peertest).await;
+        peertest::scenarios::basic::test_find_nodes(subnetwork, &target, &peertest).await;
+        peertest::scenarios::basic::test_find_nodes_zero_distance(subnetwork, &target, &peertest)
             .await;
-        peertest::scenarios::find::test_recursive_find_nodes_self(protocol, &peertest).await;
-        peertest::scenarios::find::test_recursive_find_nodes_peer(protocol, &peertest).await;
-        peertest::scenarios::find::test_recursive_find_nodes_random(protocol, &peertest).await;
+        peertest::scenarios::find::test_recursive_find_nodes_self(subnetwork, &peertest).await;
+        peertest::scenarios::find::test_recursive_find_nodes_peer(subnetwork, &peertest).await;
+        peertest::scenarios::find::test_recursive_find_nodes_random(subnetwork, &peertest).await;
     }
 
     peertest::scenarios::basic::test_history_store(&target).await;
@@ -345,7 +344,7 @@ async fn peertest_ping_cross_discv5_protocol_id() {
             "--network",
             &Network::Mainnet.to_string(),
             "--portal-subnetworks",
-            &Subnetwork::History.to_string(),
+            &Subnetwork::History.to_cli_arg(),
             "--external-address",
             external_addr.as_str(),
             "--web3-ipc-path",
@@ -399,7 +398,7 @@ async fn setup_peertest(
             "--portal-subnetworks",
             &subnetworks
                 .iter()
-                .map(|s| s.to_string())
+                .map(|s| s.to_cli_arg())
                 .collect::<Vec<String>>()
                 .join(","),
             "--external-address",
@@ -441,7 +440,7 @@ async fn setup_peertest_bridge(
     let external_addr = format!("{test_ip_addr}:{test_discovery_port}");
     let subnetworks = subnetworks
         .iter()
-        .map(|s| s.to_string())
+        .map(|s| s.to_cli_arg())
         .collect::<Vec<String>>()
         .join(",");
 

--- a/trin-beacon/src/network.rs
+++ b/trin-beacon/src/network.rs
@@ -7,7 +7,7 @@ use utp_rs::socket::UtpSocket;
 
 use crate::{storage::BeaconStorage, sync::BeaconSync, validation::BeaconValidator};
 use ethportal_api::{
-    types::{distance::XorMetric, enr::Enr, portal_wire::ProtocolId},
+    types::{distance::XorMetric, enr::Enr, network::Subnetwork},
     BeaconContentKey,
 };
 use light_client::{consensus::rpc::portal_rpc::PortalRpc, database::FileDB, Client};
@@ -54,7 +54,7 @@ impl BeaconNetwork {
             discovery,
             utp_socket,
             storage,
-            ProtocolId::Beacon,
+            Subnetwork::Beacon,
             validator,
         )
         .await;

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -13,8 +13,8 @@ use ethportal_api::{
             LightClientUpdatesByRange,
         },
         distance::Distance,
+        network::Subnetwork,
         portal::PaginateLocalContentInfo,
-        portal_wire::ProtocolId,
     },
     BeaconContentKey, OverlayContentKey, RawContentKey,
 };
@@ -309,7 +309,7 @@ impl BeaconStorage {
         let storage = Self {
             node_data_dir: config.node_data_dir,
             sql_connection_pool: config.sql_connection_pool,
-            metrics: StorageMetricsReporter::new(ProtocolId::Beacon),
+            metrics: StorageMetricsReporter::new(Subnetwork::Beacon),
             cache: BeaconStorageCache::new(),
         };
 

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -6,7 +6,7 @@ use utp_rs::socket::UtpSocket;
 
 use crate::storage::HistoryStorage;
 use ethportal_api::{
-    types::{distance::XorMetric, enr::Enr, portal_wire::ProtocolId},
+    types::{distance::XorMetric, enr::Enr, network::Subnetwork},
     HistoryContentKey,
 };
 use portalnet::{
@@ -50,7 +50,7 @@ impl HistoryNetwork {
             discovery,
             utp_socket,
             storage,
-            ProtocolId::History,
+            Subnetwork::History,
             validator,
         )
         .await;

--- a/trin-history/src/storage.rs
+++ b/trin-history/src/storage.rs
@@ -1,5 +1,5 @@
 use ethportal_api::{
-    types::{distance::Distance, portal::PaginateLocalContentInfo, portal_wire::ProtocolId},
+    types::{distance::Distance, network::Subnetwork, portal::PaginateLocalContentInfo},
     HistoryContentKey, OverlayContentKey,
 };
 use trin_storage::{
@@ -51,7 +51,7 @@ impl ContentStore for HistoryStorage {
 impl HistoryStorage {
     pub fn new(config: PortalStorageConfig) -> Result<Self, ContentStoreError> {
         let sql_connection_pool = config.sql_connection_pool.clone();
-        let config = IdIndexedV1StoreConfig::new(ContentType::History, ProtocolId::History, config);
+        let config = IdIndexedV1StoreConfig::new(ContentType::History, Subnetwork::History, config);
         Ok(Self {
             store: create_store(ContentType::History, config, sql_connection_pool)?,
         })

--- a/trin-metrics/src/labels.rs
+++ b/trin-metrics/src/labels.rs
@@ -1,23 +1,6 @@
-use ethportal_api::types::{
-    network::Subnetwork,
-    portal_wire::{Request, Response},
-};
+use ethportal_api::types::portal_wire::{Request, Response};
 
 pub type MetricLabel = &'static str;
-
-impl From<ProtocolLabel> for MetricLabel {
-    fn from(label: ProtocolLabel) -> Self {
-        match label {
-            ProtocolLabel::State => "state",
-            ProtocolLabel::VerkleState => "verkle_state",
-            ProtocolLabel::History => "history",
-            ProtocolLabel::TransactionGossip => "transaction_gossip",
-            ProtocolLabel::CanonicalIndices => "canonical_indices",
-            ProtocolLabel::Beacon => "beacon",
-            ProtocolLabel::Utp => "utp",
-        }
-    }
-}
 
 impl From<MessageDirectionLabel> for MetricLabel {
     fn from(label: MessageDirectionLabel) -> Self {
@@ -27,6 +10,7 @@ impl From<MessageDirectionLabel> for MetricLabel {
         }
     }
 }
+
 impl From<MessageLabel> for MetricLabel {
     fn from(label: MessageLabel) -> Self {
         match label {
@@ -41,6 +25,7 @@ impl From<MessageLabel> for MetricLabel {
         }
     }
 }
+
 impl From<UtpDirectionLabel> for MetricLabel {
     fn from(label: UtpDirectionLabel) -> Self {
         match label {
@@ -87,18 +72,6 @@ impl From<&Response> for MessageLabel {
         }
     }
 }
-/// Protocol Labels
-/// - These label values identify the protocol in the metrics
-#[derive(Debug, Clone, Copy)]
-pub enum ProtocolLabel {
-    State,
-    VerkleState,
-    History,
-    TransactionGossip,
-    CanonicalIndices,
-    Beacon,
-    Utp,
-}
 
 /// Message Direction Labels
 pub enum MessageDirectionLabel {
@@ -121,19 +94,6 @@ pub enum MessageLabel {
     Accept,
 }
 
-impl From<&Subnetwork> for ProtocolLabel {
-    fn from(subnetwork: &Subnetwork) -> Self {
-        match subnetwork {
-            Subnetwork::State => Self::State,
-            Subnetwork::VerkleState => Self::VerkleState,
-            Subnetwork::History => Self::History,
-            Subnetwork::TransactionGossip => Self::TransactionGossip,
-            Subnetwork::CanonicalIndices => Self::CanonicalIndices,
-            Subnetwork::Beacon => Self::Beacon,
-            Subnetwork::Utp => Self::Utp,
-        }
-    }
-}
 /// uTP Transfer Direction Labels
 #[derive(Debug, Clone, Copy)]
 pub enum UtpDirectionLabel {

--- a/trin-metrics/src/labels.rs
+++ b/trin-metrics/src/labels.rs
@@ -1,4 +1,7 @@
-use ethportal_api::types::portal_wire::{ProtocolId, Request, Response};
+use ethportal_api::types::{
+    network::Subnetwork,
+    portal_wire::{Request, Response},
+};
 
 pub type MetricLabel = &'static str;
 
@@ -118,16 +121,16 @@ pub enum MessageLabel {
     Accept,
 }
 
-impl From<&ProtocolId> for ProtocolLabel {
-    fn from(protocol: &ProtocolId) -> Self {
-        match protocol {
-            ProtocolId::State => Self::State,
-            ProtocolId::VerkleState => Self::VerkleState,
-            ProtocolId::History => Self::History,
-            ProtocolId::TransactionGossip => Self::TransactionGossip,
-            ProtocolId::CanonicalIndices => Self::CanonicalIndices,
-            ProtocolId::Beacon => Self::Beacon,
-            ProtocolId::Utp => Self::Utp,
+impl From<&Subnetwork> for ProtocolLabel {
+    fn from(subnetwork: &Subnetwork) -> Self {
+        match subnetwork {
+            Subnetwork::State => Self::State,
+            Subnetwork::VerkleState => Self::VerkleState,
+            Subnetwork::History => Self::History,
+            Subnetwork::TransactionGossip => Self::TransactionGossip,
+            Subnetwork::CanonicalIndices => Self::CanonicalIndices,
+            Subnetwork::Beacon => Self::Beacon,
+            Subnetwork::Utp => Self::Utp,
         }
     }
 }

--- a/trin-metrics/src/storage.rs
+++ b/trin-metrics/src/storage.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use ethportal_api::types::{distance::Distance, portal_wire::ProtocolId};
+use ethportal_api::types::{distance::Distance, network::Subnetwork};
 use prometheus_exporter::{
     self,
     prometheus::{
@@ -90,10 +90,10 @@ pub struct StorageMetricsReporter {
 }
 
 impl StorageMetricsReporter {
-    pub fn new(protocol_id: ProtocolId) -> Self {
+    pub fn new(subnetwork: Subnetwork) -> Self {
         Self {
             storage_metrics: PORTALNET_METRICS.storage(),
-            protocol: protocol_id.to_string(),
+            protocol: subnetwork.to_string(),
         }
     }
 

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -6,7 +6,7 @@ use utp_rs::socket::UtpSocket;
 
 use crate::storage::StateStorage;
 use ethportal_api::{
-    types::{distance::XorMetric, portal_wire::ProtocolId},
+    types::{distance::XorMetric, network::Subnetwork},
     StateContentKey,
 };
 use portalnet::{
@@ -58,7 +58,7 @@ impl StateNetwork {
             discovery,
             utp_socket,
             storage,
-            ProtocolId::State,
+            Subnetwork::State,
             validator,
         )
         .await;

--- a/trin-state/src/storage.rs
+++ b/trin-state/src/storage.rs
@@ -4,8 +4,8 @@ use ethportal_api::{
         content_key::state::{AccountTrieNodeKey, ContractBytecodeKey, ContractStorageTrieNodeKey},
         content_value::state::{ContractBytecode, TrieNode},
         distance::Distance,
+        network::Subnetwork,
         portal::PaginateLocalContentInfo,
-        portal_wire::ProtocolId,
     },
     ContentValue, OverlayContentKey, StateContentKey, StateContentValue,
 };
@@ -72,7 +72,7 @@ impl ContentStore for StateStorage {
 impl StateStorage {
     pub fn new(config: PortalStorageConfig) -> Result<Self, ContentStoreError> {
         let sql_connection_pool = config.sql_connection_pool.clone();
-        let config = IdIndexedV1StoreConfig::new(ContentType::State, ProtocolId::State, config);
+        let config = IdIndexedV1StoreConfig::new(ContentType::State, Subnetwork::State, config);
         Ok(Self {
             store: create_store(ContentType::State, config, sql_connection_pool)?,
         })

--- a/trin-storage/src/config.rs
+++ b/trin-storage/src/config.rs
@@ -63,6 +63,7 @@ impl PortalStorageConfigFactory {
             Subnetwork::History => Self::HISTORY_CAPACITY_WEIGHT,
             Subnetwork::State => Self::STATE_CAPACITY_WEIGHT,
             Subnetwork::Beacon => Self::BEACON_CAPACITY_WEIGHT,
+            _ => unreachable!("Subnetwork not activated: {subnetwork:?}"),
         }
     }
 }

--- a/trin-storage/src/versioned/id_indexed_v1/config.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/config.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use discv5::enr::NodeId;
-use ethportal_api::types::portal_wire::ProtocolId;
+use ethportal_api::types::network::Subnetwork;
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 
@@ -13,7 +13,7 @@ use super::pruning_strategy::PruningConfig;
 #[derive(Clone, Debug)]
 pub struct IdIndexedV1StoreConfig {
     pub content_type: ContentType,
-    pub network: ProtocolId,
+    pub subnetwork: Subnetwork,
     pub node_id: NodeId,
     pub node_data_dir: PathBuf,
     pub storage_capacity_bytes: u64,
@@ -25,12 +25,12 @@ pub struct IdIndexedV1StoreConfig {
 impl IdIndexedV1StoreConfig {
     pub fn new(
         content_type: ContentType,
-        network: ProtocolId,
+        subnetwork: Subnetwork,
         config: PortalStorageConfig,
     ) -> Self {
         Self {
             content_type,
-            network,
+            subnetwork,
             node_id: config.node_id,
             node_data_dir: config.node_data_dir,
             storage_capacity_bytes: config.storage_capacity_bytes,

--- a/trin-storage/src/versioned/id_indexed_v1/migration.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/migration.rs
@@ -50,7 +50,7 @@ mod tests {
     use std::collections::HashMap;
 
     use anyhow::Result;
-    use ethportal_api::{types::portal_wire::ProtocolId, IdentityContentKey, OverlayContentKey};
+    use ethportal_api::{types::network::Subnetwork, IdentityContentKey, OverlayContentKey};
     use rand::Rng;
 
     use crate::{
@@ -134,7 +134,7 @@ mod tests {
         legacy_history::create_store(&config)?;
 
         // migrate
-        let config = IdIndexedV1StoreConfig::new(ContentType::History, ProtocolId::History, config);
+        let config = IdIndexedV1StoreConfig::new(ContentType::History, Subnetwork::History, config);
         migrate_legacy_history_store(&config)?;
 
         // make sure we can initialize new store and that it's empty
@@ -160,7 +160,7 @@ mod tests {
         }
 
         // migrate
-        let config = IdIndexedV1StoreConfig::new(ContentType::History, ProtocolId::History, config);
+        let config = IdIndexedV1StoreConfig::new(ContentType::History, Subnetwork::History, config);
         migrate_legacy_history_store(&config)?;
 
         // create IdIndexedV1Store and verify content

--- a/trin-storage/src/versioned/id_indexed_v1/pruning_strategy.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/pruning_strategy.rs
@@ -197,7 +197,7 @@ mod tests {
     use std::path::PathBuf;
 
     use discv5::enr::NodeId;
-    use ethportal_api::types::portal_wire::ProtocolId;
+    use ethportal_api::types::network::Subnetwork;
     use r2d2::Pool;
     use r2d2_sqlite::SqliteConnectionManager;
     use rstest::rstest;
@@ -215,7 +215,7 @@ mod tests {
     fn create_pruning_strategy(storage_capacity_bytes: u64) -> PruningStrategy {
         let config = IdIndexedV1StoreConfig {
             content_type: ContentType::State,
-            network: ProtocolId::State,
+            subnetwork: Subnetwork::State,
             node_id: NodeId::random(),
             node_data_dir: PathBuf::default(),
             storage_capacity_bytes,

--- a/trin-storage/src/versioned/id_indexed_v1/store.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/store.rs
@@ -79,7 +79,7 @@ impl<TContentKey: OverlayContentKey> VersionedContentStore for IdIndexedV1Store<
     fn create(content_type: ContentType, config: Self::Config) -> Result<Self, ContentStoreError> {
         maybe_create_table_and_indexes(&content_type, &config.sql_connection_pool)?;
 
-        let protocol_id = config.network;
+        let subnetwork = config.subnetwork;
 
         let pruning_strategy = PruningStrategy::new(config.clone());
 
@@ -88,7 +88,7 @@ impl<TContentKey: OverlayContentKey> VersionedContentStore for IdIndexedV1Store<
             radius: Distance::MAX,
             pruning_strategy,
             usage_stats: UsageStats::default(),
-            metrics: StorageMetricsReporter::new(protocol_id),
+            metrics: StorageMetricsReporter::new(subnetwork),
             _phantom_content_key: PhantomData,
         };
         store.init()?;
@@ -543,7 +543,7 @@ fn maybe_create_table_and_indexes(
 mod tests {
     use anyhow::Result;
     use discv5::enr::NodeId;
-    use ethportal_api::{types::portal_wire::ProtocolId, IdentityContentKey};
+    use ethportal_api::{types::network::Subnetwork, IdentityContentKey};
     use rand::Rng;
     use tempfile::TempDir;
 
@@ -565,7 +565,7 @@ mod tests {
     fn create_config(temp_dir: &TempDir, storage_capacity_bytes: u64) -> IdIndexedV1StoreConfig {
         IdIndexedV1StoreConfig {
             content_type: ContentType::State,
-            network: ProtocolId::State,
+            subnetwork: Subnetwork::State,
             node_id: NodeId::random(),
             node_data_dir: temp_dir.path().to_path_buf(),
             distance_fn: DistanceFunction::Xor,

--- a/utp-testing/src/lib.rs
+++ b/utp-testing/src/lib.rs
@@ -8,10 +8,7 @@ pub mod rpc;
 use crate::rpc::RpcServer;
 use discv5::TalkRequest;
 use ethportal_api::{
-    types::{
-        enr::Enr,
-        portal_wire::{ProtocolId, MAINNET},
-    },
+    types::{enr::Enr, network::Subnetwork, portal_wire::MAINNET},
     utils::bytes::{hex_encode, hex_encode_upper},
 };
 use jsonrpsee::{
@@ -145,11 +142,11 @@ impl TestApp {
         // Forward discv5 uTP packets to uTP socket
         tokio::spawn(async move {
             while let Some(request) = talk_req_rx.recv().await {
-                let protocol_id = MAINNET
-                    .get_protocol_id_from_hex(&hex_encode_upper(request.protocol()))
+                let subnetwork = MAINNET
+                    .get_subnetwork_from_protocol_identifier(&hex_encode_upper(request.protocol()))
                     .unwrap();
 
-                if let ProtocolId::Utp = protocol_id {
+                if let Subnetwork::Utp = subnetwork {
                     utp_talk_reqs_tx.send(request).unwrap();
                 };
             }


### PR DESCRIPTION
### What was wrong?
Consolidate `ProtocolId` & `Subnetwork` types...

I chose `Subnetwork` > `ProtocolId` ( or `Protocol`) because...
1. Imo, it's a more descriptive name & generally applicable
2. Given that we use `--portal-subnetworks` as the cli flag, that seems to establish (for users) that "subnetwork" is the preferred variable name when referencing this concept

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
