### PR TITLE
Add peer failures to query traces

### DIFF
--- a/portalnet/src/find/query_pool.rs
+++ b/portalnet/src/find/query_pool.rs
@@ -63,7 +63,12 @@ pub enum QueryPoolState<'a, TNodeId, TQuery, TContentKey> {
         )>,
     ),
     /// A query has received a result from the given peer. It may require validation
-    Validating(&'a mut QueryInfo<TContentKey>, &'a mut TQuery, TNodeId),
+    Validating(
+        QueryId,
+        &'a mut QueryInfo<TContentKey>,
+        &'a mut TQuery,
+        TNodeId,
+    ),
     /// A query has finished.
     Finished(QueryId, QueryInfo<TContentKey>, TQuery),
     /// A query has timed out.
@@ -146,7 +151,7 @@ where
 
         if let Some((query_id, sending_peer)) = validating {
             let (query_info, query) = self.queries.get_mut(&query_id).expect("s.a.");
-            return QueryPoolState::Validating(query_info, query, sending_peer);
+            return QueryPoolState::Validating(query_id, query_info, query, sending_peer);
         }
 
         if let Some(query_id) = finished {


### PR DESCRIPTION
### What was wrong?

There is no way to acknowledge and track whether a peer experiences a variety of failures during a query, and how long that took.

### How was it fixed?

Add a new tracking HashMap in the QueryTrace object, to track utp and validation errors.

Still need to actually use the new QueryTrace API in the overlay service.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] In overlay service, track failures of utp connection, utp download, and content validation
