### PR TITLE
fix: accept up to 64 content items, not just 8

### DIFF
--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -36,7 +36,7 @@ pub type FindNodesInfo = Vec<Enr>;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AcceptInfo {
-    pub content_keys: BitList<typenum::U8>,
+    pub content_keys: BitList<typenum::U64>,
 }
 
 /// Response for TraceGossip endpoint


### PR DESCRIPTION
### What was wrong?

Fix #1484 

### How was it fixed?

Increase the size of the Accept Bitlist
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
