### PR TITLE
Add detailed info to offer trace

### DIFF
--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -8,6 +8,7 @@ use crate::{
             AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
             TraceContentInfo, TraceGossipInfo,
         },
+        portal_wire::OfferTrace,
     },
     RawContentValue, RoutingTableInfo,
 };
@@ -128,15 +129,14 @@ pub trait BeaconNetworkApi {
 
     /// Send an OFFER request with given ContentKey, to the designated peer.
     /// Does not store the content locally.
-    /// Returns true if the content was accepted and successfully transferred,
-    /// returns false if the content was not accepted or the transfer failed.
+    /// Returns trace info for the offer.
     #[method(name = "beaconTraceOffer")]
     async fn trace_offer(
         &self,
         enr: Enr,
         content_key: BeaconContentKey,
         content_value: RawContentValue,
-    ) -> RpcResult<bool>;
+    ) -> RpcResult<OfferTrace>;
 
     /// Send an OFFER request with given ContentKeys, to the designated peer and wait for a
     /// response. Requires the content keys to be stored locally.

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -6,6 +6,7 @@ use crate::{
             AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
             TraceContentInfo, TraceGossipInfo,
         },
+        portal_wire::OfferTrace,
     },
     RawContentValue, RoutingTableInfo,
 };
@@ -114,15 +115,14 @@ pub trait HistoryNetworkApi {
 
     /// Send an OFFER request with given ContentKey, to the designated peer.
     /// Does not store the content locally.
-    /// Returns true if the content was accepted and successfully transferred,
-    /// returns false if the content was not accepted or the transfer failed.
+    /// Returns trace info for the offer.
     #[method(name = "historyTraceOffer")]
     async fn trace_offer(
         &self,
         enr: Enr,
         content_key: HistoryContentKey,
         content_value: RawContentValue,
-    ) -> RpcResult<bool>;
+    ) -> RpcResult<OfferTrace>;
 
     /// Send an OFFER request with given ContentKeys, to the designated peer and wait for a
     /// response. Requires the content keys to be stored locally.

--- a/ethportal-api/src/state.rs
+++ b/ethportal-api/src/state.rs
@@ -6,6 +6,7 @@ use crate::{
             AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
             TraceContentInfo, TraceGossipInfo,
         },
+        portal_wire::OfferTrace,
     },
     RawContentValue, RoutingTableInfo,
 };
@@ -107,15 +108,14 @@ pub trait StateNetworkApi {
 
     /// Send an OFFER request with given ContentKey, to the designated peer.
     /// Does not store the content locally.
-    /// Returns true if the content was accepted and successfully transferred,
-    /// returns false if the content was not accepted or the transfer failed.
+    /// Returns trace info for offer.
     #[method(name = "stateTraceOffer")]
     async fn trace_offer(
         &self,
         enr: Enr,
         content_key: StateContentKey,
         content_value: RawContentValue,
-    ) -> RpcResult<bool>;
+    ) -> RpcResult<OfferTrace>;
 
     /// Store content key with a content data to the local database.
     #[method(name = "stateStore")]

--- a/ethportal-api/src/types/portal_wire.rs
+++ b/ethportal-api/src/types/portal_wire.rs
@@ -550,7 +550,17 @@ pub struct PopulatedOfferWithResult {
     /// The offered content key & value
     pub content_item: (RawContentKey, Vec<u8>),
     /// The channel to send the result of the offer to
-    pub result_tx: tokio::sync::mpsc::UnboundedSender<bool>,
+    pub result_tx: tokio::sync::mpsc::UnboundedSender<OfferTrace>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OfferTrace {
+    /// Offer was successful, all accepted content keys in bitlist were transferred
+    Success(BitList<typenum::U64>),
+    /// Peer is not interested in any of the offered content keys
+    Declined,
+    /// This offer failed, perhaps locally or from a timeout or transfer failure
+    Failed,
 }
 
 impl From<PopulatedOfferWithResult> for Offer {

--- a/ethportal-peertest/src/scenarios/offer_accept.rs
+++ b/ethportal-peertest/src/scenarios/offer_accept.rs
@@ -12,8 +12,10 @@ use crate::{
     Peertest,
 };
 use ethportal_api::{
-    jsonrpsee::async_client::Client, types::enr::Enr, utils::bytes::hex_encode, ContentValue,
-    Discv5ApiClient, HistoryNetworkApiClient,
+    jsonrpsee::async_client::Client,
+    types::{enr::Enr, portal_wire::OfferTrace},
+    utils::bytes::hex_encode,
+    ContentValue, Discv5ApiClient, HistoryNetworkApiClient,
 };
 
 pub async fn test_unpopulated_offer(peertest: &Peertest, target: &Client) {
@@ -120,7 +122,11 @@ pub async fn test_populated_offer_with_trace(peertest: &Peertest, target: &Clien
         .unwrap();
 
     // check that the result of the offer is true for a valid transfer
-    assert!(result);
+    if let OfferTrace::Success(accepted_keys) = result {
+        assert_eq!(hex_encode(accepted_keys.into_bytes()), "0x03");
+    } else {
+        panic!("Offer failed");
+    }
 
     // Check if the stored content value in bootnode's DB matches the offered
     assert_eq!(

--- a/portalnet/src/gossip.rs
+++ b/portalnet/src/gossip.rs
@@ -20,7 +20,7 @@ use ethportal_api::{
     types::{
         distance::Metric,
         enr::Enr,
-        portal_wire::{PopulatedOffer, PopulatedOfferWithResult, Request, Response},
+        portal_wire::{OfferTrace, PopulatedOffer, PopulatedOfferWithResult, Request, Response},
     },
     utils::bytes::{hex_encode, hex_encode_compact},
     OverlayContentKey,
@@ -205,11 +205,9 @@ pub async fn trace_propagate_gossip_cross_thread<
             // continue to next peer if err while waiting for response
             Err(_) => continue,
         }
-        if let Some(result) = result_rx.recv().await {
-            if result {
-                // update gossip result with peer marked as successfully transferring the content
-                gossip_result.transferred.push(enr);
-            }
+        if let Some(OfferTrace::Success(_)) = result_rx.recv().await {
+            // update gossip result with peer marked as successfully transferring the content
+            gossip_result.transferred.push(enr);
         }
     }
     gossip_result

--- a/portalnet/src/overlay/protocol.rs
+++ b/portalnet/src/overlay/protocol.rs
@@ -43,8 +43,8 @@ use ethportal_api::{
         enr::Enr,
         network::Subnetwork,
         portal_wire::{
-            Accept, Content, CustomPayload, FindContent, FindNodes, Message, Nodes, Ping, Pong,
-            PopulatedOffer, PopulatedOfferWithResult, Request, Response,
+            Accept, Content, CustomPayload, FindContent, FindNodes, Message, Nodes, OfferTrace,
+            Ping, Pong, PopulatedOffer, PopulatedOfferWithResult, Request, Response,
         },
     },
     utils::bytes::hex_encode,
@@ -593,7 +593,7 @@ where
         enr: Enr,
         content_key: RawContentKey,
         content_value: Vec<u8>,
-    ) -> Result<bool, OverlayRequestError> {
+    ) -> Result<OfferTrace, OverlayRequestError> {
         // Construct the request.
         let (result_tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let request = Request::PopulatedOfferWithResult(PopulatedOfferWithResult {

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -17,6 +17,7 @@ use ethportal_api::{
             AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
             TraceContentInfo, TraceGossipInfo,
         },
+        portal_wire::OfferTrace,
     },
     BeaconContentKey, BeaconContentValue, BeaconNetworkApiServer, ContentValue, RawContentValue,
     RoutingTableInfo,
@@ -196,14 +197,13 @@ impl BeaconNetworkApiServer for BeaconNetworkApi {
 
     /// Send an OFFER request with given ContentKey, to the designated peer.
     /// Does not store the content locally.
-    /// Returns true if the content was accepted and successfully transferred,
-    /// returns false if the content was not accepted or the transfer failed.
+    /// Returns trace info from the offer.
     async fn trace_offer(
         &self,
         enr: Enr,
         content_key: BeaconContentKey,
         content_value: RawContentValue,
-    ) -> RpcResult<bool> {
+    ) -> RpcResult<OfferTrace> {
         let content_value = BeaconContentValue::decode(&content_key, &content_value)
             .map_err(RpcServeError::from)?;
         let endpoint = BeaconEndpoint::TraceOffer(enr, content_key, content_value);

--- a/rpc/src/history_rpc.rs
+++ b/rpc/src/history_rpc.rs
@@ -9,6 +9,7 @@ use ethportal_api::{
             AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
             TraceContentInfo, TraceGossipInfo,
         },
+        portal_wire::OfferTrace,
     },
     ContentValue, HistoryContentKey, HistoryContentValue, HistoryNetworkApiServer, RawContentValue,
     RoutingTableInfo,
@@ -176,7 +177,7 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
         enr: Enr,
         content_key: HistoryContentKey,
         content_value: RawContentValue,
-    ) -> RpcResult<bool> {
+    ) -> RpcResult<OfferTrace> {
         let content_value = HistoryContentValue::decode(&content_key, &content_value)
             .map_err(RpcServeError::from)?;
         let endpoint = HistoryEndpoint::TraceOffer(enr, content_key, content_value);

--- a/rpc/src/state_rpc.rs
+++ b/rpc/src/state_rpc.rs
@@ -9,6 +9,7 @@ use ethportal_api::{
             AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
             TraceContentInfo, TraceGossipInfo,
         },
+        portal_wire::OfferTrace,
     },
     ContentValue, RawContentValue, RoutingTableInfo, StateContentKey, StateContentValue,
     StateNetworkApiServer,
@@ -162,14 +163,13 @@ impl StateNetworkApiServer for StateNetworkApi {
 
     /// Send an OFFER request with given ContentKey, to the designated peer.
     /// Does not store the content locally.
-    /// Returns true if the content was accepted and successfully transferred,
-    /// returns false if the content was not accepted or the transfer failed.
+    /// Returns trace info from the offer.
     async fn trace_offer(
         &self,
         enr: Enr,
         content_key: StateContentKey,
         content_value: RawContentValue,
-    ) -> RpcResult<bool> {
+    ) -> RpcResult<OfferTrace> {
         let content_value =
             StateContentValue::decode(&content_key, &content_value).map_err(RpcServeError::from)?;
         let endpoint = StateEndpoint::TraceOffer(enr, content_key, content_value);


### PR DESCRIPTION
### What was wrong?
Updated `trace_offer` to return more detail about what happened during the `Offer`, specifically to identify between cases where the offered key was rejected, or the transfer failed, which is helpful to know inside the state bridge.

### How was it fixed?
- added `OfferTrace` type to capture more information about failed `trace_offer` requests

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
