### PR TITLE
fix: update slow state bridge defaults

### DIFF
--- a/portal-bridge/src/census.rs
+++ b/portal-bridge/src/census.rs
@@ -30,14 +30,14 @@ pub enum CensusError {
 }
 
 /// Ping delay for liveness check of peers in census
-/// Two minutes was chosen somewhat arbitrarily, and can be adjusted
+/// One hour was chosen after 2mins was too slow, and can be adjusted
 /// in the future based on performance
-const LIVENESS_CHECK_DELAY: Duration = Duration::from_secs(120);
+const LIVENESS_CHECK_DELAY: Duration = Duration::from_secs(3600);
 
 /// The maximum number of enrs to return in a response,
 /// limiting the number of OFFER requests spawned by the bridge
 /// for each piece of content
-const ENRS_RESPONSE_LIMIT: usize = 8;
+const ENRS_RESPONSE_LIMIT: usize = 4;
 
 /// The census is responsible for maintaining a list of known peers in the network,
 /// checking their liveness, updating their data radius, iterating through their


### PR DESCRIPTION
### What was wrong?
2 defaults that come to mind which could be influencing the speed of the state bridge are...
- the rate at which we perform a liveness check on a peer in the census
- the # of enrs we offer each piece of content

I'm not quite sure how to test that these will actually improve the speed, but they seem to be likely candidates imo.

It might also be worth updating these values to be set via cli, so that we can experiment with different values on different bridges? LMK if you think this is worthwhile and I'll update

I also added a log for a "global" state bridge offer report to understand how the bridge is performing overall.

### How was it fixed?
Updated default values.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
