### PR TITLE
docs: add note about state bridges to deployment docs

### DIFF
--- a/book/src/developers/contributing/releases/deployment.md
+++ b/book/src/developers/contributing/releases/deployment.md
@@ -57,7 +57,10 @@ This step directs Ansible to use the current master version of trin. Read [about
     - Trin nodes:
         - `ansible-playbook playbook.yml --tags trin`
     - State network nodes (check with the team if there is a reason not to update them):
-        - `ansible-playbook playbook.yml --tags state-network`
+        - Recently, we don't regularly deploy state bridge nodes (because they run for a long time and we don't want to restart them). To deploy all other state nodes, use following command:
+            - `ansible-playbook playbook.yml --tags state-network --limit state_stun,state_bootnode,state_regular`
+        - To deploy to all state network nodes:
+            - `ansible-playbook playbook.yml --tags state-network`
 - Run Glados deployment: updates glados + portal client (currently configured as trin, but this could change)
     - `cd ../../glados/ansible`
     - `ansible-playbook playbook.yml --tags glados`


### PR DESCRIPTION
### What was wrong?

Deployment docs don't include information that state bridges should most likely not be updated, and it doesn't provide instructions how to deploy other state network nodes.

### How was it fixed?

Updated docs.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
