### PR TITLE
feat: add "last-block" command line flag to trin execution

### DIFF
--- a/trin-execution/src/cli.rs
+++ b/trin-execution/src/cli.rs
@@ -22,6 +22,12 @@ pub struct TrinExecutionConfig {
 
     #[arg(
         long,
+        help = "The last block that should be executed. This is useful if execution should stop early."
+    )]
+    pub last_block: Option<u64>,
+
+    #[arg(
+        long,
         default_value = "none",
         help = "The block traces will be dumped to the working directory: Configuration options ['none', 'block:<number>', 'all']."
     )]

--- a/trin-execution/src/main.rs
+++ b/trin-execution/src/main.rs
@@ -63,9 +63,11 @@ async fn main() -> anyhow::Result<()> {
         tx.send(()).expect("signal ctrl_c should never fail");
     });
 
-    let end_block = get_spec_block_number(SpecId::CANCUN);
+    let last_block = trin_execution_config
+        .last_block
+        .unwrap_or(get_spec_block_number(SpecId::CANCUN));
     trin_execution
-        .process_range_of_blocks(end_block, Some(rx))
+        .process_range_of_blocks(last_block, Some(rx))
         .await?;
 
     Ok(())


### PR DESCRIPTION
### What was wrong?

It's not possible to configure trin-execution to stop early (it will execute all blocks up to Cancun fork or until stopped).

### How was it fixed?

Added optional command line flag to support early stop.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
