### PR TITLE
feat(state-bridge): add support for gossiping blocks from a range

### DIFF
--- a/portal-bridge/README.md
+++ b/portal-bridge/README.md
@@ -1,4 +1,5 @@
 # Portal-Bridge
+
 Process to feed the portal network by gossiping data retrieved from a trusted provider. This is only compatible with `Trin` clients.
 
 ex.
@@ -8,7 +9,9 @@ cargo run -p portal-bridge -- --executable-path ./target/debug/trin --epoch-accu
 ```
 
 ## Providers
+
 `Portal-Bridge` currently supports 3 types of providers...
+
 - PandaOps (default provider for both execution and consensus layers)
   - This provider is not publicly accessible. If you don't have access, then you must use another option.
 - Infura (execution layer only)
@@ -21,7 +24,9 @@ cargo run -p portal-bridge -- --executable-path ./target/debug/trin --epoch-accu
 	- eg. `--cl-provider http://localhost:8551`
 
 ### Bridge modes
+
 #### History Subnetwork
+
 - `"--mode latest"`: follow the head of the chain and gossip latest blocks
 - `"--mode test:/path/to/test_data.json"`: gossip content keys & values found in test file.
 - `"--mode backfill:b100"`: start backfill at block #100
@@ -39,21 +44,28 @@ cargo run -p portal-bridge -- --executable-path ./target/debug/trin --epoch-accu
     - before gossiping a individual piece of content, the bridge will perform a lookup to see if the content is already in the portal network. If it is, the content will not be gossiped.
 - `"--mode fourfours:single_hunter:10:50`: sample size = 10, threshold = 50
     - same as the above hunter mode, but it will only gossip a single era1 file before exiting
+
 #### Beacon Subnetwork
+
 - `"--mode latest"`: follow the head of the chain and gossip latest blocks
 - `"--mode test:/path/to/test_data.json"`: gossip content keys & values found in test file.
+
 #### State Subnetwork
+
 - `"--mode single:b100"`: backfill, always beginning from block #0 until the specified block (#100)
+- `"--mode single:r50-100"`: backfill, gossips state diffs for blocks in #50-#100 range (inclusive)
 
 ### Subnetwork configuration
+
 You can specify the `--portal-subnetworks` flag for which network to run the bridge for
 - `"--portal-subnetworks history"`: Default value. Run the bridge for the history network.
 - `"--portal-subnetworks beacon"`: Run the bridge for the beacon network.
 - `"--portal-subnetworks history,beacon"`: Run the bridge for the history & beacon network.
 `  "--portal-subnetworks state"`: Run the bridge for the state network.
-  - Currently, the `"state"` network can only be run by itself!
+    - Currently, the `"state"` network can only be run by itself!
 
-###Test File example
+### Test File example
+
 ```json
 [{
 	"content_key": "0x006251d65b8a8668efabe2f89c96a5b6332d83b3bbe585089ea6b2ab9b6754f5e9",


### PR DESCRIPTION
### What was wrong?

State Bridge only supports gossiping blocks starting from 0.
We know that content from first ~500'000 blocks are saturated, and we might want to skip them to speed up the process.

### How was it fixed?

Add support for range gossip.
We will still execute blocks starting from zero, but we will gossip only blocks from the range.

Specifying single block would imply gossiping all blocks starting from zero and ending with provided block.
This was left unmodified for backward compatibility, until we upgrade deployment scripts.
In my opinion, single block should gossip entire state trie at the specified block (but this requires more work).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
