### PR TITLE
feat(bridge): increase total request timeout value via CLI flag

### DIFF
--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -9,7 +9,7 @@ use ethportal_api::{
 use portal_bridge::{
     api::{consensus::ConsensusApi, execution::ExecutionApi},
     bridge::{beacon::BeaconBridge, history::HistoryBridge},
-    constants::DEFAULT_GOSSIP_LIMIT,
+    constants::{DEFAULT_GOSSIP_LIMIT, DEFAULT_TOTAL_REQUEST_TIMEOUT},
     types::mode::BridgeMode,
 };
 use serde::Deserialize;
@@ -24,9 +24,13 @@ pub async fn test_history_bridge(peertest: &Peertest, portal_client: &HttpClient
     let mode = BridgeMode::Test("./test_assets/portalnet/bridge_data.json".into());
     // url doesn't matter, we're not making any requests
     let client_url = Url::parse("http://www.null.com").unwrap();
-    let execution_api = ExecutionApi::new(client_url.clone(), client_url)
-        .await
-        .unwrap();
+    let execution_api = ExecutionApi::new(
+        client_url.clone(),
+        client_url,
+        DEFAULT_TOTAL_REQUEST_TIMEOUT,
+    )
+    .await
+    .unwrap();
     // Wait for bootnode to start
     sleep(Duration::from_secs(1)).await;
     let bridge = HistoryBridge::new(
@@ -54,9 +58,13 @@ pub async fn test_beacon_bridge(peertest: &Peertest, portal_client: &HttpClient)
     sleep(Duration::from_secs(1)).await;
     // url doesn't matter, we're not making any requests
     let client_url = Url::parse("http://www.null.com").unwrap();
-    let consensus_api = ConsensusApi::new(client_url.clone(), client_url)
-        .await
-        .unwrap();
+    let consensus_api = ConsensusApi::new(
+        client_url.clone(),
+        client_url,
+        DEFAULT_TOTAL_REQUEST_TIMEOUT,
+    )
+    .await
+    .unwrap();
     let bridge = BeaconBridge::new(consensus_api, mode, portal_client.clone());
     bridge.launch().await;
 

--- a/portal-bridge/src/constants.rs
+++ b/portal-bridge/src/constants.rs
@@ -14,9 +14,9 @@ pub const HEADER_WITH_PROOF_CONTENT_VALUE: &str =
 // Beacon chain mainnet genesis time: Tue Dec 01 2020 12:00:23 GMT+0000
 pub const BEACON_GENESIS_TIME: u64 = 1606824023;
 
-// This is a very conservative timeout if a provider takes longer than even 1 second it is probably
-// overloaded and not performing well
-pub const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+/// The timeout in seconds is applied from when the request starts connecting until the response
+/// body has finished. Also considered a total deadline.
+pub const DEFAULT_TOTAL_REQUEST_TIMEOUT: u64 = 20;
 
 // The maximum number of active blocks being gossiped. Note that this doesn't
 // exactly mean the number of concurrent gossip jsonrpc requests, as the gossip

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -86,6 +86,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let consensus_api = ConsensusApi::new(
                 bridge_config.cl_provider,
                 bridge_config.cl_provider_fallback,
+                bridge_config.request_timeout,
             )
             .await?;
             let portal_client_clone = portal_client.clone();
@@ -110,6 +111,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let execution_api = ExecutionApi::new(
                 bridge_config.el_provider,
                 bridge_config.el_provider_fallback,
+                bridge_config.request_timeout,
             )
             .await?;
             match bridge_config.mode {

--- a/src/bin/test_providers.rs
+++ b/src/bin/test_providers.rs
@@ -68,6 +68,7 @@ pub async fn main() -> Result<()> {
             primary: client_url.clone(),
             fallback: client_url,
             header_validator: HeaderValidator::default(),
+            request_timeout: 20,
         };
         for gossip_range in all_ranges.iter_mut() {
             debug!("Testing range: {gossip_range:?}");


### PR DESCRIPTION
### What was wrong?
The total request timeout for the bridge was set to 20 seconds. However, getting beacon state data from the Pandaops nodes usually takes more time, which causes the transfer to fail with a `Timeout`  error.

### How was it fixed?
- Add a CLI flag to set a custom total request timeout value. The default is the current value (20 sec).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
