### PR TITLE
refactor(trin-execution): state import/export don't need TrinExecution

### DIFF
--- a/trin-execution/src/cli.rs
+++ b/trin-execution/src/cli.rs
@@ -4,6 +4,8 @@ use clap::{Args, Parser, Subcommand};
 
 use crate::types::block_to_trace::BlockToTrace;
 
+pub const APP_NAME: &str = "trin-execution";
+
 #[derive(Parser, Debug, Clone)]
 #[command(name = "Trin Execution", about = "Executing blocks with no devp2p")]
 pub struct TrinExecutionConfig {
@@ -54,12 +56,16 @@ pub enum TrinExecutionSubCommands {
 
 #[derive(Args, Debug, Default, Clone, PartialEq)]
 pub struct ImportStateConfig {
+    #[arg(long, help = "The directory where to import the snapshot data.")]
+    pub data_dir: Option<PathBuf>,
     #[arg(long, help = "path to where the era2 state snapshot is located")]
     pub path_to_era2: PathBuf,
 }
 
 #[derive(Args, Debug, Default, Clone, PartialEq)]
 pub struct ExportStateConfig {
+    #[arg(long, help = "The directory from where to export the snapshot data.")]
+    pub data_dir: Option<PathBuf>,
     #[arg(long, help = "path to where the era2 state snapshot is located")]
     pub path_to_era2: PathBuf,
 }

--- a/trin-execution/src/cli.rs
+++ b/trin-execution/src/cli.rs
@@ -56,16 +56,12 @@ pub enum TrinExecutionSubCommands {
 
 #[derive(Args, Debug, Default, Clone, PartialEq)]
 pub struct ImportStateConfig {
-    #[arg(long, help = "The directory where to import the snapshot data.")]
-    pub data_dir: Option<PathBuf>,
     #[arg(long, help = "path to where the era2 state snapshot is located")]
     pub path_to_era2: PathBuf,
 }
 
 #[derive(Args, Debug, Default, Clone, PartialEq)]
 pub struct ExportStateConfig {
-    #[arg(long, help = "The directory from where to export the snapshot data.")]
-    pub data_dir: Option<PathBuf>,
     #[arg(long, help = "path to where the era2 state snapshot is located")]
     pub path_to_era2: PathBuf,
 }

--- a/trin-execution/src/main.rs
+++ b/trin-execution/src/main.rs
@@ -15,6 +15,11 @@ async fn main() -> anyhow::Result<()> {
 
     let trin_execution_config = TrinExecutionConfig::parse();
 
+    // Initialize prometheus metrics
+    if let Some(addr) = trin_execution_config.enable_metrics_with_url {
+        prometheus_exporter::start(addr)?;
+    }
+
     let data_dir = setup_data_dir(
         APP_NAME,
         trin_execution_config.data_dir.clone(),
@@ -43,11 +48,6 @@ async fn main() -> anyhow::Result<()> {
                 return Ok(());
             }
         }
-    }
-
-    // Initialize prometheus metrics
-    if let Some(addr) = trin_execution_config.enable_metrics_with_url {
-        prometheus_exporter::start(addr)?;
     }
 
     let mut trin_execution =

--- a/trin-execution/src/storage/execution_position.rs
+++ b/trin-execution/src/storage/execution_position.rs
@@ -27,11 +27,7 @@ impl ExecutionPosition {
             Some(raw_execution_position) => {
                 Decodable::decode(&mut raw_execution_position.as_slice())?
             }
-            None => Self {
-                version: 0,
-                next_block_number: 0,
-                state_root: EMPTY_ROOT_HASH,
-            },
+            None => Self::default(),
         })
     }
 
@@ -52,5 +48,15 @@ impl ExecutionPosition {
         self.state_root = header.state_root;
         db.put(EXECUTION_POSITION_DB_KEY, alloy_rlp::encode(self))?;
         Ok(())
+    }
+}
+
+impl Default for ExecutionPosition {
+    fn default() -> Self {
+        Self {
+            version: 0,
+            next_block_number: 0,
+            state_root: EMPTY_ROOT_HASH,
+        }
     }
 }

--- a/trin-execution/src/subcommands/era2/export.rs
+++ b/trin-execution/src/subcommands/era2/export.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_rlp::Decodable;
@@ -11,10 +14,9 @@ use ethportal_api::{types::state_trie::account_state::AccountState, Header};
 use parking_lot::Mutex;
 use revm_primitives::{B256, KECCAK_EMPTY, U256};
 use tracing::info;
-use trin_utils::dir::setup_data_dir;
 
 use crate::{
-    cli::{ExportStateConfig, APP_NAME},
+    cli::ExportStateConfig,
     config::StateConfig,
     era::manager::EraManager,
     storage::{
@@ -30,13 +32,8 @@ pub struct StateExporter {
 }
 
 impl StateExporter {
-    pub async fn new(config: ExportStateConfig) -> anyhow::Result<Self> {
-        let data_dir = setup_data_dir(
-            APP_NAME,
-            config.data_dir.clone(),
-            /* ephemeral= */ false,
-        )?;
-        let rocks_db = Arc::new(setup_rocksdb(&data_dir)?);
+    pub async fn new(config: ExportStateConfig, data_dir: &Path) -> anyhow::Result<Self> {
+        let rocks_db = Arc::new(setup_rocksdb(data_dir)?);
 
         let execution_position = ExecutionPosition::initialize_from_db(rocks_db.clone())?;
         ensure!(

--- a/trin-execution/src/subcommands/era2/export.rs
+++ b/trin-execution/src/subcommands/era2/export.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_rlp::Decodable;
@@ -67,7 +67,7 @@ impl StateExporter {
         })
     }
 
-    pub fn export(&self) -> anyhow::Result<()> {
+    pub fn export(&self) -> anyhow::Result<PathBuf> {
         info!(
             "Exporting state from block number: {} with state root: {}",
             self.header.number, self.header.state_root
@@ -133,7 +133,7 @@ impl StateExporter {
 
         info!("Era2 snapshot exported");
 
-        Ok(())
+        Ok(era2.path().to_path_buf())
     }
 
     pub fn header(&self) -> &Header {

--- a/trin-execution/src/subcommands/era2/import.rs
+++ b/trin-execution/src/subcommands/era2/import.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 use anyhow::{ensure, Error};
 use e2store::era2::{AccountEntry, AccountOrStorageEntry, Era2, StorageItem};
@@ -6,10 +6,9 @@ use eth_trie::{EthTrie, Trie};
 use ethportal_api::Header;
 use revm_primitives::{keccak256, B256, U256};
 use tracing::info;
-use trin_utils::dir::setup_data_dir;
 
 use crate::{
-    cli::{ImportStateConfig, APP_NAME},
+    cli::ImportStateConfig,
     config::StateConfig,
     era::manager::EraManager,
     evm::block_executor::BLOCKHASH_SERVE_WINDOW,
@@ -25,13 +24,8 @@ pub struct StateImporter {
 }
 
 impl StateImporter {
-    pub async fn new(config: ImportStateConfig) -> anyhow::Result<Self> {
-        let data_dir = setup_data_dir(
-            APP_NAME,
-            config.data_dir.clone(),
-            /* ephemeral= */ false,
-        )?;
-        let rocks_db = Arc::new(setup_rocksdb(&data_dir)?);
+    pub async fn new(config: ImportStateConfig, data_dir: &Path) -> anyhow::Result<Self> {
+        let rocks_db = Arc::new(setup_rocksdb(data_dir)?);
 
         let execution_position = ExecutionPosition::initialize_from_db(rocks_db.clone())?;
         ensure!(

--- a/trin-execution/tests/export_import.rs
+++ b/trin-execution/tests/export_import.rs
@@ -44,19 +44,23 @@ async fn execute_export_import_execute() -> anyhow::Result<()> {
     drop(trin_execution);
 
     // 2. export from dir_1 into era2
-    let exporter = StateExporter::new(ExportStateConfig {
-        data_dir: Some(dir_1),
-        path_to_era2: era2_dir,
-    })
+    let exporter = StateExporter::new(
+        ExportStateConfig {
+            path_to_era2: era2_dir,
+        },
+        &dir_1,
+    )
     .await?;
     let era2_file = exporter.export()?;
     drop(exporter);
 
     // 3. import from era2 into dir_2
-    let importer = StateImporter::new(ImportStateConfig {
-        data_dir: Some(dir_2.clone()),
-        path_to_era2: era2_file,
-    })
+    let importer = StateImporter::new(
+        ImportStateConfig {
+            path_to_era2: era2_file,
+        },
+        &dir_2,
+    )
     .await?;
     importer.import().await?;
     drop(importer);

--- a/trin-execution/tests/export_import.rs
+++ b/trin-execution/tests/export_import.rs
@@ -1,0 +1,73 @@
+use tracing::info;
+use tracing_test::traced_test;
+use trin_execution::{
+    cli::{ExportStateConfig, ImportStateConfig},
+    config::StateConfig,
+    execution::TrinExecution,
+    subcommands::era2::{export::StateExporter, import::StateImporter},
+};
+use trin_utils::dir::create_temp_test_dir;
+
+/// Tests that exporting/importing to/from era2 files works.
+///
+/// This test does the following:
+/// 1. executes first `blocks` blocks
+/// 2. exports state to the era2
+/// 3. imports state from era2 file into new directory
+/// 4. executes another `blocks` blocks
+///
+/// Following command can be used to run the test for different number of blocks (e.g. 10000):
+///
+/// ```
+/// BLOCKS=10000 cargo test -p trin-execution --test export_import -- --nocapture
+/// ```
+#[tokio::test]
+#[traced_test]
+async fn execute_export_import_execute() -> anyhow::Result<()> {
+    let blocks = std::env::var("BLOCKS")
+        .ok()
+        .and_then(|var| var.parse::<u64>().ok())
+        .unwrap_or(1000);
+    info!("Running test for {blocks} blocks");
+
+    let temp_directory = create_temp_test_dir()?;
+    let era2_dir = temp_directory.path().join("era");
+    let dir_1 = temp_directory.path().join("dir_1");
+    let dir_2 = temp_directory.path().join("dir_2");
+
+    // 1. execute blocks in dir_1
+    let mut trin_execution = TrinExecution::new(&dir_1, StateConfig::default()).await?;
+    trin_execution
+        .process_range_of_blocks(blocks, /* stop_signal= */ None)
+        .await?;
+    assert_eq!(trin_execution.next_block_number(), blocks + 1);
+    drop(trin_execution);
+
+    // 2. export from dir_1 into era2
+    let exporter = StateExporter::new(ExportStateConfig {
+        data_dir: Some(dir_1),
+        path_to_era2: era2_dir,
+    })
+    .await?;
+    let era2_file = exporter.export()?;
+    drop(exporter);
+
+    // 3. import from era2 into dir_2
+    let importer = StateImporter::new(ImportStateConfig {
+        data_dir: Some(dir_2.clone()),
+        path_to_era2: era2_file,
+    })
+    .await?;
+    importer.import().await?;
+    drop(importer);
+
+    // 4. execute blocks in dir_2
+    let mut trin_execution = TrinExecution::new(&dir_2, StateConfig::default()).await?;
+    trin_execution
+        .process_range_of_blocks(2 * blocks, /* stop_signal= */ None)
+        .await?;
+    assert_eq!(trin_execution.next_block_number(), 2 * blocks + 1);
+    drop(trin_execution);
+
+    Ok(())
+}


### PR DESCRIPTION
### What was wrong?

The import/export state in `trin-execution` don't need TrinExecution. They only need `EvmDb` and `ExecutionPosition`.

No tests that test import/export end to end.

### How was it fixed?

Refactor how Importer/Exporter are initialized.

Also added test that:
- executes fist 1000 blocks
- exports state to era2 file
- imports state from era2 file (into new directory)
- executes another 1000 blocks

### To-Do

- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
