### PR TITLE
feat(bridge): add bridge id cli flag for state bridges

### DIFF
--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -69,6 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             portal_client.clone(),
             bridge_config.offer_limit,
             census_tx,
+            bridge_config.bridge_id,
         )
         .await?;
 

--- a/src/bin/test_providers.rs
+++ b/src/bin/test_providers.rs
@@ -10,7 +10,7 @@ use ethportal_api::{
     utils::bytes::hex_encode,
     Header,
 };
-use portal_bridge::api::execution::ExecutionApi;
+use portal_bridge::{api::execution::ExecutionApi, constants::DEFAULT_TOTAL_REQUEST_TIMEOUT};
 use rand::{
     distributions::{Distribution, Uniform},
     thread_rng,
@@ -68,7 +68,7 @@ pub async fn main() -> Result<()> {
             primary: client_url.clone(),
             fallback: client_url,
             header_validator: HeaderValidator::default(),
-            request_timeout: 20,
+            request_timeout: DEFAULT_TOTAL_REQUEST_TIMEOUT,
         };
         for gossip_range in all_ranges.iter_mut() {
             debug!("Testing range: {gossip_range:?}");


### PR DESCRIPTION
### What was wrong?
Pretty simple approach to "horizontally scaling" our state bridge nodes. Introduced a `bridge_id` flag, which calculates whether or not an individual bridge is responsible for gossiping a piece of content.

- using a simple id is easier than managing a bridge's node id and using that to calculate distance to the content
- downsides...
  - this approach requires every bridge to iterate over every node in the trie/diff to figure out whether or not it's responsible for gossiping that content. A smarter solution will be needed for gossiping an imported era2 file, or if there's a better solution for chunking the diff, lmk and I'll implement it here.
  - there's no redundancy built in, unless you adjust the `bridge_id` accordingly. aka if we have four bridges, use a `bridge_total` of 2
 
### How was it fixed?
- added `bridge_id` flag and support for filtering offers based on this value

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
