### PR TITLE
feat: split E2StoreStream into reader and writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,8 +1938,8 @@ dependencies = [
  "rstest",
  "scraper",
  "snap",
- "tempfile",
  "tokio",
+ "trin-utils",
 ]
 
 [[package]]

--- a/e2store/Cargo.toml
+++ b/e2store/Cargo.toml
@@ -25,5 +25,5 @@ snap.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
-tempfile.workspace = true
 tokio.workspace = true
+trin-utils.workspace = true

--- a/e2store/README.md
+++ b/e2store/README.md
@@ -23,4 +23,4 @@ TODO: Add chart of snapshot size at every million block interval.
 
 ## What is the difference between `e2store/memory.rs` and `e2store/stream.rs`
 
-The `e2store/memory.rs` provides an api to load a full e2store file such as `.era`/`.era1` and manipulate it in memory. For smaller e2store files this approach works well. The issue comes when dealing with e2store files of much greater size loading the whole file into memory at once often isn't possible. This is where `e2store/stream.rs` comes in where you can stream the data you need from a e2store file as you need it. This is required for `.era2` format for storing full flat state snapshots.
+`e2store/memory.rs` provides an api to load a full e2store file such as `.era`/`.era1` and manipulate it in memory. For smaller e2store files this approach works well. The issue comes when dealing with e2store files of much greater size loading the whole file into memory at once often isn't possible. This is where `e2store/stream.rs` comes in where you can stream the data you need from a e2store file as you need it. This is required for `.era2` format for storing full flat state snapshots.

--- a/e2store/README.md
+++ b/e2store/README.md
@@ -23,4 +23,4 @@ TODO: Add chart of snapshot size at every million block interval.
 
 ## What is the difference between `e2store/memory.rs` and `e2store/stream.rs`
 
-`e2store/memory.rs` provides an api to load a full e2store file such as `.era`/`.era1` and manipulate it in memory. For smaller e2store files this approach works well. The issue comes when dealing with e2store files of much greater size loading the whole file into memory at once often isn't possible. This is where `e2store/stream.rs` comes in where you can stream the data you need from a e2store file as you need it. This will be required in `.era2` a format for storing full flat state snapshots.
+The `e2store/memory.rs` provides an api to load a full e2store file such as `.era`/`.era1` and manipulate it in memory. For smaller e2store files this approach works well. The issue comes when dealing with e2store files of much greater size loading the whole file into memory at once often isn't possible. This is where `e2store/stream.rs` comes in where you can stream the data you need from a e2store file as you need it. This is required for `.era2` format for storing full flat state snapshots.

--- a/e2store/src/e2store/stream.rs
+++ b/e2store/src/e2store/stream.rs
@@ -1,51 +1,59 @@
 use std::{
     fs::File,
-    io::{Read, Write},
-    path::PathBuf,
+    io::{BufReader, BufWriter, Read, Write},
+    path::Path,
 };
 
 use super::types::{Entry, Header};
 
-/// e2store/memory.rs was built to load full .era/.era2 files into memory and provide a simple API
-/// to access the data. The issue for this is for larger files this wouldn't be feasible, as the
-/// entire file would need to be loaded into memory. This is where e2store_file.rs comes in, it
-/// provides a way to read and write e2store files in a streaming fashion.
-pub struct E2StoreStream {
-    pub e2store_file: File,
+/// Streaming reader for e2store files.
+pub struct E2StoreStreamReader {
+    reader: BufReader<File>,
 }
 
-impl E2StoreStream {
-    pub fn open(e2store_path: &PathBuf) -> anyhow::Result<Self> {
-        let e2store_file = File::open(e2store_path)?;
-        Ok(Self { e2store_file })
-    }
-
-    pub fn create(e2store_path: &PathBuf) -> anyhow::Result<Self> {
-        let e2store_file = File::create(e2store_path)?;
-        Ok(Self { e2store_file })
+impl E2StoreStreamReader {
+    pub fn new(e2store_path: &Path) -> anyhow::Result<Self> {
+        let reader = BufReader::new(File::open(e2store_path)?);
+        Ok(Self { reader })
     }
 
     pub fn next_entry(&mut self) -> anyhow::Result<Entry> {
         let mut buf = vec![0; 8];
-        self.e2store_file.read_exact(&mut buf)?;
+        self.reader.read_exact(&mut buf)?;
         let header = Header::deserialize(&buf)?;
         let mut value = vec![0; header.length as usize];
-        self.e2store_file.read_exact(&mut value)?;
+        self.reader.read_exact(&mut value)?;
         Ok(Entry { header, value })
+    }
+}
+
+/// Streaming writer for e2store files.
+pub struct E2StoreStreamWriter {
+    writer: BufWriter<File>,
+}
+
+impl E2StoreStreamWriter {
+    pub fn new(e2store_path: &Path) -> anyhow::Result<Self> {
+        let writer = BufWriter::new(File::create(e2store_path)?);
+        Ok(Self { writer })
     }
 
     /// Append an entry to the e2store file.
     pub fn append_entry(&mut self, entry: &Entry) -> anyhow::Result<()> {
         let buf = entry.serialize()?;
-        self.e2store_file.write_all(&buf)?;
+        self.writer.write_all(&buf)?;
         Ok(())
+    }
+
+    pub fn flush(&mut self) -> anyhow::Result<()> {
+        Ok(self.writer.flush()?)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use rand::Rng;
-    use tempfile::TempDir;
+    use trin_utils::dir::create_temp_test_dir;
 
     use crate::e2store::types::VersionEntry;
 
@@ -55,29 +63,29 @@ mod tests {
     fn test_e2store_stream_write_and_read() -> anyhow::Result<()> {
         // setup
         let mut rng = rand::thread_rng();
-        let tmp_dir = TempDir::new()?;
+        let tmp_dir = create_temp_test_dir()?;
         let random_number: u16 = rng.gen();
         let tmp_path = tmp_dir
-            .as_ref()
-            .to_path_buf()
+            .path()
             .join(format!("{}.e2store_stream_test", random_number));
 
         // create a new e2store file and write some data to it
-        let mut e2store_write_stream = E2StoreStream::create(&tmp_path)?;
+        let mut e2store_stream_writer = E2StoreStreamWriter::new(&tmp_path)?;
 
         let version = VersionEntry::default();
-        e2store_write_stream.append_entry(&version.clone().into())?;
+        e2store_stream_writer.append_entry(&version.clone().into())?;
 
         let value: Vec<u8> = (0..100).map(|_| rng.gen_range(0..20)).collect();
         let entry = Entry::new(0, value);
-        e2store_write_stream.append_entry(&entry)?;
-        drop(e2store_write_stream);
+        e2store_stream_writer.append_entry(&entry)?;
+        e2store_stream_writer.flush()?;
+        drop(e2store_stream_writer);
 
         // read results and see if they match
-        let mut e2store_read_stream = E2StoreStream::open(&tmp_path)?;
-        let read_version_entry = VersionEntry::try_from(&e2store_read_stream.next_entry()?)?;
+        let mut e2store_stream_reader = E2StoreStreamReader::new(&tmp_path)?;
+        let read_version_entry = VersionEntry::try_from(&e2store_stream_reader.next_entry()?)?;
         assert_eq!(version, read_version_entry);
-        let read_entry = e2store_read_stream.next_entry()?;
+        let read_entry = e2store_stream_reader.next_entry()?;
         assert_eq!(entry, read_entry);
 
         // cleanup

--- a/trin-execution/src/subcommands/era2/export.rs
+++ b/trin-execution/src/subcommands/era2/export.rs
@@ -7,7 +7,7 @@ use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_rlp::Decodable;
 use anyhow::ensure;
 use e2store::era2::{
-    AccountEntry, AccountOrStorageEntry, Era2, StorageEntry, StorageItem, MAX_STORAGE_ITEMS,
+    AccountEntry, AccountOrStorageEntry, Era2Writer, StorageEntry, StorageItem, MAX_STORAGE_ITEMS,
 };
 use eth_trie::{EthTrie, Trie};
 use ethportal_api::{types::state_trie::account_state::AccountState, Header};
@@ -69,7 +69,7 @@ impl StateExporter {
             "Exporting state from block number: {} with state root: {}",
             self.header.number, self.header.state_root
         );
-        let mut era2 = Era2::create(self.config.path_to_era2.clone(), self.header.clone())?;
+        let mut era2 = Era2Writer::new(&self.config.path_to_era2, self.header.clone())?;
         info!("Era2 initiated");
         info!("Trie leaf iterator initiated");
         let mut accounts_exported = 0;
@@ -127,6 +127,8 @@ impl StateExporter {
                 info!("Processed {} accounts", accounts_exported);
             }
         }
+
+        era2.flush()?;
 
         info!("Era2 snapshot exported");
 

--- a/trin-execution/src/subcommands/era2/export.rs
+++ b/trin-execution/src/subcommands/era2/export.rs
@@ -69,7 +69,7 @@ impl StateExporter {
             "Exporting state from block number: {} with state root: {}",
             self.header.number, self.header.state_root
         );
-        let mut era2 = Era2Writer::new(&self.config.path_to_era2, self.header.clone())?;
+        let mut era2 = Era2Writer::create(&self.config.path_to_era2, self.header.clone())?;
         info!("Era2 initiated");
         info!("Trie leaf iterator initiated");
         let mut accounts_exported = 0;

--- a/trin-execution/src/subcommands/era2/import.rs
+++ b/trin-execution/src/subcommands/era2/import.rs
@@ -56,7 +56,7 @@ impl StateImporter {
     pub fn import_state(&self) -> anyhow::Result<Header> {
         info!("Importing state from .era2 file");
 
-        let mut era2 = Era2Reader::new(&self.config.path_to_era2)?;
+        let mut era2 = Era2Reader::open(&self.config.path_to_era2)?;
         info!("Era2 reader initiated");
         let mut accounts_imported = 0;
         while let Some(account) = era2.next() {

--- a/trin-execution/src/subcommands/era2/import.rs
+++ b/trin-execution/src/subcommands/era2/import.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, sync::Arc};
 
 use anyhow::{ensure, Error};
-use e2store::era2::{AccountEntry, AccountOrStorageEntry, Era2, StorageItem};
+use e2store::era2::{AccountEntry, AccountOrStorageEntry, Era2Reader, StorageItem};
 use eth_trie::{EthTrie, Trie};
 use ethportal_api::Header;
 use revm_primitives::{keccak256, B256, U256};
@@ -56,7 +56,7 @@ impl StateImporter {
     pub fn import_state(&self) -> anyhow::Result<Header> {
         info!("Importing state from .era2 file");
 
-        let mut era2 = Era2::open(self.config.path_to_era2.clone())?;
+        let mut era2 = Era2Reader::new(&self.config.path_to_era2)?;
         info!("Era2 reader initiated");
         let mut accounts_imported = 0;
         while let Some(account) = era2.next() {


### PR DESCRIPTION
### What was wrong?

The `E2StoreStream` uses `File` structure for reading/writing into file. This can be more optimized by using `BufReader`/`BufWriter`.

### How was it fixed?

I split `E2StoreStream` into `E2StoreStreamReader` and `E2StoreStreamWriter` that use `BufReader`/`BufWriter`. I also had to split `Era2` into `Era2Reader` and `Era2Writer`.

In my opinion, this split makes more sense as it would most likely be wrong to read and write into the same file at the same time.

To measure if this actually improves performance as I expect, I did the following:

0. generated era2 files for blocks 3 million, 4 million and 5 million
1. built release version of `trin-execution` binary at both `master` and this `pr`
2. for both builds (master/pr), imported each era2 state into clean directory
3. exported era2 from directory from step2

Here are the results

| block number | import master | import pr | export master | export pr |
|--------------|---------------|-----------|---------------|-----------|
| 3'000'000    | 2m11s         | 2m10s     | 37s           | 18s       |
| 4'000'000    | 8m55s         | 9m01s     | 2m44s         | 1m35s     |
| 5'000'000    | 54m22s        | 52m55s    | 43m38s        | 37m02s    |

We can see that there is no big difference when in comes to importing era2 file (reading), but there is noticeable improvement for exporting (writing). 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
