### PR TITLE
refactor: split census into multiple types

### DIFF
--- a/portal-bridge/src/census/mod.rs
+++ b/portal-bridge/src/census/mod.rs
@@ -16,8 +16,8 @@ mod peers;
 pub enum CensusError {
     #[error("No peers found in Census")]
     NoPeers,
-    #[error("Failed to initialize Census")]
-    FailedInitialization,
+    #[error("Failed to initialize Census: {0}")]
+    FailedInitialization(&'static str),
     #[error("Subnetwork {0} is not supported")]
     UnsupportedSubnetwork(Subnetwork),
     #[error("Census already initialized")]
@@ -49,7 +49,7 @@ impl Census {
         }
     }
 
-    /// Returns ENRs interested into provided content id.
+    /// Returns ENRs interested in provided content id.
     pub fn get_interested_enrs(
         &self,
         subnetwork: Subnetwork,
@@ -77,6 +77,9 @@ impl Census {
         self.initialized = true;
 
         let subnetworks = HashSet::from_iter(subnetworks);
+        if subnetworks.is_empty() {
+            return Err(CensusError::FailedInitialization("No subnetwork"));
+        }
         for subnetwork in &subnetworks {
             info!("Initializing {subnetwork} subnetwork");
             match subnetwork {

--- a/portal-bridge/src/census/network.rs
+++ b/portal-bridge/src/census/network.rs
@@ -1,19 +1,11 @@
-use alloy_primitives::U256;
-use anyhow::{anyhow, bail};
-use delay_map::HashMapDelay;
+use anyhow::anyhow;
 use discv5::enr::NodeId;
 use ethportal_api::{
-    generate_random_remote_enr,
-    jsonrpsee::http_client::HttpClient,
-    types::{
-        distance::{Distance, Metric, XorMetric},
-        network::Subnetwork,
-        portal::PongInfo,
-    },
+    generate_random_remote_enr, jsonrpsee::http_client::HttpClient, types::network::Subnetwork,
     BeaconNetworkApiClient, Enr, HistoryNetworkApiClient, StateNetworkApiClient,
 };
-use rand::seq::IteratorRandom;
-use tokio::time::{Duration, Instant};
+use futures::StreamExt;
+use tokio::time::Instant;
 use tracing::{error, info, warn};
 
 use crate::{
@@ -21,15 +13,13 @@ use crate::{
     cli::{BridgeConfig, ClientType},
 };
 
-/// Ping delay for liveness check of peers in census
-/// One hour was chosen after 2mins was too slow, and can be adjusted
-/// in the future based on performance
-const LIVENESS_CHECK_DELAY: Duration = Duration::from_secs(3600);
+use super::peers::Peers;
 
 /// The network struct is responsible for maintaining a list of known peers
 /// in the given subnetwork.
+#[derive(Clone)]
 pub struct Network {
-    pub peers: HashMapDelay<[u8; 32], (Enr, Distance)>,
+    peers: Peers,
     client: HttpClient,
     subnetwork: Subnetwork,
     filter_clients: Vec<ClientType>,
@@ -46,7 +36,7 @@ impl Network {
         }
 
         Self {
-            peers: HashMapDelay::new(LIVENESS_CHECK_DELAY),
+            peers: Peers::new(),
             client,
             subnetwork,
             filter_clients: bridge_config.filter_clients.to_vec(),
@@ -54,102 +44,8 @@ impl Network {
         }
     }
 
-    // We initialize a network with a random rfn lookup to get an initial view of the network
-    // and then iterate through the rfn of each peer to find new peers. Since this initialization
-    // blocks the bridge's gossip feature, there is a tradeoff between the time taken to initialize
-    // the census and the time taken to start gossiping. In the future, we might consider updating
-    // the initialization process to be considered complete after it has found ~100% of the network
-    // peers. However, since the census continues to iterate through the peers after initialization,
-    // the initialization is just to reach a critical mass of peers so that gossip can begin.
-    pub async fn init(&mut self) {
-        match self.filter_clients.is_empty() {
-            true => info!("Initializing {} network census", self.subnetwork),
-            false => info!(
-                "Initializing {} network census with filtered clients: {:?}",
-                self.subnetwork, self.filter_clients
-            ),
-        }
-        let (_, random_enr) = generate_random_remote_enr();
-        let Ok(initial_enrs) = self
-            .recursive_find_nodes(&self.client, random_enr.node_id())
-            .await
-        else {
-            panic!("Failed to initialize network census");
-        };
-
-        // if this initialization is too slow, we can consider
-        // refactoring the peers structure so that it can be
-        // run in parallel
-        for enr in initial_enrs {
-            self.process_enr(enr).await;
-        }
-        if self.peers.is_empty() {
-            panic!(
-                "Failed to initialize {} census, couldn't find any peers.",
-                self.subnetwork
-            );
-        }
-        info!(
-            "Initialized {} census: found peers: {}",
-            self.subnetwork,
-            self.peers.len()
-        );
-    }
-
-    /// Only processes an enr (iterating through its rfn) if the enr's
-    /// liveness delay has expired
-    pub async fn process_enr(&mut self, enr: Enr) {
-        // ping for liveliness check
-        if !self.liveness_check(enr.clone()).await {
-            return;
-        }
-        // iterate peers routing table via rfn over various distances
-        for distance in 245..257 {
-            let Ok(result) = self
-                .find_nodes(&self.client, enr.clone(), vec![distance])
-                .await
-            else {
-                warn!("Find nodes request failed for enr: {}", enr);
-                continue;
-            };
-            for found_enr in result {
-                let _ = self.liveness_check(found_enr).await;
-            }
-        }
-    }
-
-    // Only perform liveness check on enrs if their deadline is up,
-    // since the same enr might appear multiple times between the
-    // routing tables of different peers.
-    pub async fn liveness_check(&mut self, enr: Enr) -> bool {
-        // skip if client type is filtered
-        let client_type = ClientType::from(&enr);
-        if self.filter_clients.contains(&client_type) {
-            return false;
-        }
-
-        // if enr is already registered, check if delay map deadline has expired
-        if let Some(deadline) = self.peers.deadline(&enr.node_id().raw()) {
-            if Instant::now() < deadline {
-                return false;
-            }
-        }
-
-        match self.ping(&self.client, enr.clone()).await {
-            Ok(pong_info) => {
-                let data_radius = Distance::from(U256::from(pong_info.data_radius));
-                self.peers.insert(enr.node_id().raw(), (enr, data_radius));
-                true
-            }
-            Err(_) => {
-                self.peers.remove(&enr.node_id().raw());
-                false
-            }
-        }
-    }
-
     // Look up all known interested enrs for a given content id
-    pub fn get_interested_enrs(&self, content_id: [u8; 32]) -> Result<Vec<Enr>, CensusError> {
+    pub fn get_interested_enrs(&self, content_id: &[u8; 32]) -> Result<Vec<Enr>, CensusError> {
         if self.peers.is_empty() {
             error!(
                 "No known peers in {} census, unable to offer.",
@@ -159,59 +55,168 @@ impl Network {
         }
         Ok(self
             .peers
-            .iter()
-            .filter_map(|(node_id, (enr, data_radius))| {
-                let distance = XorMetric::distance(node_id, &content_id);
-                if data_radius >= &distance {
-                    Some(enr.clone())
-                } else {
-                    None
+            .get_interested_enrs(content_id, self.enr_offer_limit))
+    }
+
+    /// Initialize the peers.
+    ///
+    /// We initialize a network with a random rfn lookup to get an initial view of the network
+    /// and then iterate through the rfn of each peer to find new peers. Since this initialization
+    /// blocks the bridge's gossip feature, there is a tradeoff between the time taken to initialize
+    /// the census and the time taken to start gossiping. In the future, we might consider updating
+    /// the initialization process to be considered complete after it has found ~100% of the network
+    /// peers. However, since the census continues to iterate through the peers after
+    /// initialization, the initialization is just to reach a critical mass of peers so that gossip
+    /// can begin.
+    pub async fn init(&self) -> Result<(), CensusError> {
+        match self.filter_clients.is_empty() {
+            true => info!("Initializing {} network census", self.subnetwork),
+            false => info!(
+                "Initializing {} network census with filtered clients: {:?}",
+                self.subnetwork, self.filter_clients
+            ),
+        }
+        let (_, random_enr) = generate_random_remote_enr();
+        let Ok(initial_enrs) = self.recursive_find_nodes(random_enr.node_id()).await else {
+            error!(
+                "Failed to initialize {} census, RFN failed",
+                self.subnetwork
+            );
+            return Err(CensusError::FailedInitialization);
+        };
+
+        // if this initialization is too slow, we can consider
+        // refactoring the peers structure so that it can be
+        // run in parallel
+        for enr in initial_enrs {
+            self.process_enr(enr).await;
+        }
+        if self.peers.is_empty() {
+            error!(
+                "Failed to initialize {} census, couldn't find any peers.",
+                self.subnetwork
+            );
+            return Err(CensusError::FailedInitialization);
+        }
+        info!(
+            "Initialized {} census: found peers: {}",
+            self.subnetwork,
+            self.peers.len()
+        );
+        Ok(())
+    }
+
+    /// Returns next peer to process.
+    pub async fn peer_to_process(&mut self) -> Option<Result<Enr, String>> {
+        self.peers.next().await
+    }
+
+    /// Processes the peer.
+    ///
+    /// If no peer is found, reinitilizes the network.
+    pub async fn process_peer(&self, peer: Option<Result<Enr, String>>) {
+        let subnetwork = &self.subnetwork;
+        match peer {
+            Some(Ok(enr)) => {
+                self.process_enr(enr).await;
+            }
+            Some(Err(err)) => {
+                error!("Error getting peer to process for {subnetwork} subnetwork: {err}");
+            }
+            None => {
+                warn!("No peers pending! Re-initializing {subnetwork} subnetwork");
+                if let Err(err) = self.init().await {
+                    error!("Error initializing {subnetwork} subnetwork: {err}");
                 }
-            })
-            .choose_multiple(&mut rand::thread_rng(), self.enr_offer_limit))
+            }
+        }
     }
 
-    async fn ping(&self, client: &HttpClient, enr: Enr) -> anyhow::Result<PongInfo> {
-        let result = match self.subnetwork {
-            Subnetwork::History => HistoryNetworkApiClient::ping(client, enr).await,
-            Subnetwork::State => StateNetworkApiClient::ping(client, enr).await,
-            Subnetwork::Beacon => BeaconNetworkApiClient::ping(client, enr).await,
-            _ => bail!("Unsupported subnetwork: {}", self.subnetwork),
+    /// Only processes an enr (iterating through its rfn) if the enr's
+    /// liveness delay has expired
+    async fn process_enr(&self, enr: Enr) {
+        // ping for liveliness check
+        if !self.liveness_check(enr.clone()).await {
+            return;
+        }
+        // iterate peers routing table via rfn over various distances
+        for distance in 245..257 {
+            let Ok(result) = self.find_nodes(enr.clone(), vec![distance]).await else {
+                warn!("Find nodes request failed for enr: {}", enr);
+                continue;
+            };
+            for found_enr in result {
+                self.liveness_check(found_enr).await;
+            }
+        }
+        info!(
+            "Updated {} census. Available peers: {}",
+            self.subnetwork,
+            self.peers.len(),
+        );
+    }
+
+    /// Performs liveness check.
+    ///
+    /// Liveness check will pass if
+    /// If they are registered but expired, we shouldn't perform liveness checked now as it will be
+    /// done when they are polled as expired (soon).
+    pub async fn liveness_check(&self, enr: Enr) -> bool {
+        // skip if client type is filtered
+        let client_type = ClientType::from(&enr);
+        if self.filter_clients.contains(&client_type) {
+            return false;
+        }
+
+        // if enr is already registered, check if delay map deadline has expired
+        if let Some(deadline) = self.peers.deadline(&enr) {
+            if Instant::now() < deadline {
+                return false;
+            }
+        }
+
+        self.ping(enr).await
+    }
+
+    async fn ping(&self, enr: Enr) -> bool {
+        let future_response = match self.subnetwork {
+            Subnetwork::History => HistoryNetworkApiClient::ping(&self.client, enr.clone()),
+            Subnetwork::State => StateNetworkApiClient::ping(&self.client, enr.clone()),
+            Subnetwork::Beacon => BeaconNetworkApiClient::ping(&self.client, enr.clone()),
+            _ => unreachable!("Unsupported subnetwork: {}", self.subnetwork),
         };
-        result.map_err(|e| anyhow!(e))
+        let response = future_response.await.map_err(|e| anyhow!(e));
+        self.peers.process_ping_response(enr, response)
     }
 
-    async fn find_nodes(
-        &self,
-        client: &HttpClient,
-        enr: Enr,
-        distances: Vec<u16>,
-    ) -> anyhow::Result<Vec<Enr>> {
+    async fn find_nodes(&self, enr: Enr, distances: Vec<u16>) -> anyhow::Result<Vec<Enr>> {
         let result = match self.subnetwork {
             Subnetwork::History => {
-                HistoryNetworkApiClient::find_nodes(client, enr, distances).await
+                HistoryNetworkApiClient::find_nodes(&self.client, enr, distances).await
             }
-            Subnetwork::State => StateNetworkApiClient::find_nodes(client, enr, distances).await,
-            Subnetwork::Beacon => BeaconNetworkApiClient::find_nodes(client, enr, distances).await,
-            _ => bail!("Unsupported subnetwork: {}", self.subnetwork),
-        };
-        result.map_err(|e| anyhow!(e))
-    }
-
-    async fn recursive_find_nodes(
-        &self,
-        client: &HttpClient,
-        node_id: NodeId,
-    ) -> anyhow::Result<Vec<Enr>> {
-        let result = match self.subnetwork {
-            Subnetwork::History => {
-                HistoryNetworkApiClient::recursive_find_nodes(client, node_id).await
+            Subnetwork::State => {
+                StateNetworkApiClient::find_nodes(&self.client, enr, distances).await
             }
-            Subnetwork::State => StateNetworkApiClient::recursive_find_nodes(client, node_id).await,
             Subnetwork::Beacon => {
-                BeaconNetworkApiClient::recursive_find_nodes(client, node_id).await
+                BeaconNetworkApiClient::find_nodes(&self.client, enr, distances).await
             }
-            _ => bail!("Unsupported subnetwork: {}", self.subnetwork),
+            _ => unreachable!("Unsupported subnetwork: {}", self.subnetwork),
+        };
+        result.map_err(|e| anyhow!(e))
+    }
+
+    async fn recursive_find_nodes(&self, node_id: NodeId) -> anyhow::Result<Vec<Enr>> {
+        let result = match self.subnetwork {
+            Subnetwork::History => {
+                HistoryNetworkApiClient::recursive_find_nodes(&self.client, node_id).await
+            }
+            Subnetwork::State => {
+                StateNetworkApiClient::recursive_find_nodes(&self.client, node_id).await
+            }
+            Subnetwork::Beacon => {
+                BeaconNetworkApiClient::recursive_find_nodes(&self.client, node_id).await
+            }
+            _ => unreachable!("Unsupported subnetwork: {}", self.subnetwork),
         };
         result.map_err(|e| anyhow!(e))
     }

--- a/portal-bridge/src/census/network.rs
+++ b/portal-bridge/src/census/network.rs
@@ -48,7 +48,7 @@ impl Network {
     pub fn get_interested_enrs(&self, content_id: &[u8; 32]) -> Result<Vec<Enr>, CensusError> {
         if self.peers.is_empty() {
             error!(
-                "No known peers in {} census, unable to offer.",
+                "No known peers in {} census, unable to look up interested enrs",
                 self.subnetwork
             );
             return Err(CensusError::NoPeers);
@@ -82,7 +82,9 @@ impl Network {
                 "Failed to initialize {} census, RFN failed",
                 self.subnetwork
             );
-            return Err(CensusError::FailedInitialization);
+            return Err(CensusError::FailedInitialization(
+                "RecursiveFindNodes failed",
+            ));
         };
 
         // if this initialization is too slow, we can consider
@@ -96,10 +98,10 @@ impl Network {
                 "Failed to initialize {} census, couldn't find any peers.",
                 self.subnetwork
             );
-            return Err(CensusError::FailedInitialization);
+            return Err(CensusError::FailedInitialization("No peers found"));
         }
         info!(
-            "Initialized {} census: found peers: {}",
+            "Initialized {} census: found {} peers",
             self.subnetwork,
             self.peers.len()
         );
@@ -113,7 +115,7 @@ impl Network {
 
     /// Processes the peer.
     ///
-    /// If no peer is found, reinitilizes the network.
+    /// If no peer is found, re-initilizes the network.
     pub async fn process_peer(&self, peer: Option<Result<Enr, String>>) {
         let subnetwork = &self.subnetwork;
         match peer {

--- a/portal-bridge/src/census/peers.rs
+++ b/portal-bridge/src/census/peers.rs
@@ -1,0 +1,103 @@
+use std::{
+    pin::Pin,
+    sync::{Arc, RwLock},
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use delay_map::HashMapDelay;
+use ethportal_api::{
+    types::{
+        distance::{Distance, Metric, XorMetric},
+        portal::PongInfo,
+    },
+    Enr,
+};
+use futures::Stream;
+use rand::seq::IteratorRandom;
+use tokio::time::Instant;
+
+/// Ping delay for liveness check of peers in census
+/// One hour was chosen after 2mins was too slow, and can be adjusted
+/// in the future based on performance
+const LIVENESS_CHECK_DELAY: Duration = Duration::from_secs(3600);
+
+type PeersHashMapDelay = HashMapDelay<[u8; 32], (Enr, Distance)>;
+
+#[derive(Clone, Debug)]
+pub(super) struct Peers {
+    pub peers: Arc<RwLock<PeersHashMapDelay>>,
+}
+
+impl Peers {
+    pub fn new() -> Self {
+        Self {
+            peers: Arc::new(RwLock::new(HashMapDelay::new(LIVENESS_CHECK_DELAY))),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.peers.read().expect("to get peers lock").is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.peers.read().expect("to get peers lock").len()
+    }
+
+    pub fn deadline(&self, enr: &Enr) -> Option<Instant> {
+        self.peers
+            .read()
+            .expect("to get peers lock")
+            .deadline(&enr.node_id().raw())
+    }
+
+    pub fn process_ping_response(&self, enr: Enr, ping_response: anyhow::Result<PongInfo>) -> bool {
+        let mut peers = self.peers.write().expect("to get peers lock");
+        match ping_response {
+            Ok(pong_info) => {
+                let data_radius = Distance::from(pong_info.data_radius);
+                peers.insert(enr.node_id().raw(), (enr, data_radius));
+                true
+            }
+            Err(_) => {
+                peers.remove(&enr.node_id().raw());
+                false
+            }
+        }
+    }
+
+    /// Selects random `limit` peers that should be interested into content.
+    pub fn get_interested_enrs(&self, content_id: &[u8; 32], limit: usize) -> Vec<Enr> {
+        self.peers
+            .read()
+            .expect("to get peers lock")
+            .iter()
+            .filter_map(|(node_id, (enr, data_radius))| {
+                let distance = XorMetric::distance(node_id, content_id);
+                if data_radius >= &distance {
+                    Some(enr.clone())
+                } else {
+                    None
+                }
+            })
+            .choose_multiple(&mut rand::thread_rng(), limit)
+    }
+}
+
+impl Stream for Peers {
+    type Item = Result<Enr, String>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.peers
+            .write()
+            .expect("to get peers lock")
+            .poll_expired(cx)
+            .map_ok(|(_node_id, (enr, _distance))| enr)
+    }
+}
+
+impl Default for Peers {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/portal-bridge/src/census/peers.rs
+++ b/portal-bridge/src/census/peers.rs
@@ -26,7 +26,7 @@ type PeersHashMapDelay = HashMapDelay<[u8; 32], (Enr, Distance)>;
 
 #[derive(Clone, Debug)]
 pub(super) struct Peers {
-    pub peers: Arc<RwLock<PeersHashMapDelay>>,
+    peers: Arc<RwLock<PeersHashMapDelay>>,
 }
 
 impl Peers {

--- a/portal-bridge/src/census/peers.rs
+++ b/portal-bridge/src/census/peers.rs
@@ -24,6 +24,10 @@ const LIVENESS_CHECK_DELAY: Duration = Duration::from_secs(3600);
 
 type PeersHashMapDelay = HashMapDelay<[u8; 32], (Enr, Distance)>;
 
+/// Contains all discovered peers on the network.
+///
+/// It provides thread safe access to peers and is responsible for deciding when they should be
+/// pinged for liveness.
 #[derive(Clone, Debug)]
 pub(super) struct Peers {
     peers: Arc<RwLock<PeersHashMapDelay>>,
@@ -66,7 +70,7 @@ impl Peers {
         }
     }
 
-    /// Selects random `limit` peers that should be interested into content.
+    /// Selects random `limit` peers that should be interested in content.
     pub fn get_interested_enrs(&self, content_id: &[u8; 32], limit: usize) -> Vec<Enr> {
         self.peers
             .read()


### PR DESCRIPTION
### What was wrong?

It's difficult to add features (e.g. #1501) to the Census in its current form.

Also, getting peers to gossip content to doesn't have to be asynchronous and as such, doesn't have to go over separate channel.

### How was it fixed?

Split the census into multiple components, each responsible for small part:

- `Peers` - contains all peers (behind RwLock) 
  - responsible for deciding when they should be pinged for liveness
  - in the future, it will also be responsible for holding additional information about peers (e.g. success/failure of other non-ping requests), and scoring peers according to those information
- `Network` - contains and propagates calls to `Peers`
  - responsible for pinging and discovering other peers
- 'Census' - the only entry point for users of Census (i.e. state bridge)
  - responsible for initializing networks and starting service that runs in the background
  - service is responsible for taking available tasks (provided by `Network`) and executing them
    - currently, this is only pinging and querying their routing table

New design allows `Peers` and `Network` (and easily `Census`) to be cloneable and shareable.

This PR shouldn't drastically change the behavior of the census, but it should make adding features easier in the future.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
