### PR TITLE
fix(beacon): revert column name change to `historical_summaries` db table

### DIFF
--- a/trin-storage/src/sql.rs
+++ b/trin-storage/src/sql.rs
@@ -31,7 +31,7 @@ pub const LC_BOOTSTRAP_LATEST_BLOCK_ROOT_QUERY: &str =
 pub const TOTAL_DATA_SIZE_QUERY_BEACON: &str = "SELECT
     (SELECT TOTAL(content_size) FROM lc_bootstrap) +
     (SELECT TOTAL(update_size) FROM lc_update) +
-    (SELECT TOTAL(content_size) FROM historical_summaries) AS total_data_size;";
+    (SELECT TOTAL(update_size) FROM historical_summaries) AS total_data_size;";
 
 pub const LC_UPDATE_CREATE_TABLE: &str = "CREATE TABLE IF NOT EXISTS lc_update (
         period INTEGER PRIMARY KEY,
@@ -58,12 +58,12 @@ pub const HISTORICAL_SUMMARIES_CREATE_TABLE: &str =
         ID INTEGER PRIMARY KEY CHECK (ID = 1),
         epoch INTEGER NOT NULL,
         value BLOB NOT NULL,
-        content_size INTEGER
+        update_size INTEGER
     );";
 
 /// Query to insert or update the historical summaries table.
 pub const INSERT_OR_REPLACE_HISTORICAL_SUMMARIES_QUERY: &str =
-    "INSERT OR REPLACE INTO historical_summaries (id, epoch, value, content_size)
+    "INSERT OR REPLACE INTO historical_summaries (id, epoch, value, update_size)
                       VALUES (?1, ?2, ?3, ?4)";
 
 /// Query to get the historical summary that is greater than or equal to the given epoch.


### PR DESCRIPTION
### What was wrong?
Deploying beacon on testnet bootnodes and state regular nodes, causes Trin to fail because of an implemented db column change without a proper migration. This change was introduced [here](https://github.com/ethereum/trin/pull/1413/files#diff-d79c9290a61b26e8d078e761fe5397feb9ace5b8a73ef8694b7fb74dbe4b905cR57).

I planned to modify the testnet databases with a bash script and ansible, but I had issues connecting to the running docker containers sqlite files and went into a rabbit hole.

### How was it fixed?
Revert the column name change causing the issue back to the original.

This is a quick and dirty?! fix to deploy beacon on testnet without db issues until we implement a proper migration for the beacon db.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
