### PR TITLE
feat: add binary for simple era2 analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,6 +1930,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "anyhow",
+ "clap",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "ethportal-api",
@@ -1939,6 +1940,7 @@ dependencies = [
  "scraper",
  "snap",
  "tokio",
+ "tracing",
  "trin-utils",
 ]
 

--- a/e2store/Cargo.toml
+++ b/e2store/Cargo.toml
@@ -15,11 +15,14 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 anyhow.workspace = true
+clap = { workspace = true, optional = true }
 ethereum_ssz.workspace = true
 ethereum_ssz_derive.workspace = true
 ethportal-api.workspace = true
 rand.workspace = true
 reqwest.workspace = true
+tracing = { workspace = true, optional = true }
+trin-utils = { workspace = true, optional = true }
 scraper.workspace = true
 snap.workspace = true
 
@@ -27,3 +30,10 @@ snap.workspace = true
 rstest.workspace = true
 tokio.workspace = true
 trin-utils.workspace = true
+
+[features]
+era2-stats-binary = ["clap", "tracing", "trin-utils"]
+
+[[bin]]
+name = "era2-stats"
+required-features = ["era2-stats-binary"]

--- a/e2store/README.md
+++ b/e2store/README.md
@@ -21,6 +21,14 @@ era2 is a format made to store full flat state snapshots, one of our first uses 
 
 TODO: Add chart of snapshot size at every million block interval.
 
+### Era2 analysis tool
+
+Analysis tool that reads era2 file and prints basic stats about it can be run with:
+
+```bash
+cargo run -p e2store --bin era2-stats --features era2-stats-binary -- <path>
+```
+
 ## What is the difference between `e2store/memory.rs` and `e2store/stream.rs`
 
 `e2store/memory.rs` provides an api to load a full e2store file such as `.era`/`.era1` and manipulate it in memory. For smaller e2store files this approach works well. The issue comes when dealing with e2store files of much greater size loading the whole file into memory at once often isn't possible. This is where `e2store/stream.rs` comes in where you can stream the data you need from a e2store file as you need it. This is required for `.era2` format for storing full flat state snapshots.

--- a/e2store/src/bin/era2-stats.rs
+++ b/e2store/src/bin/era2-stats.rs
@@ -26,7 +26,8 @@ struct Stats {
 /// Reads the era2 file and prints stats about it.
 ///
 /// It can be run with following command:
-/// ```
+///
+/// ```bash
 /// cargo run -p e2store --bin era2-stats --features era2-stats-binary -- <path>
 /// ```
 fn main() -> anyhow::Result<()> {

--- a/e2store/src/bin/era2-stats.rs
+++ b/e2store/src/bin/era2-stats.rs
@@ -1,0 +1,72 @@
+use std::path::PathBuf;
+
+use anyhow::bail;
+use clap::Parser;
+use e2store::era2::{AccountOrStorageEntry, Era2Reader};
+use tracing::info;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "Era2 stats",
+    about = "Reads the era2 file and prints stats about it."
+)]
+struct Config {
+    #[arg(help = "The path to the era2 file.")]
+    path: PathBuf,
+}
+
+#[derive(Debug, Default)]
+struct Stats {
+    account_count: usize,
+    bytecode_count: usize,
+    storage_entry_count: usize,
+    storage_item_count: usize,
+}
+
+/// Reads the era2 file and prints stats about it.
+///
+/// It can be run with following command:
+/// ```
+/// cargo run -p e2store --bin era2-stats --features era2-stats-binary -- <path>
+/// ```
+fn main() -> anyhow::Result<()> {
+    trin_utils::log::init_tracing_logger();
+
+    let config = Config::parse();
+    let mut reader = Era2Reader::open(&config.path)?;
+
+    info!(
+        "Processing era2 file for block: {}",
+        reader.header.header.number
+    );
+
+    let mut stats = Stats::default();
+    while let Some(entry) = reader.next() {
+        let AccountOrStorageEntry::Account(account) = entry else {
+            bail!("Expected account entry");
+        };
+        stats.account_count += 1;
+
+        if !account.bytecode.is_empty() {
+            stats.bytecode_count += 1;
+        }
+
+        for _ in 0..account.storage_count {
+            let Some(AccountOrStorageEntry::Storage(storage)) = reader.next() else {
+                bail!(
+                    "Expected storage entry for account: {}",
+                    account.address_hash
+                );
+            };
+            stats.storage_entry_count += 1;
+            stats.storage_item_count += storage.len();
+        }
+
+        if stats.account_count % 1_000_000 == 0 {
+            info!("Processed {} accounts", stats.account_count);
+        }
+    }
+
+    info!("Done! {stats:#?}");
+    Ok(())
+}


### PR DESCRIPTION
Adding binary that reads era2 file and prints most basic stats.

I used it to measure performance improvements of #1509, but I think it can't hurt to merge it as well (as it can easily be modified to do more complex analysis).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
