### PR TITLE
refactor(build): use alloy as dependency instead of invidivual crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "alloy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056f2c01b2aed86e15b43c47d109bfc8b82553dc34e66452875e51247ec31ab2"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-network",
+ "alloy-provider",
+ "alloy-pubsub",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-transport-ipc",
+ "alloy-transport-ws",
+]
+
+[[package]]
 name = "alloy-chains"
 version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +155,57 @@ dependencies = [
  "c-kzg",
  "derive_more 1.0.0",
  "serde",
+]
+
+[[package]]
+name = "alloy-contract"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917f7d12cf3971dc8c11c9972f732b35ccb9aaaf5f28f2f87e9e6523bee3a8ad"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-pubsub",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "alloy-transport",
+ "futures",
+ "futures-util",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-core"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb750349efda145ca6aada68d0336067f7f364d7d44ef09e2cf000b040c5e99"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f95d76a38cae906fd394a5afb0736aaceee5432efe76addfd71048e623e208af"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "const-hex",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow",
 ]
 
 [[package]]
@@ -173,6 +247,17 @@ dependencies = [
  "once_cell",
  "serde",
  "sha2 0.10.8",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8429cf4554eed9b40feec7f4451113e76596086447550275e3def933faf47ce3"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
 ]
 
 [[package]]
@@ -279,6 +364,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
+ "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-transport",
  "alloy-transport-http",
@@ -392,8 +478,6 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "derive_more 1.0.0",
- "jsonwebtoken",
- "rand",
  "serde",
  "strum",
 ]
@@ -1832,7 +1916,7 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 name = "e2store"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy",
  "alloy-rlp",
  "anyhow",
  "clap",
@@ -2082,10 +2166,9 @@ dependencies = [
 name = "ethportal-api"
 version = "0.2.2"
 dependencies = [
- "alloy-consensus",
- "alloy-primitives",
+ "alloy",
  "alloy-rlp",
- "alloy-rpc-types",
+ "alloy-rpc-types-eth",
  "anyhow",
  "base64 0.13.1",
  "bimap",
@@ -2138,8 +2221,7 @@ dependencies = [
 name = "ethportal-peertest"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
- "alloy-rlp",
+ "alloy",
  "anyhow",
  "discv5",
  "e2store",
@@ -3245,21 +3327,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "9.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
-dependencies = [
- "base64 0.21.7",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3425,7 +3492,7 @@ dependencies = [
 name = "light-client"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy",
  "anyhow",
  "async-trait",
  "chrono",
@@ -4012,16 +4079,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
-dependencies = [
- "base64 0.22.1",
- "serde",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4192,8 +4249,7 @@ dependencies = [
 name = "portal-bridge"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
- "alloy-rlp",
+ "alloy",
  "anyhow",
  "async-trait",
  "chrono",
@@ -4238,7 +4294,7 @@ dependencies = [
 name = "portalnet"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy",
  "anyhow",
  "async-trait",
  "bytes",
@@ -4730,8 +4786,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.0.7"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.7#75b7172cf77eb4fd65fe1a6924f75066fb09fcd1"
+version = "1.0.8"
+source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.8#d72e438c06e040e213b5decf5f29543c86cbad0f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4902,9 +4958,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 name = "rpc"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types",
+ "alloy",
  "discv5",
  "eth_trie",
  "ethportal-api",
@@ -5606,18 +5660,6 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core",
-]
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror",
- "time",
 ]
 
 [[package]]
@@ -6539,11 +6581,7 @@ dependencies = [
 name = "trin"
 version = "0.1.0"
 dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-provider",
- "alloy-pubsub",
- "alloy-rpc-types",
+ "alloy",
  "anyhow",
  "clap",
  "dirs",
@@ -6588,7 +6626,7 @@ dependencies = [
 name = "trin-beacon"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy",
  "anyhow",
  "chrono",
  "discv5",
@@ -6617,9 +6655,7 @@ dependencies = [
 name = "trin-evm"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types",
+ "alloy",
  "ethportal-api",
  "revm",
  "revm-primitives",
@@ -6630,11 +6666,9 @@ dependencies = [
 name = "trin-execution"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
+ "alloy",
  "alloy-rlp",
- "alloy-rpc-types",
+ "alloy-rpc-types-engine",
  "anyhow",
  "clap",
  "e2store",
@@ -6666,7 +6700,7 @@ dependencies = [
 name = "trin-history"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy",
  "anyhow",
  "discv5",
  "env_logger 0.9.3",
@@ -6706,8 +6740,7 @@ dependencies = [
 name = "trin-state"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
- "alloy-rlp",
+ "alloy",
  "anyhow",
  "discv5",
  "env_logger 0.9.3",
@@ -6736,7 +6769,7 @@ dependencies = [
 name = "trin-storage"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy",
  "anyhow",
  "discv5",
  "ethportal-api",
@@ -6770,8 +6803,7 @@ dependencies = [
 name = "trin-validation"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
- "alloy-rlp",
+ "alloy",
  "anyhow",
  "enr",
  "ethereum_hashing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,7 @@ categories = ["cryptography::cryptocurrencies"]
 description = "A Rust implementation of the Ethereum Portal Network"
 
 [dependencies]
-alloy-eips.workspace = true
-alloy-primitives.workspace = true
-alloy-provider = { version = "0.4.2", features = ["ipc", "ws"]}
-alloy-pubsub = { version = "0.4.2" }
-alloy-rpc-types.workspace = true
+alloy = { workspace = true, features = ["eips", "provider-ipc", "provider-ws", "pubsub", "reqwest", "rpc-types"] }
 anyhow.workspace = true
 clap.workspace = true
 dirs = "5.0.1"
@@ -80,11 +76,8 @@ members = [
 ]
 
 [workspace.dependencies]
-alloy-consensus = "0.4.2"
-alloy-eips = "0.4.2"
-alloy-primitives = { version ="0.8.7" , features = ["map-hashbrown"] }
-alloy-rlp = "0.3.8"
-alloy-rpc-types = "0.4.2"
+alloy = { version = "0.4.2", default-features = false, features = ["std"] }
+alloy-rlp = { version = "0.3.8", default-features = false, features = ["derive"] }
 anyhow = "1.0.68"
 async-trait = "0.1.68"
 bytes = "1.3.0"
@@ -114,7 +107,7 @@ r2d2 = "0.8.9"
 r2d2_sqlite = "0.24.0"
 rand = "0.8.5"
 reqwest = { version = "0.12.7", features = ["native-tls-vendored", "json"] }
-reth-ipc = { tag = "v1.0.7", git = "https://github.com/paradigmxyz/reth.git"}
+reth-ipc = { tag = "v1.0.8", git = "https://github.com/paradigmxyz/reth.git"}
 revm = { version = "14.0.3", default-features = false, features = ["std", "secp256k1", "serde-json", "c-kzg"] }
 revm-primitives = { version = "10.0.0", default-features = false, features = ["std", "serde"] }
 rpc = { path = "rpc"}

--- a/e2store/Cargo.toml
+++ b/e2store/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy = { workspace = true, features = ["rlp"] }
 alloy-rlp.workspace = true
 anyhow.workspace = true
 clap = { workspace = true, optional = true }

--- a/e2store/src/era1.rs
+++ b/e2store/src/era1.rs
@@ -5,8 +5,10 @@ use crate::{
     },
     types::HeaderEntry,
 };
-use alloy_primitives::{B256, U256};
-use alloy_rlp::Decodable;
+use alloy::{
+    primitives::{B256, U256},
+    rlp::Decodable,
+};
 use anyhow::ensure;
 use ethportal_api::types::execution::{block_body::BlockBody, receipts::Receipts};
 use std::{
@@ -201,7 +203,7 @@ impl TryInto<Entry> for BodyEntry {
     type Error = anyhow::Error;
 
     fn try_into(self) -> Result<Entry, Self::Error> {
-        let rlp_encoded = alloy_rlp::encode(self.body);
+        let rlp_encoded = alloy::rlp::encode(self.body);
         let buf: Vec<u8> = vec![];
         let mut encoder = snap::write::FrameEncoder::new(buf);
         let _ = encoder.write(&rlp_encoded)?;
@@ -239,7 +241,7 @@ impl TryInto<Entry> for ReceiptsEntry {
     type Error = anyhow::Error;
 
     fn try_into(self) -> Result<Entry, Self::Error> {
-        let rlp_encoded = alloy_rlp::encode(&self.receipts);
+        let rlp_encoded = alloy::rlp::encode(&self.receipts);
         let buf: Vec<u8> = vec![];
         let mut encoder = snap::write::FrameEncoder::new(buf);
         let _ = encoder.write(&rlp_encoded)?;

--- a/e2store/src/era2.rs
+++ b/e2store/src/era2.rs
@@ -32,8 +32,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use alloy_primitives::{hex, B256, U256};
-use alloy_rlp::{Decodable, RlpDecodable, RlpEncodable};
+use alloy::{
+    primitives::{hex, B256, U256},
+    rlp::{Decodable, RlpDecodable, RlpEncodable},
+};
 use anyhow::{bail, ensure};
 use ethportal_api::types::{execution::header::Header, state_trie::account_state::AccountState};
 
@@ -247,7 +249,7 @@ impl TryFrom<AccountEntry> for Entry {
     type Error = anyhow::Error;
 
     fn try_from(value: AccountEntry) -> Result<Self, Self::Error> {
-        let rlp_encoded = alloy_rlp::encode(value);
+        let rlp_encoded = alloy::rlp::encode(value);
         let mut encoder = snap::write::FrameEncoder::new(vec![]);
         let bytes_written = encoder.write(&rlp_encoded)?;
         ensure!(
@@ -300,7 +302,7 @@ impl TryFrom<StorageEntry> for Entry {
     type Error = anyhow::Error;
 
     fn try_from(value: StorageEntry) -> Result<Self, Self::Error> {
-        let rlp_encoded = alloy_rlp::encode(value.0);
+        let rlp_encoded = alloy::rlp::encode(value.0);
         let mut encoder = snap::write::FrameEncoder::new(vec![]);
         let bytes_written = encoder.write(&rlp_encoded)?;
         ensure!(
@@ -314,7 +316,7 @@ impl TryFrom<StorageEntry> for Entry {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, Bloom, B64};
+    use alloy::primitives::{Address, Bloom, B64};
     use trin_utils::dir::create_temp_test_dir;
 
     use crate::e2store::types::VersionEntry;

--- a/e2store/src/types.rs
+++ b/e2store/src/types.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Write};
 
-use alloy_rlp::Decodable;
+use alloy::rlp::Decodable;
 use anyhow::ensure;
 use ethportal_api::Header;
 
@@ -35,7 +35,7 @@ impl TryFrom<HeaderEntry> for Entry {
     type Error = anyhow::Error;
 
     fn try_from(value: HeaderEntry) -> Result<Self, Self::Error> {
-        let rlp_encoded = alloy_rlp::encode(value.header);
+        let rlp_encoded = alloy::rlp::encode(value.header);
         let buf: Vec<u8> = vec![];
         let mut encoder = snap::write::FrameEncoder::new(buf);
         let _ = encoder.write(&rlp_encoded)?;

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -11,10 +11,9 @@ categories = ["cryptography::cryptocurrencies"]
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-consensus.workspace = true
-alloy-primitives.workspace = true
+alloy = { workspace = true, features = ["consensus", "rlp", "rpc-types-eth", "serde"] }
 alloy-rlp.workspace = true
-alloy-rpc-types.workspace = true
+alloy-rpc-types-eth = { version = "0.4.2", default-features = false, features = ["serde"] }
 anyhow.workspace = true
 base64 = "0.13.0"
 bimap = "0.6.3"

--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     RawContentValue, RoutingTableInfo,
 };
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use discv5::enr::NodeId;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 

--- a/ethportal-api/src/eth.rs
+++ b/ethportal-api/src/eth.rs
@@ -1,5 +1,7 @@
-use alloy_primitives::{Address, Bytes, B256, U256};
-use alloy_rpc_types::{Block, BlockId, TransactionRequest};
+use alloy::{
+    primitives::{Address, Bytes, B256, U256},
+    rpc::types::{Block, BlockId, TransactionRequest},
+};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Web3 JSON-RPC endpoints

--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use clap::{
     arg,
     error::{Error, ErrorKind},

--- a/ethportal-api/src/types/consensus/beacon_block.rs
+++ b/ethportal-api/src/types/consensus/beacon_block.rs
@@ -3,7 +3,7 @@ use crate::consensus::{
     fork::ForkName,
     signature::BlsSignature,
 };
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use jsonrpsee::core::Serialize;
 use rs_merkle::{algorithms::Sha256, MerkleTree};
 use serde::Deserialize;

--- a/ethportal-api/src/types/consensus/beacon_state.rs
+++ b/ethportal-api/src/types/consensus/beacon_state.rs
@@ -10,7 +10,7 @@ use crate::consensus::{
     pubkey::PubKey,
     sync_committee::SyncCommittee,
 };
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use discv5::enr::k256::elliptic_curve::consts::{U1099511627776, U2048, U4, U65536, U8192};
 use jsonrpsee::core::Serialize;
 use rs_merkle::{algorithms::Sha256, MerkleTree};

--- a/ethportal-api/src/types/consensus/body.rs
+++ b/ethportal-api/src/types/consensus/body.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     types::bytes::ByteList1G,
 };
-use alloy_primitives::{Address, B256};
+use alloy::primitives::{Address, B256};
 use discv5::enr::k256::elliptic_curve::consts::U16;
 use rs_merkle::{algorithms::Sha256, MerkleTree};
 use serde::{Deserialize, Serialize};

--- a/ethportal-api/src/types/consensus/execution_payload.rs
+++ b/ethportal-api/src/types/consensus/execution_payload.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     utils::serde::{hex_fixed_vec, hex_var_list},
 };
-use alloy_primitives::{Address, B256, U256};
+use alloy::primitives::{Address, B256, U256};
 use rs_merkle::{algorithms::Sha256, MerkleTree};
 use serde::{Deserialize, Serialize};
 use serde_this_or_that::as_u64;

--- a/ethportal-api/src/types/consensus/header.rs
+++ b/ethportal-api/src/types/consensus/header.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use serde::{Deserialize, Serialize};
 use serde_this_or_that::as_u64;
 use ssz_derive::{Decode, Encode};

--- a/ethportal-api/src/types/consensus/historical_summaries.rs
+++ b/ethportal-api/src/types/consensus/historical_summaries.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum, FixedVector, VariableList};

--- a/ethportal-api/src/types/consensus/light_client/bootstrap.rs
+++ b/ethportal-api/src/types/consensus/light_client/bootstrap.rs
@@ -6,7 +6,7 @@ use crate::{
         sync_committee::SyncCommittee,
     },
 };
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use serde::{Deserialize, Serialize};
 use ssz::Decode;
 use ssz_derive::{Decode, Encode};

--- a/ethportal-api/src/types/consensus/light_client/finality_update.rs
+++ b/ethportal-api/src/types/consensus/light_client/finality_update.rs
@@ -9,7 +9,7 @@ use crate::{
         },
     },
 };
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use serde::{Deserialize, Serialize};
 use serde_this_or_that::as_u64;
 use ssz::Decode;

--- a/ethportal-api/src/types/consensus/light_client/header.rs
+++ b/ethportal-api/src/types/consensus/light_client/header.rs
@@ -1,7 +1,7 @@
 use crate::types::consensus::{
     execution_payload::ExecutionPayloadHeaderCapella, fork::ForkName, header::BeaconBlockHeader,
 };
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use serde::{Deserialize, Serialize};
 use ssz::Decode;
 use ssz_derive::{Decode, Encode};

--- a/ethportal-api/src/types/consensus/light_client/update.rs
+++ b/ethportal-api/src/types/consensus/light_client/update.rs
@@ -7,7 +7,7 @@ use crate::{
         sync_committee::SyncCommittee,
     },
 };
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use serde::{Deserialize, Serialize};
 use serde_this_or_that::as_u64;
 use ssz::Decode;

--- a/ethportal-api/src/types/consensus/serde.rs
+++ b/ethportal-api/src/types/consensus/serde.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::U256;
+use alloy::primitives::U256;
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serializer};
 use serde_json::Value;
 use ssz_types::VariableList;

--- a/ethportal-api/src/types/content_key/state.rs
+++ b/ethportal-api/src/types/content_key/state.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest as Sha2Digest, Sha256};
 use ssz::{Decode, DecodeError, Encode};
@@ -175,7 +175,7 @@ impl fmt::Display for StateContentKey {
 mod test {
     use std::{path::PathBuf, str::FromStr};
 
-    use alloy_primitives::{bytes, keccak256, Address, Bytes};
+    use alloy::primitives::{bytes, keccak256, Address, Bytes};
     use anyhow::Result;
     use rstest::rstest;
     use serde_yaml::Value;

--- a/ethportal-api/src/types/content_value/state.rs
+++ b/ethportal-api/src/types/content_value/state.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 
@@ -119,7 +119,7 @@ pub struct ContractBytecodeWithProof {
 mod test {
     use std::path::PathBuf;
 
-    use alloy_primitives::Bytes;
+    use alloy::primitives::Bytes;
     use anyhow::Result;
     use rstest::rstest;
     use serde::Deserialize;

--- a/ethportal-api/src/types/distance.rs
+++ b/ethportal-api/src/types/distance.rs
@@ -1,6 +1,6 @@
 use std::{fmt, ops::Deref};
 
-use alloy_primitives::U256;
+use alloy::primitives::U256;
 
 pub type DataRadius = U256;
 

--- a/ethportal-api/src/types/execution/accumulator.rs
+++ b/ethportal-api/src/types/execution/accumulator.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::U256;
+use alloy::primitives::U256;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum, VariableList};

--- a/ethportal-api/src/types/execution/block_body.rs
+++ b/ethportal-api/src/types/execution/block_body.rs
@@ -1,7 +1,9 @@
 use std::vec;
 
-use alloy_primitives::{keccak256, B256};
-use alloy_rlp::{Decodable, Encodable, Error as RlpError, Header as RlpHeader};
+use alloy::{
+    primitives::{keccak256, B256},
+    rlp::{Decodable, Encodable, Error as RlpError, Header as RlpHeader},
+};
 use anyhow::{anyhow, bail};
 use serde::Deserialize;
 use ssz::{Encode, SszDecoderBuilder, SszEncoder};
@@ -214,8 +216,8 @@ impl ssz::Encode for BlockBodyLegacy {
         let offset =
             <Vec<Vec<u8>> as Encode>::ssz_fixed_len() + <Vec<u8> as Encode>::ssz_fixed_len();
         let mut encoder = SszEncoder::container(buf, offset);
-        let encoded_txs: Vec<Vec<u8>> = self.txs.iter().map(alloy_rlp::encode).collect();
-        let rlp_uncles: Vec<u8> = alloy_rlp::encode(&self.uncles);
+        let encoded_txs: Vec<Vec<u8>> = self.txs.iter().map(alloy::rlp::encode).collect();
+        let rlp_uncles: Vec<u8> = alloy::rlp::encode(&self.uncles);
         encoder.append(&encoded_txs);
         encoder.append(&rlp_uncles);
         encoder.finalize();
@@ -299,9 +301,9 @@ impl ssz::Encode for BlockBodyMerge {
         let offset =
             <Vec<Vec<u8>> as Encode>::ssz_fixed_len() + <Vec<u8> as Encode>::ssz_fixed_len();
         let mut encoder = SszEncoder::container(buf, offset);
-        let encoded_txs: Vec<Vec<u8>> = self.txs.iter().map(alloy_rlp::encode).collect();
+        let encoded_txs: Vec<Vec<u8>> = self.txs.iter().map(alloy::rlp::encode).collect();
         let empty_uncles: Vec<Header> = vec![];
-        let rlp_uncles: Vec<u8> = alloy_rlp::encode(empty_uncles);
+        let rlp_uncles: Vec<u8> = alloy::rlp::encode(empty_uncles);
         encoder.append(&encoded_txs);
         encoder.append(&rlp_uncles);
         encoder.finalize();
@@ -394,11 +396,11 @@ impl ssz::Encode for BlockBodyShanghai {
             + <Vec<u8> as Encode>::ssz_fixed_len()
             + <Vec<Vec<u8>> as Encode>::ssz_fixed_len();
         let mut encoder = SszEncoder::container(buf, offset);
-        let encoded_txs: Vec<Vec<u8>> = self.txs.iter().map(alloy_rlp::encode).collect();
+        let encoded_txs: Vec<Vec<u8>> = self.txs.iter().map(alloy::rlp::encode).collect();
         let empty_uncles: Vec<Header> = vec![];
-        let rlp_uncles: Vec<u8> = alloy_rlp::encode(empty_uncles);
+        let rlp_uncles: Vec<u8> = alloy::rlp::encode(empty_uncles);
         let encoded_withdrawals: Vec<Vec<u8>> =
-            self.withdrawals.iter().map(alloy_rlp::encode).collect();
+            self.withdrawals.iter().map(alloy::rlp::encode).collect();
         encoder.append(&encoded_txs);
         encoder.append(&rlp_uncles);
         encoder.append(&encoded_withdrawals);
@@ -461,7 +463,7 @@ impl ssz::Decode for BlockBodyShanghai {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use alloy_primitives::U256;
+    use alloy::primitives::U256;
     use rstest::rstest;
     use ssz::{Decode, Encode};
 
@@ -489,7 +491,7 @@ mod tests {
             Transaction::EIP1559(tx) => assert_eq!(tx.nonce, expected_nonce),
             Transaction::Blob(tx) => assert_eq!(tx.nonce, expected_nonce),
         }
-        let encoded_tx = alloy_rlp::encode(&tx);
+        let encoded_tx = alloy::rlp::encode(&tx);
         assert_eq!(hex_encode(tx_rlp), hex_encode(encoded_tx));
     }
 

--- a/ethportal-api/src/types/execution/header.rs
+++ b/ethportal-api/src/types/execution/header.rs
@@ -1,6 +1,8 @@
-use alloy_primitives::{keccak256, Address, Bloom, Bytes, B256, B64, U256, U64};
-use alloy_rlp::{Decodable, Encodable, Header as RlpHeader};
-use alloy_rpc_types::Header as RpcHeader;
+use alloy::{
+    primitives::{keccak256, Address, Bloom, Bytes, B256, B64, U256, U64},
+    rlp::{Decodable, Encodable, Header as RlpHeader},
+    rpc::types::Header as RpcHeader,
+};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::utils::bytes::{hex_decode, hex_encode};
@@ -85,7 +87,7 @@ where
 impl Header {
     /// Returns the Keccak-256 hash of the header.
     pub fn hash(&self) -> B256 {
-        keccak256(alloy_rlp::encode(self))
+        keccak256(alloy::rlp::encode(self))
     }
 }
 
@@ -145,10 +147,10 @@ impl Encodable for Header {
 
 impl Decodable for Header {
     /// Attempt to decode a header from RLP bytes.
-    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let rlp_head = alloy_rlp::Header::decode(buf)?;
+    fn decode(buf: &mut &[u8]) -> alloy::rlp::Result<Self> {
+        let rlp_head = alloy::rlp::Header::decode(buf)?;
         if !rlp_head.list {
-            return Err(alloy_rlp::Error::UnexpectedString);
+            return Err(alloy::rlp::Error::UnexpectedString);
         }
         let started_len = buf.len();
         let mut header = Header {
@@ -330,7 +332,7 @@ mod tests {
             )
         );
 
-        let encoded_header = alloy_rlp::encode(header);
+        let encoded_header = alloy::rlp::encode(header);
         assert_eq!(header_rlp, encoded_header);
     }
 
@@ -350,7 +352,7 @@ mod tests {
                     .unwrap()
             )
         );
-        let encoded_header = alloy_rlp::encode(header);
+        let encoded_header = alloy::rlp::encode(header);
         assert_eq!(header_rlp, encoded_header);
     }
 
@@ -463,7 +465,7 @@ mod tests {
             B256::from_str("0x10aca3ebb4cf6ddd9e945a5db19385f9c105ede7374380c50d56384c3d233785")
                 .unwrap();
         assert_eq!(decoded.hash(), expected_hash);
-        let expected_header = alloy_rlp::encode(expected);
+        let expected_header = alloy::rlp::encode(expected);
         assert_eq!(data, expected_header);
     }
 

--- a/ethportal-api/src/types/execution/header_with_proof.rs
+++ b/ethportal-api/src/types/execution/header_with_proof.rs
@@ -1,6 +1,5 @@
 use crate::{types::bytes::ByteList2048, Header};
-use alloy_primitives::B256;
-use alloy_rlp::Decodable;
+use alloy::{primitives::B256, rlp::Decodable};
 use jsonrpsee::core::Serialize;
 use serde::Deserialize;
 use ssz::{Encode, SszDecoderBuilder, SszEncoder};
@@ -22,7 +21,7 @@ impl ssz::Encode for HeaderWithProof {
     }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
-        let header = alloy_rlp::encode(&self.header);
+        let header = alloy::rlp::encode(&self.header);
         let header = ByteList2048::from(header);
         let offset = <ByteList2048 as Encode>::ssz_fixed_len()
             + <PreMergeAccumulatorProof as Encode>::ssz_fixed_len();
@@ -33,7 +32,7 @@ impl ssz::Encode for HeaderWithProof {
     }
 
     fn ssz_bytes_len(&self) -> usize {
-        let header = alloy_rlp::encode(&self.header);
+        let header = alloy::rlp::encode(&self.header);
         let header = ByteList2048::from(header);
         header.len() + self.proof.ssz_bytes_len()
     }

--- a/ethportal-api/src/types/execution/transaction.rs
+++ b/ethportal-api/src/types/execution/transaction.rs
@@ -1,7 +1,9 @@
-use alloy_primitives::{keccak256, Address, B256, U256, U64};
-use alloy_rlp::{
-    length_of_length, Decodable, Encodable, Error as RlpError, Header as RlpHeader, RlpDecodable,
-    RlpEncodable, EMPTY_STRING_CODE,
+use alloy::{
+    primitives::{keccak256, Address, B256, U256, U64},
+    rlp::{
+        length_of_length, Decodable, Encodable, Error as RlpError, Header as RlpHeader,
+        RlpDecodable, RlpEncodable, EMPTY_STRING_CODE,
+    },
 };
 use bytes::{Buf, BufMut, Bytes};
 use secp256k1::{
@@ -25,7 +27,7 @@ pub enum Transaction {
 impl Transaction {
     /// Returns the Keccak-256 hash of the header.
     pub fn hash(&self) -> B256 {
-        keccak256(alloy_rlp::encode(self))
+        keccak256(alloy::rlp::encode(self))
     }
 
     pub fn get_transaction_sender_address(&self) -> anyhow::Result<Address> {
@@ -112,7 +114,7 @@ impl Transaction {
         }
     }
 
-    pub fn decode_enveloped_transactions(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+    pub fn decode_enveloped_transactions(buf: &mut &[u8]) -> alloy::rlp::Result<Self> {
         // at least one byte needs to be present
         if buf.is_empty() {
             return Err(RlpError::InputTooShort);
@@ -150,7 +152,7 @@ impl Encodable for Transaction {
 }
 
 impl Decodable for Transaction {
-    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+    fn decode(buf: &mut &[u8]) -> alloy::rlp::Result<Self> {
         // at least one byte needs to be present
         if buf.is_empty() {
             return Err(RlpError::InputTooShort);
@@ -627,7 +629,7 @@ impl Encodable for ToAddress {
 }
 
 impl Decodable for ToAddress {
-    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+    fn decode(buf: &mut &[u8]) -> alloy::rlp::Result<Self> {
         if let Some(&first) = buf.first() {
             if first == EMPTY_STRING_CODE {
                 buf.advance(1);
@@ -674,7 +676,7 @@ pub struct AccessList {
 }
 
 impl Decodable for AccessList {
-    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+    fn decode(buf: &mut &[u8]) -> alloy::rlp::Result<Self> {
         let list: Vec<AccessListItem> = Decodable::decode(buf)?;
         Ok(Self { list })
     }
@@ -696,7 +698,7 @@ pub struct AccessListItem {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use alloy_rlp::Decodable;
+    use alloy::rlp::Decodable;
 
     use crate::{types::execution::transaction::Transaction, utils::bytes::hex_decode};
 

--- a/ethportal-api/src/types/execution/withdrawal.rs
+++ b/ethportal-api/src/types/execution/withdrawal.rs
@@ -1,5 +1,7 @@
-use alloy_primitives::Address;
-use alloy_rlp::{RlpDecodable, RlpEncodable};
+use alloy::{
+    primitives::Address,
+    rlp::{RlpDecodable, RlpEncodable},
+};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::consensus::execution_payload::Withdrawal as ConsensusWithdrawal;

--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Bytes, U256};
+use alloy::primitives::{Bytes, U256};
 use serde::{Deserialize, Serialize};
 use ssz_types::{typenum, BitList};
 

--- a/ethportal-api/src/types/portal_wire.rs
+++ b/ethportal-api/src/types/portal_wire.rs
@@ -5,7 +5,7 @@ use std::{
     sync::Arc,
 };
 
-use alloy_primitives::U256;
+use alloy::primitives::U256;
 use anyhow::anyhow;
 use bimap::BiHashMap;
 use once_cell::sync::Lazy;
@@ -587,7 +587,7 @@ impl From<Accept> for Value {
 #[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
-    use alloy_primitives::bytes;
+    use alloy::primitives::bytes;
     use ssz_types::Error::OutOfBounds;
     use std::str::FromStr;
     use test_log::test;

--- a/ethportal-api/src/types/query_trace.rs
+++ b/ethportal-api/src/types/query_trace.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, time::SystemTime};
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use discv5::enr::NodeId;
 use serde::{Deserialize, Serialize};
 

--- a/ethportal-api/src/types/state_trie/account_state.rs
+++ b/ethportal-api/src/types/state_trie/account_state.rs
@@ -1,6 +1,8 @@
-use alloy_consensus::{constants::KECCAK_EMPTY, EMPTY_ROOT_HASH};
-use alloy_primitives::{B256, U256};
-use alloy_rlp::{RlpDecodable, RlpEncodable};
+use alloy::{
+    consensus::{constants::KECCAK_EMPTY, EMPTY_ROOT_HASH},
+    primitives::{B256, U256},
+    rlp::{RlpDecodable, RlpEncodable},
+};
 use serde::{Deserialize, Serialize};
 
 /// The Account State stored in the state trie.

--- a/ethportal-api/src/types/state_trie/mod.rs
+++ b/ethportal-api/src/types/state_trie/mod.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use alloy_primitives::{keccak256, B256};
+use alloy::primitives::{keccak256, B256};
 use eth_trie::{decode_node, node::Node, TrieError};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};

--- a/ethportal-api/src/types/state_trie/trie_traversal.rs
+++ b/ethportal-api/src/types/state_trie/trie_traversal.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Bytes, B256};
+use alloy::primitives::{Bytes, B256};
 use eth_trie::node::Node;
 use thiserror::Error;
 
@@ -115,7 +115,7 @@ impl NodeTraversal for Node {
 mod tests {
     use std::array;
 
-    use alloy_primitives::B256;
+    use alloy::primitives::B256;
     use eth_trie::{nibbles::Nibbles, node::empty_children};
     use rstest::rstest;
 

--- a/ethportal-api/src/types/state_trie/utils.rs
+++ b/ethportal-api/src/types/state_trie/utils.rs
@@ -1,5 +1,7 @@
-use alloy_primitives::B256;
-use alloy_rlp::{Encodable, Header, EMPTY_STRING_CODE};
+use alloy::{
+    primitives::B256,
+    rlp::{Encodable, Header, EMPTY_STRING_CODE},
+};
 use bytes::BufMut;
 use eth_trie::node::Node;
 use keccak_hash::keccak;

--- a/ethportal-api/src/utils/roots.rs
+++ b/ethportal-api/src/utils/roots.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
-use alloy_primitives::B256;
-use alloy_rlp::Encodable;
+use alloy::{primitives::B256, rlp::Encodable};
 use anyhow::anyhow;
 use eth_trie::{EthTrie, MemoryDB, Trie};
 
@@ -16,8 +15,8 @@ pub fn calculate_merkle_patricia_root<'a, T: Encodable + 'a>(
 
     // Insert items into merkle patricia trie
     for (index, tx) in items.into_iter().enumerate() {
-        let path = alloy_rlp::encode(index);
-        let encoded_tx = alloy_rlp::encode(tx);
+        let path = alloy::rlp::encode(index);
+        let encoded_tx = alloy::rlp::encode(tx);
         trie.insert(&path, &encoded_tx)
             .map_err(|err| anyhow!("Error inserting into merkle patricia trie: {err:?}"))?;
     }

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -11,8 +11,7 @@ description = "Testing utilities for trin"
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-primitives = { workspace = true, features = ["getrandom"] }
-alloy-rlp.workspace = true
+alloy = { workspace = true, features = ["getrandom"] }
 anyhow.workspace = true
 discv5.workspace = true
 e2store.workspace = true

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -1,5 +1,5 @@
 use crate::{utils::fixture_header_by_hash, Peertest, PeertestNode};
-use alloy_primitives::{B256, U256};
+use alloy::primitives::{B256, U256};
 use ethportal_api::{
     types::{distance::Distance, network::Subnetwork},
     BeaconNetworkApiClient, ContentValue, Discv5ApiClient, HistoryContentKey,

--- a/ethportal-peertest/src/scenarios/eth_rpc.rs
+++ b/ethportal-peertest/src/scenarios/eth_rpc.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::U256;
+use alloy::primitives::U256;
 use tracing::info;
 
 use ethportal_api::EthApiClient;

--- a/ethportal-peertest/src/scenarios/offer_accept.rs
+++ b/ethportal-peertest/src/scenarios/offer_accept.rs
@@ -1,6 +1,6 @@
 use std::{fs, str::FromStr};
 
-use alloy_primitives::Bytes;
+use alloy::primitives::Bytes;
 use ssz::Decode;
 use tracing::info;
 

--- a/ethportal-peertest/src/scenarios/paginate.rs
+++ b/ethportal-peertest/src/scenarios/paginate.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use ethportal_api::{ContentValue, HistoryContentKey, HistoryNetworkApiClient};
 
 use crate::{utils::fixture_header_by_hash, Peertest};

--- a/ethportal-peertest/src/scenarios/validation.rs
+++ b/ethportal-peertest/src/scenarios/validation.rs
@@ -4,7 +4,7 @@ use crate::{
     },
     Peertest,
 };
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use ethportal_api::{
     jsonrpsee::async_client::Client,
     types::{enr::Enr, portal::ContentInfo},

--- a/ethportal-peertest/src/utils.rs
+++ b/ethportal-peertest/src/utils.rs
@@ -3,8 +3,7 @@ use std::{
     fs,
 };
 
-use alloy_primitives::Bytes;
-use alloy_rlp::Decodable;
+use alloy::{primitives::Bytes, rlp::Decodable};
 use futures::{Future, TryFutureExt};
 use serde::Deserializer;
 use ssz::Decode;

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography::cryptocurrencies"]
 description = "Beacon chain light client implementation"
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true

--- a/light-client/src/config/checkpoints.rs
+++ b/light-client/src/config/checkpoints.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, time::Duration};
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::anyhow;
 use reqwest::Response;
 use serde::{Deserialize, Serialize};

--- a/light-client/src/consensus/consensus_client.rs
+++ b/light-client/src/consensus/consensus_client.rs
@@ -1,6 +1,6 @@
 use std::{cmp, sync::Arc};
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::{anyhow, ensure, Result};
 use chrono::Duration;
 use milagro_bls::PublicKey;

--- a/light-client/src/consensus/types.rs
+++ b/light-client/src/consensus/types.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::Result;
 use ethportal_api::{
     consensus::header::BeaconBlockHeader,

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -12,8 +12,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 
 [dependencies]
-alloy-primitives.workspace = true
-alloy-rlp.workspace = true
+alloy.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true

--- a/portal-bridge/src/api/execution.rs
+++ b/portal-bridge/src/api/execution.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::{anyhow, bail};
 use ethportal_api::{
     types::{

--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::{anyhow, ensure};
 use e2store::{
     era1::{BlockTuple, Era1},

--- a/portal-bridge/src/bridge/state.rs
+++ b/portal-bridge/src/bridge/state.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use alloy_rlp::Decodable;
+use alloy::rlp::Decodable;
 use eth_trie::{decode_node, node::Node, RootWithTrieDiff};
 use ethportal_api::{
     jsonrpsee::http_client::HttpClient,

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -1,6 +1,6 @@
 use std::{env, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use clap::Parser;
 use reqwest::{
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},

--- a/portal-bridge/src/types/full_header.rs
+++ b/portal-bridge/src/types/full_header.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::{anyhow, ensure};
 use serde::{Deserialize, Deserializer};
 use serde_json::Value;

--- a/portal-bridge/src/utils.rs
+++ b/portal-bridge/src/utils.rs
@@ -4,7 +4,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::{anyhow, bail};
 use chrono::Duration;
 use discv5::enr::{CombinedKey, Enr, NodeId};
@@ -204,7 +204,7 @@ mod tests {
     #[case(4)]
     #[case(16)]
     fn test_generate_spaced_private_keys(#[case] count: u8) {
-        use alloy_primitives::U256;
+        use alloy::primitives::U256;
 
         let private_keys = generate_spaced_private_keys(count, None);
         assert_eq!(private_keys.len() as u8, count);

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -11,7 +11,7 @@ description = "Core library for Trin."
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 bytes.workspace = true

--- a/portalnet/src/config.rs
+++ b/portalnet/src/config.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use ethportal_api::types::{
     bootnodes::Bootnodes,
     cli::{TrinConfig, DEFAULT_UTP_TRANSFER_LIMIT},

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -2601,7 +2601,7 @@ mod tests {
 
     use std::{net::SocketAddr, time::Instant};
 
-    use alloy_primitives::U256;
+    use alloy::primitives::U256;
     use discv5::kbucket;
     use kbucket::KBucketsTable;
     use rstest::*;

--- a/portalnet/src/types/kbucket.rs
+++ b/portalnet/src/types/kbucket.rs
@@ -851,7 +851,7 @@ mod tests {
     }
 
     mod interested_enrs {
-        use alloy_primitives::U256;
+        use alloy::primitives::U256;
 
         use super::*;
 

--- a/portalnet/src/utils/db.rs
+++ b/portalnet/src/utils/db.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::{anyhow, bail};
 use discv5::enr::{CombinedKey, Enr, NodeId};
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -11,9 +11,7 @@ description = "Implementations of jsonrpsee server API traits for Trin and serve
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-primitives.workspace = true
-alloy-rlp.workspace = true
-alloy-rpc-types.workspace = true
+alloy.workspace = true
 discv5.workspace = true
 eth_trie.workspace = true
 ethportal-api.workspace = true

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use discv5::enr::NodeId;
 use tokio::sync::mpsc;
 

--- a/rpc/src/eth_rpc.rs
+++ b/rpc/src/eth_rpc.rs
@@ -1,8 +1,7 @@
-use alloy_primitives::{Address, Bytes, B256, U256};
-use alloy_rpc_types::{Block, BlockId, BlockTransactions, TransactionRequest};
-use revm::primitives::ExecutionResult;
-use tokio::sync::mpsc;
-
+use alloy::{
+    primitives::{Address, Bytes, B256, U256},
+    rpc::types::{Block, BlockId, BlockTransactions, TransactionRequest},
+};
 use ethportal_api::{
     jsonrpsee::types::{error::CALL_EXECUTION_FAILED_CODE, ErrorObjectOwned},
     types::{
@@ -15,6 +14,8 @@ use ethportal_api::{
     },
     ContentValue, EthApiServer, Header, HistoryContentKey, HistoryContentValue,
 };
+use revm::primitives::ExecutionResult;
+use tokio::sync::mpsc;
 use trin_evm::{
     async_db::{execute_transaction, AsyncDatabase},
     create_block_env,

--- a/rpc/src/evm_state.rs
+++ b/rpc/src/evm_state.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
-use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
-use alloy_rlp::Decodable;
+use alloy::{
+    primitives::{keccak256, Address, Bytes, B256, U256},
+    rlp::Decodable,
+};
 use eth_trie::{node::Node, TrieError};
 use ethportal_api::{
     jsonrpsee::types::ErrorObjectOwned,
@@ -32,7 +34,7 @@ pub enum EvmStateError {
     #[error("Error decoding trie node: {0}")]
     DecodingTrieNode(#[from] TrieError),
     #[error("Error RLP decoding trie value: {0}")]
-    DecodingTrieValue(#[from] alloy_rlp::Error),
+    DecodingTrieValue(#[from] alloy::rlp::Error),
     #[error("Error traversing trie: {0}")]
     TrieTraversal(#[from] TraversalError),
     #[error("Storage value is invalid: {0}")]

--- a/src/bin/poll_latest.rs
+++ b/src/bin/poll_latest.rs
@@ -1,5 +1,7 @@
-use alloy_primitives::B256;
-use alloy_provider::{Provider, ProviderBuilder, WsConnect};
+use alloy::{
+    primitives::B256,
+    providers::{Provider, ProviderBuilder, WsConnect},
+};
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use ethportal_api::{

--- a/src/bin/purge_invalid_history_content.rs
+++ b/src/bin/purge_invalid_history_content.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::Result;
 use clap::Parser;
 use discv5::enr::{CombinedKey, Enr};

--- a/src/bin/sample_range.rs
+++ b/src/bin/sample_range.rs
@@ -3,9 +3,11 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::B256;
-use alloy_provider::{Provider, ProviderBuilder};
+use alloy::{
+    eips::BlockNumberOrTag,
+    primitives::B256,
+    providers::{Provider, ProviderBuilder},
+};
 use anyhow::Result;
 use clap::Parser;
 use futures::StreamExt;

--- a/tests/rpc_server.rs
+++ b/tests/rpc_server.rs
@@ -3,9 +3,11 @@
 use std::fs;
 use std::net::{IpAddr, Ipv4Addr};
 
-use alloy_provider::{IpcConnect, Provider, ProviderBuilder, RootProvider};
-use alloy_pubsub::PubSubFrontend;
-use alloy_rpc_types::{BlockTransactions, BlockTransactionsKind};
+use alloy::{
+    providers::{IpcConnect, Provider, ProviderBuilder, RootProvider},
+    pubsub::PubSubFrontend,
+    rpc::types::{BlockTransactions, BlockTransactionsKind},
+};
 use ethportal_api::ContentValue;
 use jsonrpsee::async_client::Client;
 use serde_yaml::Value;

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -11,7 +11,7 @@ description = "Beacon network subprotocol for Trin."
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
 discv5.workspace = true

--- a/trin-beacon/src/network.rs
+++ b/trin-beacon/src/network.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use parking_lot::RwLock as PLRwLock;
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use ethportal_api::{
     consensus::fork::ForkName,
     types::{

--- a/trin-beacon/src/sync.rs
+++ b/trin-beacon/src/sync.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use ethportal_api::BeaconContentKey;
 use light_client::{
     config::networks, consensus::rpc::portal_rpc::PortalRpc, database::FileDB, Client,

--- a/trin-beacon/src/test_utils.rs
+++ b/trin-beacon/src/test_utils.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use ethportal_api::{
     consensus::{
         beacon_state::BeaconStateDeneb,

--- a/trin-beacon/src/validation.rs
+++ b/trin-beacon/src/validation.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::anyhow;
 use chrono::Duration;
 use ethportal_api::{

--- a/trin-evm/Cargo.toml
+++ b/trin-evm/Cargo.toml
@@ -12,9 +12,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 
 [dependencies]
-alloy-primitives.workspace = true
-alloy-rlp.workspace = true
-alloy-rpc-types.workspace = true
+alloy.workspace = true
 ethportal-api.workspace = true
 revm.workspace = true
 revm-primitives.workspace = true

--- a/trin-evm/src/tx_env_modifier.rs
+++ b/trin-evm/src/tx_env_modifier.rs
@@ -1,5 +1,4 @@
-use alloy_primitives::U256;
-use alloy_rpc_types::TransactionRequest;
+use alloy::{primitives::U256, rpc::types::TransactionRequest};
 use ethportal_api::types::execution::transaction::{
     AccessListTransaction, BlobTransaction, EIP1559Transaction, LegacyTransaction, ToAddress,
 };
@@ -21,7 +20,7 @@ impl TxEnvModifier for LegacyTransaction {
             ToAddress::Empty => TransactTo::Create,
         };
         tx_env.value = self.value;
-        tx_env.data = alloy_primitives::Bytes(self.data.clone());
+        tx_env.data = alloy::primitives::Bytes(self.data.clone());
         tx_env.chain_id = if get_spec_id(block_number).is_enabled_in(SpecId::SPURIOUS_DRAGON) {
             Some(1)
         } else {
@@ -44,7 +43,7 @@ impl TxEnvModifier for EIP1559Transaction {
             ToAddress::Empty => TransactTo::Create,
         };
         tx_env.value = self.value;
-        tx_env.data = alloy_primitives::Bytes(self.data.clone());
+        tx_env.data = alloy::primitives::Bytes(self.data.clone());
         tx_env.chain_id = Some(self.chain_id.to::<u64>());
         tx_env.nonce = Some(self.nonce.to::<u64>());
         tx_env.access_list = self
@@ -71,7 +70,7 @@ impl TxEnvModifier for AccessListTransaction {
             ToAddress::Empty => TransactTo::Create,
         };
         tx_env.value = self.value;
-        tx_env.data = alloy_primitives::Bytes(self.data.clone());
+        tx_env.data = alloy::primitives::Bytes(self.data.clone());
         tx_env.chain_id = Some(self.chain_id.to::<u64>());
         tx_env.nonce = Some(self.nonce.to::<u64>());
         tx_env.access_list = self
@@ -98,7 +97,7 @@ impl TxEnvModifier for BlobTransaction {
             ToAddress::Empty => TransactTo::Create,
         };
         tx_env.value = self.value;
-        tx_env.data = alloy_primitives::Bytes(self.data.clone());
+        tx_env.data = alloy::primitives::Bytes(self.data.clone());
         tx_env.chain_id = Some(self.chain_id.to::<u64>());
         tx_env.nonce = Some(self.nonce.to::<u64>());
         tx_env.access_list = self
@@ -154,8 +153,7 @@ impl TxEnvModifier for TransactionRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::U64;
-    use alloy_rlp::Bytes;
+    use alloy::primitives::{bytes::Bytes, U64};
     use revm_primitives::TxEnv;
 
     #[test]

--- a/trin-execution/Cargo.toml
+++ b/trin-execution/Cargo.toml
@@ -12,11 +12,9 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 
 [dependencies]
-alloy-consensus.workspace = true
-alloy-eips.workspace = true
-alloy-primitives.workspace = true
+alloy = { workspace = true, features = ["eips", "rpc-types-engine", "serde"] }
 alloy-rlp.workspace = true
-alloy-rpc-types = { workspace = true, features = ["engine"]}
+alloy-rpc-types-engine = { version = "0.4.2", default-features = false, features = ["serde"] }
 anyhow.workspace = true
 clap.workspace = true
 ethportal-api.workspace = true

--- a/trin-execution/src/content.rs
+++ b/trin-execution/src/content.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{keccak256, B256};
+use alloy::primitives::{keccak256, B256};
 use anyhow::anyhow;
 use ethportal_api::{
     types::{

--- a/trin-execution/src/engine/rpc.rs
+++ b/trin-execution/src/engine/rpc.rs
@@ -1,12 +1,14 @@
-use alloy_rlp::Bytes;
-use alloy_rpc_types::{
-    engine::{
-        ExecutionPayloadBodiesV1, ExecutionPayloadBodiesV2, ExecutionPayloadInputV2,
-        ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3, ExecutionPayloadV4,
-        ForkchoiceState, ForkchoiceUpdated, PayloadAttributes, PayloadId, PayloadStatus,
-        TransitionConfiguration,
+use alloy::{
+    primitives::bytes::Bytes,
+    rpc::types::{
+        engine::{
+            ExecutionPayloadBodiesV1, ExecutionPayloadBodiesV2, ExecutionPayloadInputV2,
+            ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3, ExecutionPayloadV4,
+            ForkchoiceState, ForkchoiceUpdated, PayloadAttributes, PayloadId, PayloadStatus,
+            TransitionConfiguration,
+        },
+        Block, BlockId, Filter, Log, SyncStatus, TransactionRequest,
     },
-    Block, BlockId, Filter, Log, SyncStatus, TransactionRequest,
 };
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use revm_primitives::{Address, B256, U256};

--- a/trin-execution/src/era/beacon.rs
+++ b/trin-execution/src/era/beacon.rs
@@ -1,5 +1,7 @@
-use alloy_primitives::{Bloom, B64, U64};
-use alloy_rlp::Decodable;
+use alloy::{
+    primitives::{Bloom, B64, U64},
+    rlp::Decodable,
+};
 use ethportal_api::{
     consensus::{
         beacon_block::{
@@ -193,7 +195,7 @@ fn process_transactions(
 mod tests {
     use std::str::FromStr;
 
-    use alloy_primitives::{Address, Bloom, B256, B64, U256};
+    use alloy::primitives::{Address, Bloom, B256, B64, U256};
     use ethportal_api::{
         consensus::{beacon_block::SignedBeaconBlock, fork::ForkName},
         Header,

--- a/trin-execution/src/era/utils.rs
+++ b/trin-execution/src/era/utils.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use alloy_rlp::Bytes;
+use alloy::primitives::bytes::Bytes;
 use anyhow::anyhow;
 use e2store::{
     era::Era,

--- a/trin-execution/src/evm/block_executor.rs
+++ b/trin-execution/src/evm/block_executor.rs
@@ -151,12 +151,12 @@ impl<'a> BlockExecutor<'a> {
                 .database
                 .trie
                 .lock()
-                .insert(address_hash.as_ref(), &alloy_rlp::encode(&account))?;
+                .insert(address_hash.as_ref(), &alloy::rlp::encode(&account))?;
             self.evm
                 .db()
                 .database
                 .db
-                .put(address_hash, alloy_rlp::encode(account))?;
+                .put(address_hash, alloy::rlp::encode(account))?;
         }
 
         Ok(())

--- a/trin-execution/src/evm/post_block_beneficiaries.rs
+++ b/trin-execution/src/evm/post_block_beneficiaries.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
-use alloy_consensus::constants::{ETH_TO_WEI, GWEI_TO_WEI};
-use alloy_primitives::Address;
+use alloy::{
+    consensus::constants::{ETH_TO_WEI, GWEI_TO_WEI},
+    primitives::Address,
+};
 use revm::{db::State, Evm};
 use revm_primitives::SpecId;
 use trin_evm::spec_id::get_spec_block_number;

--- a/trin-execution/src/evm/pre_block_contracts.rs
+++ b/trin-execution/src/evm/pre_block_contracts.rs
@@ -1,4 +1,4 @@
-use alloy_eips::eip4788;
+use alloy::eips::eip4788;
 use anyhow::anyhow;
 use ethportal_api::Header;
 use revm::{db::State, DatabaseCommit, Evm};

--- a/trin-execution/src/execution.rs
+++ b/trin-execution/src/execution.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::ensure;
 use eth_trie::{RootWithTrieDiff, Trie};
 use ethportal_api::{types::execution::transaction::Transaction, Header};

--- a/trin-execution/src/storage/account_db.rs
+++ b/trin-execution/src/storage/account_db.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use alloy_primitives::{keccak256, B256};
+use alloy::primitives::{keccak256, B256};
 use eth_trie::DB;
 use rocksdb::DB as RocksDB;
 

--- a/trin-execution/src/storage/error.rs
+++ b/trin-execution/src/storage/error.rs
@@ -6,7 +6,7 @@ pub enum EVMError {
     Trie(#[from] eth_trie::TrieError),
 
     #[error("rlp error {0}")]
-    RLP(#[from] alloy_rlp::Error),
+    RLP(#[from] alloy::rlp::Error),
 
     #[error("rocksdb error {0}")]
     DB(#[from] rocksdb::Error),

--- a/trin-execution/src/storage/evm_db.rs
+++ b/trin-execution/src/storage/evm_db.rs
@@ -7,9 +7,11 @@ use crate::{
     },
     storage::error::EVMError,
 };
-use alloy_consensus::EMPTY_ROOT_HASH;
-use alloy_primitives::{keccak256, map::FbHashMap, Address, B256, U256};
-use alloy_rlp::Decodable;
+use alloy::{
+    consensus::EMPTY_ROOT_HASH,
+    primitives::{keccak256, map::FbHashMap, Address, B256, U256},
+    rlp::Decodable,
+};
 use eth_trie::{EthTrie, RootWithTrieDiff, Trie};
 use ethportal_api::types::state_trie::account_state::AccountState;
 use hashbrown::{HashMap as BrownHashMap, HashSet};
@@ -131,12 +133,12 @@ impl EvmDB {
         let _ = self
             .trie
             .lock()
-            .insert(address_hash.as_ref(), &alloy_rlp::encode(&account_state));
+            .insert(address_hash.as_ref(), &alloy::rlp::encode(&account_state));
         stop_timer(timer);
 
         let timer = start_commit_timer("account:put_account_into_db");
         self.db
-            .put(address_hash, alloy_rlp::encode(account_state))?;
+            .put(address_hash, alloy::rlp::encode(account_state))?;
         stop_timer(timer);
 
         stop_timer(plain_state_some_account_timer);
@@ -169,11 +171,11 @@ impl EvmDB {
             let _ = self.trie.lock().remove(address_hash.as_ref());
         } else {
             self.db
-                .put(address_hash, alloy_rlp::encode(&account_state))?;
+                .put(address_hash, alloy::rlp::encode(&account_state))?;
             let _ = self
                 .trie
                 .lock()
-                .insert(address_hash.as_ref(), &alloy_rlp::encode(&account_state));
+                .insert(address_hash.as_ref(), &alloy::rlp::encode(&account_state));
         }
 
         stop_timer(timer);
@@ -216,7 +218,7 @@ impl EvmDB {
             if value.is_zero() {
                 trie.remove(trie_key.as_ref())?;
             } else {
-                trie.insert(trie_key.as_ref(), &alloy_rlp::encode(value))?;
+                trie.insert(trie_key.as_ref(), &alloy::rlp::encode(value))?;
             }
         }
 
@@ -239,10 +241,10 @@ impl EvmDB {
         let _ = self
             .trie
             .lock()
-            .insert(address_hash.as_ref(), &alloy_rlp::encode(&account_state));
+            .insert(address_hash.as_ref(), &alloy::rlp::encode(&account_state));
 
         self.db
-            .put(address_hash, alloy_rlp::encode(account_state))?;
+            .put(address_hash, alloy::rlp::encode(account_state))?;
         stop_timer(timer);
         Ok(())
     }

--- a/trin-execution/src/storage/execution_position.rs
+++ b/trin-execution/src/storage/execution_position.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
-use alloy_consensus::EMPTY_ROOT_HASH;
-use alloy_rlp::{Decodable, RlpDecodable, RlpEncodable};
+use alloy::{
+    consensus::EMPTY_ROOT_HASH,
+    rlp::{Decodable, RlpDecodable, RlpEncodable},
+};
 use ethportal_api::Header;
 use revm_primitives::B256;
 use rocksdb::DB as RocksDB;
@@ -46,7 +48,7 @@ impl ExecutionPosition {
     pub fn update_position(&mut self, db: Arc<RocksDB>, header: &Header) -> anyhow::Result<()> {
         self.next_block_number = header.number + 1;
         self.state_root = header.state_root;
-        db.put(EXECUTION_POSITION_DB_KEY, alloy_rlp::encode(self))?;
+        db.put(EXECUTION_POSITION_DB_KEY, alloy::rlp::encode(self))?;
         Ok(())
     }
 }

--- a/trin-execution/src/subcommands/era2/export.rs
+++ b/trin-execution/src/subcommands/era2/export.rs
@@ -3,8 +3,7 @@ use std::{
     sync::Arc,
 };
 
-use alloy_consensus::EMPTY_ROOT_HASH;
-use alloy_rlp::Decodable;
+use alloy::{consensus::EMPTY_ROOT_HASH, rlp::Decodable};
 use anyhow::ensure;
 use e2store::era2::{
     AccountEntry, AccountOrStorageEntry, Era2Writer, StorageEntry, StorageItem, MAX_STORAGE_ITEMS,

--- a/trin-execution/src/subcommands/era2/import.rs
+++ b/trin-execution/src/subcommands/era2/import.rs
@@ -83,7 +83,7 @@ impl StateImporter {
                 } in storage_entry.0
                 {
                     storage_trie
-                        .insert(storage_index_hash.as_slice(), &alloy_rlp::encode(value))?;
+                        .insert(storage_index_hash.as_slice(), &alloy::rlp::encode(value))?;
                 }
                 // Commit storage trie every 10 million storage items, to avoid excessive memory
                 // usage
@@ -107,11 +107,11 @@ impl StateImporter {
             self.evm_db
                 .trie
                 .lock()
-                .insert(address_hash.as_slice(), &alloy_rlp::encode(&account_state))?;
+                .insert(address_hash.as_slice(), &alloy::rlp::encode(&account_state))?;
 
             self.evm_db
                 .db
-                .put(address_hash, alloy_rlp::encode(account_state))
+                .put(address_hash, alloy::rlp::encode(account_state))
                 .expect("Inserting account should never fail");
 
             accounts_imported += 1;

--- a/trin-execution/src/trie_walker.rs
+++ b/trin-execution/src/trie_walker.rs
@@ -1,7 +1,6 @@
 use std::collections::VecDeque;
 
-use alloy_consensus::EMPTY_ROOT_HASH;
-use alloy_primitives::B256;
+use alloy::{consensus::EMPTY_ROOT_HASH, primitives::B256};
 use eth_trie::{decode_node, node::Node};
 use hashbrown::HashMap as BrownHashMap;
 use serde::{Deserialize, Serialize};
@@ -161,7 +160,7 @@ impl TrieWalker {
 mod tests {
     use std::str::FromStr;
 
-    use alloy_primitives::{keccak256, Address, Bytes};
+    use alloy::primitives::{keccak256, Address, Bytes};
     use eth_trie::{RootWithTrieDiff, Trie};
     use trin_utils::dir::create_temp_test_dir;
 

--- a/trin-execution/src/utils.rs
+++ b/trin-execution/src/utils.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{keccak256, Address, B256};
+use alloy::primitives::{keccak256, Address, B256};
 
 pub fn full_nibble_path_to_address_hash(key_path: &[u8]) -> B256 {
     if key_path.len() != 64 {

--- a/trin-execution/tests/content_generation.rs
+++ b/trin-execution/tests/content_generation.rs
@@ -1,4 +1,4 @@
-use alloy_rlp::Decodable;
+use alloy::rlp::Decodable;
 use anyhow::{ensure, Result};
 use eth_trie::{decode_node, node::Node, RootWithTrieDiff};
 use ethportal_api::{

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -11,7 +11,7 @@ description = "History network subprotocol for Trin."
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy.workspace = true
 anyhow.workspace = true
 discv5.workspace = true
 ethereum_ssz.workspace = true

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::{anyhow, ensure};
 use ssz::Decode;
 use tokio::sync::RwLock;
@@ -126,7 +126,7 @@ mod tests {
     use super::*;
     use std::fs;
 
-    use alloy_primitives::U256;
+    use alloy::primitives::U256;
     use serde_json::Value;
     use ssz::Encode;
 

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -11,8 +11,7 @@ description = "State network subprotocol for Trin."
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-primitives = { workspace = true, features = ["getrandom"] }
-alloy-rlp.workspace = true
+alloy = { workspace = true, features = ["getrandom"] }
 anyhow.workspace = true
 discv5.workspace = true
 eth_trie.workspace = true

--- a/trin-state/src/storage.rs
+++ b/trin-state/src/storage.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::keccak256;
+use alloy::primitives::keccak256;
 use ethportal_api::{
     types::{
         content_key::state::{AccountTrieNodeKey, ContractBytecodeKey, ContractStorageTrieNodeKey},

--- a/trin-state/src/validation/error.rs
+++ b/trin-state/src/validation/error.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use eth_trie::TrieError;
 use ethportal_api::types::state_trie::{
     trie_traversal::{EmptyNodeInfo, TraversalError},
@@ -36,7 +36,7 @@ pub enum StateValidationError {
     #[error("Unable to decode node: {0}")]
     DecodingNode(#[from] TrieError),
     #[error("Unable to decode account state: {0}")]
-    DecodingAccountState(#[from] alloy_rlp::Error),
+    DecodingAccountState(#[from] alloy::rlp::Error),
     #[error("Failed to find header for a given hash. Err: {0}")]
     HeaderNotFound(#[from] anyhow::Error),
 }

--- a/trin-state/src/validation/trie.rs
+++ b/trin-state/src/validation/trie.rs
@@ -1,6 +1,7 @@
-use alloy_primitives::{Bytes, B256};
-use alloy_rlp::Decodable;
-
+use alloy::{
+    primitives::{Bytes, B256},
+    rlp::Decodable,
+};
 use ethportal_api::types::state_trie::{
     account_state::AccountState,
     nibbles::Nibbles,
@@ -118,7 +119,7 @@ fn check_traversal_result_is_value(
 mod tests {
     use std::{array, str::FromStr};
 
-    use alloy_primitives::{keccak256, Address, U256};
+    use alloy::primitives::{keccak256, Address, U256};
     use anyhow::Result;
     use eth_trie::{
         nibbles::Nibbles as EthTrieNibbles,
@@ -296,7 +297,7 @@ mod tests {
             storage_root: B256::random(),
             code_hash: B256::random(),
         };
-        let node = EncodedTrieNode::from(&create_leaf(&path, &alloy_rlp::encode(&account_state)));
+        let node = EncodedTrieNode::from(&create_leaf(&path, &alloy::rlp::encode(&account_state)));
         assert_eq!(
             validate_account_state(node.node_hash(), &address_hash, &vec![node].into()).unwrap(),
             account_state
@@ -325,7 +326,7 @@ mod tests {
             storage_root: B256::random(),
             code_hash: B256::random(),
         };
-        let node = EncodedTrieNode::from(&create_leaf(&path, &alloy_rlp::encode(account_state)));
+        let node = EncodedTrieNode::from(&create_leaf(&path, &alloy::rlp::encode(account_state)));
         validate_account_state(node.node_hash(), &address_hash, &vec![node].into()).unwrap();
     }
 

--- a/trin-state/src/validation/validator.rs
+++ b/trin-state/src/validation/validator.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use alloy_primitives::{keccak256, B256};
+use alloy::primitives::{keccak256, B256};
 use anyhow::anyhow;
 use ethportal_api::{
     types::content_key::state::{
@@ -155,8 +155,7 @@ impl StateValidator {
 mod tests {
     use std::path::PathBuf;
 
-    use alloy_primitives::Bytes;
-    use alloy_rlp::Decodable;
+    use alloy::{primitives::Bytes, rlp::Decodable};
     use anyhow::Result;
     use ethportal_api::{
         types::{

--- a/trin-storage/Cargo.toml
+++ b/trin-storage/Cargo.toml
@@ -11,7 +11,7 @@ description = "Storage library for Trin."
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy.workspace = true
 discv5.workspace = true
 ethportal-api.workspace = true
 r2d2.workspace = true

--- a/trin-storage/src/lib.rs
+++ b/trin-storage/src/lib.rs
@@ -5,7 +5,7 @@ pub mod test_utils;
 pub mod utils;
 pub mod versioned;
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use discv5::enr::NodeId;
 use error::ContentStoreError;
 use ethportal_api::types::{
@@ -204,7 +204,7 @@ pub struct DataSize {
 #[allow(clippy::unwrap_used)]
 pub mod test {
     use super::*;
-    use alloy_primitives::B512;
+    use alloy::primitives::B512;
     use ethportal_api::IdentityContentKey;
 
     #[test]

--- a/trin-validation/Cargo.toml
+++ b/trin-validation/Cargo.toml
@@ -11,7 +11,7 @@ description = "Validation layer for the Portal Network data."
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy.workspace = true
 anyhow.workspace = true
 enr = "0.10.0"
 ethereum_hashing = "0.7.0"
@@ -28,7 +28,6 @@ tree_hash.workspace = true
 tree_hash_derive.workspace = true
 
 [dev-dependencies]
-alloy-rlp.workspace = true
 quickcheck.workspace = true
 quickcheck_macros = "1.0.0"
 rstest.workspace = true

--- a/trin-validation/src/accumulator.rs
+++ b/trin-validation/src/accumulator.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{B256, U256};
+use alloy::primitives::{B256, U256};
 use std::path::PathBuf;
 
 use anyhow::anyhow;

--- a/trin-validation/src/header_validator.rs
+++ b/trin-validation/src/header_validator.rs
@@ -6,7 +6,7 @@ use crate::{
     historical_roots_acc::HistoricalRootsAccumulator,
     merkle::proof::verify_merkle_proof,
 };
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::anyhow;
 use ethportal_api::{
     consensus::historical_summaries::HistoricalSummaries,
@@ -223,8 +223,10 @@ mod test {
     use super::*;
     use std::{fs, str::FromStr};
 
-    use alloy_primitives::{Address, Bloom, B256, U256};
-    use alloy_rlp::Decodable;
+    use alloy::{
+        primitives::{Address, Bloom, B256, U256},
+        rlp::Decodable,
+    };
     use rstest::*;
     use serde_json::Value;
     use ssz::{Decode, Encode};

--- a/trin-validation/src/merkle/proof.rs
+++ b/trin-validation/src/merkle/proof.rs
@@ -2,7 +2,7 @@
 /// Code sourced from:
 /// https://github.com/sigp/lighthouse/blob/bf533c8e42/consensus/merkle_proof/src/lib.rs
 use crate::merkle::safe_arith::ArithError;
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use ethereum_hashing::{hash, hash32_concat, ZERO_HASHES};
 use lazy_static::lazy_static;
 
@@ -408,7 +408,7 @@ impl From<InvalidSnapshot> for MerkleTreeError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::U256;
+    use alloy::primitives::U256;
     use quickcheck::TestResult;
     use quickcheck_macros::quickcheck;
 

--- a/trin-validation/src/oracle.rs
+++ b/trin-validation/src/oracle.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::anyhow;
 use enr::NodeId;
 use serde_json::Value;


### PR DESCRIPTION
## Issue

Currently we use many different `alloy-*` crates. Adding new `alloy-*` crate or updating existing ones can be tricky, as we don't want many different versions (and sometimes different versions don't work well together).

## Proposed solution

Idea of this PR is that trin should depend only on `alloy` [crate](https://docs.rs/crate/alloy/latest), which is Meta-crate of all others. It includes only `alloy-primitives` by default, and other "sub-crates" can be enabled using features.

I'm not sure if this is something we want, but I wanted to crate this PR and we can discuss and make a decision.
I think this makes maintaining and updating dependencies much easier, and I don't see too many drawbacks.

### Sidenote

It seems that `RlpDecodable` and `RlpEncodable` derive macros don't work unless `alloy-rlp` is declared as dependency directly. I will try to create minimal reproducible case of this and open an issue at alloy github.

In addition, it seems that "serde" feature doesn't include "serde" feature of "alloy-rpc-types-eth".
