### PR TITLE
fix(trin-beacon): fix light client finality update validation

### DIFF
--- a/trin-beacon/src/validation.rs
+++ b/trin-beacon/src/validation.rs
@@ -164,9 +164,9 @@ impl Validator<BeaconContentKey> for BeaconValidator {
                 // slot
                 let finalized_slot = lc_finality_update.get_finalized_slot();
 
-                if key.finalized_slot != finalized_slot {
+                if key.finalized_slot > finalized_slot {
                     return Err(anyhow!(
-                        "Light client finality update finalized slot does not match the content key finalized slot: {} != {}",
+                        "Light client finality update finalized slot should be equal or greater than content key finalized slot: {} < {}",
                         finalized_slot,
                         key.finalized_slot
                     ));


### PR DESCRIPTION
### What was wrong?
We were incorrectly validating the `LightClientFinalityUpdate` content key against the value.

### How was it fixed?
Update the comparison because the portal beacon protocol is designed always to return the latest finality update with finalized slot that is bigger or equal to the requested content key.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
