### PR TITLE
fix: revert changed const in peertest utils and fix light client update validation test

### DIFF
--- a/ethportal-peertest/src/utils.rs
+++ b/ethportal-peertest/src/utils.rs
@@ -29,7 +29,7 @@ where
     Fut: Future<Output = Result<O>>,
 {
     // If content is absent an error will be returned.
-    for counter in 0..10 {
+    for counter in 0..60 {
         let result = f().await;
         match result {
             Ok(val) => return val,

--- a/trin-beacon/src/validation.rs
+++ b/trin-beacon/src/validation.rs
@@ -441,10 +441,11 @@ mod tests {
 
         assert!(result.valid_for_storing);
 
-        // Expect error because the finalized slot does not match the content key finalized slot
+        // Expect error because the content key finalized slot is greaten than the light client
+        // update  finalized slot
         let invalid_content_key =
             BeaconContentKey::LightClientFinalityUpdate(LightClientFinalityUpdateKey {
-                finalized_slot: 0,
+                finalized_slot: 17748599031001599584 + 1,
             });
         let result = validator
             .validate_content(&invalid_content_key, &content)
@@ -453,7 +454,7 @@ mod tests {
 
         assert_eq!(
             result.to_string(),
-            "Light client finality update finalized slot does not match the content key finalized slot: 17748599031001599584 != 0"
+            "Light client finality update finalized slot should be equal or greater than content key finalized slot: 17748599031001599584 < 17748599031001599585"
         );
 
         // Expect error because the light client finality update is not from the recent fork


### PR DESCRIPTION
### What was wrong?

### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
