### PR TITLE
feat: add support for eth_getBlockByNumber

### DIFF
--- a/ethportal-api/src/eth.rs
+++ b/ethportal-api/src/eth.rs
@@ -1,6 +1,6 @@
 use alloy::{
     primitives::{Address, Bytes, B256, U256},
-    rpc::types::{Block, BlockId, TransactionRequest},
+    rpc::types::{Block, BlockId, BlockNumberOrTag, TransactionRequest},
 };
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
@@ -9,6 +9,13 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 pub trait EthApi {
     #[method(name = "chainId")]
     async fn chain_id(&self) -> RpcResult<U256>;
+
+    #[method(name = "getBlockByNumber")]
+    async fn get_block_by_number(
+        &self,
+        block_number_or_tag: BlockNumberOrTag,
+        hydrated_transactions: bool,
+    ) -> RpcResult<Block>;
 
     #[method(name = "getBlockByHash")]
     async fn get_block_by_hash(

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -11,7 +11,7 @@ description = "Implementations of jsonrpsee server API traits for Trin and serve
 authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 
 [dependencies]
-alloy.workspace = true
+alloy = { workspace = true, features = ["rpc-types-eth"] }
 discv5.workspace = true
 eth_trie.workspace = true
 ethportal-api.workspace = true

--- a/tests/rpc_server.rs
+++ b/tests/rpc_server.rs
@@ -6,23 +6,22 @@ use std::net::{IpAddr, Ipv4Addr};
 use alloy::{
     providers::{IpcConnect, Provider, ProviderBuilder, RootProvider},
     pubsub::PubSubFrontend,
-    rpc::types::{BlockTransactions, BlockTransactionsKind},
+    rpc::types::{BlockNumberOrTag, BlockTransactions, BlockTransactionsKind, Header as RpcHeader},
+    transports::RpcError,
 };
-use ethportal_api::ContentValue;
-use jsonrpsee::async_client::Client;
-use serde_yaml::Value;
-use serial_test::serial;
-use ssz::Decode;
-
 use ethportal_api::{
     types::{
         cli::{TrinConfig, DEFAULT_WEB3_IPC_PATH},
         execution::{block_body::BlockBody, header_with_proof::HeaderWithProof},
     },
     utils::bytes::{hex_decode, hex_encode},
-    HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
+    ContentValue, Header, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
 };
+use jsonrpsee::async_client::Client;
 use rpc::RpcServerHandle;
+use serde_yaml::Value;
+use serial_test::serial;
+use ssz::Decode;
 
 mod utils;
 use utils::init_tracing;
@@ -79,96 +78,41 @@ async fn test_eth_chain_id() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
-async fn test_eth_get_block_by_hash() {
+async fn test_eth_get_block_by_number() {
     let (web3_server, web3_client, native_client) = setup_web3_server().await;
 
     let (hwp, body) = get_full_block();
-    // Save values for later comparison
-    let (
-        block_number,
-        block_hash,
-        parent_hash,
-        nonce,
-        uncles_hash,
-        logs_bloom,
-        author,
-        state_root,
-        transactions_root,
-        receipts_root,
-        extra_data,
-        mix_hash,
-        gas_used,
-        gas_limit,
-        difficulty,
-        timestamp,
-    ) = (
-        hwp.header.number,
-        hwp.header.hash(),
-        hwp.header.parent_hash,
-        hwp.header.nonce,
-        hwp.header.uncles_hash,
-        hwp.header.logs_bloom,
-        hwp.header.author,
-        hwp.header.state_root,
-        hwp.header.transactions_root,
-        hwp.header.receipts_root,
-        hwp.header.extra_data.clone(),
-        hwp.header.mix_hash,
-        hwp.header.gas_used,
-        hwp.header.gas_limit,
-        hwp.header.difficulty,
-        hwp.header.timestamp,
-    );
-
-    let BlockBody::Shanghai(shanghai_body) = body.clone() else {
-        panic!("expected shanghai body")
-    };
+    let block_number = hwp.header.number;
 
     // Store header with proof in server
-    let content_key = HistoryContentKey::new_block_header_by_hash(block_hash);
-    let content_value = HistoryContentValue::BlockHeaderWithProof(hwp);
-    let result = native_client
-        .store(content_key, content_value.encode())
+    assert!(native_client
+        .store(
+            HistoryContentKey::new_block_header_by_number(block_number),
+            HistoryContentValue::BlockHeaderWithProof(hwp.clone()).encode(),
+        )
         .await
-        .unwrap();
-    assert!(result);
+        .unwrap());
 
     // Store block in server
-    let content_key = HistoryContentKey::new_block_body(block_hash);
-    let content_value = HistoryContentValue::BlockBody(body);
-    let result = native_client
-        .store(content_key, content_value.encode())
+    assert!(native_client
+        .store(
+            HistoryContentKey::new_block_body(hwp.header.hash()),
+            HistoryContentValue::BlockBody(body.clone()).encode(),
+        )
         .await
-        .unwrap();
-    assert!(result);
+        .unwrap());
 
     // The meat of the test is here:
     // Retrieve block over json-rpc
     let block = web3_client
-        .get_block_by_hash(block_hash, BlockTransactionsKind::Hashes)
+        .get_block_by_number(block_number.into(), /* hydrate= */ false)
         .await
         .expect("request to get block failed")
         .expect("specified block not found");
-    web3_server.stop().unwrap();
 
-    assert_eq!(block.header.number, block_number);
-    assert_eq!(block.header.hash, block_hash);
-    assert_eq!(block.header.parent_hash, parent_hash);
-    assert_eq!(block.header.nonce, nonce);
-    assert_eq!(block.header.uncles_hash, uncles_hash);
-    assert_eq!(block.header.logs_bloom, logs_bloom);
-    assert_eq!(block.header.miner, author);
-    assert_eq!(block.header.state_root, state_root);
-    assert_eq!(block.header.transactions_root, transactions_root);
-    assert_eq!(block.header.receipts_root, receipts_root);
-    assert_eq!(block.header.extra_data, extra_data);
-    assert_eq!(block.header.mix_hash, mix_hash);
-    assert_eq!(block.header.gas_used, gas_used.to::<u64>());
-    assert_eq!(block.header.gas_limit, gas_limit.to::<u64>());
-    assert_eq!(block.header.difficulty, difficulty);
-    assert_eq!(block.header.timestamp, timestamp);
+    assert_header(&block.header, &hwp.header);
     assert_eq!(block.size, None);
-    assert_eq!(block.transactions.len(), shanghai_body.txs.len());
+    assert_eq!(block.transactions.len(), body.transactions().len());
 
     let BlockTransactions::Hashes(hashes) = block.transactions else {
         panic!("expected hashes")
@@ -189,6 +133,175 @@ async fn test_eth_get_block_by_hash() {
         hex_encode(hashes[5]),
         "0x2f678341f550f7073a514c4b34f09824119f31dfbe7cc73ffccb21b7a2ba5710"
     );
+
+    web3_server.stop().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn test_eth_get_block_by_number_hydrated() {
+    let (web3_server, web3_client, native_client) = setup_web3_server().await;
+
+    let (hwp, _body) = get_full_block();
+    let block_number = hwp.header.number;
+
+    // Store header with proof in server
+    assert!(native_client
+        .store(
+            HistoryContentKey::new_block_header_by_number(block_number),
+            HistoryContentValue::BlockHeaderWithProof(hwp.clone()).encode(),
+        )
+        .await
+        .unwrap());
+
+    let response = web3_client
+        .get_block_by_number(block_number.into(), /* hydrate= */ true)
+        .await;
+
+    let err = match response {
+        Err(RpcError::ErrorResp(err)) => err,
+        _ => panic!("Unexpected response: {response:?}"),
+    };
+    assert_eq!(
+        err.message, "replying with all transaction bodies is not supported yet",
+        "Unexpected error: {err}"
+    );
+
+    web3_server.stop().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn test_eth_get_block_by_tag() {
+    let (web3_server, web3_client, _native_client) = setup_web3_server().await;
+
+    let response = web3_client
+        .get_block_by_number(BlockNumberOrTag::Latest, /* hydrate= */ false)
+        .await;
+
+    let err = match response {
+        Err(RpcError::ErrorResp(err)) => err,
+        _ => panic!("Unexpected response: {response:?}"),
+    };
+    assert_eq!(
+        err.message, "Block tag is not supported yet.",
+        "Unexpected error: {err}"
+    );
+
+    web3_server.stop().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn test_eth_get_block_by_hash() {
+    let (web3_server, web3_client, native_client) = setup_web3_server().await;
+
+    let (hwp, body) = get_full_block();
+    let block_hash = hwp.header.hash();
+
+    // Store header with proof in server
+    assert!(native_client
+        .store(
+            HistoryContentKey::new_block_header_by_hash(block_hash),
+            HistoryContentValue::BlockHeaderWithProof(hwp.clone()).encode(),
+        )
+        .await
+        .unwrap());
+
+    // Store block in server
+    assert!(native_client
+        .store(
+            HistoryContentKey::new_block_body(block_hash),
+            HistoryContentValue::BlockBody(body.clone()).encode(),
+        )
+        .await
+        .unwrap());
+
+    // The meat of the test is here:
+    // Retrieve block over json-rpc
+    let block = web3_client
+        .get_block_by_hash(block_hash, BlockTransactionsKind::Hashes)
+        .await
+        .expect("request to get block failed")
+        .expect("specified block not found");
+
+    assert_header(&block.header, &hwp.header);
+    assert_eq!(block.size, None);
+    assert_eq!(block.transactions.len(), body.transactions().len());
+
+    let BlockTransactions::Hashes(hashes) = block.transactions else {
+        panic!("expected hashes")
+    };
+    // Spot check a few transaction hashes:
+    // First tx
+    assert_eq!(
+        hex_encode(hashes[0]),
+        "0xd06a110de42d674a84b2091cbd85ef514fb4e903f9a80dd7b640c48365a1a832"
+    );
+    // Last tx
+    assert_eq!(
+        hex_encode(hashes[84]),
+        "0x27e9e8fb3745d990c7d775268539fa17bbf06255e24a882c3153bf3b513ced9e"
+    );
+    // Legacy block
+    assert_eq!(
+        hex_encode(hashes[5]),
+        "0x2f678341f550f7073a514c4b34f09824119f31dfbe7cc73ffccb21b7a2ba5710"
+    );
+
+    web3_server.stop().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn test_eth_get_block_by_hash_hydrated() {
+    let (web3_server, web3_client, native_client) = setup_web3_server().await;
+
+    let (hwp, _body) = get_full_block();
+    let block_hash = hwp.header.hash();
+
+    // Store header with proof in server
+    assert!(native_client
+        .store(
+            HistoryContentKey::new_block_header_by_hash(block_hash),
+            HistoryContentValue::BlockHeaderWithProof(hwp.clone()).encode(),
+        )
+        .await
+        .unwrap());
+
+    let response = web3_client
+        .get_block_by_hash(block_hash, BlockTransactionsKind::Full)
+        .await;
+
+    let err = match response {
+        Err(RpcError::ErrorResp(err)) => err,
+        _ => panic!("Unexpected response: {response:?}"),
+    };
+    assert_eq!(
+        err.message, "replying with all transaction bodies is not supported yet",
+        "Unexpected error: {err}"
+    );
+
+    web3_server.stop().unwrap();
+}
+
+fn assert_header(actual: &RpcHeader, expected: &Header) {
+    assert_eq!(actual.number, expected.number);
+    assert_eq!(actual.hash, expected.hash());
+    assert_eq!(actual.parent_hash, expected.parent_hash);
+    assert_eq!(actual.nonce, expected.nonce);
+    assert_eq!(actual.uncles_hash, expected.uncles_hash);
+    assert_eq!(actual.logs_bloom, expected.logs_bloom);
+    assert_eq!(actual.miner, expected.author);
+    assert_eq!(actual.state_root, expected.state_root);
+    assert_eq!(actual.transactions_root, expected.transactions_root);
+    assert_eq!(actual.receipts_root, expected.receipts_root);
+    assert_eq!(actual.extra_data, expected.extra_data);
+    assert_eq!(actual.mix_hash, expected.mix_hash);
+    assert_eq!(actual.gas_used, expected.gas_used.to::<u64>());
+    assert_eq!(actual.gas_limit, expected.gas_limit.to::<u64>());
+    assert_eq!(actual.difficulty, expected.difficulty);
+    assert_eq!(actual.timestamp, expected.timestamp);
 }
 
 fn get_full_block() -> (HeaderWithProof, BlockBody) {


### PR DESCRIPTION
### What was wrong?

Trin currently doesn't support eth_getBlockByNumber or eth_call with block specified as number.

### How was it fixed?

Added support for `eth_*` JSON rpc request for fetching block by number.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
