### PR TITLE
fix: set Enr sequence to current epoch timestamp

### DIFF
--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -120,6 +120,7 @@ pub async fn test_lookup_enr(subnetwork: Subnetwork, peertest: &Peertest) {
 pub async fn test_ping(subnetwork: Subnetwork, target: &Client, peertest: &Peertest) {
     info!("Testing ping for {subnetwork}");
     let bootnode_enr = peertest.bootnode.enr.clone();
+    let bootnode_sequence = bootnode_enr.seq();
     let result = match subnetwork {
         Subnetwork::Beacon => BeaconNetworkApiClient::ping(target, bootnode_enr),
         Subnetwork::History => HistoryNetworkApiClient::ping(target, bootnode_enr),
@@ -132,7 +133,7 @@ pub async fn test_ping(subnetwork: Subnetwork, target: &Client, peertest: &Peert
         result.data_radius,
         U256::from_be_slice(Distance::MAX.as_ssz_bytes().as_slice())
     );
-    assert_eq!(result.enr_seq, 1);
+    assert_eq!(result.enr_seq, bootnode_sequence);
 }
 
 pub async fn test_ping_cross_network(mainnet_target: &Client, angelfood_node: &PeertestNode) {

--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -2606,13 +2606,11 @@ mod tests {
     use kbucket::KBucketsTable;
     use rstest::*;
     use serial_test::serial;
-    use tempfile::TempDir;
     use tokio::{
         sync::{mpsc::unbounded_channel, RwLock as TokioRwLock},
         time::timeout,
     };
     use tokio_test::{assert_pending, assert_ready, task};
-    use trin_utils::dir::create_temp_test_dir;
 
     use crate::{
         config::PortalnetConfig,
@@ -2637,15 +2635,13 @@ mod tests {
     }
 
     fn build_service(
-        temp_dir: &TempDir,
     ) -> OverlayService<IdentityContentKey, XorMetric, MockValidator, MemoryContentStore> {
         let portal_config = PortalnetConfig {
             no_stun: true,
             no_upnp: true,
             ..Default::default()
         };
-        let discovery =
-            Arc::new(Discovery::new(portal_config, temp_dir.path(), MAINNET.clone()).unwrap());
+        let discovery = Arc::new(Discovery::new(portal_config, MAINNET.clone()).unwrap());
 
         let header_oracle = HeaderOracle::default();
         let header_oracle = Arc::new(TokioRwLock::new(header_oracle));
@@ -2725,8 +2721,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn process_ping_source_in_table_higher_enr_seq() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, source) = generate_random_remote_enr();
         let node_id = source.node_id();
@@ -2779,8 +2774,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn process_ping_source_not_in_table() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, source) = generate_random_remote_enr();
         let node_id = source.node_id();
@@ -2799,8 +2793,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn process_request_failure() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, destination) = generate_random_remote_enr();
         let node_id = destination.node_id();
@@ -2835,8 +2828,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn process_pong_source_in_table_higher_enr_seq() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, source) = generate_random_remote_enr();
         let status = NodeStatus {
@@ -2888,8 +2880,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn process_pong_source_not_in_table() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, source) = generate_random_remote_enr();
         let data_radius = Distance::MAX;
@@ -2907,8 +2898,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn process_discovered_enrs_local_enr() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
         let local_enr = service.discovery.local_enr();
         service.process_discovered_enrs(vec![local_enr.clone()]);
 
@@ -2927,8 +2917,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn process_discovered_enrs_unknown_enrs() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         // Generate random ENRs to simulate.
         let (_, enr1) = generate_random_remote_enr();
@@ -2969,8 +2958,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn process_discovered_enrs_known_enrs() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         // Generate random ENRs to simulate.
         let (sk1, mut enr1) = generate_random_remote_enr();
@@ -3020,8 +3008,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn poke_content() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let content_key = IdentityContentKey::new(service.local_enr().node_id().raw());
         let content = vec![0xef];
@@ -3065,8 +3052,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn poke_content_unknown_peers() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let content_key = IdentityContentKey::new(service.local_enr().node_id().raw());
         let content = vec![0xef];
@@ -3091,8 +3077,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn poke_content_peers_with_sufficient_radius() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let content_key = IdentityContentKey::new(service.local_enr().node_id().raw());
         let content = vec![0xef];
@@ -3143,8 +3128,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn request_node() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, destination) = generate_random_remote_enr();
         service.request_node(&destination);
@@ -3179,8 +3163,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn ping_node() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, destination) = generate_random_remote_enr();
         service.ping_node(&destination);
@@ -3208,8 +3191,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn connect_node() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, enr) = generate_random_remote_enr();
         let node_id = enr.node_id();
@@ -3237,8 +3219,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn update_node_connection_state_disconnected_to_connected() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, enr) = generate_random_remote_enr();
         let node_id = enr.node_id();
@@ -3276,8 +3257,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[serial]
     async fn update_node_connection_state_connected_to_disconnected() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, enr) = generate_random_remote_enr();
         let node_id = enr.node_id();
@@ -3336,8 +3316,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_init_find_nodes_query() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, bootnode1) = generate_random_remote_enr();
         let (_, bootnode2) = generate_random_remote_enr();
@@ -3377,8 +3356,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_advance_findnodes_query() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = build_service(&temp_dir);
+        let mut service = build_service();
 
         let (_, bootnode) = generate_random_remote_enr();
         let bootnodes = vec![bootnode.clone()];
@@ -3499,8 +3477,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_find_enrs() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, bootnode) = generate_random_remote_enr();
         let bootnodes = vec![bootnode.clone()];
@@ -3558,8 +3535,7 @@ mod tests {
 
     #[tokio::test]
     async fn init_find_content_query() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, bootnode_enr) = generate_random_remote_enr();
 
@@ -3608,8 +3584,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_content_no_nodes() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let target_content = NodeId::random();
         let target_content_key = IdentityContentKey::new(target_content.raw());
@@ -3622,8 +3597,7 @@ mod tests {
 
     #[tokio::test]
     async fn advance_find_content_query_with_enrs() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, bootnode_enr) = generate_random_remote_enr();
 
@@ -3682,8 +3656,7 @@ mod tests {
 
     #[tokio::test]
     async fn advance_find_content_query_with_content() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, bootnode_enr) = generate_random_remote_enr();
         let bootnode_node_id = bootnode_enr.node_id();
@@ -3745,8 +3718,7 @@ mod tests {
 
     #[tokio::test]
     async fn advance_find_content_query_with_connection_id() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, bootnode_enr) = generate_random_remote_enr();
         let bootnode_node_id = bootnode_enr.node_id();
@@ -3811,8 +3783,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn handle_find_content_query_event() {
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
 
         let (_, bootnode_enr) = generate_random_remote_enr();
 
@@ -3927,8 +3898,7 @@ mod tests {
     #[tokio::test]
     async fn test_event_stream() {
         // Get overlay service event stream
-        let temp_dir = create_temp_test_dir().unwrap();
-        let mut service = task::spawn(build_service(&temp_dir));
+        let mut service = task::spawn(build_service());
         let (sender, mut receiver) = broadcast::channel(1);
         service.event_stream = sender;
         // Emit LightClientUpdate event

--- a/rpc/src/rpc_server.rs
+++ b/rpc/src/rpc_server.rs
@@ -624,7 +624,6 @@ mod tests {
     use ethportal_api::types::portal_wire::MAINNET;
     use portalnet::discovery::Discovery;
     use std::{io, sync::Arc};
-    use trin_utils::dir::create_temp_test_dir;
 
     /// Localhost with port 0 so a free port is used.
     pub fn test_address() -> SocketAddr {
@@ -644,9 +643,7 @@ mod tests {
     pub fn test_rpc_builder() -> RpcModuleBuilder {
         let (history_tx, _) = tokio::sync::mpsc::unbounded_channel();
         let (beacon_tx, _) = tokio::sync::mpsc::unbounded_channel();
-        let temp_dir = create_temp_test_dir().unwrap().into_path();
-        let discv5 =
-            Arc::new(Discovery::new(Default::default(), &temp_dir, MAINNET.clone()).unwrap());
+        let discv5 = Arc::new(Discovery::new(Default::default(), MAINNET.clone()).unwrap());
         RpcModuleBuilder::new(discv5)
             .with_history(history_tx)
             .with_beacon(beacon_tx)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,11 +55,7 @@ pub async fn run_trin(
     let portalnet_config = PortalnetConfig::new(&trin_config, private_key);
 
     // Initialize base discovery protocol
-    let mut discovery = Discovery::new(
-        portalnet_config.clone(),
-        &node_data_dir,
-        trin_config.network.clone(),
-    )?;
+    let mut discovery = Discovery::new(portalnet_config.clone(), trin_config.network.clone())?;
     let talk_req_rx = discovery.start().await?;
     let discovery = Arc::new(discovery);
 

--- a/utp-testing/src/lib.rs
+++ b/utp-testing/src/lib.rs
@@ -25,7 +25,6 @@ use tokio::sync::{
     mpsc::{self, Receiver},
     RwLock,
 };
-use trin_utils::dir::create_temp_test_dir;
 use trin_validation::oracle::HeaderOracle;
 use utp_rs::{conn::ConnectionConfig, socket::UtpSocket};
 
@@ -167,8 +166,7 @@ pub async fn run_test_app(
         ..Default::default()
     };
 
-    let temp_dir = create_temp_test_dir()?.into_path();
-    let mut discovery = Discovery::new(config, &temp_dir, MAINNET.clone()).unwrap();
+    let mut discovery = Discovery::new(config, MAINNET.clone()).unwrap();
     let talk_req_rx = discovery.start().await.unwrap();
     let enr = discovery.local_enr();
     let discovery = Arc::new(discovery);


### PR DESCRIPTION
### What was wrong?
last year I attempted to fix a bug where every time trin booted our sequence number was always default (0 or something) which was bad because that meant that peers would think our Enr we were sending  was outdated as they would have an enr of our node already with a higher sequence https://github.com/ethereum/trin/pull/937

The issue with this solution was sigp/discv5 would sometimes update the Enr and incremeant the sequence because this is done on the sigp/discv5 level we wouldn't save the sequence number to a file to restore on reboot so the same bug could occur which I tried to fix before.

sigp/discv5 sometimes updates the IP of the node which is good because most households have dynamic IP address or what if Trin is running on a laptop we need to be able to handle IP changes.
### How was it fixed?

By setting the sequence number to the current epoch timestamp on Trin's initalization, even if sigp/discv5 increments the sequence number of our Enr when we reboot Trin, we will set the sequence to the latest timestamp again, which will always be higher than what the sequence was before boot.

Hence the problem is fixed! I meant to make this PR months ago but I was distracted by higher-priority issues