### PR TITLE
refactor: update jsonrpc endpoint from *RecursiveFindContent to *GetContent

### DIFF
--- a/book/src/developers/protocols/json_rpc.md
+++ b/book/src/developers/protocols/json_rpc.md
@@ -16,7 +16,7 @@ The specification for these endpoints can be found [here](https://playground.ope
 - `portal_historyLocalContent`
 - `portal_historyPing`
 - `portal_historyOffer`
-- `portal_historyRecursiveFindContent`
+- `portal_historyGetContent`
 - `portal_historyStore`
 - `portal_stateFindContent`
 - `portal_stateFindNodes`
@@ -30,7 +30,7 @@ The specification for these endpoints can be found [here](https://playground.ope
 The following endpoints are not part of the Portal Network specification and are defined
 in subsequent sections:
 - [`portal_historyRadius`](#portal_historyradius)
-- [`portal_historyTraceRecursiveFindContent`](#portal_historytracerecursivefindcontent)
+- [`portal_historyTraceGetContent`](#portal_historytracegetcontent)
 - [`portal_paginateLocalContentKeys`](#portal_paginatelocalcontentkeys)
 - [`portal_stateRadius`](#portal_stateradius)
 
@@ -54,8 +54,8 @@ Returns the current data storage radius being used for the History network.
 }
 ```
 
-## `portal_historyTraceRecursiveFindContent`
-Same as `portal_historyRecursiveFindContent`, but will also return a "route" with the content. The "route" contains all of the ENR's contacted during the lookup, and their respective distance to the target content. If the content is available in local storage, the route will contain an empty array.
+## `portal_historyTraceGetContent`
+Same as `portal_historyGetContent`, but will also return a "route" with the content. The "route" contains all of the ENR's contacted during the lookup, and their respective distance to the target content. If the content is available in local storage, the route will contain an empty array.
 
 ### Parameters
 - `content_key`: Target content key.

--- a/book/src/users/use/portal_network_data.md
+++ b/book/src/users/use/portal_network_data.md
@@ -19,19 +19,19 @@ Let us request the block body for block 16624561
 - Block hash: `0xd27f5e55d88b447788667b3d72cca66b7c944160f68f0a62aaf02aa7e4b2af17`
 - Selector for a block body: `0x01` (defined in Portal Network spec under the History sub-protocol).
 - Content key: `0x01d27f5e55d88b447788667b3d72cca66b7c944160f68f0a62aaf02aa7e4b2af17`
-- Request: `portal_historyRecursiveFindContent`, which accepts a content key as a parameter
+- Request: `portal_historyGetContent`, which accepts a content key as a parameter
 
 ```json
-{"jsonrpc":"2.0","method":"portal_historyRecursiveFindContent","params":["0x01d27f5e55d88b447788667b3d72cca66b7c944160f68f0a62aaf02aa7e4b2af17"],"id":1}
+{"jsonrpc":"2.0","method":"portal_historyGetContent","params":["0x01d27f5e55d88b447788667b3d72cca66b7c944160f68f0a62aaf02aa7e4b2af17"],"id":1}
 ```
 ## HTTP
 
 ```sh
-curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"portal_historyRecursiveFindContent","params":["0x01d27f5e55d88b447788667b3d72cca66b7c944160f68f0a62aaf02aa7e4b2af17"],"id":1}' http://localhost:8545 | jq
+curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"portal_historyGetContent","params":["0x01d27f5e55d88b447788667b3d72cca66b7c944160f68f0a62aaf02aa7e4b2af17"],"id":1}' http://localhost:8545 | jq
 ```
 
 ## IPC
 
 ```sh
-echo '{"jsonrpc":"2.0","method":"portal_historyRecursiveFindContent","params":["0x01d27f5e55d88b447788667b3d72cca66b7c944160f68f0a62aaf02aa7e4b2af17"],"id":1}' | nc -U /tmp/trin-jsonrpc.ipc | jq
+echo '{"jsonrpc":"2.0","method":"portal_historyGetContent","params":["0x01d27f5e55d88b447788667b3d72cca66b7c944160f68f0a62aaf02aa7e4b2af17"],"id":1}' | nc -U /tmp/trin-jsonrpc.ipc | jq
 ```

--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -78,16 +78,13 @@ pub trait BeaconNetworkApi {
         -> RpcResult<ContentInfo>;
 
     /// Lookup a target content key in the network
-    #[method(name = "beaconRecursiveFindContent")]
-    async fn recursive_find_content(&self, content_key: BeaconContentKey)
-        -> RpcResult<ContentInfo>;
+    #[method(name = "beaconGetContent")]
+    async fn get_content(&self, content_key: BeaconContentKey) -> RpcResult<ContentInfo>;
 
     /// Lookup a target content key in the network. Return tracing info.
-    #[method(name = "beaconTraceRecursiveFindContent")]
-    async fn trace_recursive_find_content(
-        &self,
-        content_key: BeaconContentKey,
-    ) -> RpcResult<TraceContentInfo>;
+    #[method(name = "beaconTraceGetContent")]
+    async fn trace_get_content(&self, content_key: BeaconContentKey)
+        -> RpcResult<TraceContentInfo>;
 
     /// Pagination of local content keys
     #[method(name = "beaconPaginateLocalContentKeys")]

--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -77,7 +77,8 @@ pub trait BeaconNetworkApi {
     async fn find_content(&self, enr: Enr, content_key: BeaconContentKey)
         -> RpcResult<ContentInfo>;
 
-    /// Lookup a target content key in the network
+    /// First checks local storage if content is not found lookup a target content key in the
+    /// network
     #[method(name = "beaconGetContent")]
     async fn get_content(&self, content_key: BeaconContentKey) -> RpcResult<ContentInfo>;
 

--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -82,7 +82,8 @@ pub trait BeaconNetworkApi {
     #[method(name = "beaconGetContent")]
     async fn get_content(&self, content_key: BeaconContentKey) -> RpcResult<ContentInfo>;
 
-    /// Lookup a target content key in the network. Return tracing info.
+    /// First checks local storage if content is not found lookup a target content key in the
+    /// network. Return tracing info.
     #[method(name = "beaconTraceGetContent")]
     async fn trace_get_content(&self, content_key: BeaconContentKey)
         -> RpcResult<TraceContentInfo>;

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -62,15 +62,12 @@ pub trait HistoryNetworkApi {
     ) -> RpcResult<ContentInfo>;
 
     /// Lookup a target content key in the network
-    #[method(name = "historyRecursiveFindContent")]
-    async fn recursive_find_content(
-        &self,
-        content_key: HistoryContentKey,
-    ) -> RpcResult<ContentInfo>;
+    #[method(name = "historyGetContent")]
+    async fn get_content(&self, content_key: HistoryContentKey) -> RpcResult<ContentInfo>;
 
     /// Lookup a target content key in the network. Return tracing info.
-    #[method(name = "historyTraceRecursiveFindContent")]
-    async fn trace_recursive_find_content(
+    #[method(name = "historyTraceGetContent")]
+    async fn trace_get_content(
         &self,
         content_key: HistoryContentKey,
     ) -> RpcResult<TraceContentInfo>;

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -61,11 +61,13 @@ pub trait HistoryNetworkApi {
         content_key: HistoryContentKey,
     ) -> RpcResult<ContentInfo>;
 
-    /// Lookup a target content key in the network
+    /// First checks local storage if content is not found lookup a target content key in the
+    /// network
     #[method(name = "historyGetContent")]
     async fn get_content(&self, content_key: HistoryContentKey) -> RpcResult<ContentInfo>;
 
-    /// Lookup a target content key in the network. Return tracing info.
+    /// First checks local storage if content is not found lookup a target content key in the
+    /// network. Return tracing info.
     #[method(name = "historyTraceGetContent")]
     async fn trace_get_content(
         &self,

--- a/ethportal-api/src/state.rs
+++ b/ethportal-api/src/state.rs
@@ -58,15 +58,12 @@ pub trait StateNetworkApi {
     async fn find_content(&self, enr: Enr, content_key: StateContentKey) -> RpcResult<ContentInfo>;
 
     /// Lookup a target content key in the network
-    #[method(name = "stateRecursiveFindContent")]
-    async fn recursive_find_content(&self, content_key: StateContentKey) -> RpcResult<ContentInfo>;
+    #[method(name = "stateGetContent")]
+    async fn get_content(&self, content_key: StateContentKey) -> RpcResult<ContentInfo>;
 
     /// Lookup a target content key in the network. Return tracing info.
-    #[method(name = "stateTraceRecursiveFindContent")]
-    async fn trace_recursive_find_content(
-        &self,
-        content_key: StateContentKey,
-    ) -> RpcResult<TraceContentInfo>;
+    #[method(name = "stateTraceGetContent")]
+    async fn trace_get_content(&self, content_key: StateContentKey) -> RpcResult<TraceContentInfo>;
 
     /// Pagination of local content keys
     #[method(name = "statePaginateLocalContentKeys")]

--- a/ethportal-api/src/state.rs
+++ b/ethportal-api/src/state.rs
@@ -57,11 +57,13 @@ pub trait StateNetworkApi {
     #[method(name = "stateFindContent")]
     async fn find_content(&self, enr: Enr, content_key: StateContentKey) -> RpcResult<ContentInfo>;
 
-    /// Lookup a target content key in the network
+    /// First checks local storage if content is not found lookup a target content key in the
+    /// network
     #[method(name = "stateGetContent")]
     async fn get_content(&self, content_key: StateContentKey) -> RpcResult<ContentInfo>;
 
-    /// Lookup a target content key in the network. Return tracing info.
+    /// First checks local storage if content is not found lookup a target content key in the
+    /// network. Return tracing info.
     #[method(name = "stateTraceGetContent")]
     async fn trace_get_content(&self, content_key: StateContentKey) -> RpcResult<TraceContentInfo>;
 

--- a/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -37,9 +37,9 @@ pub enum StateEndpoint {
     /// params: [enr, content_key]
     FindContent(Enr, StateContentKey),
     /// params: content_key
-    RecursiveFindContent(StateContentKey),
+    GetContent(StateContentKey),
     /// params: content_key
-    TraceRecursiveFindContent(StateContentKey),
+    TraceGetContent(StateContentKey),
     /// params: [content_key, content_value]
     Store(StateContentKey, StateContentValue),
     /// params: [enr, Vec<(content_key, content_value>)]
@@ -84,9 +84,9 @@ pub enum HistoryEndpoint {
     /// params: [enr]
     Ping(Enr),
     /// params: content_key
-    RecursiveFindContent(HistoryContentKey),
+    GetContent(HistoryContentKey),
     /// params: content_key
-    TraceRecursiveFindContent(HistoryContentKey),
+    TraceGetContent(HistoryContentKey),
     /// params: [content_key, content_value]
     Store(HistoryContentKey, HistoryContentValue),
     /// params: None
@@ -136,9 +136,9 @@ pub enum BeaconEndpoint {
     /// params: enr
     Ping(Enr),
     /// params: content_key
-    RecursiveFindContent(BeaconContentKey),
+    GetContent(BeaconContentKey),
     /// params: content_key
-    TraceRecursiveFindContent(BeaconContentKey),
+    TraceGetContent(BeaconContentKey),
     /// params: [content_key, content_value]
     Store(BeaconContentKey, BeaconContentValue),
     /// params: None

--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -14,14 +14,6 @@ pub type RawContentValue = Bytes;
 pub type DataRadius = U256;
 pub type Distance = U256;
 
-/// Part of a TraceGetContent response
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NodeInfo {
-    pub enr: Enr,
-    pub distance: Distance,
-}
-
 /// Response for Ping endpoint
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -14,7 +14,7 @@ pub type RawContentValue = Bytes;
 pub type DataRadius = U256;
 pub type Distance = U256;
 
-/// Part of a TraceRecursiveFindContent response
+/// Part of a TraceGetContent response
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeInfo {
@@ -53,7 +53,7 @@ pub struct TraceGossipInfo {
     pub transferred: Vec<String>,
 }
 
-/// Response for FindContent & RecursiveFindContent endpoints
+/// Response for FindContent & GetContent endpoints
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
@@ -69,7 +69,7 @@ pub enum ContentInfo {
     Enrs { enrs: Vec<Enr> },
 }
 
-/// Parsed response for TraceRecursiveFindContent endpoint
+/// Parsed response for TraceGetContent endpoint
 ///
 /// This struct represents the content info, and is only used
 /// when the content is found locally or on the network.

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -81,7 +81,7 @@ pub async fn test_find_content_return_enr(target: &Client, peertest: &Peertest) 
     }
 }
 
-pub async fn test_trace_recursive_find_content(peertest: &Peertest) {
+pub async fn test_trace_get_content(peertest: &Peertest) {
     info!("Testing trace recursive find content");
     let (content_key, content_value) = fixture_header_by_hash();
     let store_result = HistoryNetworkApiClient::store(
@@ -95,7 +95,7 @@ pub async fn test_trace_recursive_find_content(peertest: &Peertest) {
     assert!(store_result);
 
     let query_start_time = SystemTime::now();
-    let trace_content_info = HistoryNetworkApiClient::trace_recursive_find_content(
+    let trace_content_info = HistoryNetworkApiClient::trace_get_content(
         &peertest.nodes[0].ipc_client,
         content_key.clone(),
     )
@@ -136,11 +136,11 @@ pub async fn test_trace_recursive_find_content(peertest: &Peertest) {
 }
 
 // This test ensures that when content is not found the correct response is returned.
-pub async fn test_trace_recursive_find_content_for_absent_content(peertest: &Peertest) {
+pub async fn test_trace_get_content_for_absent_content(peertest: &Peertest) {
     let client = &peertest.nodes[0].ipc_client;
     let (content_key, _) = fixture_header_by_hash();
 
-    let error = HistoryNetworkApiClient::trace_recursive_find_content(client, content_key)
+    let error = HistoryNetworkApiClient::trace_get_content(client, content_key)
         .await
         .unwrap_err()
         .to_string();
@@ -150,7 +150,7 @@ pub async fn test_trace_recursive_find_content_for_absent_content(peertest: &Pee
     assert!(error.contains("-39001"));
 }
 
-pub async fn test_trace_recursive_find_content_local_db(peertest: &Peertest) {
+pub async fn test_trace_get_content_local_db(peertest: &Peertest) {
     let (content_key, content_value) = fixture_header_by_hash();
 
     let store_result = HistoryNetworkApiClient::store(
@@ -163,12 +163,10 @@ pub async fn test_trace_recursive_find_content_local_db(peertest: &Peertest) {
 
     assert!(store_result);
 
-    let trace_content_info = HistoryNetworkApiClient::trace_recursive_find_content(
-        &peertest.bootnode.ipc_client,
-        content_key,
-    )
-    .await
-    .unwrap();
+    let trace_content_info =
+        HistoryNetworkApiClient::trace_get_content(&peertest.bootnode.ipc_client, content_key)
+            .await
+            .unwrap();
     assert!(!trace_content_info.utp_transfer);
     assert_eq!(trace_content_info.content, content_value.encode());
 

--- a/ethportal-peertest/src/scenarios/gossip.rs
+++ b/ethportal-peertest/src/scenarios/gossip.rs
@@ -296,7 +296,7 @@ pub async fn test_gossip_dropped_with_find_content(peertest: &Peertest, target: 
         .await
         .unwrap();
 
-    // send find_content request from fresh target to target
+    // send get_content request from fresh target to target
     let _result = fresh_target.get_content(body_key_2.clone()).await.unwrap();
 
     // check that the fresh target has stored body_2 stored

--- a/ethportal-peertest/src/scenarios/gossip.rs
+++ b/ethportal-peertest/src/scenarios/gossip.rs
@@ -297,11 +297,7 @@ pub async fn test_gossip_dropped_with_find_content(peertest: &Peertest, target: 
         .unwrap();
 
     // send find_content request from fresh target to target
-    let _result = fresh_target
-        //.find_content(target.node_info().await.unwrap().enr, acc_key_2.clone())
-        .get_content(body_key_2.clone())
-        .await
-        .unwrap();
+    let _result = fresh_target.get_content(body_key_2.clone()).await.unwrap();
 
     // check that the fresh target has stored body_2 stored
     assert_eq!(

--- a/ethportal-peertest/src/scenarios/gossip.rs
+++ b/ethportal-peertest/src/scenarios/gossip.rs
@@ -299,7 +299,7 @@ pub async fn test_gossip_dropped_with_find_content(peertest: &Peertest, target: 
     // send find_content request from fresh target to target
     let _result = fresh_target
         //.find_content(target.node_info().await.unwrap().enr, acc_key_2.clone())
-        .recursive_find_content(body_key_2.clone())
+        .get_content(body_key_2.clone())
         .await
         .unwrap();
 

--- a/ethportal-peertest/src/scenarios/utp.rs
+++ b/ethportal-peertest/src/scenarios/utp.rs
@@ -34,7 +34,7 @@ pub async fn test_recursive_utp(peertest: &Peertest) {
 
     let content_info = peertest.nodes[0]
         .ipc_client
-        .recursive_find_content(content_key)
+        .get_content(content_key)
         .await
         .unwrap();
 
@@ -76,7 +76,7 @@ pub async fn test_trace_recursive_utp(peertest: &Peertest) {
 
     let trace_content_info: TraceContentInfo = peertest.nodes[0]
         .ipc_client
-        .trace_recursive_find_content(content_key)
+        .trace_get_content(content_key)
         .await
         .unwrap();
 

--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -175,10 +175,7 @@ impl Era1Bridge {
             let mut found = 0;
             let hunter_threshold = (content_keys_to_sample.len() as u64 * threshold / 100) as usize;
             for content_key in content_keys_to_sample {
-                let result = self
-                    .portal_client
-                    .recursive_find_content(content_key.clone())
-                    .await;
+                let result = self.portal_client.get_content(content_key.clone()).await;
                 if let Ok(ContentInfo::Content { .. }) = result {
                     found += 1;
                     if found == hunter_threshold {
@@ -370,9 +367,7 @@ impl Era1Bridge {
         if hunt {
             let header_hash = block_tuple.header.header.hash();
             let header_content_key = HistoryContentKey::new_block_header_by_hash(header_hash);
-            let header_content_info = portal_client
-                .recursive_find_content(header_content_key.clone())
-                .await;
+            let header_content_info = portal_client.get_content(header_content_key.clone()).await;
             if let Ok(ContentInfo::Content { .. }) = header_content_info {
                 info!(
                     "Skipping header by hash at height: {} as header already found",
@@ -423,9 +418,7 @@ impl Era1Bridge {
         if hunt {
             let header_content_key =
                 HistoryContentKey::new_block_header_by_number(block_tuple.header.header.number);
-            let header_content_info = portal_client
-                .recursive_find_content(header_content_key.clone())
-                .await;
+            let header_content_info = portal_client.get_content(header_content_key.clone()).await;
             if let Ok(ContentInfo::Content { .. }) = header_content_info {
                 info!(
                     "Skipping header by number at height: {} as header already found",
@@ -466,9 +459,7 @@ impl Era1Bridge {
         if hunt {
             let body_hash = block_tuple.header.header.hash();
             let body_content_key = HistoryContentKey::new_block_body(body_hash);
-            let body_content_info = portal_client
-                .recursive_find_content(body_content_key.clone())
-                .await;
+            let body_content_info = portal_client.get_content(body_content_key.clone()).await;
             if let Ok(ContentInfo::Content { .. }) = body_content_info {
                 info!(
                     "Skipping body at height: {} as body already found",
@@ -508,7 +499,7 @@ impl Era1Bridge {
             let receipts_hash = block_tuple.header.header.hash();
             let receipts_content_key = HistoryContentKey::new_block_receipts(receipts_hash);
             let receipts_content_info = portal_client
-                .recursive_find_content(receipts_content_key.clone())
+                .get_content(receipts_content_key.clone())
                 .await;
             if let Ok(ContentInfo::Content { .. }) = receipts_content_info {
                 info!(

--- a/portal-bridge/src/gossip.rs
+++ b/portal-bridge/src/gossip.rs
@@ -60,8 +60,7 @@ async fn beacon_trace_gossip(
             }
         }
         // if not, make rfc request to see if data is available on network
-        let result =
-            BeaconNetworkApiClient::recursive_find_content(&client, content_key.clone()).await;
+        let result = BeaconNetworkApiClient::get_content(&client, content_key.clone()).await;
         if let Ok(ContentInfo::Content { .. }) = result {
             debug!("Found content on network, after failing to gossip, aborting gossip. content key={:?}", content_key.to_hex());
             found = true;
@@ -133,8 +132,7 @@ async fn history_trace_gossip(
             }
         }
         // if not, make rfc request to see if data is available on network
-        let result =
-            HistoryNetworkApiClient::recursive_find_content(&client, content_key.clone()).await;
+        let result = HistoryNetworkApiClient::get_content(&client, content_key.clone()).await;
         if let Ok(ContentInfo::Content { .. }) = result {
             debug!("Found content on network, after failing to gossip, aborting gossip. content key={:?}", content_key.to_hex());
             found = true;

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -125,13 +125,15 @@ impl BeaconNetworkApiServer for BeaconNetworkApi {
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
-    /// Lookup a target content key in the network
+    /// First checks local storage if content is not found lookup a target content key in the
+    /// network
     async fn get_content(&self, content_key: BeaconContentKey) -> RpcResult<ContentInfo> {
         let endpoint = BeaconEndpoint::GetContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
-    /// Lookup a target content key in the network. Return tracing info.
+    /// First checks local storage if content is not found lookup a target content key in the
+    /// network. Return tracing info.
     async fn trace_get_content(
         &self,
         content_key: BeaconContentKey,

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -126,20 +126,17 @@ impl BeaconNetworkApiServer for BeaconNetworkApi {
     }
 
     /// Lookup a target content key in the network
-    async fn recursive_find_content(
-        &self,
-        content_key: BeaconContentKey,
-    ) -> RpcResult<ContentInfo> {
-        let endpoint = BeaconEndpoint::RecursiveFindContent(content_key);
+    async fn get_content(&self, content_key: BeaconContentKey) -> RpcResult<ContentInfo> {
+        let endpoint = BeaconEndpoint::GetContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Lookup a target content key in the network. Return tracing info.
-    async fn trace_recursive_find_content(
+    async fn trace_get_content(
         &self,
         content_key: BeaconContentKey,
     ) -> RpcResult<TraceContentInfo> {
-        let endpoint = BeaconEndpoint::TraceRecursiveFindContent(content_key);
+        let endpoint = BeaconEndpoint::TraceGetContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 

--- a/rpc/src/eth_rpc.rs
+++ b/rpc/src/eth_rpc.rs
@@ -171,11 +171,11 @@ impl EthApi {
         &self,
         content_key: HistoryContentKey,
     ) -> Result<HistoryContentValue, RpcServeError> {
-        let endpoint = HistoryEndpoint::RecursiveFindContent(content_key.clone());
+        let endpoint = HistoryEndpoint::GetContent(content_key.clone());
         let response: ContentInfo = proxy_to_subnet(&self.history_network, endpoint).await?;
         let ContentInfo::Content { content, .. } = response else {
             return Err(RpcServeError::Message(format!(
-                "Invalid response variant: History RecursiveFindContent should contain content value; got {response:?}"
+                "Invalid response variant: History GetContent should contain content value; got {response:?}"
             )));
         };
 

--- a/rpc/src/evm_state.rs
+++ b/rpc/src/evm_state.rs
@@ -161,13 +161,13 @@ impl EvmBlockState {
             return Ok(value.clone());
         }
 
-        let endpoint = StateEndpoint::RecursiveFindContent(content_key.clone());
+        let endpoint = StateEndpoint::GetContent(content_key.clone());
         let response: ContentInfo = proxy_to_subnet(&self.state_network, endpoint)
             .await
             .map_err(|err| EvmStateError::InternalError(err.to_string()))?;
         let ContentInfo::Content { content, .. } = response else {
             return Err(EvmStateError::InternalError(format!(
-                "Invalid response variant: State RecursiveFindContent should contain content value; got {response:?}"
+                "Invalid response variant: State GetContent should contain content value; got {response:?}"
             )));
         };
 

--- a/rpc/src/history_rpc.rs
+++ b/rpc/src/history_rpc.rs
@@ -99,20 +99,17 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
     }
 
     /// Lookup a target content key in the network
-    async fn recursive_find_content(
-        &self,
-        content_key: HistoryContentKey,
-    ) -> RpcResult<ContentInfo> {
-        let endpoint = HistoryEndpoint::RecursiveFindContent(content_key);
+    async fn get_content(&self, content_key: HistoryContentKey) -> RpcResult<ContentInfo> {
+        let endpoint = HistoryEndpoint::GetContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Lookup a target content key in the network. Return tracing info.
-    async fn trace_recursive_find_content(
+    async fn trace_get_content(
         &self,
         content_key: HistoryContentKey,
     ) -> RpcResult<TraceContentInfo> {
-        let endpoint = HistoryEndpoint::TraceRecursiveFindContent(content_key);
+        let endpoint = HistoryEndpoint::TraceGetContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 

--- a/rpc/src/history_rpc.rs
+++ b/rpc/src/history_rpc.rs
@@ -98,13 +98,15 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
-    /// Lookup a target content key in the network
+    /// First checks local storage if content is not found lookup a target content key in the
+    /// network
     async fn get_content(&self, content_key: HistoryContentKey) -> RpcResult<ContentInfo> {
         let endpoint = HistoryEndpoint::GetContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
-    /// Lookup a target content key in the network. Return tracing info.
+    /// First checks local storage if content is not found lookup a target content key in the
+    /// network. Return tracing info.
     async fn trace_get_content(
         &self,
         content_key: HistoryContentKey,

--- a/rpc/src/state_rpc.rs
+++ b/rpc/src/state_rpc.rs
@@ -95,17 +95,14 @@ impl StateNetworkApiServer for StateNetworkApi {
     }
 
     /// Lookup a target content key in the network
-    async fn recursive_find_content(&self, content_key: StateContentKey) -> RpcResult<ContentInfo> {
-        let endpoint = StateEndpoint::RecursiveFindContent(content_key);
+    async fn get_content(&self, content_key: StateContentKey) -> RpcResult<ContentInfo> {
+        let endpoint = StateEndpoint::GetContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Lookup a target content key in the network. Return tracing info.
-    async fn trace_recursive_find_content(
-        &self,
-        content_key: StateContentKey,
-    ) -> RpcResult<TraceContentInfo> {
-        let endpoint = StateEndpoint::TraceRecursiveFindContent(content_key);
+    async fn trace_get_content(&self, content_key: StateContentKey) -> RpcResult<TraceContentInfo> {
+        let endpoint = StateEndpoint::TraceGetContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 

--- a/rpc/src/state_rpc.rs
+++ b/rpc/src/state_rpc.rs
@@ -94,13 +94,15 @@ impl StateNetworkApiServer for StateNetworkApi {
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
-    /// Lookup a target content key in the network
+    /// First checks local storage if content is not found lookup a target content key in the
+    /// network
     async fn get_content(&self, content_key: StateContentKey) -> RpcResult<ContentInfo> {
         let endpoint = StateEndpoint::GetContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
-    /// Lookup a target content key in the network. Return tracing info.
+    /// First checks local storage if content is not found lookup a target content key in the
+    /// network. Return tracing info.
     async fn trace_get_content(&self, content_key: StateContentKey) -> RpcResult<TraceContentInfo> {
         let endpoint = StateEndpoint::TraceGetContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)

--- a/src/bin/poll_latest.rs
+++ b/src/bin/poll_latest.rs
@@ -237,7 +237,7 @@ async fn audit_content_key(
 ) -> anyhow::Result<Instant> {
     let mut attempts = 0;
     while Instant::now() - timestamp < timeout {
-        match client.recursive_find_content(content_key.clone()).await? {
+        match client.get_content(content_key.clone()).await? {
             ContentInfo::Content { .. } => {
                 return Ok(Instant::now());
             }

--- a/src/bin/sample_range.rs
+++ b/src/bin/sample_range.rs
@@ -142,7 +142,7 @@ async fn audit_block(
     let header_by_number_ck = HistoryContentKey::new_block_header_by_number(block_number);
     let body_ck = HistoryContentKey::new_block_body(hash);
     let receipts_ck = HistoryContentKey::new_block_receipts(hash);
-    match client.recursive_find_content(header_by_hash_ck).await {
+    match client.get_content(header_by_hash_ck).await {
         Ok(_) => {
             metrics.lock().unwrap().header_by_hash.success_count += 1;
         }
@@ -151,7 +151,7 @@ async fn audit_block(
             metrics.lock().unwrap().header_by_hash.failure_count += 1;
         }
     }
-    match client.recursive_find_content(header_by_number_ck).await {
+    match client.get_content(header_by_number_ck).await {
         Ok(_) => {
             metrics.lock().unwrap().header_by_number.success_count += 1;
         }
@@ -160,7 +160,7 @@ async fn audit_block(
             metrics.lock().unwrap().header_by_number.failure_count += 1;
         }
     }
-    match client.recursive_find_content(body_ck).await {
+    match client.get_content(body_ck).await {
         Ok(_) => {
             metrics.lock().unwrap().block_body.success_count += 1;
         }
@@ -169,7 +169,7 @@ async fn audit_block(
             metrics.lock().unwrap().block_body.failure_count += 1;
         }
     }
-    match client.recursive_find_content(receipts_ck).await {
+    match client.get_content(receipts_ck).await {
         Ok(_) => {
             metrics.lock().unwrap().receipts.success_count += 1;
         }

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -112,31 +112,30 @@ async fn peertest_find_content_return_enr() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
-async fn peertest_trace_recursive_find_content_local_db() {
+async fn peertest_trace_get_content_local_db() {
     let (peertest, _target, handle) =
         setup_peertest(&Network::Mainnet, &[Subnetwork::History]).await;
-    peertest::scenarios::find::test_trace_recursive_find_content_local_db(&peertest).await;
+    peertest::scenarios::find::test_trace_get_content_local_db(&peertest).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
-async fn peertest_trace_recursive_find_content_for_absent_content() {
+async fn peertest_trace_get_content_for_absent_content() {
     let (peertest, _target, handle) =
         setup_peertest(&Network::Mainnet, &[Subnetwork::History]).await;
-    peertest::scenarios::find::test_trace_recursive_find_content_for_absent_content(&peertest)
-        .await;
+    peertest::scenarios::find::test_trace_get_content_for_absent_content(&peertest).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
-async fn peertest_trace_recursive_find_content() {
+async fn peertest_trace_get_content() {
     let (peertest, _target, handle) =
         setup_peertest(&Network::Mainnet, &[Subnetwork::History]).await;
-    peertest::scenarios::find::test_trace_recursive_find_content(&peertest).await;
+    peertest::scenarios::find::test_trace_get_content(&peertest).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
 }

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -47,11 +47,9 @@ async fn complete_request(network: Arc<BeaconNetwork>, request: BeaconJsonRpcReq
         BeaconEndpoint::Store(content_key, content_value) => {
             store(network, content_key, content_value).await
         }
-        BeaconEndpoint::RecursiveFindContent(content_key) => {
-            recursive_find_content(network, content_key, false).await
-        }
-        BeaconEndpoint::TraceRecursiveFindContent(content_key) => {
-            recursive_find_content(network, content_key, true).await
+        BeaconEndpoint::GetContent(content_key) => get_content(network, content_key, false).await,
+        BeaconEndpoint::TraceGetContent(content_key) => {
+            get_content(network, content_key, true).await
         }
         BeaconEndpoint::AddEnr(enr) => add_enr(network, enr).await,
         BeaconEndpoint::DataRadius => {
@@ -125,8 +123,8 @@ async fn complete_request(network: Arc<BeaconNetwork>, request: BeaconJsonRpcReq
     let _ = request.resp.send(response);
 }
 
-/// Constructs a JSON call for the RecursiveFindContent method.
-async fn recursive_find_content(
+/// Constructs a JSON call for the GetContent method.
+async fn get_content(
     network: Arc<BeaconNetwork>,
     content_key: BeaconContentKey,
     is_trace: bool,

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -46,11 +46,9 @@ async fn complete_request(network: Arc<HistoryNetwork>, request: HistoryJsonRpcR
         HistoryEndpoint::Store(content_key, content_value) => {
             store(network, content_key, content_value).await
         }
-        HistoryEndpoint::RecursiveFindContent(content_key) => {
-            recursive_find_content(network, content_key, false).await
-        }
-        HistoryEndpoint::TraceRecursiveFindContent(content_key) => {
-            recursive_find_content(network, content_key, true).await
+        HistoryEndpoint::GetContent(content_key) => get_content(network, content_key, false).await,
+        HistoryEndpoint::TraceGetContent(content_key) => {
+            get_content(network, content_key, true).await
         }
         HistoryEndpoint::AddEnr(enr) => add_enr(network, enr).await,
         HistoryEndpoint::DataRadius => {
@@ -86,8 +84,8 @@ async fn complete_request(network: Arc<HistoryNetwork>, request: HistoryJsonRpcR
     let _ = request.resp.send(response);
 }
 
-/// Constructs a JSON call for the RecursiveFindContent method.
-async fn recursive_find_content(
+/// Constructs a JSON call for the GetContent method.
+async fn get_content(
     network: Arc<HistoryNetwork>,
     content_key: HistoryContentKey,
     is_trace: bool,

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -52,11 +52,11 @@ impl StateRequestHandler {
             StateEndpoint::FindContent(enr, content_key) => {
                 find_content(network, enr, content_key).await
             }
-            StateEndpoint::RecursiveFindContent(content_key) => {
-                recursive_find_content(network, content_key, /* is_trace= */ false).await
+            StateEndpoint::GetContent(content_key) => {
+                get_content(network, content_key, /* is_trace= */ false).await
             }
-            StateEndpoint::TraceRecursiveFindContent(content_key) => {
-                recursive_find_content(network, content_key, /* is_trace= */ true).await
+            StateEndpoint::TraceGetContent(content_key) => {
+                get_content(network, content_key, /* is_trace= */ true).await
             }
             StateEndpoint::Store(content_key, content_value) => {
                 store(network, content_key, content_value).await
@@ -211,7 +211,7 @@ async fn find_content(
     to_json_result("FindContent", result)
 }
 
-async fn recursive_find_content(
+async fn get_content(
     network: Arc<StateNetwork>,
     content_key: StateContentKey,
     is_trace: bool,

--- a/trin-state/src/validation/validator.rs
+++ b/trin-state/src/validation/validator.rs
@@ -185,7 +185,7 @@ mod tests {
         });
         let history_jsonrpc_tx = MockJsonRpcBuilder::new()
             .with_response(
-                HistoryEndpoint::RecursiveFindContent(HistoryContentKey::new_block_header_by_hash(
+                HistoryEndpoint::GetContent(HistoryContentKey::new_block_header_by_hash(
                     header.hash(),
                 )),
                 ContentInfo::Content {

--- a/trin-validation/src/oracle.rs
+++ b/trin-validation/src/oracle.rs
@@ -56,7 +56,7 @@ impl HeaderOracle {
         block_hash: B256,
     ) -> anyhow::Result<HeaderWithProof> {
         let content_key = HistoryContentKey::new_block_header_by_hash(block_hash);
-        let endpoint = HistoryEndpoint::RecursiveFindContent(content_key.clone());
+        let endpoint = HistoryEndpoint::GetContent(content_key.clone());
         let (resp, mut resp_rx) = mpsc::unbounded_channel::<Result<Value, String>>();
         let request = HistoryJsonRpcRequest { endpoint, resp };
         let tx = self.history_jsonrpc_tx()?;


### PR DESCRIPTION
### What was wrong?
updates our codebase to match spec https://github.com/ethereum/portal-network-specs/pull/344
### How was it fixed?

by renaming `portal_*RecursiveFindContent` to `portal_*GetContent`
