### PR TITLE
fix: add uncles and withdrawals to eth_getBlockByNumber and eth_getBlockByHash

### DIFF
--- a/ethportal-api/src/types/execution/header.rs
+++ b/ethportal-api/src/types/execution/header.rs
@@ -277,7 +277,7 @@ impl From<Header> for RpcHeader {
             excess_blob_gas: excess_blob_gas.map(|v| v.to()),
             hash,
             parent_beacon_block_root: parent_beacon_block_root.map(|h264| h264.0.into()),
-            total_difficulty: Some(difficulty),
+            total_difficulty: None,
             requests_root: None,
         }
     }

--- a/ethportal-api/src/types/execution/header.rs
+++ b/ethportal-api/src/types/execution/header.rs
@@ -277,6 +277,7 @@ impl From<Header> for RpcHeader {
             excess_blob_gas: excess_blob_gas.map(|v| v.to()),
             hash,
             parent_beacon_block_root: parent_beacon_block_root.map(|h264| h264.0.into()),
+            // We don't have access to total_difficulty
             total_difficulty: None,
             requests_root: None,
         }

--- a/ethportal-api/src/types/execution/withdrawal.rs
+++ b/ethportal-api/src/types/execution/withdrawal.rs
@@ -1,6 +1,7 @@
 use alloy::{
     primitives::Address,
     rlp::{RlpDecodable, RlpEncodable},
+    rpc::types::Withdrawal as AlloyWithdrawal,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -29,6 +30,17 @@ where
 
 impl From<&ConsensusWithdrawal> for Withdrawal {
     fn from(withdrawal: &ConsensusWithdrawal) -> Self {
+        Self {
+            index: withdrawal.index,
+            validator_index: withdrawal.validator_index,
+            address: withdrawal.address,
+            amount: withdrawal.amount,
+        }
+    }
+}
+
+impl From<&Withdrawal> for AlloyWithdrawal {
+    fn from(withdrawal: &Withdrawal) -> Self {
         Self {
             index: withdrawal.index,
             validator_index: withdrawal.validator_index,

--- a/rpc/src/eth_rpc.rs
+++ b/rpc/src/eth_rpc.rs
@@ -1,6 +1,5 @@
 use alloy::{
     primitives::{Address, Bytes, B256, U256},
-    rlp,
     rpc::types::{
         Block, BlockId, BlockNumberOrTag, BlockTransactions, TransactionRequest, Withdrawal,
     },
@@ -221,23 +220,17 @@ impl EthApi {
             .withdrawals()
             .map(|withdrawals| withdrawals.iter().map(Withdrawal::from).collect());
 
-        // Calculate block's encoded size:
-        // len(rlp(header, transactions, uncles, withdrawals))
-        let mut items = Vec::<Box<dyn rlp::Encodable>>::new();
-        items.push(Box::new(header.clone()));
-        items.push(Box::new(body.transactions().to_vec()));
-        items.push(Box::new(body.uncles().unwrap_or_default().to_vec()));
-        if let Some(withdrawals) = body.withdrawals() {
-            items.push(Box::new(withdrawals.to_vec()));
-        }
-        let size = rlp::Encodable::length(&items);
+        // TODO: Add calculation for the block's size:
+        //   len(rlp(header, transactions, uncles, withdrawals))
+        // NOTE: Transactions should be encoded with envelope
+        let size = None;
 
         // Combine header and block body into the single json representation of the block.
         let block = Block {
             header: header.into(),
             transactions,
             uncles,
-            size: Some(U256::from(size)),
+            size,
             withdrawals,
         };
         Ok(block)

--- a/rpc/src/eth_rpc.rs
+++ b/rpc/src/eth_rpc.rs
@@ -1,5 +1,6 @@
 use alloy::{
     primitives::{Address, Bytes, B256, U256},
+    rlp,
     rpc::types::{
         Block, BlockId, BlockNumberOrTag, BlockTransactions, TransactionRequest, Withdrawal,
     },
@@ -220,12 +221,23 @@ impl EthApi {
             .withdrawals()
             .map(|withdrawals| withdrawals.iter().map(Withdrawal::from).collect());
 
+        // Calculate block's encoded size:
+        // len(rlp(header, transactions, uncles, withdrawals))
+        let mut items = Vec::<Box<dyn rlp::Encodable>>::new();
+        items.push(Box::new(header.clone()));
+        items.push(Box::new(body.transactions().to_vec()));
+        items.push(Box::new(body.uncles().unwrap_or_default().to_vec()));
+        if let Some(withdrawals) = body.withdrawals() {
+            items.push(Box::new(withdrawals.to_vec()));
+        }
+        let size = rlp::Encodable::length(&items);
+
         // Combine header and block body into the single json representation of the block.
         let block = Block {
             header: header.into(),
             transactions,
             uncles,
-            size: None,
+            size: Some(U256::from(size)),
             withdrawals,
         };
         Ok(block)

--- a/tests/rpc_server.rs
+++ b/tests/rpc_server.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::net::{IpAddr, Ipv4Addr};
 
 use alloy::{
+    primitives::U256,
     providers::{IpcConnect, Provider, ProviderBuilder, RootProvider},
     pubsub::PubSubFrontend,
     rpc::types::{BlockNumberOrTag, BlockTransactions, BlockTransactionsKind, Header as RpcHeader},
@@ -111,7 +112,7 @@ async fn test_eth_get_block_by_number() {
         .expect("specified block not found");
 
     assert_header(&block.header, &hwp.header);
-    assert_eq!(block.size, None);
+    assert_eq!(block.size, Some(U256::from(37729)));
     assert_eq!(block.transactions.len(), body.transactions().len());
 
     let BlockTransactions::Hashes(hashes) = block.transactions else {
@@ -226,7 +227,7 @@ async fn test_eth_get_block_by_hash() {
         .expect("specified block not found");
 
     assert_header(&block.header, &hwp.header);
-    assert_eq!(block.size, None);
+    assert_eq!(block.size, Some(U256::from(37729)));
     assert_eq!(block.transactions.len(), body.transactions().len());
 
     let BlockTransactions::Hashes(hashes) = block.transactions else {

--- a/tests/rpc_server.rs
+++ b/tests/rpc_server.rs
@@ -4,7 +4,6 @@ use std::fs;
 use std::net::{IpAddr, Ipv4Addr};
 
 use alloy::{
-    primitives::U256,
     providers::{IpcConnect, Provider, ProviderBuilder, RootProvider},
     pubsub::PubSubFrontend,
     rpc::types::{BlockNumberOrTag, BlockTransactions, BlockTransactionsKind, Header as RpcHeader},
@@ -112,8 +111,13 @@ async fn test_eth_get_block_by_number() {
         .expect("specified block not found");
 
     assert_header(&block.header, &hwp.header);
-    assert_eq!(block.size, Some(U256::from(37729)));
+    assert_eq!(block.size, None);
     assert_eq!(block.transactions.len(), body.transactions().len());
+    assert!(block.uncles.is_empty());
+    assert_eq!(
+        block.withdrawals.unwrap_or_default().len(),
+        body.withdrawals().unwrap_or_default().len()
+    );
 
     let BlockTransactions::Hashes(hashes) = block.transactions else {
         panic!("expected hashes")
@@ -227,8 +231,13 @@ async fn test_eth_get_block_by_hash() {
         .expect("specified block not found");
 
     assert_header(&block.header, &hwp.header);
-    assert_eq!(block.size, Some(U256::from(37729)));
+    assert_eq!(block.size, None);
     assert_eq!(block.transactions.len(), body.transactions().len());
+    assert!(block.uncles.is_empty());
+    assert_eq!(
+        block.withdrawals.unwrap_or_default().len(),
+        body.withdrawals().unwrap_or_default().len()
+    );
 
     let BlockTransactions::Hashes(hashes) = block.transactions else {
         panic!("expected hashes")


### PR DESCRIPTION
### What was wrong?

The eth_getBlockByNumber and eth_getBlockByHash don't populate uncles and withdrawals fields of the response (but we have data available).

### How was it fixed?

Populate required fields.

**Note:** I don't know how `size` field should be calculated. Let me know if you do.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
