### PR TITLE
refactor! clean up ContentInfo type, remove unexpected paths

### DIFF
--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -5,8 +5,8 @@ use crate::{
         content_key::beacon::BeaconContentKey,
         enr::Enr,
         portal::{
-            AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
-            TraceContentInfo, TraceGossipInfo,
+            AcceptInfo, DataRadius, FindContentInfo, FindNodesInfo, GetContentInfo,
+            PaginateLocalContentInfo, PongInfo, TraceContentInfo, TraceGossipInfo,
         },
         portal_wire::OfferTrace,
     },
@@ -74,13 +74,16 @@ pub trait BeaconNetworkApi {
 
     /// Send FINDCONTENT message to get the content with a content key.
     #[method(name = "beaconFindContent")]
-    async fn find_content(&self, enr: Enr, content_key: BeaconContentKey)
-        -> RpcResult<ContentInfo>;
+    async fn find_content(
+        &self,
+        enr: Enr,
+        content_key: BeaconContentKey,
+    ) -> RpcResult<FindContentInfo>;
 
     /// First checks local storage if content is not found lookup a target content key in the
     /// network
     #[method(name = "beaconGetContent")]
-    async fn get_content(&self, content_key: BeaconContentKey) -> RpcResult<ContentInfo>;
+    async fn get_content(&self, content_key: BeaconContentKey) -> RpcResult<GetContentInfo>;
 
     /// First checks local storage if content is not found lookup a target content key in the
     /// network. Return tracing info.

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -3,8 +3,8 @@ use crate::{
         content_key::history::HistoryContentKey,
         enr::Enr,
         portal::{
-            AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
-            TraceContentInfo, TraceGossipInfo,
+            AcceptInfo, DataRadius, FindContentInfo, FindNodesInfo, GetContentInfo,
+            PaginateLocalContentInfo, PongInfo, TraceContentInfo, TraceGossipInfo,
         },
         portal_wire::OfferTrace,
     },
@@ -59,12 +59,12 @@ pub trait HistoryNetworkApi {
         &self,
         enr: Enr,
         content_key: HistoryContentKey,
-    ) -> RpcResult<ContentInfo>;
+    ) -> RpcResult<FindContentInfo>;
 
     /// First checks local storage if content is not found lookup a target content key in the
     /// network
     #[method(name = "historyGetContent")]
-    async fn get_content(&self, content_key: HistoryContentKey) -> RpcResult<ContentInfo>;
+    async fn get_content(&self, content_key: HistoryContentKey) -> RpcResult<GetContentInfo>;
 
     /// First checks local storage if content is not found lookup a target content key in the
     /// network. Return tracing info.

--- a/ethportal-api/src/state.rs
+++ b/ethportal-api/src/state.rs
@@ -3,8 +3,8 @@ use crate::{
         content_key::state::StateContentKey,
         enr::Enr,
         portal::{
-            AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
-            TraceContentInfo, TraceGossipInfo,
+            AcceptInfo, DataRadius, FindContentInfo, FindNodesInfo, GetContentInfo,
+            PaginateLocalContentInfo, PongInfo, TraceContentInfo, TraceGossipInfo,
         },
         portal_wire::OfferTrace,
     },
@@ -55,12 +55,16 @@ pub trait StateNetworkApi {
 
     /// Send FINDCONTENT message to get the content with a content key.
     #[method(name = "stateFindContent")]
-    async fn find_content(&self, enr: Enr, content_key: StateContentKey) -> RpcResult<ContentInfo>;
+    async fn find_content(
+        &self,
+        enr: Enr,
+        content_key: StateContentKey,
+    ) -> RpcResult<FindContentInfo>;
 
     /// First checks local storage if content is not found lookup a target content key in the
     /// network
     #[method(name = "stateGetContent")]
-    async fn get_content(&self, content_key: StateContentKey) -> RpcResult<ContentInfo>;
+    async fn get_content(&self, content_key: StateContentKey) -> RpcResult<GetContentInfo>;
 
     /// First checks local storage if content is not found lookup a target content key in the
     /// network. Return tracing info.

--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -49,9 +49,7 @@ pub struct TraceGossipInfo {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
-pub enum ContentInfo {
-    #[serde(rename_all = "camelCase")]
-    ConnectionId { connection_id: u16 },
+pub enum FindContentInfo {
     #[serde(rename_all = "camelCase")]
     Content {
         content: RawContentValue,
@@ -61,8 +59,15 @@ pub enum ContentInfo {
     Enrs { enrs: Vec<Enr> },
 }
 
-/// Parsed response for TraceGetContent endpoint
-///
+/// Response for GetContent endpoints
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetContentInfo {
+    pub content: RawContentValue,
+    pub utp_transfer: bool,
+}
+
+/// Parsed response for TraceRecursiveFindContent endpoint
 /// This struct represents the content info, and is only used
 /// when the content is found locally or on the network.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -45,10 +45,9 @@ pub struct TraceGossipInfo {
     pub transferred: Vec<String>,
 }
 
-/// Response for FindContent & GetContent endpoints
+/// Response for the FindContent endpoint
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
-#[allow(clippy::large_enum_variant)]
 pub enum FindContentInfo {
     #[serde(rename_all = "camelCase")]
     Content {
@@ -59,7 +58,7 @@ pub enum FindContentInfo {
     Enrs { enrs: Vec<Enr> },
 }
 
-/// Response for GetContent endpoints
+/// Response for the GetContent endpoint
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetContentInfo {

--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -67,7 +67,7 @@ pub struct GetContentInfo {
     pub utp_transfer: bool,
 }
 
-/// Parsed response for TraceRecursiveFindContent endpoint
+/// Parsed response for TraceGetContent endpoint
 /// This struct represents the content info, and is only used
 /// when the content is found locally or on the network.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -6,7 +6,7 @@ use tracing::info;
 
 use crate::{utils::fixture_header_by_hash, Peertest};
 use ethportal_api::{
-    types::{network::Subnetwork, portal::ContentInfo},
+    types::{network::Subnetwork, portal::FindContentInfo},
     utils::bytes::hex_decode,
     BeaconNetworkApiClient, ContentValue, Enr, HistoryNetworkApiClient, OverlayContentKey,
     StateNetworkApiClient,
@@ -69,7 +69,7 @@ pub async fn test_find_content_return_enr(target: &Client, peertest: &Peertest) 
     )
     .await;
 
-    let enrs = if let Ok(ContentInfo::Enrs { enrs }) = result {
+    let enrs = if let Ok(FindContentInfo::Enrs { enrs }) = result {
         enrs
     } else {
         panic!("Error: Invalid response from FINDCONTENT request, expected ENRs got: {result:?}");

--- a/ethportal-peertest/src/scenarios/utp.rs
+++ b/ethportal-peertest/src/scenarios/utp.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use discv5::enr::NodeId;
 use ethportal_api::{
-    types::portal::{ContentInfo, TraceContentInfo},
+    types::portal::{GetContentInfo, TraceContentInfo},
     ContentValue, HistoryNetworkApiClient,
 };
 use tracing::info;
@@ -32,22 +32,17 @@ pub async fn test_recursive_utp(peertest: &Peertest) {
 
     assert!(store_result);
 
-    let content_info = peertest.nodes[0]
+    let GetContentInfo {
+        content,
+        utp_transfer,
+    } = peertest.nodes[0]
         .ipc_client
         .get_content(content_key)
         .await
         .unwrap();
 
-    if let ContentInfo::Content {
-        content,
-        utp_transfer,
-    } = content_info
-    {
-        assert_eq!(content, content_value.encode());
-        assert!(utp_transfer);
-    } else {
-        panic!("Error: Unexpected content info response");
-    }
+    assert_eq!(content, content_value.encode());
+    assert!(utp_transfer);
 }
 
 pub async fn test_trace_recursive_utp(peertest: &Peertest) {

--- a/ethportal-peertest/src/scenarios/validation.rs
+++ b/ethportal-peertest/src/scenarios/validation.rs
@@ -7,7 +7,7 @@ use crate::{
 use alloy::primitives::B256;
 use ethportal_api::{
     jsonrpsee::async_client::Client,
-    types::{enr::Enr, portal::ContentInfo},
+    types::{enr::Enr, portal::FindContentInfo},
     ContentValue, HistoryContentKey, HistoryNetworkApiClient,
 };
 use std::str::FromStr;
@@ -38,7 +38,7 @@ pub async fn test_validate_pre_merge_header_by_hash(peertest: &Peertest, target:
         .unwrap();
 
     match result {
-        ContentInfo::Content {
+        FindContentInfo::Content {
             content,
             utp_transfer,
         } => {
@@ -74,7 +74,7 @@ pub async fn test_validate_pre_merge_header_by_number(peertest: &Peertest, targe
         .unwrap();
 
     match result {
-        ContentInfo::Content {
+        FindContentInfo::Content {
             content,
             utp_transfer,
         } => {
@@ -146,7 +146,7 @@ pub async fn test_validate_pre_merge_block_body(peertest: &Peertest, target: &Cl
         .unwrap();
 
     match result {
-        ContentInfo::Content {
+        FindContentInfo::Content {
             content,
             utp_transfer,
         } => {
@@ -189,7 +189,7 @@ pub async fn test_validate_pre_merge_receipts(peertest: &Peertest, target: &Clie
         .unwrap();
 
     match result {
-        ContentInfo::Content {
+        FindContentInfo::Content {
             content,
             utp_transfer,
         } => {

--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -36,7 +36,7 @@ use crate::{
 };
 use ethportal_api::{
     jsonrpsee::http_client::HttpClient,
-    types::{execution::accumulator::EpochAccumulator, portal::ContentInfo},
+    types::{execution::accumulator::EpochAccumulator, portal::GetContentInfo},
     HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
 };
 use trin_validation::{
@@ -176,7 +176,7 @@ impl Era1Bridge {
             let hunter_threshold = (content_keys_to_sample.len() as u64 * threshold / 100) as usize;
             for content_key in content_keys_to_sample {
                 let result = self.portal_client.get_content(content_key.clone()).await;
-                if let Ok(ContentInfo::Content { .. }) = result {
+                if let Ok(GetContentInfo { .. }) = result {
                     found += 1;
                     if found == hunter_threshold {
                         info!("Hunter found enough content ({hunter_threshold}) to stop hunting in epoch {epoch}");
@@ -368,7 +368,7 @@ impl Era1Bridge {
             let header_hash = block_tuple.header.header.hash();
             let header_content_key = HistoryContentKey::new_block_header_by_hash(header_hash);
             let header_content_info = portal_client.get_content(header_content_key.clone()).await;
-            if let Ok(ContentInfo::Content { .. }) = header_content_info {
+            if let Ok(GetContentInfo { .. }) = header_content_info {
                 info!(
                     "Skipping header by hash at height: {} as header already found",
                     block_tuple.header.header.number
@@ -419,7 +419,7 @@ impl Era1Bridge {
             let header_content_key =
                 HistoryContentKey::new_block_header_by_number(block_tuple.header.header.number);
             let header_content_info = portal_client.get_content(header_content_key.clone()).await;
-            if let Ok(ContentInfo::Content { .. }) = header_content_info {
+            if let Ok(GetContentInfo { .. }) = header_content_info {
                 info!(
                     "Skipping header by number at height: {} as header already found",
                     block_tuple.header.header.number
@@ -460,7 +460,7 @@ impl Era1Bridge {
             let body_hash = block_tuple.header.header.hash();
             let body_content_key = HistoryContentKey::new_block_body(body_hash);
             let body_content_info = portal_client.get_content(body_content_key.clone()).await;
-            if let Ok(ContentInfo::Content { .. }) = body_content_info {
+            if let Ok(GetContentInfo { .. }) = body_content_info {
                 info!(
                     "Skipping body at height: {} as body already found",
                     block_tuple.header.header.number
@@ -501,7 +501,7 @@ impl Era1Bridge {
             let receipts_content_info = portal_client
                 .get_content(receipts_content_key.clone())
                 .await;
-            if let Ok(ContentInfo::Content { .. }) = receipts_content_info {
+            if let Ok(GetContentInfo { .. }) = receipts_content_info {
                 info!(
                     "Skipping receipts at height: {} as receipts already found",
                     block_tuple.header.header.number

--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -35,8 +35,7 @@ use crate::{
     types::mode::{BridgeMode, FourFoursMode},
 };
 use ethportal_api::{
-    jsonrpsee::http_client::HttpClient,
-    types::{execution::accumulator::EpochAccumulator, portal::GetContentInfo},
+    jsonrpsee::http_client::HttpClient, types::execution::accumulator::EpochAccumulator,
     HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
 };
 use trin_validation::{
@@ -368,7 +367,7 @@ impl Era1Bridge {
             let header_hash = block_tuple.header.header.hash();
             let header_content_key = HistoryContentKey::new_block_header_by_hash(header_hash);
             let header_content_info = portal_client.get_content(header_content_key.clone()).await;
-            if let Ok(GetContentInfo { .. }) = header_content_info {
+            if header_content_info.is_ok() {
                 info!(
                     "Skipping header by hash at height: {} as header already found",
                     block_tuple.header.header.number
@@ -419,7 +418,7 @@ impl Era1Bridge {
             let header_content_key =
                 HistoryContentKey::new_block_header_by_number(block_tuple.header.header.number);
             let header_content_info = portal_client.get_content(header_content_key.clone()).await;
-            if let Ok(GetContentInfo { .. }) = header_content_info {
+            if header_content_info.is_ok() {
                 info!(
                     "Skipping header by number at height: {} as header already found",
                     block_tuple.header.header.number
@@ -460,7 +459,7 @@ impl Era1Bridge {
             let body_hash = block_tuple.header.header.hash();
             let body_content_key = HistoryContentKey::new_block_body(body_hash);
             let body_content_info = portal_client.get_content(body_content_key.clone()).await;
-            if let Ok(GetContentInfo { .. }) = body_content_info {
+            if body_content_info.is_ok() {
                 info!(
                     "Skipping body at height: {} as body already found",
                     block_tuple.header.header.number
@@ -501,7 +500,7 @@ impl Era1Bridge {
             let receipts_content_info = portal_client
                 .get_content(receipts_content_key.clone())
                 .await;
-            if let Ok(GetContentInfo { .. }) = receipts_content_info {
+            if receipts_content_info.is_ok() {
                 info!(
                     "Skipping receipts at height: {} as receipts already found",
                     block_tuple.header.header.number

--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -176,7 +176,7 @@ impl Era1Bridge {
             let hunter_threshold = (content_keys_to_sample.len() as u64 * threshold / 100) as usize;
             for content_key in content_keys_to_sample {
                 let result = self.portal_client.get_content(content_key.clone()).await;
-                if let Ok(GetContentInfo { .. }) = result {
+                if result.is_ok() {
                     found += 1;
                     if found == hunter_threshold {
                         info!("Hunter found enough content ({hunter_threshold}) to stop hunting in epoch {epoch}");

--- a/portal-bridge/src/gossip.rs
+++ b/portal-bridge/src/gossip.rs
@@ -6,7 +6,7 @@ use tracing::{debug, warn, Instrument};
 
 use crate::stats::{BeaconSlotStats, HistoryBlockStats, StatsReporter};
 use ethportal_api::{
-    types::portal::{ContentInfo, TraceGossipInfo},
+    types::portal::{GetContentInfo, TraceGossipInfo},
     BeaconContentKey, BeaconContentValue, BeaconNetworkApiClient, ContentValue, HistoryContentKey,
     HistoryContentValue, HistoryNetworkApiClient, OverlayContentKey,
 };
@@ -61,7 +61,7 @@ async fn beacon_trace_gossip(
         }
         // if not, make rfc request to see if data is available on network
         let result = BeaconNetworkApiClient::get_content(&client, content_key.clone()).await;
-        if let Ok(ContentInfo::Content { .. }) = result {
+        if let Ok(GetContentInfo { .. }) = result {
             debug!("Found content on network, after failing to gossip, aborting gossip. content key={:?}", content_key.to_hex());
             found = true;
             return GossipReport {
@@ -133,7 +133,7 @@ async fn history_trace_gossip(
         }
         // if not, make rfc request to see if data is available on network
         let result = HistoryNetworkApiClient::get_content(&client, content_key.clone()).await;
-        if let Ok(ContentInfo::Content { .. }) = result {
+        if let Ok(GetContentInfo { .. }) = result {
             debug!("Found content on network, after failing to gossip, aborting gossip. content key={:?}", content_key.to_hex());
             found = true;
             return GossipReport {

--- a/portal-bridge/src/gossip.rs
+++ b/portal-bridge/src/gossip.rs
@@ -6,9 +6,9 @@ use tracing::{debug, warn, Instrument};
 
 use crate::stats::{BeaconSlotStats, HistoryBlockStats, StatsReporter};
 use ethportal_api::{
-    types::portal::{GetContentInfo, TraceGossipInfo},
-    BeaconContentKey, BeaconContentValue, BeaconNetworkApiClient, ContentValue, HistoryContentKey,
-    HistoryContentValue, HistoryNetworkApiClient, OverlayContentKey,
+    types::portal::TraceGossipInfo, BeaconContentKey, BeaconContentValue, BeaconNetworkApiClient,
+    ContentValue, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
+    OverlayContentKey,
 };
 
 const GOSSIP_RETRY_COUNT: u64 = 3;
@@ -61,7 +61,7 @@ async fn beacon_trace_gossip(
         }
         // if not, make rfc request to see if data is available on network
         let result = BeaconNetworkApiClient::get_content(&client, content_key.clone()).await;
-        if let Ok(GetContentInfo { .. }) = result {
+        if result.is_ok() {
             debug!("Found content on network, after failing to gossip, aborting gossip. content key={:?}", content_key.to_hex());
             found = true;
             return GossipReport {
@@ -133,7 +133,7 @@ async fn history_trace_gossip(
         }
         // if not, make rfc request to see if data is available on network
         let result = HistoryNetworkApiClient::get_content(&client, content_key.clone()).await;
-        if let Ok(GetContentInfo { .. }) = result {
+        if result.is_ok() {
             debug!("Found content on network, after failing to gossip, aborting gossip. content key={:?}", content_key.to_hex());
             found = true;
             return GossipReport {

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -14,8 +14,9 @@ use ethportal_api::{
         enr::Enr,
         jsonrpc::{endpoints::BeaconEndpoint, request::BeaconJsonRpcRequest},
         portal::{
-            AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
-            TraceContentInfo, TraceGossipInfo, MAX_CONTENT_KEYS_PER_OFFER,
+            AcceptInfo, DataRadius, FindContentInfo, FindNodesInfo, GetContentInfo,
+            PaginateLocalContentInfo, PongInfo, TraceContentInfo, TraceGossipInfo,
+            MAX_CONTENT_KEYS_PER_OFFER,
         },
         portal_wire::OfferTrace,
     },
@@ -120,14 +121,14 @@ impl BeaconNetworkApiServer for BeaconNetworkApi {
         &self,
         enr: Enr,
         content_key: BeaconContentKey,
-    ) -> RpcResult<ContentInfo> {
+    ) -> RpcResult<FindContentInfo> {
         let endpoint = BeaconEndpoint::FindContent(enr, content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// First checks local storage if content is not found lookup a target content key in the
     /// network
-    async fn get_content(&self, content_key: BeaconContentKey) -> RpcResult<ContentInfo> {
+    async fn get_content(&self, content_key: BeaconContentKey) -> RpcResult<GetContentInfo> {
         let endpoint = BeaconEndpoint::GetContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }

--- a/rpc/src/eth_rpc.rs
+++ b/rpc/src/eth_rpc.rs
@@ -10,7 +10,7 @@ use ethportal_api::{
             endpoints::HistoryEndpoint,
             request::{HistoryJsonRpcRequest, StateJsonRpcRequest},
         },
-        portal::ContentInfo,
+        portal::GetContentInfo,
     },
     ContentValue, EthApiServer, Header, HistoryContentKey, HistoryContentValue,
 };
@@ -153,13 +153,8 @@ impl EthApi {
         content_key: HistoryContentKey,
     ) -> Result<HistoryContentValue, RpcServeError> {
         let endpoint = HistoryEndpoint::GetContent(content_key.clone());
-        let response: ContentInfo = proxy_to_subnet(&self.history_network, endpoint).await?;
-        let ContentInfo::Content { content, .. } = response else {
-            return Err(RpcServeError::Message(format!(
-                "Invalid response variant: History GetContent should contain content value; got {response:?}"
-            )));
-        };
-
+        let GetContentInfo { content, .. } =
+            proxy_to_subnet(&self.history_network, endpoint).await?;
         let content_value = HistoryContentValue::decode(&content_key, &content)?;
         Ok(content_value)
     }

--- a/rpc/src/evm_state.rs
+++ b/rpc/src/evm_state.rs
@@ -10,7 +10,7 @@ use ethportal_api::{
     types::{
         content_key::state::{AccountTrieNodeKey, ContractBytecodeKey, ContractStorageTrieNodeKey},
         jsonrpc::{endpoints::StateEndpoint, request::StateJsonRpcRequest},
-        portal::ContentInfo,
+        portal::GetContentInfo,
         state_trie::{
             account_state::AccountState,
             nibbles::Nibbles,
@@ -162,15 +162,10 @@ impl EvmBlockState {
         }
 
         let endpoint = StateEndpoint::GetContent(content_key.clone());
-        let response: ContentInfo = proxy_to_subnet(&self.state_network, endpoint)
-            .await
-            .map_err(|err| EvmStateError::InternalError(err.to_string()))?;
-        let ContentInfo::Content { content, .. } = response else {
-            return Err(EvmStateError::InternalError(format!(
-                "Invalid response variant: State GetContent should contain content value; got {response:?}"
-            )));
-        };
-
+        let GetContentInfo { content, .. } =
+            proxy_to_subnet(&self.state_network, endpoint)
+                .await
+                .map_err(|err| EvmStateError::InternalError(err.to_string()))?;
         let content_value = StateContentValue::decode(&content_key, &content)?;
         self.cache.insert(content_key, content_value.clone());
         Ok(content_value)

--- a/rpc/src/history_rpc.rs
+++ b/rpc/src/history_rpc.rs
@@ -6,8 +6,9 @@ use ethportal_api::{
         enr::Enr,
         jsonrpc::{endpoints::HistoryEndpoint, request::HistoryJsonRpcRequest},
         portal::{
-            AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
-            TraceContentInfo, TraceGossipInfo, MAX_CONTENT_KEYS_PER_OFFER,
+            AcceptInfo, DataRadius, FindContentInfo, FindNodesInfo, GetContentInfo,
+            PaginateLocalContentInfo, PongInfo, TraceContentInfo, TraceGossipInfo,
+            MAX_CONTENT_KEYS_PER_OFFER,
         },
         portal_wire::OfferTrace,
     },
@@ -93,14 +94,14 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
         &self,
         enr: Enr,
         content_key: HistoryContentKey,
-    ) -> RpcResult<ContentInfo> {
+    ) -> RpcResult<FindContentInfo> {
         let endpoint = HistoryEndpoint::FindContent(enr, content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// First checks local storage if content is not found lookup a target content key in the
     /// network
-    async fn get_content(&self, content_key: HistoryContentKey) -> RpcResult<ContentInfo> {
+    async fn get_content(&self, content_key: HistoryContentKey) -> RpcResult<GetContentInfo> {
         let endpoint = HistoryEndpoint::GetContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }

--- a/rpc/src/state_rpc.rs
+++ b/rpc/src/state_rpc.rs
@@ -6,8 +6,9 @@ use ethportal_api::{
         enr::Enr,
         jsonrpc::{endpoints::StateEndpoint, request::StateJsonRpcRequest},
         portal::{
-            AcceptInfo, ContentInfo, DataRadius, FindNodesInfo, PaginateLocalContentInfo, PongInfo,
-            TraceContentInfo, TraceGossipInfo, MAX_CONTENT_KEYS_PER_OFFER,
+            AcceptInfo, DataRadius, FindContentInfo, FindNodesInfo, GetContentInfo,
+            PaginateLocalContentInfo, PongInfo, TraceContentInfo, TraceGossipInfo,
+            MAX_CONTENT_KEYS_PER_OFFER,
         },
         portal_wire::OfferTrace,
     },
@@ -89,14 +90,18 @@ impl StateNetworkApiServer for StateNetworkApi {
     }
 
     /// Send FINDCONTENT message to get the content with a content key.
-    async fn find_content(&self, enr: Enr, content_key: StateContentKey) -> RpcResult<ContentInfo> {
+    async fn find_content(
+        &self,
+        enr: Enr,
+        content_key: StateContentKey,
+    ) -> RpcResult<FindContentInfo> {
         let endpoint = StateEndpoint::FindContent(enr, content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// First checks local storage if content is not found lookup a target content key in the
     /// network
-    async fn get_content(&self, content_key: StateContentKey) -> RpcResult<ContentInfo> {
+    async fn get_content(&self, content_key: StateContentKey) -> RpcResult<GetContentInfo> {
         let endpoint = StateEndpoint::GetContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }

--- a/src/bin/poll_latest.rs
+++ b/src/bin/poll_latest.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Result};
 use clap::Parser;
 use ethportal_api::{
     jsonrpsee::http_client::{HttpClient, HttpClientBuilder},
-    types::{content_key::overlay::OverlayContentKey, portal::GetContentInfo},
+    types::content_key::overlay::OverlayContentKey,
     HistoryContentKey, HistoryNetworkApiClient,
 };
 use futures::StreamExt;
@@ -15,7 +15,7 @@ use std::{
     sync::{Arc, Mutex},
     time::Instant,
 };
-use tokio::time::Duration;
+use tokio::time::{sleep, Duration};
 use tracing::{debug, info, warn};
 use url::Url;
 
@@ -103,6 +103,10 @@ pub async fn main() -> Result<()> {
     init_tracing_logger();
     info!("Running Poll Latest script.");
     let audit_config = AuditConfig::parse();
+    let timeout = match audit_config.timeout {
+        Some(timeout) => Duration::from_secs(timeout),
+        None => MAX_TIMEOUT,
+    };
     let infura_project_id = std::env::var("TRIN_INFURA_PROJECT_ID")?;
     let ws = WsConnect::new(format!("wss://mainnet.infura.io/ws/v3/{infura_project_id}"));
     let provider = ProviderBuilder::new().on_ws(ws).await?;
@@ -119,6 +123,8 @@ pub async fn main() -> Result<()> {
             block_hash,
             block_number,
             timestamp,
+            timeout,
+            audit_config.backoff,
             metrics,
             client.clone(),
         ));
@@ -130,24 +136,38 @@ async fn audit_block(
     hash: B256,
     block_number: u64,
     timestamp: Instant,
+    timeout: Duration,
+    backoff: Backoff,
     metrics: Arc<Mutex<Metrics>>,
     client: HttpClient,
 ) -> Result<()> {
     metrics.lock().unwrap().active_audit_count += 3;
     let header_by_hash_handle = tokio::spawn(audit_content_key(
         HistoryContentKey::new_block_header_by_hash(hash),
+        timestamp,
+        timeout,
+        backoff,
         client.clone(),
     ));
     let header_by_number_handle = tokio::spawn(audit_content_key(
         HistoryContentKey::new_block_header_by_number(block_number),
+        timestamp,
+        timeout,
+        backoff,
         client.clone(),
     ));
     let block_body_handle = tokio::spawn(audit_content_key(
         HistoryContentKey::new_block_body(hash),
+        timestamp,
+        timeout,
+        backoff,
         client.clone(),
     ));
     let receipts_handle = tokio::spawn(audit_content_key(
         HistoryContentKey::new_block_receipts(hash),
+        timestamp,
+        timeout,
+        backoff,
         client.clone(),
     ));
     match header_by_hash_handle.await? {
@@ -210,19 +230,31 @@ async fn audit_block(
 
 async fn audit_content_key(
     content_key: HistoryContentKey,
+    timestamp: Instant,
+    timeout: Duration,
+    backoff: Backoff,
     client: HttpClient,
 ) -> anyhow::Result<Instant> {
-    match client.get_content(content_key.clone()).await {
-        Ok(GetContentInfo { .. }) => Ok(Instant::now()),
-        Err(err) => {
-            let err_msg = format!(
-                "Unable to find content_key: {:?} error: {err:?}",
-                content_key.to_hex(),
-            );
-            warn!(err_msg);
-            Err(anyhow!("{err_msg}"))
+    let mut attempts = 0;
+    while Instant::now() - timestamp < timeout {
+        match client.get_content(content_key.clone()).await {
+            Ok(_) => return Ok(Instant::now()),
+            _ => {
+                attempts += 1;
+                let sleep_time = match backoff {
+                    Backoff::Exponential => attempts * 2,
+                    Backoff::Linear(delay) => delay,
+                };
+                sleep(Duration::from_secs(sleep_time)).await;
+            }
         }
     }
+    let err_msg = format!(
+        "Unable to find content_key: {:?} within {timeout:?}",
+        content_key.to_hex(),
+    );
+    warn!("{}", err_msg);
+    Err(anyhow!("{}", err_msg))
 }
 
 // CLI Parameter Handling

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -6,7 +6,7 @@ use ethportal_api::{
         content_value::ContentValue,
         distance::Distance,
         jsonrpc::{endpoints::BeaconEndpoint, request::BeaconJsonRpcRequest},
-        portal::{AcceptInfo, ContentInfo, FindNodesInfo, PongInfo, TraceContentInfo},
+        portal::{AcceptInfo, FindNodesInfo, GetContentInfo, PongInfo, TraceContentInfo},
         portal_wire::Content,
         query_trace::QueryTrace,
     },
@@ -187,7 +187,7 @@ async fn get_content(
 
     // If tracing is not required, return content.
     if !is_trace {
-        return Ok(json!(ContentInfo::Content {
+        return Ok(json!(GetContentInfo {
             content: serde_json::from_value(content_response_string).map_err(|e| e.to_string())?,
             utp_transfer,
         }));

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -5,7 +5,7 @@ use ethportal_api::{
     types::{
         distance::Distance,
         jsonrpc::{endpoints::HistoryEndpoint, request::HistoryJsonRpcRequest},
-        portal::{AcceptInfo, ContentInfo, FindNodesInfo, PongInfo, TraceContentInfo},
+        portal::{AcceptInfo, FindNodesInfo, GetContentInfo, PongInfo, TraceContentInfo},
         portal_wire::Content,
         query_trace::QueryTrace,
     },
@@ -148,7 +148,7 @@ async fn get_content(
 
     // If tracing is not required, return content.
     if !is_trace {
-        return Ok(json!(ContentInfo::Content {
+        return Ok(json!(GetContentInfo {
             content: serde_json::from_value(content_response_string).map_err(|e| e.to_string())?,
             utp_transfer,
         }));

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -13,7 +13,7 @@ use ethportal_api::{
     types::{
         distance::Distance,
         jsonrpc::{endpoints::StateEndpoint, request::StateJsonRpcRequest},
-        portal::{AcceptInfo, ContentInfo, FindNodesInfo, PongInfo, TraceContentInfo},
+        portal::{AcceptInfo, FindNodesInfo, GetContentInfo, PongInfo, TraceContentInfo},
         portal_wire::Content,
         query_trace::QueryTrace,
     },
@@ -275,7 +275,7 @@ async fn get_content(
             trace: trace.ok_or("Content query trace requested but none provided.".to_string())?,
         }))
     } else {
-        Ok(json!(ContentInfo::Content {
+        Ok(json!(GetContentInfo {
             content: RawContentValue::from(content_bytes),
             utp_transfer
         }))

--- a/trin-state/src/validation/validator.rs
+++ b/trin-state/src/validation/validator.rs
@@ -161,7 +161,7 @@ mod tests {
         types::{
             execution::header_with_proof::{BlockHeaderProof, HeaderWithProof, SszNone},
             jsonrpc::{endpoints::HistoryEndpoint, json_rpc_mock::MockJsonRpcBuilder},
-            portal::ContentInfo,
+            portal::GetContentInfo,
         },
         Header, HistoryContentKey, HistoryContentValue, OverlayContentKey,
     };
@@ -188,7 +188,7 @@ mod tests {
                 HistoryEndpoint::GetContent(HistoryContentKey::new_block_header_by_hash(
                     header.hash(),
                 )),
-                ContentInfo::Content {
+                GetContentInfo {
                     content: history_content_value.encode(),
                     utp_transfer: false,
                 },

--- a/trin-validation/src/oracle.rs
+++ b/trin-validation/src/oracle.rs
@@ -14,7 +14,7 @@ use ethportal_api::{
             endpoints::{BeaconEndpoint, HistoryEndpoint, StateEndpoint},
             request::{BeaconJsonRpcRequest, HistoryJsonRpcRequest, StateJsonRpcRequest},
         },
-        portal::ContentInfo,
+        portal::GetContentInfo,
     },
     ContentValue, Enr, HistoryContentKey, HistoryContentValue,
 };
@@ -68,20 +68,8 @@ impl HeaderOracle {
             }
             None => return Err(anyhow!("No response from chain history subnetwork")),
         };
-        let content = match serde_json::from_value(content)? {
-            ContentInfo::Content { content, .. } => content,
-            ContentInfo::ConnectionId { .. } => {
-                return Err(anyhow!(
-                    "Invalid ContentInfo (cid) received from HeaderWithProof lookup"
-                ))
-            }
-            ContentInfo::Enrs { .. } => {
-                return Err(anyhow!(
-                    "Invalid ContentInfo (enrs) received from HeaderWithProof lookup"
-                ))
-            }
-        };
-        let content = HistoryContentValue::decode(&content_key, &content)?;
+        let GetContentInfo { content, .. } = serde_json::from_value(content)?;
+        let content: HistoryContentValue = HistoryContentValue::decode(&content_key, &content)?;
 
         match content {
             HistoryContentValue::BlockHeaderWithProof(content) => Ok(content),


### PR DESCRIPTION
### What was wrong?
fixes https://github.com/ethereum/trin/pull/1526#discussion_r1799174704

Basically the `ContentInfo` type we were using for our `FindContent` and `GetContent` RPC endpoints were leaking information implementation details not related to the endpoints
### How was it fixed?
Split `ContentInfo` into 
- `FindContentInfo`
- `GetContentInfo`

and only expose the datatypes specified in the `portal-network-specs` json-rpc specification
