### PR TITLE
feat: shorter utp timeout, for more reliable query

### DIFF
--- a/portalnet/src/utp_controller.rs
+++ b/portalnet/src/utp_controller.rs
@@ -1,7 +1,7 @@
 use crate::discovery::UtpEnr;
 use anyhow::anyhow;
 use lazy_static::lazy_static;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::debug;
 use trin_metrics::{
@@ -26,7 +26,13 @@ pub struct UtpController {
 
 lazy_static! {
     /// The default configuration to use for uTP connections.
-    pub static ref UTP_CONN_CFG: ConnectionConfig = ConnectionConfig { max_packet_size: 1024, ..Default::default()};
+    pub static ref UTP_CONN_CFG: ConnectionConfig = ConnectionConfig {
+        max_packet_size: 1024,
+        // 10 seconds of idle timeout is plenty for transfer, and allows 5 attempts at
+        //   the initial connection before giving up.
+        max_idle_timeout: Duration::from_secs(10),
+        ..Default::default()
+    };
 }
 
 /// An enum for deciding to initiate the uTP connection as connecting or accepting.


### PR DESCRIPTION
Shrink the idle timeout from the default of 60 seconds to 10. This comes up most often in failed connections, which are perpetually idle, and keep trying until the timeout expires.

During a find-content call, if a uTP transfer is initiated and the remote peer fails to connect, the default timeout waits for 60 seconds. The problem is that 60s is also our entire query timeout. So if the utp connection fails by timeout, then there is no time to attempt downloads from alternate peers.

By shrinking the timeout to 10 seconds, we leave plenty of room for contacting other peers for the same content. It still allows us to make a few attempts at connection (after 1s, then another 1.5s, then another 2.25s, then another 3.375s).

### Historical Context

This timeout was previously 32 seconds, then increased to 60s: https://github.com/ethereum/trin/pull/909

The reason I feel differently now from before is that reattempts make it actually *more* likely for success, when shrinking the timeout. Before reattempts were implemented, we were only decreasing our chance of success by shrinking the timeout.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
