### PR TITLE
feat: add offer metric to state bridge

### DIFF
--- a/trin-metrics/src/bridge.rs
+++ b/trin-metrics/src/bridge.rs
@@ -15,6 +15,7 @@ pub struct BridgeMetrics {
     pub process_timer: HistogramVec,
     pub bridge_info: IntGaugeVec,
     pub gossip_total: IntCounterVec,
+    pub offer_total: IntCounterVec,
     pub current_block: IntGaugeVec,
 }
 
@@ -41,6 +42,11 @@ impl BridgeMetrics {
             &["bridge", "success", "type"],
             registry
         )?;
+        let offer_total = register_int_counter_vec_with_registry!(
+            opts!("bridge_offer_total", "counts all content offer requests"),
+            &["bridge", "type", "result"],
+            registry
+        )?;
         let current_block = register_int_gauge_vec_with_registry!(
             opts!(
                 "bridge_current_block",
@@ -53,6 +59,7 @@ impl BridgeMetrics {
             process_timer,
             bridge_info,
             gossip_total,
+            offer_total,
             current_block,
         })
     }
@@ -91,6 +98,13 @@ impl BridgeMetricsReporter {
         self.bridge_metrics
             .gossip_total
             .with_label_values(&labels)
+            .inc();
+    }
+
+    pub fn report_offer(&self, content_type: &str, status: &str) {
+        self.bridge_metrics
+            .offer_total
+            .with_label_values(&[&self.bridge, content_type, status])
             .inc();
     }
 


### PR DESCRIPTION
### What was wrong?

There is no metric on how state bridge is performing (only timer that measures how long it takes).

### How was it fixed?

Added metric that counts total number of offer requests and their result (success, rejected, failed).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
