### PR TITLE
fix: add size to eth_getBlockByNumber and eth_getBlockByHash

### DIFF
--- a/ethportal-api/src/types/execution/block_body.rs
+++ b/ethportal-api/src/types/execution/block_body.rs
@@ -156,7 +156,7 @@ impl BlockBody {
     }
 }
 
-fn rlp_encode_transaction_list(out: &mut dyn bytes::BufMut, txs: &[Transaction]) {
+pub fn rlp_encode_transaction_list(out: &mut dyn bytes::BufMut, txs: &[Transaction]) {
     let mut transactions_list = Vec::<u8>::new();
     for tx in txs {
         tx.encode_with_envelope(&mut transactions_list, true);

--- a/tests/rpc_server.rs
+++ b/tests/rpc_server.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::net::{IpAddr, Ipv4Addr};
 
 use alloy::{
+    primitives::U256,
     providers::{IpcConnect, Provider, ProviderBuilder, RootProvider},
     pubsub::PubSubFrontend,
     rpc::types::{BlockNumberOrTag, BlockTransactions, BlockTransactionsKind, Header as RpcHeader},
@@ -111,7 +112,7 @@ async fn test_eth_get_block_by_number() {
         .expect("specified block not found");
 
     assert_header(&block.header, &hwp.header);
-    assert_eq!(block.size, None);
+    assert_eq!(block.size, Some(U256::from(37890)));
     assert_eq!(block.transactions.len(), body.transactions().len());
     assert!(block.uncles.is_empty());
     assert_eq!(
@@ -231,7 +232,7 @@ async fn test_eth_get_block_by_hash() {
         .expect("specified block not found");
 
     assert_header(&block.header, &hwp.header);
-    assert_eq!(block.size, None);
+    assert_eq!(block.size, Some(U256::from(37890)));
     assert_eq!(block.transactions.len(), body.transactions().len());
     assert!(block.uncles.is_empty());
     assert_eq!(


### PR DESCRIPTION
This PR should be reviewed after https://github.com/ethereum/trin/pull/1527

### What was wrong?
followup PR to https://github.com/ethereum/trin/pull/1527 which adds size
### How was it fixed?
properly handle rlp encoding for the block to get the size