### PR TITLE
refactor: transaction rlp encoding

### DIFF
--- a/ethportal-api/src/types/execution/block_body.rs
+++ b/ethportal-api/src/types/execution/block_body.rs
@@ -121,8 +121,6 @@ impl BlockBody {
     }
 
     /// Returns reference to uncle headers.
-    ///
-    /// Returns None post Merge fork.
     pub fn uncles(&self) -> &[Header] {
         match self {
             BlockBody::Legacy(body) => &body.uncles,
@@ -191,7 +189,7 @@ impl Decodable for BlockBodyLegacy {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         let mut payload_view = rlp::Header::decode_bytes(buf, true)?;
         let txs = rlp_decode_transaction_list_with_header(&mut payload_view)?;
-        let uncles = Vec::<Header>::decode(buf)?;
+        let uncles = Vec::<Header>::decode(&mut payload_view)?;
         Ok(Self { txs, uncles })
     }
 }
@@ -353,7 +351,7 @@ impl Decodable for BlockBodyShanghai {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         let mut payload_view = rlp::Header::decode_bytes(buf, true)?;
         let txs = rlp_decode_transaction_list_with_header(&mut payload_view)?;
-        let withdrawals = Vec::<Withdrawal>::decode(buf)?;
+        let withdrawals = Vec::<Withdrawal>::decode(&mut payload_view)?;
         Ok(Self { txs, withdrawals })
     }
 }

--- a/ethportal-api/src/types/execution/block_body.rs
+++ b/ethportal-api/src/types/execution/block_body.rs
@@ -2,7 +2,7 @@ use std::vec;
 
 use alloy::{
     primitives::{keccak256, B256},
-    rlp::{Decodable, Encodable, Error as RlpError, Header as RlpHeader},
+    rlp::{self, Decodable, Encodable},
 };
 use anyhow::{anyhow, bail};
 use serde::Deserialize;
@@ -45,7 +45,7 @@ impl Decodable for BlockBody {
         } else if let Ok(val) = BlockBodyShanghai::decode(buf) {
             Ok(BlockBody::Shanghai(val))
         } else {
-            Err(RlpError::Custom("Invalid block body rlp"))
+            Err(rlp::Error::Custom("Invalid block body rlp"))
         }
     }
 }
@@ -123,17 +123,16 @@ impl BlockBody {
     /// Returns reference to uncle headers.
     ///
     /// Returns None post Merge fork.
-    pub fn uncles(&self) -> Option<&[Header]> {
+    pub fn uncles(&self) -> &[Header] {
         match self {
-            BlockBody::Legacy(body) => Some(&body.uncles),
-            BlockBody::Merge(_) => None,
-            BlockBody::Shanghai(_) => None,
+            BlockBody::Legacy(body) => &body.uncles,
+            BlockBody::Merge(_) => &[],
+            BlockBody::Shanghai(_) => &[],
         }
     }
 
     pub fn uncles_root(&self) -> B256 {
-        let uncles = self.uncles().unwrap_or_default().to_vec();
-        let encoded_uncles = alloy_rlp::encode(uncles);
+        let encoded_uncles = alloy_rlp::encode(self.uncles().to_vec());
         keccak256(&encoded_uncles)
     }
 
@@ -156,17 +155,16 @@ impl BlockBody {
     }
 }
 
-fn rlp_encode_transaction_list(out: &mut dyn bytes::BufMut, txs: &[Transaction]) {
-    let mut transactions_list = Vec::<u8>::new();
-    for tx in txs {
-        tx.encode_with_envelope(&mut transactions_list, true);
-    }
-    let header = RlpHeader {
-        list: true,
-        payload_length: transactions_list.len(),
-    };
-    header.encode(out);
-    out.put_slice(transactions_list.as_slice());
+fn rlp_encode_transaction_list_with_header(out: &mut dyn bytes::BufMut, txs: &[Transaction]) {
+    txs.iter()
+        .map(Transaction::with_rlp_header)
+        .collect::<Vec<_>>()
+        .encode(out);
+}
+
+fn rlp_decode_transaction_list_with_header(buf: &mut &[u8]) -> rlp::Result<Vec<Transaction>> {
+    let txs = Vec::<Transaction</* RLP_HEADER= */ true>>::decode(buf)?;
+    Ok(txs.into_iter().map(Transaction::from).collect())
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
@@ -178,9 +176,9 @@ pub struct BlockBodyLegacy {
 impl Encodable for BlockBodyLegacy {
     fn encode(&self, out: &mut dyn bytes::BufMut) {
         let mut list = Vec::<u8>::new();
-        rlp_encode_transaction_list(&mut list, &self.txs);
+        rlp_encode_transaction_list_with_header(&mut list, &self.txs);
         self.uncles.encode(&mut list);
-        let header = RlpHeader {
+        let header = rlp::Header {
             list: true,
             payload_length: list.len(),
         };
@@ -191,17 +189,9 @@ impl Encodable for BlockBodyLegacy {
 
 impl Decodable for BlockBodyLegacy {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let header = RlpHeader::decode(buf)?;
-        if !header.list {
-            return Err(RlpError::UnexpectedString);
-        }
-        let mut bytes = RlpHeader::decode_bytes(buf, true)?;
-        let mut txs: Vec<Transaction> = vec![];
-        let payload_view = &mut bytes;
-        while !payload_view.is_empty() {
-            txs.push(Transaction::decode_enveloped_transactions(payload_view)?);
-        }
-        let uncles: Vec<Header> = Decodable::decode(buf)?;
+        let mut payload_view = rlp::Header::decode_bytes(buf, true)?;
+        let txs = rlp_decode_transaction_list_with_header(&mut payload_view)?;
+        let uncles = Vec::<Header>::decode(buf)?;
         Ok(Self { txs, uncles })
     }
 }
@@ -264,8 +254,8 @@ pub struct BlockBodyMerge {
 impl Encodable for BlockBodyMerge {
     fn encode(&self, out: &mut dyn bytes::BufMut) {
         let mut list = Vec::<u8>::new();
-        rlp_encode_transaction_list(&mut list, &self.txs);
-        let header = RlpHeader {
+        rlp_encode_transaction_list_with_header(&mut list, &self.txs);
+        let header = rlp::Header {
             list: true,
             payload_length: list.len(),
         };
@@ -276,17 +266,8 @@ impl Encodable for BlockBodyMerge {
 
 impl Decodable for BlockBodyMerge {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let header = RlpHeader::decode(buf)?;
-        if !header.list {
-            return Err(RlpError::UnexpectedString);
-        }
-        let mut bytes = RlpHeader::decode_bytes(buf, true)?;
-        let mut txs: Vec<Transaction> = vec![];
-        let payload_view = &mut bytes;
-        while !payload_view.is_empty() {
-            txs.push(Transaction::decode_enveloped_transactions(payload_view)?);
-        }
-
+        let mut payload_view = rlp::Header::decode_bytes(buf, true)?;
+        let txs = rlp_decode_transaction_list_with_header(&mut payload_view)?;
         Ok(Self { txs })
     }
 }
@@ -357,9 +338,9 @@ pub struct BlockBodyShanghai {
 impl Encodable for BlockBodyShanghai {
     fn encode(&self, out: &mut dyn bytes::BufMut) {
         let mut list = Vec::<u8>::new();
-        rlp_encode_transaction_list(&mut list, &self.txs);
+        rlp_encode_transaction_list_with_header(&mut list, &self.txs);
         self.withdrawals.encode(&mut list);
-        let header = RlpHeader {
+        let header = rlp::Header {
             list: true,
             payload_length: list.len(),
         };
@@ -370,17 +351,9 @@ impl Encodable for BlockBodyShanghai {
 
 impl Decodable for BlockBodyShanghai {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let header = RlpHeader::decode(buf)?;
-        if !header.list {
-            return Err(RlpError::UnexpectedString);
-        }
-        let mut bytes = RlpHeader::decode_bytes(buf, true)?;
-        let mut txs: Vec<Transaction> = vec![];
-        let payload_view = &mut bytes;
-        while !payload_view.is_empty() {
-            txs.push(Transaction::decode_enveloped_transactions(payload_view)?);
-        }
-        let withdrawals: Vec<Withdrawal> = Decodable::decode(buf)?;
+        let mut payload_view = rlp::Header::decode_bytes(buf, true)?;
+        let txs = rlp_decode_transaction_list_with_header(&mut payload_view)?;
+        let withdrawals = Vec::<Withdrawal>::decode(buf)?;
         Ok(Self { txs, withdrawals })
     }
 }
@@ -483,7 +456,8 @@ mod tests {
     #[case(TX6, 41942)]
     fn encode_and_decode_txs(#[case] tx: &str, #[case] expected_nonce: u32) {
         let tx_rlp = hex_decode(tx).unwrap();
-        let tx = Decodable::decode(&mut tx_rlp.as_slice()).expect("error decoding tx");
+        let tx = Transaction::</* RLP_HEADER= */ false>::decode(&mut tx_rlp.as_slice())
+            .expect("error decoding tx");
         let expected_nonce = U256::from(expected_nonce);
         match &tx {
             Transaction::Legacy(tx) => assert_eq!(tx.nonce, expected_nonce),
@@ -521,7 +495,7 @@ mod tests {
         let invalid_txs = &block_body.transactions()[..1];
         let invalid_block_body = BlockBody::Legacy(BlockBodyLegacy {
             txs: invalid_txs.to_vec(),
-            uncles: block_body.uncles().unwrap().to_vec(),
+            uncles: block_body.uncles().to_vec(),
         });
 
         let expected_tx_root =
@@ -537,8 +511,8 @@ mod tests {
         let block_body = get_14764013_block_body();
         // invalid uncles
         let invalid_uncles = vec![
-            block_body.uncles().unwrap()[0].clone(),
-            block_body.uncles().unwrap()[0].clone(),
+            block_body.uncles()[0].clone(),
+            block_body.uncles()[0].clone(),
         ];
         let invalid_block_body = BlockBody::Legacy(BlockBodyLegacy {
             txs: block_body.transactions().to_vec(),

--- a/tests/rpc_server.rs
+++ b/tests/rpc_server.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::net::{IpAddr, Ipv4Addr};
 
 use alloy::{
+    primitives::U256,
     providers::{IpcConnect, Provider, ProviderBuilder, RootProvider},
     pubsub::PubSubFrontend,
     rpc::types::{BlockNumberOrTag, BlockTransactions, BlockTransactionsKind, Header as RpcHeader},
@@ -111,7 +112,7 @@ async fn test_eth_get_block_by_number() {
         .expect("specified block not found");
 
     assert_header(&block.header, &hwp.header);
-    assert_eq!(block.size, None);
+    assert_eq!(block.size, Some(U256::from(37890)));
     assert_eq!(block.transactions.len(), body.transactions().len());
     assert!(block.uncles.is_empty());
     assert_eq!(
@@ -231,7 +232,7 @@ async fn test_eth_get_block_by_hash() {
         .expect("specified block not found");
 
     assert_header(&block.header, &hwp.header);
-    assert_eq!(block.size, None);
+    assert_eq!(block.size, Some(U256::from(37890)));
     assert_eq!(block.transactions.len(), body.transactions().len());
     assert!(block.uncles.is_empty());
     assert_eq!(


### PR DESCRIPTION
### What was wrong?

Transaction can be rlp encoded/decoded with (less common) or without (most common) additional rlp header.

Currently, we have to deal with less common case manually, which isn't great. As of now, we have two use cases for it: inside `BlockBody` and as block size inside `eth_getBlockBy*` calls (which is not implemented).

### How was it fixed?

Added const generic argument to the `Transaction` struct.

The default value represents the most common case, which means that we don't have to specify it in most of the cases.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
