### PR TITLE
docs: add quickstart, dark mermaid theme, etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea
 .python-version
 .DS_Store
+*rusty-tags.vi

--- a/book/mermaid-init.js
+++ b/book/mermaid-init.js
@@ -1,0 +1,1 @@
+mermaid.initialize({startOnLoad:true, theme: 'dark'});

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,7 +1,7 @@
 # Summary
 
 - [Introduction](introduction/README.md)
-    - [Portal Network](introduction/portal_network.md)
+    - [Quickstart](introduction/quickstart.md)
 - [Users](users/README.md)
     - [Requirements](users/requirements.md)
     - [Startup](users/startup.md)
@@ -12,6 +12,8 @@
     - [Monitoring](users/monitoring.md)
     - [Problems](users/problems.md)
     - [FAQ](users/faq.md)
+- [Concepts](concepts/README.md)
+    - [Portal Network](introduction/portal_network.md)
 - [Developers](developers/README.md)
     - [Quick setup](developers/quick_setup.md)
     - [Developer stories](developers/developer_stories.md)

--- a/book/src/concepts/README.md
+++ b/book/src/concepts/README.md
@@ -1,0 +1,31 @@
+# Concepts
+
+## Why Portal Network?
+
+Portal is an important way to support the evolution of the core Ethereum protocol.
+
+To relieve pressure on Ethereum clients, the core protocol will allow full nodes to forget old data in a
+likely future upgrade.
+
+When that happens, the Portal Network can supply users with that purged data.
+
+## Why do Portal clients use less space?
+
+Each Portal Network client stores a user-configurable fraction of the data. The client retrieves any missing data from peers, on demand. Just like a full node, the client can cryptographically prove the data it serves.
+
+```mermaid
+flowchart TB
+    subgraph Full node data: on one computer
+    full[Regular full node]
+    end
+    subgraph Full node data: spread amongst computers
+    p1[Portal node]
+    p2[Portal node]
+    p3[Portal node]
+    p1 <--> p2
+    p2 <--> p3
+    p1 <--> p3
+
+    end
+
+```

--- a/book/src/introduction/README.md
+++ b/book/src/introduction/README.md
@@ -1,31 +1,13 @@
-# Introduction
+# Introduction to Trin
 
-> This book is about Trin, which is software used to interact with the Ethereum protocol
-via the Portal Network.
+> trin: a fast Rust client for Ethereum access via the Portal Network.
 
-Trin is a Portal network client which acts as a json-rpc server with:
+Trin acts as a json-rpc server, like an Ethereum client.
+
+Unlike an Ethereum client, trin has:
 - Nearly instant sync
 - Low CPU & storage usage
 
-The Ethereum protocol will allow full nodes to forget old data in an
-likely future upgrade. Portal network nodes can supply users with that data.
+Continue reading to see how to use trin.
 
-Trin makes it possible to access Ethereum with less computer resources
-than a regular full node. It does this by spreading data amongst peers.
-```mermaid
-flowchart TB
-    subgraph Full node data: on one computer
-    full[Regular full node]
-    end
-    subgraph Full node data: spread amongst computers
-    p1[Portal node]
-    p2[Portal node]
-    p3[Portal node]
-    p1 <--> p2
-    p2 <--> p3
-    p1 <--> p3
-
-    end
-
-```
 &#x1F3D7; The sections, content and links of this book are subject to change.

--- a/book/src/introduction/portal_network.md
+++ b/book/src/introduction/portal_network.md
@@ -57,10 +57,8 @@ is likely to have what data based on these names.
 ```mermaid
 sequenceDiagram
     Alice-->>Bob: Looking for data 0xabc
-    Bob-->>Alice: Sorry, but try Charlie (gives address)
+    Bob->>Alice: Sorry, but try Charlie (gives address)
     Alice-->>Charlie: Looking for data 0xabc
-    Charlie-->>Alice: I have it, do you want?
-    Alice-->>Charlie: Yes
     Charlie->>Alice: Data 0xabc
 ```
 
@@ -76,4 +74,4 @@ graph TD;
     id4[(Charlie, medium)]
 ```
 
-In addition to Trin, other portal clients are in development and participate in the same network.
+In addition to Trin, [several other Portal clients](https://ethportal.net/clients#more-information) participate in the same network.

--- a/book/src/introduction/quickstart.md
+++ b/book/src/introduction/quickstart.md
@@ -1,0 +1,46 @@
+# Quickstart
+
+Trin runs on Linux, MacOS, and Windows. There are two ways to run it: download a binary executable, or install it from source.
+
+Let's download the binary executable.
+
+## Download an executable
+
+The github repository hosts the binaries. Download the latest release for your platform from the [releases page](https://github.com/ethereum/trin/releases).
+
+Extract the compressed file to get the `trin` executable.
+
+### Extraction on Linux / MacOS
+
+The binary is compressed in a tarball, so first we need to extract it.
+
+For example, to extract version 0.1.0-alpha.51:
+
+```sh
+tar -xzvf trin-v0.1.0-alpha.51-x86_64-unknown-linux-gnu.tar.gz
+```
+
+You now have a `trin` executable in the current directory.
+
+## Run trin
+
+Launch the executable with 2GB local disk space:
+```sh
+./trin --portal-subnetworks state,history --mb 2000
+```
+
+## Load a block from Ethereum history
+
+Print the block data at height 20,987,654:
+
+```sh
+BLOCK_NUM=20987654; echo '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x'$(printf "%x" $BLOCK_NUM)'", false],"id":1}' | nc -U /tmp/trin-jsonrpc.ipc | jq
+```
+
+For a deeper understanding of how to interact with Ethereum, like invoking a contract function, see the [Ethereum data](/users/use/ethereum_data.md) section.
+
+## Alternatively, install from source
+
+To get the very latest updates, install from source. This path is intended for power users and developers, who want access to the very latest code.
+
+There are platform-specific [build instructions](/developers/contributing/build_instructions.md).


### PR DESCRIPTION
### What was wrong?

There was no Quickstart to get a user quickly using trin.

### How was it fixed?

- Simplified the intro page
- Added a new Quickstart page immediately after the intro
- Moved Portal Network concepts to a new Concepts chapter
- Switch mermaid diagrams to use dark theme, which better matches the book theme (it was hard to see diagram arrows)
- Cleaned up a content network search diagram that incorrectly added a network hop

Unrelated: ignore ctags created by rusty-tags

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
