### PR TITLE
feat: set default storage size to 1GB

### DIFF
--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -18,7 +18,7 @@ pub const DEFAULT_DISCOVERY_PORT: u16 = 9009;
 pub const DEFAULT_UTP_TRANSFER_LIMIT: usize = 50;
 const DEFAULT_SUBNETWORKS: &str = "history";
 pub const DEFAULT_NETWORK: &str = "mainnet";
-pub const DEFAULT_STORAGE_CAPACITY_MB: &str = "100";
+pub const DEFAULT_STORAGE_CAPACITY_MB: &str = "1000";
 pub const DEFAULT_WEB3_TRANSPORT: &str = "ipc";
 
 use crate::dashboard::grafana::{GrafanaAPI, DASHBOARD_TEMPLATES};


### PR DESCRIPTION
1GB seems like a reasonable default number. Big enough to help the network, small enough to not be a nuisance on most setups.

---
For context: this PR used to be about turning on state by default. Now it's just about the storage size default.