### PR TITLE
feat: support "size" in eth_getBlockBy*

### DIFF
--- a/tests/rpc_server.rs
+++ b/tests/rpc_server.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::net::{IpAddr, Ipv4Addr};
 
 use alloy::{
+    primitives::U256,
     providers::{IpcConnect, Provider, ProviderBuilder, RootProvider},
     pubsub::PubSubFrontend,
     rpc::types::{BlockNumberOrTag, BlockTransactions, BlockTransactionsKind, Header as RpcHeader},
@@ -111,7 +112,7 @@ async fn test_eth_get_block_by_number() {
         .expect("specified block not found");
 
     assert_header(&block.header, &hwp.header);
-    assert_eq!(block.size, None);
+    assert_eq!(block.size, Some(U256::from(37890)));
     assert_eq!(block.transactions.len(), body.transactions().len());
     assert!(block.uncles.is_empty());
     assert_eq!(
@@ -231,7 +232,7 @@ async fn test_eth_get_block_by_hash() {
         .expect("specified block not found");
 
     assert_header(&block.header, &hwp.header);
-    assert_eq!(block.size, None);
+    assert_eq!(block.size, Some(U256::from(37890)));
     assert_eq!(block.transactions.len(), body.transactions().len());
     assert!(block.uncles.is_empty());
     assert_eq!(


### PR DESCRIPTION
### What was wrong?

The `eth_getBlockBy*` JSON rpc calls didn't return `size` field.

### How was it fixed?

The #1541 added support for calculating `size` field easily, so we are using it here.

Tested it locally by trying dozens of blocks (both recent and pre-merge) and comparing size field with the ones returned by: https://sandbox.alchemy.com/?method=eth_getBlockByNumber

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
