### PR TITLE
refactor!: make content key decoding more flexible

### DIFF
--- a/ethportal-api/src/types/content_key/overlay.rs
+++ b/ethportal-api/src/types/content_key/overlay.rs
@@ -1,6 +1,7 @@
 use std::{fmt, hash::Hash, ops::Deref};
 
 use quickcheck::{Arbitrary, Gen};
+use sha2::{Digest, Sha256};
 
 use crate::{
     types::content_key::error::ContentKeyError,
@@ -13,18 +14,13 @@ use std::str::FromStr;
 ///
 /// Keys are serializable as "0x" prefixed hex strings.
 pub trait OverlayContentKey:
-    TryFrom<RawContentKey, Error = ContentKeyError>
-    + Clone
-    + fmt::Debug
-    + fmt::Display
-    + Eq
-    + PartialEq
-    + Hash
-    + std::marker::Unpin
+    Clone + fmt::Debug + fmt::Display + Eq + PartialEq + Hash + std::marker::Unpin
 {
     /// Returns the identifier for the content referred to by the key.
     /// The identifier locates the content in the overlay.
-    fn content_id(&self) -> [u8; 32];
+    fn content_id(&self) -> [u8; 32] {
+        Sha256::digest(self.to_bytes()).into()
+    }
 
     /// Returns the bytes of the content key.
     ///
@@ -33,14 +29,17 @@ pub trait OverlayContentKey:
     /// obtain it with: `key.to_bytes().to_vec()`.
     fn to_bytes(&self) -> RawContentKey;
 
+    /// Decodes bytes as content key.
+    fn try_from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, ContentKeyError>;
+
     /// Returns the content key as a hex encoded "0x"-prefixed string.
     fn to_hex(&self) -> String {
         hex_encode(self.to_bytes())
     }
 
     /// Returns the content key from a hex encoded "0x"-prefixed string.
-    fn from_hex(data: &str) -> anyhow::Result<Self> {
-        Ok(Self::try_from(RawContentKey::from_str(data)?)?)
+    fn try_from_hex(data: &str) -> anyhow::Result<Self> {
+        Ok(Self::try_from_bytes(RawContentKey::from_str(data)?)?)
     }
 }
 
@@ -69,26 +68,6 @@ impl Arbitrary for IdentityContentKey {
             *byte = u8::arbitrary(g);
         }
         Self::new(value)
-    }
-}
-
-impl TryFrom<RawContentKey> for IdentityContentKey {
-    type Error = ContentKeyError;
-
-    fn try_from(value: RawContentKey) -> Result<Self, Self::Error> {
-        // Require that length of input is equal to 32.
-        if value.len() != 32 {
-            return Err(ContentKeyError::InvalidLength {
-                received: value.len(),
-                expected: 32,
-            });
-        }
-
-        // The following will not panic because of the length check above.
-        let mut key_value: [u8; 32] = [0; 32];
-        key_value.copy_from_slice(&value[..32]);
-
-        Ok(Self { value: key_value })
     }
 }
 
@@ -123,5 +102,22 @@ impl OverlayContentKey for IdentityContentKey {
     }
     fn to_bytes(&self) -> RawContentKey {
         RawContentKey::from(self.value)
+    }
+
+    fn try_from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, ContentKeyError> {
+        // Require that length of input is equal to 32.
+        let bytes = bytes.as_ref();
+        if bytes.len() != 32 {
+            return Err(ContentKeyError::InvalidLength {
+                received: bytes.len(),
+                expected: 32,
+            });
+        }
+
+        // The following will not panic because of the length check above.
+        let mut key_value: [u8; 32] = [0; 32];
+        key_value.copy_from_slice(&bytes[..32]);
+
+        Ok(Self { value: key_value })
     }
 }

--- a/portalnet/src/overlay/protocol.rs
+++ b/portalnet/src/overlay/protocol.rs
@@ -2,7 +2,6 @@
 
 use std::{
     collections::HashSet,
-    fmt::{Debug, Display},
     future::Future,
     marker::{PhantomData, Sync},
     sync::Arc,
@@ -95,8 +94,6 @@ impl<
         TValidator: 'static + Validator<TContentKey> + Send + Sync,
         TStore: 'static + ContentStore<Key = TContentKey> + Send + Sync,
     > OverlayProtocol<TContentKey, TMetric, TValidator, TStore>
-where
-    <TContentKey as TryFrom<RawContentKey>>::Error: Debug + Display + Send,
 {
     pub async fn new(
         config: OverlayConfig,
@@ -394,7 +391,7 @@ where
         let direction = RequestDirection::Outgoing {
             destination: enr.clone(),
         };
-        let content_key = TContentKey::try_from(content_key.into()).map_err(|err| {
+        let content_key = TContentKey::try_from_bytes(&content_key).map_err(|err| {
             OverlayRequestError::FailedValidation(format!(
                 "Error decoding content key for received utp content: {err}"
             ))

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -119,7 +119,7 @@ pub struct BeaconStorage {
 impl ContentStore for BeaconStorage {
     type Key = BeaconContentKey;
 
-    fn get(&self, key: &Self::Key) -> Result<Option<Vec<u8>>, ContentStoreError> {
+    fn get(&self, key: &BeaconContentKey) -> Result<Option<Vec<u8>>, ContentStoreError> {
         match key {
             BeaconContentKey::LightClientBootstrap(content_key) => self
                 .lookup_lc_bootstrap_value(&content_key.block_hash)
@@ -193,9 +193,9 @@ impl ContentStore for BeaconStorage {
 
     fn put<V: AsRef<[u8]>>(
         &mut self,
-        key: Self::Key,
+        key: BeaconContentKey,
         value: V,
-    ) -> Result<Vec<(Self::Key, Vec<u8>)>, ContentStoreError> {
+    ) -> Result<Vec<(BeaconContentKey, Vec<u8>)>, ContentStoreError> {
         // in the beacon network we don't return any dropped content for propagation
         self.store(&key, &value.as_ref().to_vec()).and(Ok(vec![]))
     }
@@ -203,7 +203,7 @@ impl ContentStore for BeaconStorage {
     /// The "radius" concept is not applicable for Beacon network
     fn is_key_within_radius_and_unavailable(
         &self,
-        key: &Self::Key,
+        key: &BeaconContentKey,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
         match key {
             BeaconContentKey::LightClientBootstrap(content_key) => {

--- a/trin-history/src/storage.rs
+++ b/trin-history/src/storage.rs
@@ -17,21 +17,21 @@ pub struct HistoryStorage {
 impl ContentStore for HistoryStorage {
     type Key = HistoryContentKey;
 
-    fn get(&self, key: &Self::Key) -> Result<Option<Vec<u8>>, ContentStoreError> {
+    fn get(&self, key: &HistoryContentKey) -> Result<Option<Vec<u8>>, ContentStoreError> {
         self.store.lookup_content_value(&key.content_id().into())
     }
 
     fn put<V: AsRef<[u8]>>(
         &mut self,
-        key: Self::Key,
+        key: HistoryContentKey,
         value: V,
-    ) -> Result<Vec<(Self::Key, Vec<u8>)>, ContentStoreError> {
+    ) -> Result<Vec<(HistoryContentKey, Vec<u8>)>, ContentStoreError> {
         self.store.insert(&key, value.as_ref().to_vec())
     }
 
     fn is_key_within_radius_and_unavailable(
         &self,
-        key: &Self::Key,
+        key: &HistoryContentKey,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
         let content_id = ContentId::from(key.content_id());
         if self.store.distance_to_content_id(&content_id) > self.store.radius() {

--- a/trin-state/src/storage.rs
+++ b/trin-state/src/storage.rs
@@ -33,7 +33,6 @@ impl ContentStore for StateStorage {
         key: Self::Key,
         value: V,
     ) -> Result<Vec<(Self::Key, Vec<u8>)>, ContentStoreError> {
-        let key = StateContentKey::try_from(key.to_bytes())?;
         let value = StateContentValue::decode(&key, value.as_ref())?;
 
         match &key {

--- a/trin-state/src/storage.rs
+++ b/trin-state/src/storage.rs
@@ -24,15 +24,15 @@ pub struct StateStorage {
 impl ContentStore for StateStorage {
     type Key = StateContentKey;
 
-    fn get(&self, key: &Self::Key) -> Result<Option<Vec<u8>>, ContentStoreError> {
+    fn get(&self, key: &StateContentKey) -> Result<Option<Vec<u8>>, ContentStoreError> {
         self.store.lookup_content_value(&key.content_id().into())
     }
 
     fn put<V: AsRef<[u8]>>(
         &mut self,
-        key: Self::Key,
+        key: StateContentKey,
         value: V,
-    ) -> Result<Vec<(Self::Key, Vec<u8>)>, ContentStoreError> {
+    ) -> Result<Vec<(StateContentKey, Vec<u8>)>, ContentStoreError> {
         let value = StateContentValue::decode(&key, value.as_ref())?;
 
         match &key {
@@ -51,7 +51,7 @@ impl ContentStore for StateStorage {
 
     fn is_key_within_radius_and_unavailable(
         &self,
-        key: &Self::Key,
+        key: &StateContentKey,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
         let content_id = ContentId::from(key.content_id());
         if self.store.distance_to_content_id(&content_id) > self.store.radius() {

--- a/trin-storage/src/versioned/id_indexed_v1/store.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/store.rs
@@ -202,7 +202,7 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
                 named_params! { ":content_id": content_id.to_vec() },
                 |row| {
                     let bytes: Vec<u8> = row.get("content_key")?;
-                    TContentKey::try_from(bytes.into()).map_err(|e| {
+                    TContentKey::try_from_bytes(bytes).map_err(|e| {
                         rusqlite::Error::FromSqlConversionFailure(0, Type::Blob, e.into())
                     })
                 },
@@ -337,7 +337,7 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
                 },
                 |row| {
                     let bytes = row.get::<&str, Vec<u8>>("content_key")?;
-                    TContentKey::try_from(bytes.into()).map_err(|e| {
+                    TContentKey::try_from_bytes(bytes).map_err(|e| {
                         rusqlite::Error::FromSqlConversionFailure(0, Type::Blob, e.into())
                     })
                 },
@@ -480,7 +480,7 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
                     let key_bytes: Vec<u8> = row.get("content_key")?;
                     let value_bytes: Vec<u8> = row.get("content_value")?;
                     let size: u64 = row.get("content_size")?;
-                    TContentKey::try_from(key_bytes.into())
+                    TContentKey::try_from_bytes(key_bytes)
                         .map(|key| (key, value_bytes, size))
                         .map_err(|e| {
                             rusqlite::Error::FromSqlConversionFailure(0, Type::Blob, e.into())

--- a/trin-validation/src/header_validator.rs
+++ b/trin-validation/src/header_validator.rs
@@ -241,7 +241,7 @@ mod test {
             },
         },
         utils::bytes::{hex_decode, hex_encode},
-        HistoryContentKey, RawContentKey,
+        HistoryContentKey, OverlayContentKey,
     };
 
     #[rstest]
@@ -268,8 +268,7 @@ mod test {
         let obj = hwps.get(&block_number.to_string()).unwrap();
         // Validate content_key decodes
         let raw_ck = obj.get("content_key").unwrap().as_str().unwrap();
-        let raw_ck = RawContentKey::from_str(raw_ck).unwrap();
-        let ck = HistoryContentKey::try_from(raw_ck).unwrap();
+        let ck = HistoryContentKey::try_from_hex(raw_ck).unwrap();
         match ck {
             HistoryContentKey::BlockHeaderByHash(_) => (),
             _ => panic!("Invalid test, content key decoded improperly"),


### PR DESCRIPTION
### What was wrong?

Conversion from byte array into content key isn't flexible enough.

Currently, `OverlayContentKey` has to implement `TryFrom<RawContentKey>`, while sometimes it would be easier if we wouldn't have to convert other byte array  types (e.g. `Vec<u8>`) into `RawContentKey` (even though performance wise, it might not make big difference).

### How was it fixed?

Instead of `OverlayContentKey` extending `TryFrom<RawContentKey>` it now has `try_from_bytes` function that has to be called explicitly. This goes nicely with `to_bytes` function.

The `from_hex` function was renamed to `try_from_hex` function in order to have same naming scheme.

### Other refactorings

Additional smaller refactoring is done in beacon, history and state content key implementations:

- `to_bytes` implementation is now identical
    - instead of using `Vec<u8>` we use `BytesMut`, with preset capacity
- the `content_id` implementation is moved into `OverlayContentKey`
    - if needed in the future, it can still be overridden
- (de)serialization now uses `RawContentKey` as a intermediate type (instead of String)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
