### PR TITLE
test: relax e2store test that depends on website

### DIFF
--- a/e2store/Cargo.toml
+++ b/e2store/Cargo.toml
@@ -21,7 +21,7 @@ ethereum_ssz_derive.workspace = true
 ethportal-api.workspace = true
 rand.workspace = true
 reqwest.workspace = true
-tracing = { workspace = true, optional = true }
+tracing.workspace = true
 trin-utils = { workspace = true, optional = true }
 scraper.workspace = true
 snap.workspace = true
@@ -32,7 +32,7 @@ tokio.workspace = true
 trin-utils.workspace = true
 
 [features]
-era2-stats-binary = ["clap", "tracing", "trin-utils"]
+era2-stats-binary = ["clap", "trin-utils"]
 
 [[bin]]
 name = "era2-stats"

--- a/e2store/src/utils.rs
+++ b/e2store/src/utils.rs
@@ -47,10 +47,12 @@ pub async fn download_era_links(
 pub async fn get_era_files(http_client: &Client) -> anyhow::Result<HashMap<u64, String>> {
     let era_files = download_era_links(http_client, ERA_DIR_URL).await?;
     ensure!(!era_files.is_empty(), "No era files found at {ERA_DIR_URL}");
-    ensure!(
-        (0..era_files.len()).all(|epoch| era_files.contains_key(&(epoch as u64))),
-        "Epoch indices are not starting from zero or not consecutive",
-    );
+    for epoch_num in 0..era_files.len() {
+        ensure!(
+            era_files.contains_key(&(epoch_num as u64)),
+            "Epoch indices are not starting from zero or not consecutive: missing epoch {epoch_num}",
+        );
+    }
     Ok(era_files)
 }
 


### PR DESCRIPTION
### What was wrong?

We saw master failing because https://mainnet.era.nimbus.team/ stopped listing these epochs: 701, 707, 709, 719, 725, 731, 759, 779, and 780. We can't just leave it red.

Also, when the epoch list is incomplete, the current message doesn't help you identify which one.

### How was it fixed?

Convert the test failure to a log warning.

Bonus: add the epoch index into the log.

### Possible follow-up work

Multi-source the data?