### PR TITLE
chore: remove/ignore tests which download from a remote server

### DIFF
--- a/e2store/src/utils.rs
+++ b/e2store/src/utils.rs
@@ -47,9 +47,15 @@ pub async fn download_era_links(
 pub async fn get_era_files(http_client: &Client) -> anyhow::Result<HashMap<u64, String>> {
     let era_files = download_era_links(http_client, ERA_DIR_URL).await?;
     ensure!(!era_files.is_empty(), "No era files found at {ERA_DIR_URL}");
+    let missing_epochs: Vec<String> = (0..era_files.len())
+        .filter(|&epoch_num| !era_files.contains_key(&(epoch_num as u64)))
+        .map(|epoch_num| epoch_num.to_string())
+        .collect();
+
     ensure!(
-        (0..era_files.len()).all(|epoch| era_files.contains_key(&(epoch as u64))),
-        "Epoch indices are not starting from zero or not consecutive",
+        missing_epochs.is_empty(),
+        "Epoch indices are not starting from zero or not consecutive: missing epochs [{}]",
+        missing_epochs.join(", ")
     );
     Ok(era_files)
 }

--- a/e2store/src/utils.rs
+++ b/e2store/src/utils.rs
@@ -78,22 +78,3 @@ pub async fn get_shuffled_era1_files(http_client: &Client) -> anyhow::Result<Vec
     era1_files.shuffle(&mut thread_rng());
     Ok(era1_files)
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_get_shuffled_era1_files() {
-        let http_client = Client::new();
-        let era1_files = get_shuffled_era1_files(&http_client).await.unwrap();
-        assert_eq!(era1_files.len(), ERA1_FILE_COUNT);
-    }
-
-    #[tokio::test]
-    async fn test_get_era_file_download_links() {
-        let http_client = Client::new();
-        let era_files = get_era_files(&http_client).await.unwrap();
-        assert!(!era_files.is_empty());
-    }
-}

--- a/trin-execution/src/execution.rs
+++ b/trin-execution/src/execution.rs
@@ -171,6 +171,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[ignore = "This test downloads data from a remote server"]
     async fn test_we_generate_the_correct_state_root_for_the_first_8192_blocks() {
         let temp_directory = create_temp_test_dir().unwrap();
         let mut trin_execution = TrinExecution::new(temp_directory.path(), StateConfig::default())

--- a/trin-execution/src/trie_walker.rs
+++ b/trin-execution/src/trie_walker.rs
@@ -167,6 +167,7 @@ mod tests {
     use crate::{config::StateConfig, execution::TrinExecution, trie_walker::TrieWalker};
 
     #[tokio::test]
+    #[ignore = "This test downloads data from a remote server"]
     async fn test_trie_walker_builds_valid_proof() {
         let temp_directory = create_temp_test_dir().unwrap();
         let mut trin_execution = TrinExecution::new(temp_directory.path(), StateConfig::default())

--- a/trin-execution/tests/export_import.rs
+++ b/trin-execution/tests/export_import.rs
@@ -23,6 +23,7 @@ use trin_utils::dir::create_temp_test_dir;
 /// ```
 #[tokio::test]
 #[traced_test]
+#[ignore = "This test downloads data from a remote server"]
 async fn execute_export_import_execute() -> anyhow::Result<()> {
     let blocks = std::env::var("BLOCKS")
         .ok()


### PR DESCRIPTION
### What was wrong?
We had tests which would fail due to missing data on a website, some tests still fail too due to this, but we want those tests so I set them to ignore
### How was it fixed?

removing the tests or ignore them. Trin Execution will still exit on start with the errors if any era files are missing so we are good