### PR TITLE
feat: log cpu utilization in state network report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,6 +1452,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpu-time"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6742,6 +6752,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "anyhow",
+ "cpu-time",
  "discv5",
  "env_logger 0.9.3",
  "eth_trie",

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -13,6 +13,7 @@ authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 [dependencies]
 alloy = { workspace = true, features = ["getrandom"] }
 anyhow.workspace = true
+cpu-time = "1.0.0"
 discv5.workspace = true
 eth_trie.workspace = true
 ethportal-api.workspace = true


### PR DESCRIPTION
### What was wrong?

Related to #1545 -- to start we at least want to measure CPU usage. However we decide to respond to it, it is a thing we will want to respond to. So this is an experiment to see how well the library works at observing usage, to lay the groundwork for later steps.

### How was it fixed?

Add `cpu_time` to track the amount of cpu usage that trin has. It's a bit hacky to put it in the `trin-state` report, because it's just measuring everything happening in the process. But since state is not stabilizing (and seems to be the culprit for high usage currently), it seems like a good place to add the log.

It's already been a convenient way to watch my machine react as I experiment with the CPU effect of various changes.

Example log:
```
2024-10-24T04:53:32.129663Z  INFO trin_state: reports~ data: radius=12% content=53.3/495mb #=131860 disk=204.9mb; msgs: offers=5235/5522, accepts=7070/7070, validations=706/707; cpu=8.4%
```