### PR TITLE
feat: limit radius to at most 1/8 of MAX

### DIFF
--- a/ethportal-api/src/types/distance.rs
+++ b/ethportal-api/src/types/distance.rs
@@ -43,6 +43,10 @@ impl Distance {
         be_bytes.copy_from_slice(&self.big_endian()[..4]);
         u32::from_be_bytes(be_bytes)
     }
+
+    pub fn max_practical_radius() -> Self {
+        Self(U256::MAX / U256::from(8))
+    }
 }
 
 impl From<U256> for Distance {


### PR DESCRIPTION
Why shrink the limit to less than MAX at all?

Our goal is not for nodes to store all data. Even if they did, it would be inefficient to find the data. So we might as well skip the step of storing and then deleting a bunch of data outside the radius.

Additionally, the state network is using higher CPU than expected. Maybe tamping the starting radius down a bit at the beginning will shrink CPU usage during that load-data-in phase. 

Why not go lower than 1/8?
10% is the cutoff for when Glados consides that a node is actually storing all the data that it claims in the radius. So starting at 12.5% means that a new node is still correctly ignored by glados in that set of filled-up nodes, until the node actually collects enough content to shrink below 10%.

### To-Do

Come up with a solution for the inevitable test failures here and in Hive. Many tests will assume that fresh clients will store all data.