### PR TITLE
feat: add format validation to era2-stats binary

### DIFF
--- a/e2store/src/bin/era2-stats.rs
+++ b/e2store/src/bin/era2-stats.rs
@@ -9,7 +9,7 @@ use tracing::info;
 #[derive(Debug, Parser)]
 #[command(
     name = "Era2 stats",
-    about = "Reads the era2 file, validates it, and prints stats about it."
+    about = "Reads the era2 file, validates the format, and prints stats about it."
 )]
 struct Config {
     #[arg(help = "The path to the era2 file.")]
@@ -24,7 +24,7 @@ struct Stats {
     storage_item_count: usize,
 }
 
-/// Reads the era2 file, validates it, and prints stats about it.
+/// Reads the era2 file, validates the format, and prints stats about it.
 ///
 /// It can be run with following command:
 ///

--- a/e2store/src/bin/era2-stats.rs
+++ b/e2store/src/bin/era2-stats.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use alloy::primitives::{keccak256, B256};
 use anyhow::bail;
 use clap::Parser;
-use e2store::era2::{AccountOrStorageEntry, Era2Reader};
+use e2store::era2::{self, AccountOrStorageEntry, Era2Reader};
 use tracing::info;
 
 #[derive(Debug, Parser)]
@@ -79,11 +79,15 @@ fn main() -> anyhow::Result<()> {
             stats.storage_entry_count += 1;
             stats.storage_item_count += storage.len();
 
+            // Check that every storage entry is full (has 10M items), except the last one.
             if index + 1 < account.storage_count {
                 assert_eq!(
                     storage.len(),
-                    10_000_000,
-                    "Non-final storage entry doesn't have 10M items",
+                    era2::MAX_STORAGE_ITEMS,
+                    "Non-final storage entry (address_hash: {}, index: {index}/{}) should be full, but has {} items instead",
+                    account.address_hash,
+                    account.storage_count,
+                    storage.len(),
                 );
             }
 


### PR DESCRIPTION
### What was wrong?

The "era2-stats" binary doesn't check validity of the file.

### How was it fixed?

Added validation. The only thing missing is checking that state data actually results in the canonical state trie, but that is covered by `import-state` subcommand of the trin-execution.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
