### PR TITLE
feat: only bridge newly created contracts

### DIFF
--- a/portal-bridge/src/bridge/state.rs
+++ b/portal-bridge/src/bridge/state.rs
@@ -195,7 +195,7 @@ impl StateBridge {
                 // gossip contract bytecode
                 if let Some(code) = trin_execution
                     .database
-                    .get_newly_created_contract_if_available(account.code_hash)
+                    .get_newly_created_contract(account.code_hash)
                 {
                     self.gossip_contract_bytecode(
                         address_hash,

--- a/trin-execution/src/config.rs
+++ b/trin-execution/src/config.rs
@@ -3,8 +3,9 @@ use crate::{cli::TrinExecutionConfig, types::block_to_trace::BlockToTrace};
 #[derive(Debug, Clone)]
 pub struct StateConfig {
     /// This flag when enabled will storage all the trie keys from block execution in a cache, this
-    /// is needed for gossiping the storage trie's changes.
-    pub cache_contract_storage_changes: bool,
+    /// is needed for gossiping the storage trie's changes. It is also needed for gossiping newly
+    /// created contracts.
+    pub cache_contract_changes: bool,
     pub block_to_trace: BlockToTrace,
 }
 
@@ -12,7 +13,7 @@ pub struct StateConfig {
 impl Default for StateConfig {
     fn default() -> Self {
         Self {
-            cache_contract_storage_changes: false,
+            cache_contract_changes: false,
             block_to_trace: BlockToTrace::None,
         }
     }
@@ -21,7 +22,7 @@ impl Default for StateConfig {
 impl From<TrinExecutionConfig> for StateConfig {
     fn from(cli_config: TrinExecutionConfig) -> Self {
         Self {
-            cache_contract_storage_changes: false,
+            cache_contract_changes: false,
             block_to_trace: cli_config.block_to_trace,
         }
     }

--- a/trin-execution/src/storage/evm_db.rs
+++ b/trin-execution/src/storage/evm_db.rs
@@ -106,7 +106,7 @@ impl EvmDB {
         trie_diff
     }
 
-    pub fn get_newly_created_contract_if_available(&self, code_hash: B256) -> Option<Bytecode> {
+    pub fn get_newly_created_contract(&self, code_hash: B256) -> Option<Bytecode> {
         self.newly_created_contracts.lock().get(&code_hash).cloned()
     }
 

--- a/trin-execution/tests/content_generation.rs
+++ b/trin-execution/tests/content_generation.rs
@@ -159,7 +159,7 @@ async fn test_we_can_generate_content_key_values_up_to_x() -> Result<()> {
             if account.code_hash != keccak256([]) {
                 if let Some(code) = trin_execution
                     .database
-                    .get_newly_created_contract_if_available(account.code_hash)
+                    .get_newly_created_contract(account.code_hash)
                 {
                     let content_key = create_contract_content_key(address_hash, account.code_hash)
                         .expect("Content key should be present");

--- a/trin-execution/tests/content_generation.rs
+++ b/trin-execution/tests/content_generation.rs
@@ -8,7 +8,6 @@ use ethportal_api::{
     },
     ContentValue, OverlayContentKey, StateContentKey, StateContentValue,
 };
-use revm::DatabaseRef;
 use revm_primitives::keccak256;
 use tracing::info;
 use tracing_test::traced_test;
@@ -96,7 +95,7 @@ async fn test_we_can_generate_content_key_values_up_to_x() -> Result<()> {
     let mut trin_execution = TrinExecution::new(
         temp_directory.path(),
         StateConfig {
-            cache_contract_storage_changes: true,
+            cache_contract_changes: true,
             block_to_trace: BlockToTrace::None,
         },
     )
@@ -158,16 +157,18 @@ async fn test_we_can_generate_content_key_values_up_to_x() -> Result<()> {
 
             // check contract code content key/value
             if account.code_hash != keccak256([]) {
-                let code = trin_execution
+                if let Some(code) = trin_execution
                     .database
-                    .code_by_hash_ref(account.code_hash)?;
-
-                let content_key = create_contract_content_key(address_hash, account.code_hash)
-                    .expect("Content key should be present");
-                let content_value = create_contract_content_value(block_hash, &account_proof, code)
-                    .expect("Content key should be present");
-                block_stats.check_content(&content_key, &content_value);
-                stats.check_content(&content_key, &content_value);
+                    .get_newly_created_contract_if_available(account.code_hash)
+                {
+                    let content_key = create_contract_content_key(address_hash, account.code_hash)
+                        .expect("Content key should be present");
+                    let content_value =
+                        create_contract_content_value(block_hash, &account_proof, code)
+                            .expect("Content key should be present");
+                    block_stats.check_content(&content_key, &content_value);
+                    stats.check_content(&content_key, &content_value);
+                }
             }
 
             // check contract storage content key/value
@@ -188,7 +189,7 @@ async fn test_we_can_generate_content_key_values_up_to_x() -> Result<()> {
 
         // flush the database cache
         // This is used for gossiping storage trie diffs
-        trin_execution.database.storage_cache.lock().clear();
+        trin_execution.database.clear_contract_cache();
         info!("Block {block_number} finished: {block_stats:?}");
     }
     temp_directory.close()?;


### PR DESCRIPTION
### What was wrong?
We would always bridge contracts, which isn't good because the contract should already be gossiped on the network. This takes up a lot of bridge bandwidth, which is redundant as the contracts should already be on the network.
### How was it fixed?

By using a `cache` to store newly created contracts like we do for `storage_trie` diffs.
