### PR TITLE
feat: update state:history storage to 1:1

### DIFF
--- a/trin-storage/src/config.rs
+++ b/trin-storage/src/config.rs
@@ -20,7 +20,7 @@ pub struct PortalStorageConfigFactory {
 
 impl PortalStorageConfigFactory {
     const HISTORY_CAPACITY_WEIGHT: u64 = 1;
-    const STATE_CAPACITY_WEIGHT: u64 = 99;
+    const STATE_CAPACITY_WEIGHT: u64 = 1;
     const BEACON_CAPACITY_WEIGHT: u64 = 0; // Beacon doesn't care about given capacity
 
     pub fn new(


### PR DESCRIPTION
_I don't have strong feelings about what the new ratio should be. I just picked one, mostly to kick off discussion. Now, we have more information than we did at the 99:1 ratio selection._


The new ratio is still a loose guess. But it is based on some recently acquired state data, specifically:

A recent average amount of new state generated is about 1.75MB / block or ~375 GB per month. Let's make room for 10 years of intremental state at that rate, which gives us a network size of: ~45 TB.

The typical history node can fill up 35GB of storage with a ~2% radius, implying a network size of: ~1.75 TB.

45 TB / 1.75 TB ~= 25:1 ratio

Inspired by conversation and data collection here: https://discord.com/channels/890617081744220180/1089234065816821860/1300370058366947370
