### PR TITLE
chore: simplify TrinConfig::new_from usage

### DIFF
--- a/ethportal-api/src/types/bootnodes.rs
+++ b/ethportal-api/src/types/bootnodes.rs
@@ -149,7 +149,7 @@ mod test {
 
     #[test_log::test]
     fn test_bootnodes_default_with_default_bootnodes() {
-        let config = TrinConfig::new_from(["trin"].iter()).unwrap();
+        let config = TrinConfig::new_from(["trin"]).unwrap();
         assert_eq!(config.bootnodes, Bootnodes::Default);
         let bootnodes: Vec<Enr> = config.bootnodes.to_enrs(Network::Mainnet);
         assert_eq!(bootnodes.len(), 11);
@@ -157,7 +157,7 @@ mod test {
 
     #[test_log::test]
     fn test_bootnodes_default_with_explicit_default_bootnodes() {
-        let config = TrinConfig::new_from(["trin", "--bootnodes", "default"].iter()).unwrap();
+        let config = TrinConfig::new_from(["trin", "--bootnodes", "default"]).unwrap();
         assert_eq!(config.bootnodes, Bootnodes::Default);
         let bootnodes: Vec<Enr> = config.bootnodes.to_enrs(Network::Mainnet);
         assert_eq!(bootnodes.len(), 11);
@@ -165,7 +165,7 @@ mod test {
 
     #[test_log::test]
     fn test_bootnodes_default_with_no_bootnodes() {
-        let config = TrinConfig::new_from(["trin", "--bootnodes", "none"].iter()).unwrap();
+        let config = TrinConfig::new_from(["trin", "--bootnodes", "none"]).unwrap();
         assert_eq!(config.bootnodes, Bootnodes::None);
         let bootnodes: Vec<Enr> = config.bootnodes.to_enrs(Network::Mainnet);
         assert_eq!(bootnodes.len(), 0);
@@ -176,7 +176,7 @@ mod test {
     #[case("enr:-IS4QBISSFfBzsBrjq61iSIxPMfp5ShBTW6KQUglzH_tj8_SJaehXdlnZI-NAkTGeoclwnTB-pU544BQA44BiDZ2rkMBgmlkgnY0gmlwhKEjVaWJc2VjcDI1NmsxoQOSGugH1jSdiE_fRK1FIBe9oLxaWH8D_7xXSnaOVBe-SYN1ZHCCIyg,invalid")]
     #[should_panic]
     fn test_bootnodes_invalid_enr(#[case] bootnode: &str) {
-        TrinConfig::new_from(["trin", "--bootnodes", bootnode].iter()).unwrap();
+        TrinConfig::new_from(["trin", "--bootnodes", bootnode]).unwrap();
     }
 
     #[rstest]
@@ -184,7 +184,7 @@ mod test {
     #[case("enr:-IS4QBISSFfBzsBrjq61iSIxPMfp5ShBTW6KQUglzH_tj8_SJaehXdlnZI-NAkTGeoclwnTB-pU544BQA44BiDZ2rkMBgmlkgnY0gmlwhKEjVaWJc2VjcDI1NmsxoQOSGugH1jSdiE_fRK1FIBe9oLxaWH8D_7xXSnaOVBe-SYN1ZHCCIyg,enr:-IS4QPUT9hwV4YfNTxazR2ltch4qKzvX_HwxQBw8gUN3q1MDfNyaD1EHc1wQZRTUzQQD-RVYx3h4nA1Sqk0Wx9DwzNABgmlkgnY0gmlwhM69ZOyJc2VjcDI1NmsxoQLaI-m2CDIjpwcnUf1ESspvOctJLpIrLA8AZ4zbo_1bFIN1ZHCCIyg", 2)]
     #[case("enr:-IS4QBISSFfBzsBrjq61iSIxPMfp5ShBTW6KQUglzH_tj8_SJaehXdlnZI-NAkTGeoclwnTB-pU544BQA44BiDZ2rkMBgmlkgnY0gmlwhKEjVaWJc2VjcDI1NmsxoQOSGugH1jSdiE_fRK1FIBe9oLxaWH8D_7xXSnaOVBe-SYN1ZHCCIyg,enr:-IS4QPUT9hwV4YfNTxazR2ltch4qKzvX_HwxQBw8gUN3q1MDfNyaD1EHc1wQZRTUzQQD-RVYx3h4nA1Sqk0Wx9DwzNABgmlkgnY0gmlwhM69ZOyJc2VjcDI1NmsxoQLaI-m2CDIjpwcnUf1ESspvOctJLpIrLA8AZ4zbo_1bFIN1ZHCCIyg,enr:-IS4QB77AROcGX-TSkY-U-SaZJ5ma9ICQj6ETO3FqUdCnTZeJ0mDrdCKUqd5AQ0jrHa7m9-mOLvFFKMV_-tBD8uDYZUBgmlkgnY0gmlwhJ_fCDaJc2VjcDI1NmsxoQN9rahqamBOJfj4u6yssJQJ1-EZoyAw-7HIgp1FwNUdnoN1ZHCCIyg", 3)]
     fn test_bootnodes_valid_enrs(#[case] bootnode: &str, #[case] expected_length: usize) {
-        let config = TrinConfig::new_from(["trin", "--bootnodes", bootnode].iter()).unwrap();
+        let config = TrinConfig::new_from(["trin", "--bootnodes", bootnode]).unwrap();
         match config.bootnodes.clone() {
             Bootnodes::Custom(bootnodes) => {
                 assert_eq!(bootnodes.len(), expected_length);
@@ -197,7 +197,7 @@ mod test {
 
     #[rstest]
     fn test_angelfood_network_defaults_to_correct_bootnodes() {
-        let config = TrinConfig::new_from(["trin", "--network", "angelfood"].iter()).unwrap();
+        let config = TrinConfig::new_from(["trin", "--network", "angelfood"]).unwrap();
         assert_eq!(config.bootnodes, Bootnodes::Default);
         let bootnodes: Vec<Enr> = config.bootnodes.to_enrs(Network::Angelfood);
         assert_eq!(bootnodes.len(), 1);
@@ -207,8 +207,7 @@ mod test {
     fn test_custom_bootnodes_override_angelfood_default() {
         let enr = "enr:-IS4QBISSFfBzsBrjq61iSIxPMfp5ShBTW6KQUglzH_tj8_SJaehXdlnZI-NAkTGeoclwnTB-pU544BQA44BiDZ2rkMBgmlkgnY0gmlwhKEjVaWJc2VjcDI1NmsxoQOSGugH1jSdiE_fRK1FIBe9oLxaWH8D_7xXSnaOVBe-SYN1ZHCCIyg";
         let config =
-            TrinConfig::new_from(["trin", "--network", "angelfood", "--bootnodes", enr].iter())
-                .unwrap();
+            TrinConfig::new_from(["trin", "--network", "angelfood", "--bootnodes", enr]).unwrap();
         assert_eq!(
             config.bootnodes,
             Bootnodes::Custom(vec![Bootnode {

--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -560,7 +560,7 @@ mod tests {
     #[test]
     fn test_default_args() {
         let expected_config = TrinConfig::default();
-        let actual_config = TrinConfig::new_from(["trin"].iter()).unwrap();
+        let actual_config = TrinConfig::new_from(["trin"]).unwrap();
         assert_eq!(actual_config.web3_transport, expected_config.web3_transport);
         assert_eq!(
             actual_config.web3_http_address,
@@ -574,7 +574,7 @@ mod tests {
 
     #[test]
     fn test_help() {
-        TrinConfig::new_from(["trin", "-h"].iter()).expect_err("Should be an error to exit early");
+        TrinConfig::new_from(["trin", "-h"]).expect_err("Should be an error to exit early");
     }
 
     #[test]
@@ -584,16 +584,13 @@ mod tests {
             web3_transport: Web3TransportType::HTTP,
             ..Default::default()
         };
-        let actual_config = TrinConfig::new_from(
-            [
-                "trin",
-                "--web3-transport",
-                "http",
-                "--web3-http-address",
-                "http://0.0.0.0:8080/",
-            ]
-            .iter(),
-        )
+        let actual_config = TrinConfig::new_from([
+            "trin",
+            "--web3-transport",
+            "http",
+            "--web3-http-address",
+            "http://0.0.0.0:8080/",
+        ])
         .unwrap();
         assert_eq!(actual_config.web3_transport, expected_config.web3_transport);
         assert_eq!(
@@ -620,7 +617,7 @@ mod tests {
     #[test]
     fn test_ipc_with_custom_path() {
         let actual_config =
-            TrinConfig::new_from(["trin", "--web3-ipc-path", "/path/test.ipc"].iter()).unwrap();
+            TrinConfig::new_from(["trin", "--web3-ipc-path", "/path/test.ipc"]).unwrap();
         let expected_config = TrinConfig {
             web3_http_address: Url::parse(DEFAULT_WEB3_HTTP_ADDRESS).unwrap(),
             web3_ipc_path: PathBuf::from("/path/test.ipc"),
@@ -639,24 +636,20 @@ mod tests {
     #[should_panic(expected = "Must not supply an ipc path when using http")]
 
     fn test_http_protocol_rejects_custom_web3_ipc_path() {
-        TrinConfig::new_from(
-            [
-                "trin",
-                "--web3-transport",
-                "http",
-                "--web3-ipc-path",
-                "/path/test.ipc",
-            ]
-            .iter(),
-        )
+        TrinConfig::new_from([
+            "trin",
+            "--web3-transport",
+            "http",
+            "--web3-ipc-path",
+            "/path/test.ipc",
+        ])
         .unwrap();
     }
 
     #[test]
     #[should_panic(expected = "Must not supply an http address when using ipc")]
     fn test_ipc_protocol_rejects_custom_web3_http_address() {
-        TrinConfig::new_from(["trin", "--web3-http-address", "http://127.0.0.1:1234/"].iter())
-            .unwrap();
+        TrinConfig::new_from(["trin", "--web3-http-address", "http://127.0.0.1:1234/"]).unwrap();
     }
 
     #[test]
@@ -665,15 +658,14 @@ mod tests {
             discovery_port: 999,
             ..Default::default()
         };
-        let actual_config =
-            TrinConfig::new_from(["trin", "--discovery-port", "999"].iter()).unwrap();
+        let actual_config = TrinConfig::new_from(["trin", "--discovery-port", "999"]).unwrap();
         assert_eq!(actual_config.discovery_port, expected_config.discovery_port);
     }
 
     #[test]
     fn test_manual_external_addr_v4() {
         let actual_config =
-            TrinConfig::new_from(["trin", "--external-address", "127.0.0.1:1234"].iter()).unwrap();
+            TrinConfig::new_from(["trin", "--external-address", "127.0.0.1:1234"]).unwrap();
         assert_eq!(
             actual_config.external_addr,
             Some(SocketAddr::from(([127, 0, 0, 1], 1234)))
@@ -683,7 +675,7 @@ mod tests {
     #[test]
     fn test_manual_external_addr_v6() {
         let actual_config =
-            TrinConfig::new_from(["trin", "--external-address", "[::1]:1234"].iter()).unwrap();
+            TrinConfig::new_from(["trin", "--external-address", "[::1]:1234"]).unwrap();
         assert_eq!(
             actual_config.external_addr,
             Some(SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 1234)))
@@ -696,14 +688,11 @@ mod tests {
             private_key: Some(B256::from_slice(&[1; 32])),
             ..Default::default()
         };
-        let actual_config = TrinConfig::new_from(
-            [
-                "trin",
-                "--unsafe-private-key",
-                "0x0101010101010101010101010101010101010101010101010101010101010101",
-            ]
-            .iter(),
-        )
+        let actual_config = TrinConfig::new_from([
+            "trin",
+            "--unsafe-private-key",
+            "0x0101010101010101010101010101010101010101010101010101010101010101",
+        ])
         .unwrap();
         assert_eq!(actual_config.private_key, expected_config.private_key);
     }
@@ -714,7 +703,7 @@ mod tests {
             ephemeral: true,
             ..Default::default()
         };
-        let actual_config = TrinConfig::new_from(["trin", "--ephemeral"].iter()).unwrap();
+        let actual_config = TrinConfig::new_from(["trin", "--ephemeral"]).unwrap();
         assert_eq!(actual_config.ephemeral, expected_config.ephemeral);
     }
 
@@ -728,8 +717,7 @@ mod tests {
             ..Default::default()
         };
         let actual_config =
-            TrinConfig::new_from(["trin", "--enable-metrics-with-url", "127.0.0.1:1234"].iter())
-                .unwrap();
+            TrinConfig::new_from(["trin", "--enable-metrics-with-url", "127.0.0.1:1234"]).unwrap();
         assert_eq!(
             actual_config.enable_metrics_with_url,
             expected_config.enable_metrics_with_url
@@ -741,14 +729,11 @@ mod tests {
         expected = "Invalid private key length: 65, expected 66 (0x-prefixed 32 byte hexstring)"
     )]
     fn test_custom_private_key_odd_length() {
-        TrinConfig::new_from(
-            [
-                "trin",
-                "--unsafe-private-key",
-                "0x010101010101010101010101010101010101010101010101010101010101010",
-            ]
-            .iter(),
-        )
+        TrinConfig::new_from([
+            "trin",
+            "--unsafe-private-key",
+            "0x010101010101010101010101010101010101010101010101010101010101010",
+        ])
         .unwrap();
     }
 
@@ -757,14 +742,11 @@ mod tests {
         expected = "Invalid private key length: 64, expected 66 (0x-prefixed 32 byte hexstring)"
     )]
     fn test_custom_private_key_requires_32_bytes() {
-        TrinConfig::new_from(
-            [
-                "trin",
-                "--unsafe-private-key",
-                "0x01010101010101010101010101010101010101010101010101010101010101",
-            ]
-            .iter(),
-        )
+        TrinConfig::new_from([
+            "trin",
+            "--unsafe-private-key",
+            "0x01010101010101010101010101010101010101010101010101010101010101",
+        ])
         .unwrap();
     }
 
@@ -773,28 +755,22 @@ mod tests {
         expected = "Invalid trusted block root length: 64, expected 66 (0x-prefixed 32 byte hexstring)"
     )]
     fn test_trusted_block_root_requires_32_bytes() {
-        TrinConfig::new_from(
-            [
-                "trin",
-                "--trusted-block-root",
-                "0x01010101010101010101010101010101010101010101010101010101010101",
-            ]
-            .iter(),
-        )
+        TrinConfig::new_from([
+            "trin",
+            "--trusted-block-root",
+            "0x01010101010101010101010101010101010101010101010101010101010101",
+        ])
         .unwrap();
     }
 
     #[test]
     #[should_panic(expected = "Trusted block root must be prefixed with 0x")]
     fn test_trusted_block_root_starts_with_0x() {
-        TrinConfig::new_from(
-            [
-                "trin",
-                "--trusted-block-root",
-                "010101010101010101010101010101010101010101010101010101010101010101",
-            ]
-            .iter(),
-        )
+        TrinConfig::new_from([
+            "trin",
+            "--trusted-block-root",
+            "010101010101010101010101010101010101010101010101010101010101010101",
+        ])
         .unwrap();
     }
 
@@ -828,7 +804,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Invalid web3-transport arg. Expected either 'http' or 'ipc'")]
     fn test_invalid_web3_transport_argument() {
-        TrinConfig::new_from(["trin", "--web3-transport", "invalid"].iter()).unwrap();
+        TrinConfig::new_from(["trin", "--web3-transport", "invalid"]).unwrap();
     }
 
     mod storage_config {

--- a/ethportal-peertest/src/lib.rs
+++ b/ethportal-peertest/src/lib.rs
@@ -89,7 +89,7 @@ fn generate_trin_config(
         .join(",");
     let network = network.to_string();
 
-    let trin_config_args = vec![
+    let trin_config_args = [
         "trin",
         "--network",
         &network,
@@ -107,7 +107,7 @@ fn generate_trin_config(
         private_key.as_str(),
         "--ephemeral",
     ];
-    TrinConfig::new_from(trin_config_args.iter()).unwrap()
+    TrinConfig::new_from(trin_config_args).unwrap()
 }
 
 pub async fn launch_peertest_nodes(

--- a/ethportal-peertest/src/scenarios/gossip.rs
+++ b/ethportal-peertest/src/scenarios/gossip.rs
@@ -349,28 +349,25 @@ fn fresh_node_config() -> (String, TrinConfig) {
     let test_discovery_port = 8889;
     let external_addr = format!("{test_ip_addr}:{test_discovery_port}");
     let fresh_ipc_path = format!("/tmp/trin-jsonrpc-{test_discovery_port}.ipc");
-    let trin_config = TrinConfig::new_from(
-        [
-            "trin",
-            "--portal-subnetworks",
-            "history",
-            "--external-address",
-            external_addr.as_str(),
-            "--mb",
-            "1", // set storage to 1mb so that we can easily test dropping data
-            "--web3-ipc-path",
-            fresh_ipc_path.as_str(),
-            "--ephemeral",
-            "--discovery-port",
-            test_discovery_port.to_string().as_ref(),
-            "--bootnodes",
-            "none",
-            "--unsafe-private-key",
-            // node id: 0x27128939ed60d6f4caef0374da15361a2c1cd6baa1a5bccebac1acd18f485900
-            "0x9ca7889c09ef1162132251b6284bd48e64bd3e71d75ea33b959c37be0582a2fd",
-        ]
-        .iter(),
-    )
+    let trin_config = TrinConfig::new_from([
+        "trin",
+        "--portal-subnetworks",
+        "history",
+        "--external-address",
+        external_addr.as_str(),
+        "--mb",
+        "1", // set storage to 1mb so that we can easily test dropping data
+        "--web3-ipc-path",
+        fresh_ipc_path.as_str(),
+        "--ephemeral",
+        "--discovery-port",
+        test_discovery_port.to_string().as_ref(),
+        "--bootnodes",
+        "none",
+        "--unsafe-private-key",
+        // node id: 0x27128939ed60d6f4caef0374da15361a2c1cd6baa1a5bccebac1acd18f485900
+        "0x9ca7889c09ef1162132251b6284bd48e64bd3e71d75ea33b959c37be0582a2fd",
+    ])
     .unwrap();
     (fresh_ipc_path, trin_config)
 }

--- a/tests/rpc_server.rs
+++ b/tests/rpc_server.rs
@@ -36,21 +36,18 @@ async fn setup_web3_server() -> (RpcServerHandle, RootProvider<PubSubFrontend>, 
     let external_addr = format!("{test_ip_addr}:{test_discovery_port}");
 
     // Run a client, to be tested
-    let trin_config = TrinConfig::new_from(
-        [
-            "trin",
-            "--external-address",
-            external_addr.as_str(),
-            "--web3-ipc-path",
-            DEFAULT_WEB3_IPC_PATH,
-            "--ephemeral",
-            "--discovery-port",
-            &test_discovery_port.to_string(),
-            "--bootnodes",
-            "none",
-        ]
-        .iter(),
-    )
+    let trin_config = TrinConfig::new_from([
+        "trin",
+        "--external-address",
+        external_addr.as_str(),
+        "--web3-ipc-path",
+        DEFAULT_WEB3_IPC_PATH,
+        "--ephemeral",
+        "--discovery-port",
+        &test_discovery_port.to_string(),
+        "--bootnodes",
+        "none",
+    ])
     .unwrap();
 
     let web3_server = trin::run_trin(trin_config).await.unwrap();

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -324,25 +324,22 @@ async fn peertest_ping_cross_discv5_protocol_id() {
     let test_discovery_port = 8999;
     let external_addr = format!("{}:{test_discovery_port}", Ipv4Addr::new(127, 0, 0, 1));
 
-    let trin_config = TrinConfig::new_from(
-        [
-            "trin",
-            "--network",
-            &Network::Mainnet.to_string(),
-            "--portal-subnetworks",
-            &Subnetwork::History.to_cli_arg(),
-            "--external-address",
-            external_addr.as_str(),
-            "--web3-ipc-path",
-            DEFAULT_WEB3_IPC_PATH,
-            "--ephemeral",
-            "--discovery-port",
-            test_discovery_port.to_string().as_ref(),
-            "--bootnodes",
-            "none",
-        ]
-        .iter(),
-    )
+    let trin_config = TrinConfig::new_from([
+        "trin",
+        "--network",
+        &Network::Mainnet.to_string(),
+        "--portal-subnetworks",
+        &Subnetwork::History.to_cli_arg(),
+        "--external-address",
+        external_addr.as_str(),
+        "--web3-ipc-path",
+        DEFAULT_WEB3_IPC_PATH,
+        "--ephemeral",
+        "--discovery-port",
+        test_discovery_port.to_string().as_ref(),
+        "--bootnodes",
+        "none",
+    ])
     .unwrap();
     let mainnet_handle = trin::run_trin(trin_config).await.unwrap();
     let mainnet_target = reth_ipc::client::IpcClientBuilder::default()
@@ -376,29 +373,26 @@ async fn setup_peertest(
     let external_addr = format!("{test_ip_addr}:{test_discovery_port}");
 
     // Run a client, to be tested
-    let trin_config = TrinConfig::new_from(
-        [
-            "trin",
-            "--network",
-            &network.to_string(),
-            "--portal-subnetworks",
-            &subnetworks
-                .iter()
-                .map(|s| s.to_cli_arg())
-                .collect::<Vec<String>>()
-                .join(","),
-            "--external-address",
-            external_addr.as_str(),
-            "--web3-ipc-path",
-            DEFAULT_WEB3_IPC_PATH,
-            "--ephemeral",
-            "--discovery-port",
-            test_discovery_port.to_string().as_ref(),
-            "--bootnodes",
-            "none",
-        ]
-        .iter(),
-    )
+    let trin_config = TrinConfig::new_from([
+        "trin",
+        "--network",
+        &network.to_string(),
+        "--portal-subnetworks",
+        &subnetworks
+            .iter()
+            .map(|s| s.to_cli_arg())
+            .collect::<Vec<String>>()
+            .join(","),
+        "--external-address",
+        external_addr.as_str(),
+        "--web3-ipc-path",
+        DEFAULT_WEB3_IPC_PATH,
+        "--ephemeral",
+        "--discovery-port",
+        test_discovery_port.to_string().as_ref(),
+        "--bootnodes",
+        "none",
+    ])
     .unwrap();
 
     let test_client_rpc_handle = trin::run_trin(trin_config).await.unwrap();
@@ -434,28 +428,25 @@ async fn setup_peertest_bridge(
     env::set_var("PANDAOPS_CLIENT_ID", "xxx");
     env::set_var("PANDAOPS_CLIENT_SECRET", "xxx");
     // Run a client, to be tested
-    let trin_config = TrinConfig::new_from(
-        [
-            "trin",
-            "--network",
-            &network.to_string(),
-            "--portal-subnetworks",
-            &subnetworks,
-            "--external-address",
-            external_addr.as_str(),
-            // Run bridge test with http, since bridge doesn't support ipc yet.
-            "--web3-transport",
-            "http",
-            "--web3-http-address",
-            DEFAULT_WEB3_HTTP_ADDRESS,
-            "--ephemeral",
-            "--discovery-port",
-            test_discovery_port.to_string().as_ref(),
-            "--bootnodes",
-            &peertest.bootnode.enr.to_base64(),
-        ]
-        .iter(),
-    )
+    let trin_config = TrinConfig::new_from([
+        "trin",
+        "--network",
+        &network.to_string(),
+        "--portal-subnetworks",
+        &subnetworks,
+        "--external-address",
+        external_addr.as_str(),
+        // Run bridge test with http, since bridge doesn't support ipc yet.
+        "--web3-transport",
+        "http",
+        "--web3-http-address",
+        DEFAULT_WEB3_HTTP_ADDRESS,
+        "--ephemeral",
+        "--discovery-port",
+        test_discovery_port.to_string().as_ref(),
+        "--bootnodes",
+        &peertest.bootnode.enr.to_base64(),
+    ])
     .unwrap();
 
     let test_client_rpc_handle = trin::run_trin(trin_config).await.unwrap();


### PR DESCRIPTION
### What was wrong?

#1558 changed argument of `TrinConfig::new_from` from `Iterator<T>` to `IntoIterator<T>`.
This left many places unnecessarily using `.iter()` when calling it.

### How was it fixed?

Removed `.iter()`.
