### PR TITLE
feat(cli): set query timeout value via CLI argument

### DIFF
--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -20,6 +20,7 @@ const DEFAULT_SUBNETWORKS: &str = "history";
 pub const DEFAULT_NETWORK: &str = "mainnet";
 pub const DEFAULT_STORAGE_CAPACITY_MB: &str = "1000";
 pub const DEFAULT_WEB3_TRANSPORT: &str = "ipc";
+pub const DEFAULT_QUERY_TIMEOUT: u64 = 60;
 
 use crate::dashboard::grafana::{GrafanaAPI, DASHBOARD_TEMPLATES};
 
@@ -212,6 +213,13 @@ pub struct TrinConfig {
     )]
     pub utp_transfer_limit: usize,
 
+    #[arg(
+        long = "query-timeout",
+        help = "The timeout for a content query in seconds",
+        default_value_t = DEFAULT_QUERY_TIMEOUT,
+    )]
+    pub query_timeout: u64,
+
     #[command(subcommand)]
     pub command: Option<TrinConfigCommands>,
 }
@@ -245,6 +253,7 @@ impl Default for TrinConfig {
             command: None,
             utp_transfer_limit: DEFAULT_UTP_TRANSFER_LIMIT,
             network: MAINNET.clone(),
+            query_timeout: DEFAULT_QUERY_TIMEOUT,
         }
     }
 }

--- a/portalnet/src/config.rs
+++ b/portalnet/src/config.rs
@@ -1,12 +1,11 @@
-use std::net::SocketAddr;
-
 use alloy::primitives::B256;
 use ethportal_api::types::{
     bootnodes::Bootnodes,
-    cli::{TrinConfig, DEFAULT_UTP_TRANSFER_LIMIT},
+    cli::{TrinConfig, DEFAULT_QUERY_TIMEOUT, DEFAULT_UTP_TRANSFER_LIMIT},
     enr::Enr,
     network::Network,
 };
+use std::{net::SocketAddr, time::Duration};
 
 /// Capacity of the cache for observed `NodeAddress` values.
 /// Provides capacity for 32 full k-buckets. This capacity will be shared among all active portal
@@ -26,6 +25,7 @@ pub struct PortalnetConfig {
     pub trusted_block_root: Option<B256>,
     // the max number of concurrent utp transfers
     pub utp_transfer_limit: usize,
+    pub query_timeout: Duration,
 }
 
 // to be used inside test code only
@@ -42,6 +42,7 @@ impl Default for PortalnetConfig {
             disable_poke: false,
             trusted_block_root: None,
             utp_transfer_limit: DEFAULT_UTP_TRANSFER_LIMIT,
+            query_timeout: Duration::from_secs(DEFAULT_QUERY_TIMEOUT),
         }
     }
 }
@@ -59,6 +60,7 @@ impl PortalnetConfig {
             disable_poke: trin_config.disable_poke,
             trusted_block_root: trin_config.trusted_block_root,
             utp_transfer_limit: trin_config.utp_transfer_limit,
+            query_timeout: Duration::from_secs(trin_config.query_timeout),
         }
     }
 }

--- a/portalnet/src/overlay/config.rs
+++ b/portalnet/src/overlay/config.rs
@@ -5,7 +5,10 @@ use std::time::Duration;
 use discv5::kbucket::{Filter, MAX_NODES_PER_BUCKET};
 
 use crate::types::node::Node;
-use ethportal_api::types::{cli::DEFAULT_UTP_TRANSFER_LIMIT, enr::Enr};
+use ethportal_api::types::{
+    cli::{DEFAULT_QUERY_TIMEOUT, DEFAULT_UTP_TRANSFER_LIMIT},
+    enr::Enr,
+};
 
 /// Configuration parameters for the overlay network.
 #[derive(Clone)]
@@ -37,7 +40,7 @@ impl Default for OverlayConfig {
             ping_queue_interval: None,
             query_parallelism: 3, // (recommended α from kademlia paper)
             query_peer_timeout: Duration::from_secs(2),
-            query_timeout: Duration::from_secs(60),
+            query_timeout: Duration::from_secs(DEFAULT_QUERY_TIMEOUT),
             query_num_results: MAX_NODES_PER_BUCKET,
             findnodes_query_distances_per_peer: 3,
             disable_poke: false,

--- a/trin-beacon/src/network.rs
+++ b/trin-beacon/src/network.rs
@@ -43,6 +43,7 @@ impl BeaconNetwork {
             bootnode_enrs: portal_config.bootnodes,
             utp_transfer_limit: portal_config.utp_transfer_limit,
             gossip_dropped: GOSSIP_DROPPED,
+            query_timeout: portal_config.query_timeout,
             ..Default::default()
         };
         let storage = Arc::new(PLRwLock::new(BeaconStorage::new(storage_config)?));

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -1,6 +1,5 @@
-use std::sync::Arc;
-
 use parking_lot::RwLock as PLRwLock;
+use std::sync::Arc;
 use tokio::sync::RwLock;
 use utp_rs::socket::UtpSocket;
 
@@ -44,6 +43,7 @@ impl HistoryNetwork {
             disable_poke: portal_config.disable_poke,
             gossip_dropped: GOSSIP_DROPPED,
             utp_transfer_limit: portal_config.utp_transfer_limit,
+            query_timeout: portal_config.query_timeout,
             ..Default::default()
         };
         let storage = Arc::new(PLRwLock::new(HistoryStorage::new(storage_config)?));

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -49,6 +49,7 @@ impl StateNetwork {
             disable_poke: DISABLE_POKE,
             gossip_dropped: GOSSIP_DROPPED,
             utp_transfer_limit: portal_config.utp_transfer_limit,
+            query_timeout: portal_config.query_timeout,
             ..Default::default()
         };
         let storage = Arc::new(PLRwLock::new(StateStorage::new(storage_config)?));


### PR DESCRIPTION
### What was wrong?
When a beacon trin node request a light client content (while keeping in sync with the latest header), the query can take more time than the beacon slot duration (12 sec), because the default query timeout duration is set to 60 sec. 

For beacon, we want to set this timeout to no more than 12 sec, so we can always request the light client content for the next slot and not miss slots.

### How was it fixed?
Set the query timeout via CLI argument.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
