### PR TITLE
fix: show workspace version from trin --version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6800,7 +6800,7 @@ dependencies = [
 
 [[package]]
 name = "trin-utils"
-version = "0.1.1-alpha.1"
+version = "0.1.0"
 dependencies = [
  "ansi_term",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "trin"
-version = "0.1.0"
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
-edition = "2021"
-rust-version = "1.81.0"
 default-run = "trin"
-repository = "https://github.com/ethereum/trin"
-license = "GPL-3.0"
-readme = "README.md"
-keywords = ["ethereum", "portal-network"]
-categories = ["cryptography::cryptocurrencies"]
 description = "A Rust implementation of the Ethereum Portal Network"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 alloy = { workspace = true, features = ["eips", "provider-ipc", "provider-ws", "pubsub", "reqwest", "rpc-types"] }
@@ -74,6 +74,17 @@ members = [
     "trin-validation",
     "utp-testing",
 ]
+
+[workspace.package]
+authors = ["https://github.com/ethereum/trin/graphs/contributors"]
+categories = ["cryptography::cryptocurrencies"]
+edition = "2021"
+keywords = ["ethereum", "portal-network"]
+license = "GPL-3.0"
+readme = "README.md"
+repository = "https://github.com/ethereum/trin"
+rust-version = "1.81.0"
+version = "0.1.0"
 
 [workspace.dependencies]
 alloy = { version = "0.4.2", default-features = false, features = ["std"] }

--- a/e2store/Cargo.toml
+++ b/e2store/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "e2store"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/ethereum/trin/tree/master/e2store"
-license = "GPL-3.0"
-readme = "README.md"
 keywords = ["ethereum", "portal-network", "e2store", "era", "era1"]
-categories = ["cryptography::cryptocurrencies"]
 description = "E2store, era, and era1 implementations for Ethereum"
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
-
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 alloy = { workspace = true, features = ["rlp"] }

--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "ethportal-api"
 version = "0.2.2"
-edition = "2021"
 description = "Definitions for various Ethereum Portal Network JSONRPC APIs"
-license = "GPL-3.0"
-repository = "https://github.com/ethereum/trin/tree/master/ethportal-api"
-readme = "README.md"
-keywords = ["ethereum", "portal-network"]
-categories = ["cryptography::cryptocurrencies"]
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 alloy = { workspace = true, features = ["consensus", "rlp", "rpc-types-eth", "serde"] }

--- a/ethportal-peertest/Cargo.toml
+++ b/ethportal-peertest/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "ethportal-peertest"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/ethereum/trin/tree/master/ethportal-peertest"
-license = "GPL-3.0"
-readme = "README.md"
-keywords = ["ethereum", "portal-network"]
-categories = ["cryptography::cryptocurrencies"]
 description = "Testing utilities for trin"
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 alloy = { workspace = true, features = ["getrandom"] }

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "light-client"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/ethereum/trin"
-license = "GPL-3.0"
-readme = "README.md"
-keywords = ["ethereum", "portal-network"]
-categories = ["cryptography::cryptocurrencies"]
 description = "Beacon chain light client implementation"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 alloy.workspace = true

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "portal-bridge"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/ethereum/trin/tree/master/portal-bridge"
-license = "GPL-3.0"
-readme = "README.md"
-keywords = ["ethereum", "portal-network"]
-categories = ["cryptography::cryptocurrencies"]
 description = "Bridge node for the Portal Network"
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
-
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 alloy.workspace = true

--- a/portalnet/Cargo.toml
+++ b/portalnet/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "portalnet"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/ethereum/trin/tree/master/portalnet"
-license = "GPL-3.0"
-readme = "README.md"
-keywords = ["ethereum", "portal-network"]
-categories = ["cryptography::cryptocurrencies"]
 description = "Core library for Trin."
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 alloy.workspace = true

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "rpc"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/ethereum/trin/tree/master/rpc"
-license = "GPL-3.0"
-readme = "README.md"
-keywords = ["ethereum", "portal-network"]
-categories = ["cryptography::cryptocurrencies"]
 description = "Implementations of jsonrpsee server API traits for Trin and server interface"
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 alloy = { workspace = true, features = ["rpc-types-eth"] }

--- a/trin-beacon/Cargo.toml
+++ b/trin-beacon/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "trin-beacon"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/ethereum/trin/tree/master/trin-beacon"
-license = "GPL-3.0"
-readme = "README.md"
-keywords = ["ethereum", "portal-network"]
-categories = ["cryptography::cryptocurrencies"]
 description = "Beacon network subprotocol for Trin."
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 alloy.workspace = true

--- a/trin-evm/Cargo.toml
+++ b/trin-evm/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "trin-evm"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/ethereum/trin/tree/master/trin-evm"
-license = "GPL-3.0"
-readme = "README.md"
 keywords = ["ethereum", "execution-layer"]
-categories = ["cryptography::cryptocurrencies"]
 description = "Common EVM functionality"
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
-
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 alloy.workspace = true

--- a/trin-execution/Cargo.toml
+++ b/trin-execution/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "trin-execution"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/ethereum/trin/tree/master/trin-execution"
-license = "GPL-3.0"
-readme = "README.md"
 keywords = ["ethereum", "execution-layer"]
-categories = ["cryptography::cryptocurrencies"]
 description = "Trin's execution used for gossiping state and soon an execution layer client for Ethereum?"
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
-
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 alloy = { workspace = true, features = ["eips", "rpc-types-engine", "serde"] }

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "trin-history"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/ethereum/trin/tree/master/trin-history"
-license = "GPL-3.0"
-readme = "README.md"
-keywords = ["ethereum", "portal-network"]
-categories = ["cryptography::cryptocurrencies"]
 description = "History network subprotocol for Trin."
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 alloy.workspace = true

--- a/trin-metrics/Cargo.toml
+++ b/trin-metrics/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "trin-metrics"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/ethereum/trin"
-license = "GPL-3.0"
-readme = "README.md"
-keywords = ["ethereum", "portal-network"]
-categories = ["cryptography::cryptocurrencies"]
 description = "Trin metrics"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/trin-state/Cargo.toml
+++ b/trin-state/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "trin-state"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/ethereum/trin/tree/master/trin-state"
-license = "GPL-3.0"
-readme = "README.md"
-keywords = ["ethereum", "portal-network"]
-categories = ["cryptography::cryptocurrencies"]
 description = "State network subprotocol for Trin."
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 alloy = { workspace = true, features = ["getrandom"] }

--- a/trin-storage/Cargo.toml
+++ b/trin-storage/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "trin-storage"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/ethereum/trin/tree/master/trin-storage"
-license = "GPL-3.0"
-readme = "README.md"
-keywords = ["ethereum", "portal-network"]
-categories = ["cryptography::cryptocurrencies"]
 description = "Storage library for Trin."
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 alloy.workspace = true

--- a/trin-utils/Cargo.toml
+++ b/trin-utils/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "trin-utils"
-version = "0.1.1-alpha.1"
-edition = "2021"
-repository = "https://github.com/ethereum/trin/tree/main/trin-utils"
-license = "GPL-3.0"
-readme = "README.md"
-keywords = ["ethereum", "portal-network"]
-categories = ["cryptography::cryptocurrencies"]
 description = "Utils library for Trin."
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
 build = "build.rs"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 directories.workspace = true

--- a/trin-validation/Cargo.toml
+++ b/trin-validation/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "trin-validation"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/ethereum/trin/tree/master/trin-validation"
-license = "GPL-3.0"
-readme = "README.md"
-keywords = ["ethereum", "portal-network"]
-categories = ["cryptography::cryptocurrencies"]
 description = "Validation layer for the Portal Network data."
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 alloy.workspace = true

--- a/utp-testing/Cargo.toml
+++ b/utp-testing/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "utp-testing"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/ethereum/trin/tree/master/utp-testing"
-license = "GPL-3.0"
-readme = "README.md"
-keywords = ["ethereum", "portal-network"]
-categories = ["cryptography::cryptocurrencies"]
 description = "A testing suite for the UTP protocol."
-authors = ["https://github.com/ethereum/trin/graphs/contributors"]
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
Closes #878 

The printed version from `trin --version` is the one from the trin-utils package. This change makes the trin-utils version always track the workspace version.

While I was at it, I also set a bunch of other properties to track the matching workspace properties.

Would be nice to get this fix in before the upcoming stable release of trin.