### PR TITLE
chore: bump `eth-trie.rs` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,8 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "eth_trie"
-version = "0.4.0"
-source = "git+https://github.com/ethereum/eth-trie.rs?tag=v0.1.0-alpha.2#46da867d8a7eace0a9e912271b236b2007e4cd41"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7ffb0d2fa42ad87f02c0683c04b31cb41bf3853f2327d037738345bc5b56671"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ directories = "3.0"
 discv5 = { version = "0.4.1", features = ["serde"] }
 e2store = { path = "e2store" }
 env_logger = "0.9.0"
-eth_trie = { tag = "v0.1.0-alpha.2", git = "https://github.com/ethereum/eth-trie.rs" }
+eth_trie = "0.5.0"
 ethereum_ssz = "0.7.1"
 ethereum_ssz_derive = "0.7.1"
 ethportal-api = { path = "ethportal-api" }


### PR DESCRIPTION
### What was wrong?
we were using `eth-trie.rs` from a git instead of crates.io which prevented us from publishing `ethportal-api` to creates.io
### How was it fixed?
publish `eth-trie.rs` then bump our dependency here

