### PR TITLE
fix: properly encode/decode targetId QueryTrace json

### DIFF
--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -2406,7 +2406,7 @@ impl<
 
         let trace: Option<QueryTrace> = {
             if config.is_trace {
-                let mut trace = QueryTrace::new(&self.local_enr(), target_node_id.raw());
+                let mut trace = QueryTrace::new(&self.local_enr(), target_node_id.raw().into());
                 let local_enr = self.local_enr();
                 trace.node_responded_with(&local_enr, closest_enrs.iter().collect());
                 Some(trace)

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -145,7 +145,10 @@ async fn get_content(
     let (content_bytes, utp_transfer, trace) = match local_content {
         Some(val) => {
             let local_enr = network.overlay.local_enr();
-            let mut trace = QueryTrace::new(&network.overlay.local_enr(), content_key.content_id());
+            let mut trace = QueryTrace::new(
+                &network.overlay.local_enr(),
+                content_key.content_id().into(),
+            );
             trace.node_responded_with_content(&local_enr);
             trace.content_validated(local_enr.into());
             (val, false, if is_trace { Some(trace) } else { None })

--- a/trin-history/src/jsonrpc.rs
+++ b/trin-history/src/jsonrpc.rs
@@ -106,7 +106,10 @@ async fn get_content(
     let (content_bytes, utp_transfer, trace) = match local_content {
         Some(val) => {
             let local_enr = network.overlay.local_enr();
-            let mut trace = QueryTrace::new(&network.overlay.local_enr(), content_key.content_id());
+            let mut trace = QueryTrace::new(
+                &network.overlay.local_enr(),
+                content_key.content_id().into(),
+            );
             trace.node_responded_with_content(&local_enr);
             trace.content_validated(local_enr.into());
             (val, false, if is_trace { Some(trace) } else { None })

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -231,7 +231,7 @@ async fn get_content(
         Some(value) => {
             let trace = if is_trace {
                 let local_enr = network.overlay.local_enr();
-                let mut trace = QueryTrace::new(&local_enr, content_key.content_id());
+                let mut trace = QueryTrace::new(&local_enr, content_key.content_id().into());
                 trace.node_responded_with_content(&local_enr);
                 trace.content_validated(local_enr.into());
                 Some(trace)


### PR DESCRIPTION
### What was wrong?
Currently `portal_*TraceGetContent` is returning invalid json which doesn't match our spec `"targetId":[68,242,233,134,103,149,29,153,254,120,82,109,83,70,208,241,93,36,72,99,184,112,233,160,21,78,36,239,144,203,239,22]` for encoding/decoding the `targetId`
### How was it fixed?

