### PR TITLE
feat: add ci docker build for trin-execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,37 @@ jobs:
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             docker push $IMAGE_NAME:latest-bridge
+  docker-build-execution:
+    resource_class: xlarge
+    executor: docker-publisher
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker execution image
+          no_output_timeout: 30m
+          command: docker build -f ./trin-execution/Dockerfile -t $IMAGE_NAME:latest-execution --build-arg GIT_HASH=$CIRCLE_SHA1 .
+      - run:
+          name: Archive Docker image
+          command: docker save -o execution-image.tar $IMAGE_NAME
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./execution-image.tar
+  docker-publish-execution:
+    executor: docker-publisher
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run:
+          name: Load archived Docker image
+          command: docker load -i /tmp/workspace/execution-image.tar
+      - run:
+          name: Publish docker image to Docker Hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker push $IMAGE_NAME:latest-execution
   cargo-fmt:
     description: |
       Check linting with rustfmt.
@@ -324,6 +355,16 @@ workflows:
           filters:
             branches:
               only: master
+      - docker-build-execution:
+          filters:
+            branches:
+              only: master
+      - docker-publish-execution:
+          requires:
+            - docker-build-execution
+          filters:
+            branches:
+              only: master              
       - cargo-fmt
       - cargo-clippy
       - build

--- a/trin-execution/Dockerfile
+++ b/trin-execution/Dockerfile
@@ -1,0 +1,48 @@
+# select build image
+FROM rust:1.81.0 AS builder
+
+# create a new empty shell project
+RUN USER=root cargo new --bin trin-execution
+WORKDIR /trin
+
+# Docker build command *SHOULD* include --build-arg GIT_HASH=...
+# eg. --build-arg GIT_HASH=$(git rev-parse HEAD)
+ARG GIT_HASH=unknown
+ENV GIT_HASH=$GIT_HASH
+
+RUN apt-get update && apt-get install clang -y
+
+# copy over manifests and source to build image
+COPY ./Cargo.lock ./Cargo.lock
+COPY ./Cargo.toml ./Cargo.toml
+COPY ./e2store ./e2store
+COPY ./ethportal-api ./ethportal-api
+COPY ./ethportal-peertest ./ethportal-peertest
+COPY ./light-client ./light-client
+COPY ./portalnet ./portalnet
+COPY ./portal-bridge ./portal-bridge
+COPY ./rpc ./rpc
+COPY ./src ./src 
+COPY ./trin-beacon ./trin-beacon
+COPY ./trin-evm ./trin-evm
+COPY ./trin-execution ./trin-execution
+COPY ./trin-history ./trin-history
+COPY ./trin-metrics ./trin-metrics
+COPY ./trin-state ./trin-state
+COPY ./trin-storage ./trin-storage
+COPY ./trin-utils ./trin-utils
+COPY ./trin-validation ./trin-validation 
+COPY ./utp-testing ./utp-testing
+
+# build for release
+RUN cargo build -p trin-execution --release
+
+# final base
+FROM ubuntu:22.04
+
+# copy build artifacts from build stage
+COPY --from=builder /trin/target/release/trin-execution /usr/bin/
+
+ENV RUST_LOG=debug
+
+ENTRYPOINT ["/usr/bin/trin-execution"]


### PR DESCRIPTION
### What was wrong?
I am at the stage where I want to run trin-execution through hive tests, hive tests require a docker image is built
### How was it fixed?
by adding a CI and dockerfile to build and publish images for trin-execution so I can use it on hive