### PR TITLE
feat: add holesky network type

### DIFF
--- a/ethportal-api/src/types/bootnodes.rs
+++ b/ethportal-api/src/types/bootnodes.rs
@@ -81,14 +81,19 @@ lazy_static! {
             enr:
         Enr::from_str("enr:-IS4QA5hpJikeDFf1DD1_Le6_ylgrLGpdwn3SRaneGu9hY2HUI7peHep0f28UUMzbC0PvlWjN8zSfnqMG07WVcCyBhADgmlkgnY0gmlwhKRc9-KJc2VjcDI1NmsxoQJMpHmGj1xSP1O-Mffk_jYIHVcg6tY5_CjmWVg1gJEsPIN1ZHCCE4o").expect("Parsing static bootnode enr to work"),
             alias: "ultralight-4".to_string()
-        }];
+        }
+    ];
 
     // AngelFood bootstrap nodes
     pub static ref ANGELFOOD_BOOTNODES: Vec<Bootnode> = vec![
-        Bootnode{
+        Bootnode {
             enr: Enr::from_str("enr:-LC4QMnoW2m4YYQRPjZhJ5hEpcA6a3V7iQs3slQ1TepzKBIVWQtjpcHsPINc0TcheMCbx6I2n5aax8M3AtUObt74ySUCY6p0IDVhYzI2NzViNGRmMjNhNmEwOWVjNDFkZTRlYTQ2ODQxNjk2ZTQ1YzSCaWSCdjSCaXCEQONKaYlzZWNwMjU2azGhAvZgYbpA9G8NQ6X4agu-R7Ymtu0hcX6xBQ--UEel_b6Pg3VkcIIjKA").expect("Parsing static bootnode enr to work"),
             alias: "angelfood-trin-1".to_string()
-        }];
+        }
+    ];
+
+    // Holesky bootstrap nodes
+    pub static ref HOLESKY_BOOTNODES: Vec<Bootnode> = vec![];
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -111,6 +116,9 @@ impl Bootnodes {
                 .iter()
                 .map(|bn| bn.enr.clone())
                 .collect(),
+            (Bootnodes::Default, Network::Holesky) => {
+                HOLESKY_BOOTNODES.iter().map(|bn| bn.enr.clone()).collect()
+            }
             (Bootnodes::None, _) => vec![],
             (Bootnodes::Custom(bootnodes), _) => {
                 bootnodes.iter().map(|bn| bn.enr.clone()).collect()

--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -26,7 +26,7 @@ pub const DEFAULT_WEB3_TRANSPORT: &str = "ipc";
 
 use crate::dashboard::grafana::{GrafanaAPI, DASHBOARD_TEMPLATES};
 
-use super::portal_wire::{NetworkSpec, ANGELFOOD, MAINNET};
+use super::portal_wire::{NetworkSpec, ANGELFOOD, HOLESKY, MAINNET};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Web3TransportType {
@@ -446,8 +446,9 @@ pub fn network_parser(network_string: &str) -> Result<Arc<NetworkSpec>, String> 
     match network_string {
         "mainnet" => Ok(MAINNET.clone()),
         "angelfood" => Ok(ANGELFOOD.clone()),
+        "holesky" => Ok(HOLESKY.clone()),
         _ => Err(format!(
-            "Not a valid network: {network_string}, must be 'angelfood' or 'mainnet'"
+            "Not a valid network: {network_string}, must be 'angelfood', 'holesky' or 'mainnet'"
         )),
     }
 }

--- a/ethportal-api/src/types/network.rs
+++ b/ethportal-api/src/types/network.rs
@@ -4,7 +4,8 @@ use std::fmt;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Network {
     Mainnet,
-    Angelfood, // aka testnet
+    Angelfood, // aka Portal testnet with mainnet data
+    Holesky,   // aka https://github.com/eth-clients/holesky Ethereum testnet
 }
 
 impl fmt::Display for Network {
@@ -12,6 +13,7 @@ impl fmt::Display for Network {
         match self {
             Network::Mainnet => write!(f, "mainnet"),
             Network::Angelfood => write!(f, "angelfood"),
+            Network::Holesky => write!(f, "holesky"),
         }
     }
 }
@@ -23,6 +25,7 @@ impl std::str::FromStr for Network {
         match s {
             "mainnet" => Ok(Network::Mainnet),
             "angelfood" => Ok(Network::Angelfood),
+            "holesky" => Ok(Network::Holesky),
             _ => Err(format!("Unknown network: {s}")),
         }
     }

--- a/ethportal-api/src/types/portal_wire.rs
+++ b/ethportal-api/src/types/portal_wire.rs
@@ -222,6 +222,22 @@ pub static ANGELFOOD: Lazy<Arc<NetworkSpec>> = Lazy::new(|| {
     .into()
 });
 
+pub static HOLESKY: Lazy<Arc<NetworkSpec>> = Lazy::new(|| {
+    let mut portal_subnetworks = BiHashMap::new();
+    portal_subnetworks.insert(Subnetwork::State, "0x514A".to_string());
+    portal_subnetworks.insert(Subnetwork::History, "0x514B".to_string());
+    portal_subnetworks.insert(Subnetwork::Beacon, "0x514C".to_string());
+    portal_subnetworks.insert(Subnetwork::CanonicalIndices, "0x514D".to_string());
+    portal_subnetworks.insert(Subnetwork::VerkleState, "0x514E".to_string());
+    portal_subnetworks.insert(Subnetwork::TransactionGossip, "0x514F".to_string());
+    portal_subnetworks.insert(Subnetwork::Utp, "0x757470".to_string());
+    NetworkSpec {
+        portal_subnetworks,
+        network: Network::Holesky,
+    }
+    .into()
+});
+
 /// A Portal protocol message.
 #[derive(Debug, PartialEq, Clone, Encode, Decode)]
 #[ssz(enum_behaviour = "union")]


### PR DESCRIPTION
### What was wrong?
![image](https://github.com/user-attachments/assets/bc868a98-75db-40a9-88d6-2d5c94ad2cce)

Devnets and testnets are important for ensuring the robustness of Ethereum to continue shipping upgrades. As Portal gets integrated and becomes more important infrastructure for L1's clients, the idea is that Portal would be run by default on testnets, the same way any default feature is run on both main nets and testnets.

### How was it fixed?

I am adding a network outline for Holesky as it is the newest testnet, goreli is now discontinued. Future testnets won't have a pre-merge phase. I believe sepolia will be the last testnet (which is still supported) to have any per-merge data.

Anyways there isn't a rush to add sepolia, adding holesky should allow me to fix most of our hardcoded mainnet stuff.

### Work left to do in follow-up PR's
- add testing that testnet values work might be an optional flag in hive or some tests in the trin repo, this will be on on-going thing
- Make Trin work with networks other than the mainnet. This will probably result in multiple PRs over time.


In short this is the start
