### PR TITLE
refactor(light-client): Replace `ssz-rs` with `ethereum_ssz` in Light Client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
  "derive_more 1.0.0",
  "once_cell",
  "serde",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -1988,7 +1988,7 @@ dependencies = [
  "ed25519",
  "rand_core",
  "serde",
- "sha2 0.10.8",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -2145,7 +2145,7 @@ checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
 dependencies = [
  "cpufeatures",
  "ring",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -2221,7 +2221,7 @@ dependencies = [
  "serde-this-or-that",
  "serde_json",
  "serde_yaml",
- "sha2 0.10.8",
+ "sha2",
  "sha3 0.9.1",
  "shadow-rs",
  "snap",
@@ -3487,7 +3487,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.8",
+ "sha2",
  "signature",
 ]
 
@@ -3647,6 +3647,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "ethereum_ssz",
  "ethportal-api",
  "figment",
  "futures",
@@ -3660,7 +3661,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "snowbridge-milagro-bls",
- "ssz-rs",
  "ssz_types",
  "strum",
  "thiserror",
@@ -5028,7 +5028,7 @@ dependencies = [
  "revm-primitives",
  "ripemd",
  "secp256k1",
- "sha2 0.10.8",
+ "sha2",
  "substrate-bn",
 ]
 
@@ -5143,7 +5143,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b241d2e59b74ef9e98d94c78c47623d04c8392abaf82014dfd372a16041128f"
 dependencies = [
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -5249,7 +5249,7 @@ version = "7.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d38ff6bf570dc3bb7100fce9f7b60c33fa71d80e88da3f2580df4ff2bdded74"
 dependencies = [
- "sha2 0.10.8",
+ "sha2",
  "walkdir",
 ]
 
@@ -5719,19 +5719,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
@@ -5921,31 +5908,6 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
-]
-
-[[package]]
-name = "ssz-rs"
-version = "0.8.0"
-source = "git+https://github.com/ralexstokes/ssz-rs?rev=d09f55b4f8554491e3431e01af1c32347a8781cd#d09f55b4f8554491e3431e01af1c32347a8781cd"
-dependencies = [
- "bitvec",
- "hex",
- "lazy_static",
- "num-bigint",
- "serde",
- "sha2 0.9.9",
- "ssz-rs-derive",
- "thiserror",
-]
-
-[[package]]
-name = "ssz-rs-derive"
-version = "0.8.0"
-source = "git+https://github.com/ralexstokes/ssz-rs?rev=d09f55b4f8554491e3431e01af1c32347a8781cd#d09f55b4f8554491e3431e01af1c32347a8781cd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -29,7 +29,6 @@ serde.workspace = true
 serde-this-or-that.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
-ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "d09f55b4f8554491e3431e01af1c32347a8781cd" }
 ssz_types.workspace = true
 strum.workspace = true
 thiserror.workspace = true
@@ -37,6 +36,7 @@ tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tree_hash.workspace = true
+ethereum_ssz.workspace = true
 
 [lib]
 name = "light_client"

--- a/light-client/src/consensus/utils.rs
+++ b/light-client/src/consensus/utils.rs
@@ -1,8 +1,11 @@
 use crate::{types::Bytes32, utils::bytes32_to_node};
+use alloy::primitives::B256;
 use anyhow::Result;
 use ethportal_api::consensus::{header::BeaconBlockHeader, signature::BlsSignature};
 use milagro_bls::{AggregateSignature, PublicKey};
-use ssz_rs::prelude::*;
+use serde::Serialize;
+use ssz::*;
+use ssz_types::{typenum, FixedVector};
 use tree_hash::TreeHash;
 
 pub fn calc_sync_period(slot: u64) -> u64 {
@@ -26,7 +29,7 @@ pub fn is_proof_valid<L: TreeHash>(
     index: usize,
 ) -> bool {
     let res: Result<bool> = (move || {
-        let leaf_hash = Node::from_bytes(<[u8; 32]>::from(leaf_object.tree_hash_root()));
+        let leaf_hash = B256::from_ssz_bytes(&<[u8; 32]>::from(leaf_object.tree_hash_root()));
         let state_root = bytes32_to_node(
             &Bytes32::try_from(attested_header.state_root.0.to_vec())
                 .expect("Unable to convert state root to bytes"),
@@ -40,19 +43,19 @@ pub fn is_proof_valid<L: TreeHash>(
     res.unwrap_or_default()
 }
 
-#[derive(SimpleSerialize, Default, Debug)]
-struct SigningData {
+#[derive(Serialize, Default, Debug)]
+pub struct SigningData {
     object_root: Bytes32,
     domain: Bytes32,
 }
 
-#[derive(SimpleSerialize, Default, Debug)]
-struct ForkData {
-    current_version: Vector<u8, 4>,
+#[derive(Serialize, Default, Debug)]
+pub struct ForkData {
+    current_version: FixedVector<u8, typenum::U4>,
     genesis_validator_root: Bytes32,
 }
 
-pub fn compute_signing_root(object_root: Bytes32, domain: Bytes32) -> Result<Node> {
+pub fn compute_signing_root(object_root: Bytes32, domain: Bytes32) -> Result<B256> {
     let mut data = SigningData {
         object_root,
         domain,
@@ -62,20 +65,20 @@ pub fn compute_signing_root(object_root: Bytes32, domain: Bytes32) -> Result<Nod
 
 pub fn compute_domain(
     domain_type: &[u8],
-    fork_version: Vector<u8, 4>,
+    fork_version: FixedVector<u8, typenum::U4>,
     genesis_root: Bytes32,
 ) -> Result<Bytes32> {
     let fork_data_root = compute_fork_data_root(fork_version, genesis_root)?;
     let start = domain_type;
-    let end = &fork_data_root.as_bytes()[..28];
+    let end = &fork_data_root.as_slice()[..28];
     let d = [start, end].concat();
     Ok(d.to_vec().try_into()?)
 }
 
-fn compute_fork_data_root(
-    current_version: Vector<u8, 4>,
+pub fn compute_fork_data_root(
+    current_version: FixedVector<u8, typenum::U4>,
     genesis_validator_root: Bytes32,
-) -> Result<Node> {
+) -> Result<B256> {
     let mut fork_data = ForkData {
         current_version,
         genesis_validator_root,
@@ -83,9 +86,9 @@ fn compute_fork_data_root(
     Ok(fork_data.hash_tree_root()?)
 }
 
-pub fn branch_to_nodes(branch: Vec<Bytes32>) -> Result<Vec<Node>> {
+pub fn branch_to_nodes(branch: Vec<Bytes32>) -> Result<Vec<B256>> {
     branch
         .iter()
         .map(bytes32_to_node)
-        .collect::<Result<Vec<Node>>>()
+        .collect::<Result<Vec<B256>>>()
 }

--- a/light-client/src/types.rs
+++ b/light-client/src/types.rs
@@ -1,3 +1,3 @@
-use ssz_rs::Vector;
+use ssz_types::{typenum::U32, FixedVector};
 
-pub type Bytes32 = Vector<u8, 32>;
+pub type Bytes32 = FixedVector<u8, U32>;

--- a/light-client/src/utils.rs
+++ b/light-client/src/utils.rs
@@ -1,13 +1,17 @@
 use crate::types::Bytes32;
+use alloy::primitives::B256;
 use anyhow::Result;
-use ssz_rs::{Node, Vector};
+use ssz::{Decode, TryFromIter};
+use ssz_types::FixedVector;
 
 pub fn bytes_to_bytes32(bytes: &[u8]) -> Bytes32 {
-    Vector::from_iter(bytes.to_vec())
+    FixedVector::try_from_iter(bytes.to_vec()).expect("should convert bytes to fixed vector")
 }
 
-pub fn bytes32_to_node(bytes: &Bytes32) -> Result<Node> {
-    Ok(Node::from_bytes(bytes.as_slice().try_into()?))
+pub fn bytes32_to_node(bytes: &Bytes32) -> Result<B256> {
+    let array = <[u8; 32]>::try_from(bytes.as_ref())
+        .map_err(|_| anyhow::anyhow!("Failed to convert bytes to array"))?;
+    B256::from_ssz_bytes(&array).map_err(|_| anyhow::anyhow!("Failed to decode SSZ bytes"))
 }
 
 pub fn u64_to_hex_string(val: u64) -> String {


### PR DESCRIPTION
Closes #1417
### What was wrong?
The light-client module was using `ssz-rs` for SSZ handling, while the rest of the project primarily relied on `ethereum_ssz`. This inconsistency introduced an additional dependency and potential maintainability challenges.

### How was it fixed?
Replaced `ssz-rs` with `ethereum_ssz` in the light-client module. Adjusted usages of types like Vector and Node to their equivalents in ethereum_ssz (FixedVector and B256, respectively). Updated the relevant code paths to align with the new library's API.

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
