### PR TITLE
fix: properly encode/decode `started_at_ms` in QueryTrace object

### DIFF
--- a/ethportal-api/src/types/query_trace.rs
+++ b/ethportal-api/src/types/query_trace.rs
@@ -383,18 +383,17 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_started_at_ms_time_is_serialized_to_json_properly() {
+    #[rstest::rstest]
+    #[case(5)]
+    #[case(534543)]
+    #[case(64574556345)]
+    #[case(5435345345)]
+    fn test_started_at_ms_time_is_serialized_to_json_properly(#[case] number: u64) {
         let (_, local_enr) = generate_random_remote_enr();
-        let target_id = B256::from([0; 32]);
-        let tracer = QueryTrace::new(&local_enr, target_id);
-        let json_tracer: Value = json!(&tracer);
-        assert_eq!(json_tracer["startedAtMs"], tracer.started_at_ms);
-
-        // Manually set the started_at_ms to 5 so we can test it.
+        let target_id = B256::ZERO;
         let mut tracer = QueryTrace::new(&local_enr, target_id);
-        tracer.started_at_ms = 5;
+        tracer.started_at_ms = number;
         let json_tracer: Value = json!(&tracer);
-        assert_eq!(json_tracer["startedAtMs"], 5);
+        assert_eq!(json_tracer["startedAtMs"], number);
     }
 }

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -1,4 +1,4 @@
-use std::time::SystemTime;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use discv5::enr::NodeId;
 use jsonrpsee::async_client::Client;
@@ -94,7 +94,11 @@ pub async fn test_trace_get_content(peertest: &Peertest) {
 
     assert!(store_result);
 
-    let query_start_time = SystemTime::now();
+    let query_start_time = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+
     let trace_content_info = HistoryNetworkApiClient::trace_get_content(
         &peertest.nodes[0].ipc_client,
         content_key.clone(),


### PR DESCRIPTION
### What was wrong?

fixes the second part of https://github.com/ethereum/portal-network-specs/issues/352


We were exposing the implementation details of `SystemTime` for the `started_at_ms` when encoding the `QueryTrace` object. This doesn't comply with our Json-RPC spec.

As `started_at_ms` is supposed to be encoded as a milisecond timestamp.
Json only allows for u64's which will last us for millions of years.

for example this is what we are currently returning before this fix

```rust
"startedAtMs": {
    "secs_since_epoch": 1730857625,
    "nanos_since_epoch": 447534202
}
```

but the result is supposed to be like
```rust
"startedAtMs": 1730857625000,
```


### How was it fixed?

- updating the returned type for `started_at_ms` to a u64
- adding a test to make sure things don't break in the future

