### PR TITLE
feat: add state snapshot bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4899,10 +4899,12 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "windows-registry",
 ]
@@ -6854,6 +6856,7 @@ dependencies = [
  "e2store",
  "eth_trie",
  "ethportal-api",
+ "futures-util",
  "hashbrown 0.14.5",
  "jsonrpsee",
  "lazy_static",
@@ -7422,6 +7425,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wasm-timer"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,6 +1952,7 @@ dependencies = [
  "tokio",
  "tracing",
  "trin-utils",
+ "url",
 ]
 
 [[package]]
@@ -2854,6 +2855,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humanize-duration"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082247a9fa508369fe52b235aef8a8dbf931b08d223a1a9b70cd400a8a77ae9c"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "humantime"
@@ -4420,6 +4430,7 @@ dependencies = [
  "ethereum_ssz",
  "ethportal-api",
  "futures",
+ "humanize-duration",
  "itertools 0.13.0",
  "jsonrpsee",
  "portalnet",
@@ -6858,6 +6869,7 @@ dependencies = [
  "ethportal-api",
  "futures-util",
  "hashbrown 0.14.5",
+ "humanize-duration",
  "jsonrpsee",
  "lazy_static",
  "parking_lot 0.11.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ ethportal-api = { path = "ethportal-api" }
 futures = "0.3.23"
 futures-util = "0.3.23"
 hex = "0.4.3"
+humanize-duration = "0.0.6"
 itertools = "0.13.0"
 jsonrpsee = "0.24.4"
 keccak-hash = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ ethereum_ssz = "0.7.1"
 ethereum_ssz_derive = "0.7.1"
 ethportal-api = { path = "ethportal-api" }
 futures = "0.3.23"
+futures-util = "0.3.23"
 hex = "0.4.3"
 itertools = "0.13.0"
 jsonrpsee = "0.24.4"

--- a/e2store/Cargo.toml
+++ b/e2store/Cargo.toml
@@ -25,6 +25,7 @@ tracing = { workspace = true, optional = true }
 trin-utils = { workspace = true, optional = true }
 scraper.workspace = true
 snap.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/portal-bridge/Cargo.toml
+++ b/portal-bridge/Cargo.toml
@@ -24,6 +24,7 @@ eth_trie.workspace = true
 ethereum_ssz.workspace = true
 ethportal-api.workspace = true
 futures.workspace = true
+humanize-duration.workspace = true
 itertools.workspace = true
 jsonrpsee = { workspace = true, features = [
   "async-client",

--- a/portal-bridge/README.md
+++ b/portal-bridge/README.md
@@ -44,8 +44,6 @@ cargo run -p portal-bridge -- --executable-path ./target/debug/trin --epoch-accu
     - before gossiping a individual piece of content, the bridge will perform a lookup to see if the content is already in the portal network. If it is, the content will not be gossiped.
 - `"--mode fourfours:single_hunter:10:50`: sample size = 10, threshold = 50
     - same as the above hunter mode, but it will only gossip a single era1 file before exiting
-- `"--mode snapshot:1000000"`: gossips a state snapshot at the respective block, in this example the state snapshot at block 1,000,000 will be gossiped. This mode is only used for the State Network.
-
 #### Beacon Subnetwork
 
 - `"--mode latest"`: follow the head of the chain and gossip latest blocks
@@ -55,6 +53,8 @@ cargo run -p portal-bridge -- --executable-path ./target/debug/trin --epoch-accu
 
 - `"--mode single:b100"`: backfill, always beginning from block #0 until the specified block (#100)
 - `"--mode single:r50-100"`: backfill, gossips state diffs for blocks in #50-#100 range (inclusive)
+- `"--mode snapshot:1000000"`: gossips a state snapshot at the respective block, in this example the state snapshot at block 1,000,000 will be gossiped. This mode is only used for the State Network.
+
 
 ### Subnetwork configuration
 

--- a/portal-bridge/README.md
+++ b/portal-bridge/README.md
@@ -44,6 +44,7 @@ cargo run -p portal-bridge -- --executable-path ./target/debug/trin --epoch-accu
     - before gossiping a individual piece of content, the bridge will perform a lookup to see if the content is already in the portal network. If it is, the content will not be gossiped.
 - `"--mode fourfours:single_hunter:10:50`: sample size = 10, threshold = 50
     - same as the above hunter mode, but it will only gossip a single era1 file before exiting
+- `"--mode snapshot:1000000"`: gossips a state snapshot at the respective block, in this example the state snapshot at block 1,000,000 will be gossiped. This mode is only used for the State Network.
 
 #### Beacon Subnetwork
 

--- a/portal-bridge/src/bridge/state.rs
+++ b/portal-bridge/src/bridge/state.rs
@@ -1,19 +1,26 @@
 use std::{
+    path::PathBuf,
     sync::{Arc, Mutex},
     time::Instant,
 };
 
-use alloy::rlp::Decodable;
-use eth_trie::{decode_node, node::Node, RootWithTrieDiff};
+use alloy::{consensus::EMPTY_ROOT_HASH, rlp::Decodable};
+use anyhow::ensure;
+use e2store::utils::get_era2_files;
+use eth_trie::{decode_node, node::Node, EthTrie, RootWithTrieDiff, Trie};
 use ethportal_api::{
     jsonrpsee::http_client::HttpClient,
     types::{
-        network::Subnetwork, portal_wire::OfferTrace,
-        state_trie::account_state::AccountState as AccountStateInfo,
+        network::Subnetwork, portal_wire::OfferTrace, state_trie::account_state::AccountState,
     },
     ContentValue, Enr, OverlayContentKey, StateContentKey, StateContentValue,
     StateNetworkApiClient,
 };
+use reqwest::{
+    header::{HeaderMap, HeaderValue, CONTENT_TYPE},
+    Client,
+};
+use revm::{Database, DatabaseRef};
 use revm_primitives::{keccak256, Bytecode, SpecId, B256};
 use tokio::{
     sync::{OwnedSemaphorePermit, Semaphore},
@@ -22,18 +29,27 @@ use tokio::{
 use tracing::{debug, enabled, error, info, warn, Level};
 use trin_evm::spec_id::get_spec_block_number;
 use trin_execution::{
+    cli::ImportStateConfig,
     config::StateConfig,
     content::{
         create_account_content_key, create_account_content_value, create_contract_content_key,
         create_contract_content_value, create_storage_content_key, create_storage_content_value,
     },
     execution::TrinExecution,
+    storage::{
+        account_db::AccountDB, evm_db::EvmDB, execution_position::ExecutionPosition,
+        utils::setup_rocksdb,
+    },
+    subcommands::era2::{
+        import::StateImporter,
+        utils::{download_with_progress, format_eta, percentage_from_address_hash},
+    },
     trie_walker::TrieWalker,
     types::{block_to_trace::BlockToTrace, trie_proof::TrieProof},
     utils::full_nibble_path_to_address_hash,
 };
 use trin_metrics::bridge::BridgeMetricsReporter;
-use trin_utils::dir::create_temp_dir;
+use trin_utils::dir::{create_temp_dir, setup_data_dir};
 
 use crate::{
     bridge::history::SERVE_BLOCK_TIMEOUT,
@@ -55,6 +71,7 @@ pub struct StateBridge {
     global_offer_report: Arc<Mutex<GlobalOfferReport>>,
     // Bridge id used to determine which content keys to gossip
     bridge_id: BridgeId,
+    data_dir: Option<PathBuf>,
 }
 
 impl StateBridge {
@@ -64,6 +81,7 @@ impl StateBridge {
         offer_limit: usize,
         census: Census,
         bridge_id: BridgeId,
+        data_dir: Option<PathBuf>,
     ) -> anyhow::Result<Self> {
         let metrics = BridgeMetricsReporter::new("state".to_string(), &format!("{mode:?}"));
         let offer_semaphore = Arc::new(Semaphore::new(offer_limit));
@@ -76,6 +94,7 @@ impl StateBridge {
             census,
             global_offer_report: Arc::new(Mutex::new(global_offer_report)),
             bridge_id,
+            data_dir,
         })
     }
 
@@ -85,6 +104,12 @@ impl StateBridge {
             // TODO: This should only gossip state trie at this block
             BridgeMode::Single(ModeType::Block(block)) => (0, block),
             BridgeMode::Single(ModeType::BlockRange(start_block, end_block)) => (start_block, end_block),
+            BridgeMode::Snapshot(snapshot_block) => {
+                self.launch_snapshot(snapshot_block)
+                    .await
+                    .expect("State bridge failed");
+                return;
+            },
             _ => panic!("State bridge only supports 'single' mode, for single block (implies 0..=block range) or range of blocks."),
         };
 
@@ -148,6 +173,88 @@ impl StateBridge {
         Ok(())
     }
 
+    async fn launch_snapshot(&self, snapshot_block: u64) -> anyhow::Result<()> {
+        ensure!(snapshot_block > 0, "Snapshot block must be greater than 0");
+
+        // 1. Download the era2 file and import the state snapshot
+        let data_dir = setup_data_dir("trin-execution", self.data_dir.clone(), false)?;
+        let next_block_number = {
+            let rocks_db = Arc::new(setup_rocksdb(&data_dir)?);
+            let execution_position = ExecutionPosition::initialize_from_db(rocks_db.clone())?;
+            execution_position.next_block_number()
+        };
+
+        if next_block_number == snapshot_block + 1 {
+            info!("State snapshot already imported. Skipping import.");
+        } else {
+            // Remove the existing database and create a new fresh folder
+            info!("Deleting existing database and importing state snapshot");
+            std::fs::remove_dir_all(&data_dir)
+                .and_then(|_| std::fs::create_dir(&data_dir))
+                .expect("Failed to delete existing database");
+
+            let http_client = Client::builder()
+                .default_headers(HeaderMap::from_iter([(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("application/xml"),
+                )]))
+                .build()?;
+
+            let era2_files = get_era2_files(&http_client).await?;
+            let era2_blocks = era2_files.keys().cloned().collect::<Vec<_>>();
+
+            ensure!(
+                era2_files.contains_key(&snapshot_block),
+                "Era2 file doesn't exist for requested snapshot block: try these {era2_blocks:?}"
+            );
+
+            info!(
+                "Downloading era2 file for snapshot block: {}",
+                snapshot_block
+            );
+
+            let path_to_era2 = data_dir.join(format!("era2-{snapshot_block}.bin"));
+            if let Err(e) = download_with_progress(
+                &http_client,
+                &era2_files[&snapshot_block],
+                path_to_era2.clone(),
+            )
+            .await
+            {
+                return Err(anyhow::anyhow!("Failed to download era2 file: {e}"));
+            };
+
+            let import_state_config = ImportStateConfig { path_to_era2 };
+
+            let state_importer = StateImporter::new(import_state_config, &data_dir).await?;
+            let header = state_importer.import().await?;
+            info!(
+                "Imported state from era2: {} {}",
+                header.number, header.state_root,
+            );
+        }
+
+        info!("State snapshot imported successfully, starting state bridge");
+
+        // 2. Start the state bridge
+
+        let rocks_db = Arc::new(setup_rocksdb(&data_dir)?);
+
+        let execution_position = ExecutionPosition::initialize_from_db(rocks_db.clone())?;
+        ensure!(
+            execution_position.next_block_number() > 0,
+            "Trin execution not initialized!"
+        );
+
+        let mut evm_db = EvmDB::new(StateConfig::default(), rocks_db, &execution_position)
+            .expect("Failed to create EVM database");
+
+        self.gossip_whole_state_snapshot(&mut evm_db, execution_position)
+            .await
+            .expect("State bridge failed");
+        Ok(())
+    }
+
     async fn gossip_trie_diff(
         &self,
         root_with_trie_diff: RootWithTrieDiff,
@@ -183,7 +290,7 @@ impl StateBridge {
             let Node::Leaf(leaf) = decoded_node else {
                 continue;
             };
-            let account: AccountStateInfo = Decodable::decode(&mut leaf.value.as_slice())?;
+            let account: AccountState = Decodable::decode(&mut leaf.value.as_slice())?;
 
             // reconstruct the address hash from the path so that we can fetch the
             // address from the database
@@ -234,6 +341,108 @@ impl StateBridge {
         // flush the database cache
         // This is used for gossiping storage trie diffs and newly created contracts
         trin_execution.database.clear_contract_cache();
+
+        Ok(())
+    }
+
+    async fn gossip_whole_state_snapshot(
+        &self,
+        evm_db: &mut EvmDB,
+        execution_position: ExecutionPosition,
+    ) -> anyhow::Result<()> {
+        let start = Instant::now();
+
+        let number = execution_position.next_block_number() - 1;
+        let block_hash = evm_db.block_hash(number)?;
+
+        let mut leaf_count = 0;
+
+        let root_hash = evm_db.trie.lock().root_hash()?;
+        let mut content_idx = 0;
+        let state_walker = TrieWalker::new(root_hash, evm_db.trie.lock().db.clone())?;
+        for account_proof in state_walker {
+            // gossip the account
+            self.gossip_account(&account_proof, block_hash, content_idx)
+                .await?;
+            content_idx += 1;
+
+            let Some(encoded_last_node) = account_proof.proof.last() else {
+                panic!("Account proof is empty");
+            };
+
+            let Node::Leaf(leaf) = decode_node(&mut encoded_last_node.as_ref())? else {
+                continue;
+            };
+
+            let account: AccountState = Decodable::decode(&mut leaf.value.as_slice())?;
+
+            // reconstruct the address hash from the path so that we can fetch the
+            // address from the database
+            let mut partial_key_path = leaf.key.get_data().to_vec();
+            partial_key_path.pop();
+            let full_key_path = [&account_proof.path.clone(), partial_key_path.as_slice()].concat();
+            let address_hash = full_nibble_path_to_address_hash(&full_key_path);
+
+            leaf_count += 1;
+            if leaf_count % 100 == 0 {
+                let elapsed_secs = start.elapsed().as_secs_f64();
+                let percentage_done = percentage_from_address_hash(address_hash);
+
+                if percentage_done > 0.0 {
+                    let estimated_total_time = elapsed_secs / (percentage_done / 100.0);
+                    let eta_secs = estimated_total_time - elapsed_secs;
+
+                    let eta_formatted = format_eta(eta_secs);
+
+                    info!(
+                        "Processed {leaf_count} leaves, {:.2}% done, ETA: {}, last address_hash processed: {address_hash}",
+                        percentage_done, eta_formatted
+                    );
+                } else {
+                    info!(
+                        "Processed {leaf_count} leaves, {:.2}% done, ETA: calculating..., last address_hash processed: {address_hash}",
+                        percentage_done
+                    );
+                }
+            }
+
+            // check contract code content key/value
+            if account.code_hash != keccak256([]) {
+                let code: Bytecode = evm_db.code_by_hash_ref(account.code_hash)?;
+
+                self.gossip_contract_bytecode(
+                    address_hash,
+                    &account_proof,
+                    block_hash,
+                    account.code_hash,
+                    code,
+                    content_idx,
+                )
+                .await?;
+                content_idx += 1;
+            }
+
+            // check contract storage content key/value
+            if account.storage_root != EMPTY_ROOT_HASH {
+                let account_db = AccountDB::new(address_hash, evm_db.db.clone());
+                let trie = EthTrie::from(Arc::new(account_db), account.storage_root)?.db;
+
+                let storage_walker = TrieWalker::new(account.storage_root, trie)?;
+                for storage_proof in storage_walker {
+                    self.gossip_storage(
+                        &account_proof,
+                        &storage_proof,
+                        address_hash,
+                        block_hash,
+                        content_idx,
+                    )
+                    .await?;
+                    content_idx += 1;
+                }
+            }
+        }
+
+        info!("Took {} seconds to complete", start.elapsed().as_secs());
 
         Ok(())
     }

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -188,6 +188,12 @@ pub struct BridgeConfig {
         default_value = "1/1"
     )]
     pub bridge_id: BridgeId,
+
+    #[arg(
+        long,
+        help = "The directory for storing trin-execution data, useful for storing state in non standard locations."
+    )]
+    pub data_dir: Option<PathBuf>,
 }
 
 /// Used to identify the bridge amongst a set of bridges,

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -59,6 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             bridge_config.offer_limit,
             census,
             bridge_config.bridge_id,
+            bridge_config.data_dir,
         )
         .await?;
 

--- a/portal-bridge/src/types/mode.rs
+++ b/portal-bridge/src/types/mode.rs
@@ -14,6 +14,8 @@ use trin_validation::constants::EPOCH_SIZE;
 ///   - ex: "r10-12" backfills a block range from #10 to #12 (inclusive)
 /// - FourFours: gossips randomly sequenced era1 files
 ///   - ex: "fourfours"
+/// - Snapshot: gossips a State snapshot, this mode is only used for the state network
+///  - ex: "snapshot:1000000" gossips the state snapshot at block 1000000
 #[derive(Clone, Debug, PartialEq, Default, Eq)]
 pub enum BridgeMode {
     #[default]

--- a/portal-bridge/src/types/mode.rs
+++ b/portal-bridge/src/types/mode.rs
@@ -21,6 +21,7 @@ pub enum BridgeMode {
     FourFours(FourFoursMode),
     Backfill(ModeType),
     Single(ModeType),
+    Snapshot(u64),
     Test(PathBuf),
 }
 
@@ -41,6 +42,9 @@ impl BridgeMode {
             }
             BridgeMode::Test(_) => {
                 return Err(anyhow!("BridgeMode `test` does not have a block range"))
+            }
+            BridgeMode::Snapshot(_) => {
+                return Err(anyhow!("BridgeMode `snapshot` does not have a block range"))
             }
         };
         let (start, end) = match mode_type.clone() {
@@ -95,6 +99,12 @@ impl FromStr for BridgeMode {
                     "single" => {
                         let mode_type = ModeType::from_str(&val[1..])?;
                         Ok(BridgeMode::Single(mode_type))
+                    }
+                    "snapshot" => {
+                        let snapshot = val[1..]
+                            .parse()
+                            .map_err(|_| "Invalid snapshot arg: snapshot number")?;
+                        Ok(BridgeMode::Snapshot(snapshot))
                     }
                     "test" => {
                         let path =

--- a/trin-execution/Cargo.toml
+++ b/trin-execution/Cargo.toml
@@ -20,13 +20,14 @@ clap.workspace = true
 ethportal-api.workspace = true
 e2store.workspace = true
 eth_trie.workspace = true
+futures-util.workspace = true
 hashbrown = "0.14.0"
 jsonrpsee = { workspace = true, features = ["async-client", "client", "macros", "server"]}
 lazy_static.workspace = true
 parking_lot.workspace = true
 prometheus_exporter.workspace = true
 rayon = "1.10.0"
-reqwest.workspace = true
+reqwest =  { workspace = true, features = ["stream"] }
 revm.workspace = true
 revm-inspectors = "0.8.1"
 revm-primitives.workspace = true

--- a/trin-execution/Cargo.toml
+++ b/trin-execution/Cargo.toml
@@ -22,6 +22,7 @@ e2store.workspace = true
 eth_trie.workspace = true
 futures-util.workspace = true
 hashbrown = "0.14.0"
+humanize-duration.workspace = true
 jsonrpsee = { workspace = true, features = ["async-client", "client", "macros", "server"]}
 lazy_static.workspace = true
 parking_lot.workspace = true

--- a/trin-execution/src/subcommands/era2/export.rs
+++ b/trin-execution/src/subcommands/era2/export.rs
@@ -22,6 +22,7 @@ use crate::{
         account_db::AccountDB, evm_db::EvmDB, execution_position::ExecutionPosition,
         utils::setup_rocksdb,
     },
+    subcommands::era2::utils::percentage_from_address_hash,
 };
 
 pub struct StateExporter {
@@ -123,7 +124,7 @@ impl StateExporter {
 
             accounts_exported += 1;
             if accounts_exported % 10000 == 0 {
-                info!("Processed {} accounts", accounts_exported);
+                info!("Processed {accounts_exported} leaves, {:.2}% done, last address_hash processed: {account_hash}", percentage_from_address_hash(account_hash));
             }
         }
 

--- a/trin-execution/src/subcommands/era2/mod.rs
+++ b/trin-execution/src/subcommands/era2/mod.rs
@@ -1,2 +1,3 @@
 pub mod export;
 pub mod import;
+pub mod utils;

--- a/trin-execution/src/subcommands/era2/utils.rs
+++ b/trin-execution/src/subcommands/era2/utils.rs
@@ -1,0 +1,116 @@
+use std::{
+    fs::File,
+    io::Write,
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+
+use alloy::primitives::B256;
+use futures_util::StreamExt;
+use reqwest::Client;
+use tracing::{info, warn};
+
+/// Returns the percentage of the address hash in the total address space.
+/// we can assume that the address hashes are evenly distributed due to keccak256
+/// hash's properties
+/// This should only be used when walking the trie linearly
+pub fn percentage_from_address_hash(address_hash: B256) -> f64 {
+    let mut be_bytes = [0u8; 4];
+    be_bytes.copy_from_slice(&address_hash.0[..4]);
+    let address_hash_bytes = u32::from_be_bytes(be_bytes);
+    address_hash_bytes as f64 / u32::MAX as f64 * 100.0
+}
+
+pub async fn download_with_progress(
+    http_client: &Client,
+    url: &str,
+    output_path: PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    info!("Downloading from: {url}");
+
+    let response = http_client
+        .get(url)
+        .send()
+        .await
+        .or(Err(format!("Failed to GET from '{}'", &url)))?;
+
+    // Get total size of the content
+    let total_size = response.content_length().unwrap_or(0);
+    if total_size == 0 {
+        warn!("Failed to get content length; progress will not be estimated.");
+    }
+
+    let mut file = File::create(output_path.clone())?;
+
+    // Track downloaded size
+    let mut downloaded: u64 = 0;
+
+    // Start a timer
+    let start_time = Instant::now();
+    let mut last_report_time = Instant::now();
+
+    // Stream the response body
+    let mut stream = response.bytes_stream();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        file.write_all(&chunk)?;
+        downloaded += chunk.len() as u64;
+
+        // Check if enough time has passed since the last report
+        if last_report_time.elapsed() >= Duration::from_secs(2) {
+            // Report every 2 seconds
+            // Calculate elapsed time
+            let elapsed = start_time.elapsed().as_secs_f64();
+            let speed = downloaded as f64 / elapsed; // Bytes per second
+            let remaining_time = if total_size > 0 {
+                let remaining_bytes = total_size.saturating_sub(downloaded) as f64;
+                Some(remaining_bytes / speed)
+            } else {
+                None
+            };
+
+            // Log progress with estimated time remaining
+            if total_size > 0 {
+                let remaining = remaining_time.unwrap_or(0.0);
+                info!(
+                    "Downloaded {:.2}/{:.2} MB | Speed: {:.2} MB/s | ETA: {}",
+                    downloaded as f64 / 1_048_576.0,
+                    total_size as f64 / 1_048_576.0,
+                    speed / 1_048_576.0,
+                    format_eta(remaining)
+                );
+            } else {
+                info!(
+                    "Downloaded {:.2} MB | Speed: {:.2} MB/s",
+                    downloaded as f64 / 1_048_576.0,
+                    speed / 1_048_576.0
+                );
+            }
+
+            // Update last report time
+            last_report_time = Instant::now();
+        }
+    }
+
+    info!("Download complete: {:?}", output_path);
+    Ok(())
+}
+
+pub fn format_eta(seconds: f64) -> String {
+    let total_seconds = seconds.round() as u64;
+    let days = total_seconds / 86_400;
+    let hours = (total_seconds % 86_400) / 3_600;
+    let minutes = (total_seconds % 3_600) / 60;
+    let secs = total_seconds % 60;
+
+    if days > 0 {
+        format!("{days}d {hours}h {minutes}m {secs}s")
+    } else if hours > 0 {
+        format!("{hours}h {minutes}m {secs}s")
+    } else if minutes > 0 {
+        format!("{minutes}m {secs}s")
+    } else {
+        format!("{secs}s")
+    }
+}

--- a/trin-execution/src/trie_walker/db.rs
+++ b/trin-execution/src/trie_walker/db.rs
@@ -3,7 +3,7 @@ use anyhow::anyhow;
 use eth_trie::DB;
 use hashbrown::HashMap;
 
-use crate::storage::trie_db::TrieRocksDB;
+use crate::storage::{account_db::AccountDB, trie_db::TrieRocksDB};
 
 pub trait TrieWalkerDb {
     fn get(&self, key: &[u8]) -> anyhow::Result<Option<Bytes>>;
@@ -16,6 +16,14 @@ impl TrieWalkerDb for HashMap<B256, Vec<u8>> {
 }
 
 impl TrieWalkerDb for TrieRocksDB {
+    fn get(&self, key: &[u8]) -> anyhow::Result<Option<Bytes>> {
+        DB::get(self, key)
+            .map(|result| result.map(Bytes::from))
+            .map_err(|err| anyhow!("Failed to read key value from TrieRocksDB {err}"))
+    }
+}
+
+impl TrieWalkerDb for AccountDB {
     fn get(&self, key: &[u8]) -> anyhow::Result<Option<Bytes>> {
         DB::get(self, key)
             .map(|result| result.map(Bytes::from))


### PR DESCRIPTION
### What was wrong?

We didn't have code to gossip a state snapshot from an Era2 file

### How was it fixed?

implementing a era2 snapshot bridging mode

### To-Do in future PR's

- add a feature to only gossip a portion of the snapshot so that bridging the snapshot can be horizontally scaled


### The Plans for the latest state bridging

Currently Trin Execution is used as a dependency for `portal-bridge`.

Since `Trin-Execution` will bridge latest diffs by default, and will also eventually run Trin as a library by default. I think I am going to move the State Bridge code into Trin Execution.

So `Trin Execution` will then depend on the `portal-bridge` crate then. Bridging state depends on Trin Execution heavily, whereas the History and Beacon bridge use a JSON-RPC provider. Currently only `portal-bridge` beacon and history can be ran together whereas state must be ran alone regardless.

It is important to note as well the state bridge doesn't rely on using a 3rd party JSON-RPC provider like the History and Beacon network do.

So since `Trin-Execution` will be bridging by default (if a users uses Trin Execution it will gossip a small random section of the state diff), It is my opinion that all state bridging belongs in Trin Execution. I don't want to support latest bridging in both `trin-execution` and `portal-bridge`. Supporting latest bridging in `portal-bridge` would just be running `trin-execution` either way so it doesn't really make any sense, when it would be better UX to just use `trin-execution` to bridge directly.

After I finish `Trin execution keeping up with latest,` there will be quite a few PRs to review.

By default, `trin-execution` will gossip a small amount of the latest state, but you can configure it to do more and horizontally bridge and such. That is my current plan.

It is also always for
- better UX, as the commandline options be more focused
- Trin Execution is becoming more service-based; having the state bridge a part of trin-execution simplifies logic and reduces code duplication.
- to put it plainly, it would simplify things.