### PR TITLE
feat: lower ENR_OFFER_LIMIT from 4 to 2

### DIFF
--- a/portal-bridge/src/census/mod.rs
+++ b/portal-bridge/src/census/mod.rs
@@ -34,7 +34,7 @@ pub enum CensusError {
 /// The maximum number of enrs to return in a response,
 /// limiting the number of OFFER requests spawned by the bridge
 /// for each piece of content
-pub const ENR_OFFER_LIMIT: usize = 4;
+pub const ENR_OFFER_LIMIT: usize = 2;
 
 /// The census is responsible for maintaining a list of known peers in the network,
 /// checking their liveness, updating their data radius, iterating through their


### PR DESCRIPTION
### What was wrong?
It takes 1,200 days to gossip a state snapshot
### How was it fixed?
By lowering `ENR_OFFER_LIMIT` it would drop our time to gossip a state snapshot from 1,200 days to 600 days.

The trade offs of this approach is

- we are gossipping it to less nodes, so there is a lower chance of the gossip succeeding, but this isn't an issue because our new Census/enr choosing mechanism will statistically pick the most optimal nodes. So gossiping to less shouldn't have that big of an impact.

I would say this solution makes sense due to `Neighborhood gossip` https://github.com/ethereum/portal-network-specs/blob/master/portal-wire-protocol.md#neighborhood-gossip so since we now have a higher likely hood of gossiping the data that nodes that do want it, we can rely on `Neighborhood gossip` to do the rest of the work.

I choose 2 instead of 1 to still be somewhat conservative, it might make sense to do 1 because it would heavily lower our costs, but I think it is good to still have some redundancy

