### PR TITLE
feat: add Filter to TrieWalker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6874,6 +6874,7 @@ dependencies = [
  "lazy_static",
  "parking_lot 0.11.2",
  "prometheus_exporter",
+ "rand",
  "rayon",
  "reqwest",
  "revm",

--- a/portal-bridge/src/bridge/state.rs
+++ b/portal-bridge/src/bridge/state.rs
@@ -360,7 +360,7 @@ impl StateBridge {
 
         let root_hash = evm_db.trie.lock().root_hash()?;
         let mut content_idx = 0;
-        let state_walker = TrieWalker::new(root_hash, evm_db.trie.lock().db.clone())?;
+        let state_walker = TrieWalker::new(root_hash, evm_db.trie.lock().db.clone(), None)?;
         for account_proof in state_walker {
             // gossip the account
             self.gossip_account(&account_proof, block_hash, content_idx)
@@ -426,7 +426,7 @@ impl StateBridge {
                 let account_db = AccountDB::new(address_hash, evm_db.db.clone());
                 let trie = EthTrie::from(Arc::new(account_db), account.storage_root)?.db;
 
-                let storage_walker = TrieWalker::new(account.storage_root, trie)?;
+                let storage_walker = TrieWalker::new(account.storage_root, trie, None)?;
                 for storage_proof in storage_walker {
                     self.gossip_storage(
                         &account_proof,

--- a/trin-execution/Cargo.toml
+++ b/trin-execution/Cargo.toml
@@ -27,6 +27,7 @@ jsonrpsee = { workspace = true, features = ["async-client", "client", "macros", 
 lazy_static.workspace = true
 parking_lot.workspace = true
 prometheus_exporter.workspace = true
+rand.workspace = true
 rayon = "1.10.0"
 reqwest =  { workspace = true, features = ["stream"] }
 revm.workspace = true

--- a/trin-execution/src/trie_walker/filter.rs
+++ b/trin-execution/src/trie_walker/filter.rs
@@ -1,0 +1,72 @@
+use alloy::primitives::{B256, U256};
+use rand::{thread_rng, Rng};
+
+use crate::utils::partial_nibble_path_to_right_padded_b256;
+
+#[derive(Debug, Clone)]
+pub struct Filter {
+    start_prefix: B256,
+    end_prefix: B256,
+}
+
+impl Filter {
+    pub fn new_random_filter(slice_count: u16) -> Self {
+        // if slice_count is 0 or 1, we want to include the whole trie
+        if slice_count == 0 || slice_count == 1 {
+            return Self {
+                start_prefix: B256::ZERO,
+                end_prefix: B256::from(U256::MAX),
+            };
+        }
+
+        let slice_size = U256::MAX / U256::from(slice_count);
+        let random_slice_index = thread_rng().gen_range(0..slice_count);
+
+        let start_prefix = U256::from(random_slice_index) * slice_size;
+        let end_prefix = if random_slice_index == slice_count - 1 {
+            U256::MAX
+        } else {
+            start_prefix + slice_size - U256::from(1)
+        };
+
+        Self {
+            start_prefix: B256::from(start_prefix),
+            end_prefix: B256::from(end_prefix),
+        }
+    }
+
+    pub fn is_included(&self, path: &[u8]) -> bool {
+        let path = partial_nibble_path_to_right_padded_b256(path);
+        (self.start_prefix..=self.end_prefix).contains(&path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_random_filter() {
+        let filter = Filter::new_random_filter(0);
+        assert_eq!(filter.start_prefix, B256::ZERO);
+        assert_eq!(filter.end_prefix, B256::from(U256::MAX));
+
+        let filter = Filter::new_random_filter(1);
+        assert_eq!(filter.start_prefix, B256::ZERO);
+        assert_eq!(filter.end_prefix, B256::from(U256::MAX));
+    }
+
+    #[test]
+    fn test_is_included() {
+        let filter = Filter {
+            start_prefix: partial_nibble_path_to_right_padded_b256(&[0x1]),
+            end_prefix: partial_nibble_path_to_right_padded_b256(&[0x3]),
+        };
+
+        assert!(!filter.is_included(&[0x00]));
+        assert!(filter.is_included(&[0x01]));
+        assert!(filter.is_included(&[0x02]));
+        assert!(filter.is_included(&[0x03]));
+        assert!(!filter.is_included(&[0x04]));
+    }
+}

--- a/trin-execution/src/trie_walker/filter.rs
+++ b/trin-execution/src/trie_walker/filter.rs
@@ -5,8 +5,8 @@ use crate::utils::partial_nibble_path_to_right_padded_b256;
 
 #[derive(Debug, Clone)]
 pub struct Filter {
-    start_prefix: B256,
-    end_prefix: B256,
+    start_prefix: U256,
+    end_prefix: U256,
 }
 
 impl Filter {
@@ -14,8 +14,8 @@ impl Filter {
         // if slice_count is 0 or 1, we want to include the whole trie
         if slice_count == 0 || slice_count == 1 {
             return Self {
-                start_prefix: B256::ZERO,
-                end_prefix: B256::from(U256::MAX),
+                start_prefix: U256::ZERO,
+                end_prefix: U256::MAX,
             };
         }
 
@@ -30,43 +30,91 @@ impl Filter {
         };
 
         Self {
-            start_prefix: B256::from(start_prefix),
-            end_prefix: B256::from(end_prefix),
+            start_prefix,
+            end_prefix,
         }
     }
 
+    fn partial_prefix(prefix: U256, shift_amount: usize) -> B256 {
+        prefix
+            .arithmetic_shr(shift_amount)
+            .wrapping_shl(shift_amount)
+            .into()
+    }
+
     pub fn is_included(&self, path: &[u8]) -> bool {
+        // we need to use partial prefixes to not artificially exclude paths that are not exactly
+        // the same length as the filter
+        let shift_amount = 256 - path.len() * 4;
+        let partial_start_prefix = Filter::partial_prefix(self.start_prefix, shift_amount);
+        let partial_end_prefix = Filter::partial_prefix(self.end_prefix, shift_amount);
         let path = partial_nibble_path_to_right_padded_b256(path);
-        (self.start_prefix..=self.end_prefix).contains(&path)
+
+        (partial_start_prefix..=partial_end_prefix).contains(&path)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use alloy::hex::FromHex;
+
     use super::*;
 
     #[test]
     fn test_new_random_filter() {
         let filter = Filter::new_random_filter(0);
-        assert_eq!(filter.start_prefix, B256::ZERO);
-        assert_eq!(filter.end_prefix, B256::from(U256::MAX));
+        assert_eq!(filter.start_prefix, U256::ZERO);
+        assert_eq!(filter.end_prefix, U256::MAX);
 
         let filter = Filter::new_random_filter(1);
-        assert_eq!(filter.start_prefix, B256::ZERO);
-        assert_eq!(filter.end_prefix, B256::from(U256::MAX));
+        assert_eq!(filter.start_prefix, U256::ZERO);
+        assert_eq!(filter.end_prefix, U256::MAX);
     }
 
     #[test]
     fn test_is_included() {
         let filter = Filter {
-            start_prefix: partial_nibble_path_to_right_padded_b256(&[0x1]),
-            end_prefix: partial_nibble_path_to_right_padded_b256(&[0x3]),
+            start_prefix: partial_nibble_path_to_right_padded_b256(&[0x1, 0x5, 0x5]).into(),
+            end_prefix: partial_nibble_path_to_right_padded_b256(&[0x3]).into(),
         };
 
-        assert!(!filter.is_included(&[0x00]));
-        assert!(filter.is_included(&[0x01]));
-        assert!(filter.is_included(&[0x02]));
-        assert!(filter.is_included(&[0x03]));
-        assert!(!filter.is_included(&[0x04]));
+        assert!(!filter.is_included(&[0x0]));
+        assert!(filter.is_included(&[0x1]));
+        assert!(filter.is_included(&[0x1, 0x5]));
+        assert!(filter.is_included(&[0x1, 0x5, 0x5]));
+        assert!(!filter.is_included(&[0x1, 0x5, 0x4]));
+        assert!(filter.is_included(&[0x2]));
+        assert!(filter.is_included(&[0x3]));
+        assert!(!filter.is_included(&[0x4]));
+    }
+
+    #[test]
+    fn test_partial_prefix() {
+        let prefix: &[u8] = &[0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8];
+        let prefix: U256 = partial_nibble_path_to_right_padded_b256(prefix).into();
+
+        assert_eq!(
+            Filter::partial_prefix(prefix, 256),
+            B256::from_hex("0x0000000000000000000000000000000000000000000000000000000000000000")
+                .unwrap()
+        );
+
+        assert_eq!(
+            Filter::partial_prefix(prefix, 256 - 4),
+            B256::from_hex("0x1000000000000000000000000000000000000000000000000000000000000000")
+                .unwrap()
+        );
+
+        assert_eq!(
+            Filter::partial_prefix(prefix, 256 - 4 * 4),
+            B256::from_hex("0x1234000000000000000000000000000000000000000000000000000000000000")
+                .unwrap()
+        );
+
+        assert_eq!(
+            Filter::partial_prefix(prefix, 256 - 5 * 4),
+            B256::from_hex("0x1234500000000000000000000000000000000000000000000000000000000000")
+                .unwrap()
+        );
     }
 }

--- a/trin-execution/src/trie_walker/filter.rs
+++ b/trin-execution/src/trie_walker/filter.rs
@@ -39,6 +39,14 @@ impl Filter {
     }
 
     pub fn random(slice_count: u16) -> Self {
+        // if slice_count is 0 or 1, we want to include the whole trie
+        if slice_count == 0 || slice_count == 1 {
+            return Self {
+                start: U256::ZERO,
+                end: U256::MAX,
+            };
+        }
+
         Self::new(thread_rng().gen_range(0..slice_count), slice_count)
     }
 

--- a/trin-execution/src/trie_walker/filter.rs
+++ b/trin-execution/src/trie_walker/filter.rs
@@ -13,11 +13,6 @@ impl Filter {
     /// Create a new filter that includes the whole trie
     /// Slice index must be less than slice count or it will panic
     pub fn new(slice_index: u16, slice_count: u16) -> Self {
-        assert!(
-            slice_index < slice_count,
-            "slice_index must be less than slice_count"
-        );
-
         // if slice_count is 0 or 1, we want to include the whole trie
         if slice_count == 0 || slice_count == 1 {
             return Self {
@@ -25,6 +20,11 @@ impl Filter {
                 end: U256::MAX,
             };
         }
+
+        assert!(
+            slice_index < slice_count,
+            "slice_index must be less than slice_count"
+        );
 
         let slice_size = U256::MAX / U256::from(slice_count) + U256::from(1);
 
@@ -68,7 +68,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_new_random_filter() {
+    fn random() {
         let filter = Filter::random(0);
         assert_eq!(filter.start, U256::ZERO);
         assert_eq!(filter.end, U256::MAX);
@@ -79,7 +79,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_included() {
+    fn contains() {
         let filter = Filter {
             start: nibbles_to_right_padded_b256(&[0x1, 0x5, 0x5]).into(),
             end: nibbles_to_right_padded_b256(&[0x3]).into(),
@@ -97,7 +97,7 @@ mod tests {
     }
 
     #[test]
-    fn test_new() {
+    fn new() {
         let filter = Filter::new(0, 1);
         assert_eq!(filter.start, U256::ZERO);
         assert_eq!(filter.end, U256::MAX);

--- a/trin-execution/src/trie_walker/mod.rs
+++ b/trin-execution/src/trie_walker/mod.rs
@@ -84,7 +84,7 @@ impl<DB: TrieWalkerDb> TrieWalker<DB> {
     ) -> anyhow::Result<()> {
         // If we have a filter, we only want to include nodes that are in the filter
         if let Some(filter) = &self.filter {
-            if !filter.is_included(&path) {
+            if !filter.contains(&path) {
                 return Ok(());
             }
         }

--- a/trin-execution/src/trie_walker/mod.rs
+++ b/trin-execution/src/trie_walker/mod.rs
@@ -1,4 +1,5 @@
 pub mod db;
+pub mod filter;
 
 use std::sync::Arc;
 
@@ -6,6 +7,7 @@ use alloy::primitives::{Bytes, B256};
 use anyhow::{anyhow, Ok};
 use db::TrieWalkerDb;
 use eth_trie::{decode_node, node::Node};
+use filter::Filter;
 
 use crate::types::trie_proof::TrieProof;
 
@@ -21,10 +23,13 @@ pub struct TrieWalker<DB: TrieWalkerDb> {
     is_partial_trie: bool,
     trie: Arc<DB>,
     stack: Vec<TrieProof>,
+
+    /// You can filter what slice of the trie you want to walk
+    filter: Option<Filter>,
 }
 
 impl<DB: TrieWalkerDb> TrieWalker<DB> {
-    pub fn new(root_hash: B256, trie: Arc<DB>) -> anyhow::Result<Self> {
+    pub fn new(root_hash: B256, trie: Arc<DB>, filter: Option<Filter>) -> anyhow::Result<Self> {
         let root_node_trie = match trie.get(root_hash.as_slice())? {
             Some(root_node_trie) => root_node_trie,
             None => return Err(anyhow!("Root node not found in the database")),
@@ -38,6 +43,7 @@ impl<DB: TrieWalkerDb> TrieWalker<DB> {
             is_partial_trie: false,
             trie,
             stack: vec![root_proof],
+            filter,
         })
     }
 
@@ -52,6 +58,7 @@ impl<DB: TrieWalkerDb> TrieWalker<DB> {
                     is_partial_trie: true,
                     trie: Arc::new(trie),
                     stack: vec![],
+                    filter: None,
                 });
             }
         };
@@ -65,6 +72,7 @@ impl<DB: TrieWalkerDb> TrieWalker<DB> {
             is_partial_trie: true,
             trie: Arc::new(trie),
             stack: vec![root_proof],
+            filter: None,
         })
     }
 
@@ -74,6 +82,13 @@ impl<DB: TrieWalkerDb> TrieWalker<DB> {
         partial_proof: Vec<Bytes>,
         path: Vec<u8>,
     ) -> anyhow::Result<()> {
+        // If we have a filter, we only want to include nodes that are in the filter
+        if let Some(filter) = &self.filter {
+            if !filter.is_included(&path) {
+                return Ok(());
+            }
+        }
+
         // We only need to process hash nodes, because if the node isn't a hash node then none of
         // its children is
         if let Node::Hash(hash) = node {
@@ -191,7 +206,7 @@ mod tests {
         }
 
         let root_hash = trie.root_hash().unwrap();
-        let walker = TrieWalker::new(root_hash, trie.db.clone()).unwrap();
+        let walker = TrieWalker::new(root_hash, trie.db.clone(), None).unwrap();
         let mut count = 0;
         let mut leaf_count = 0;
         for proof in walker {

--- a/trin-execution/src/utils.rs
+++ b/trin-execution/src/utils.rs
@@ -1,17 +1,5 @@
 use alloy::primitives::{keccak256, Address, B256};
 
-fn compress_nibbles(nibbles: &[u8]) -> Vec<u8> {
-    let mut compressed_nibbles = vec![];
-    for i in 0..nibbles.len() {
-        if i % 2 == 0 {
-            compressed_nibbles.push(nibbles[i] << 4);
-        } else {
-            compressed_nibbles[i / 2] |= nibbles[i];
-        }
-    }
-    compressed_nibbles
-}
-
 pub fn full_nibble_path_to_address_hash(key_path: &[u8]) -> B256 {
     if key_path.len() != 64 {
         panic!(
@@ -20,11 +8,19 @@ pub fn full_nibble_path_to_address_hash(key_path: &[u8]) -> B256 {
         );
     }
 
-    B256::from_slice(&compress_nibbles(key_path))
+    nibbles_to_right_padded_b256(key_path)
 }
 
-pub fn partial_nibble_path_to_right_padded_b256(partial_nibble_path: &[u8]) -> B256 {
-    B256::right_padding_from(&compress_nibbles(partial_nibble_path))
+pub fn nibbles_to_right_padded_b256(nibbles: &[u8]) -> B256 {
+    let mut result = B256::ZERO;
+    for (i, nibble) in nibbles.iter().enumerate() {
+        if i % 2 == 0 {
+            result[i / 2] |= nibble << 4;
+        } else {
+            result[i / 2] |= nibble;
+        };
+    }
+    result
 }
 
 pub fn address_to_nibble_path(address: Address) -> Vec<u8> {
@@ -41,8 +37,7 @@ mod tests {
     use revm_primitives::{keccak256, Address, B256};
 
     use crate::utils::{
-        address_to_nibble_path, full_nibble_path_to_address_hash,
-        partial_nibble_path_to_right_padded_b256,
+        address_to_nibble_path, full_nibble_path_to_address_hash, nibbles_to_right_padded_b256,
     };
 
     #[test]
@@ -68,7 +63,7 @@ mod tests {
     #[test]
     fn test_partial_nibble_path_to_right_padded_b256() {
         let partial_nibble_path = vec![0xf, 0xf, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3];
-        let partial_path = partial_nibble_path_to_right_padded_b256(&partial_nibble_path);
+        let partial_path = nibbles_to_right_padded_b256(&partial_nibble_path);
         assert_eq!(
             partial_path,
             B256::from_hex("0xff01020300000000000000000000000000000000000000000000000000000000")


### PR DESCRIPTION
### What was wrong?
Walking a whole state trie is very time consuming
### How was it fixed?

By making it so you can filter the trie to only walk a slice of it, this PR will be used in my followup PR, which adds a random walking state snapshot mode.

This mode will be useful for the random slice state snapshot bridge mode I will be adding

