### PR TITLE
fix: add debug logs to OverlayService::find_enr

### DIFF
--- a/portalnet/src/overlay/service.rs
+++ b/portalnet/src/overlay/service.rs
@@ -2436,11 +2436,13 @@ impl<
 
         // Check whether this node id is in our discv5 routing table
         if let Some(enr) = self.discovery.find_enr(node_id) {
+            debug!(node_id=%node_id, enr=%enr, "#1596: discv5 routing table");
             return Some(enr);
         }
 
         // Check whether this node id is in our discovery ENR cache
         if let Some(node_addr) = self.discovery.cached_node_addr(node_id) {
+            debug!(node_id=%node_id, enr=?node_addr, "#1596: cached node addr");
             return Some(node_addr.enr);
         }
 
@@ -2451,6 +2453,7 @@ impl<
                 .iter()
                 .find(|v| v.node_id() == *node_id)
             {
+                debug!(node_id=%node_id, enr=%enr, "#1596: node query_pool");
                 return Some(enr.clone());
             }
         }
@@ -2462,10 +2465,12 @@ impl<
                 .iter()
                 .find(|v| v.node_id() == *node_id)
             {
+                debug!(node_id=%node_id, enr=%enr, "#1596: content query_pool");
                 return Some(enr.clone());
             }
         }
 
+        debug!(node_id=%node_id, "#1596: none");
         None
     }
 


### PR DESCRIPTION
### What was wrong?

It seems that `OverlayService::find_enr` sometimes finds wrong Enr.

See https://github.com/ethereum/trin/issues/1596#issuecomment-2525302159 for more details

### How was it fixed?

This isn't a fix. I'm just adding extra logging to confirm my suspicious and try to find out the root cause of the problem.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
