### PR TITLE
fix: fallback to custom error if we can't parse ContentNotFound error

### DIFF
--- a/rpc/src/fetch.rs
+++ b/rpc/src/fetch.rs
@@ -35,16 +35,11 @@ where
         Ok(result) => from_value(result),
         Err(msg) => {
             if msg.contains("Unable to locate content on the network") {
-                let error: ContentNotFoundJsonError = serde_json::from_str(&msg).map_err(|e| {
-                    RpcServeError::Message(format!(
-                        "Failed to parse error message from {} subnetwork: {e:?}",
-                        TEndpoint::subnetwork(),
-                    ))
-                })?;
-                Err(error.into())
-            } else {
-                Err(RpcServeError::Message(msg))
+                if let Ok(err) = serde_json::from_str::<ContentNotFoundJsonError>(&msg) {
+                    return Err(err.into());
+                }
             }
+            Err(RpcServeError::Message(msg))
         }
     }
 }


### PR DESCRIPTION
### What was wrong?

The error message of failed JSON response can contain `"Unable to locate content on the network"` text, but error itself is not `ContentNotFound` error.

This can happen if `ContentNotFound` error is nested inside some other message.

Currently, returned response doesn't contain details of the original failure (instead it tells us why parsing failed, in not so useful way).

### How was it fixed?

If parsing `ContentNotFoundJsonError` fails, fallback to generic error message instead.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
