### PR TITLE
style: enable fmt linting for grouped imports by std external and crates

### DIFF
--- a/book/src/developers/contributing/rust/imports.md
+++ b/book/src/developers/contributing/rust/imports.md
@@ -6,7 +6,7 @@
   3. self, super and crate imports.
 - Alphabetize imports in `Cargo.toml`
 
-```rust
+```rust,ignore
 use alloc::alloc::Layout;
 use core::f32;
 use std::sync::Arc;

--- a/book/src/developers/contributing/rust/imports.md
+++ b/book/src/developers/contributing/rust/imports.md
@@ -1,7 +1,22 @@
 # Imports
 
-- In `*.rs` files, imports should be split into 3 groups [src](https://github.com/rust-dev-tools/fmt-rfcs/issues/131) and separated by a single line. Within a single group, imported items should be sorted alphabetically.
-	- Imports from `'std'`
-	- Imports from external crates
-	- Imports from crates within trin
+- In `*.rs` files, imports should be split into 3 groups [src](https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=#StdExternalCrate) and separated by a single line. Within a single group, imported items should be sorted alphabetically.
+  1. std, core and alloc,
+  2. external crates,
+  3. self, super and crate imports.
 - Alphabetize imports in `Cargo.toml`
+
+```rust
+use alloc::alloc::Layout;
+use core::f32;
+use std::sync::Arc;
+
+use broker::database::PooledConnection;
+use chrono::Utc;
+use juniper::{FieldError, FieldResult};
+use uuid::Uuid;
+
+use super::schema::{Context, Payload};
+use super::update::convert_publish_payload;
+use crate::models::Event;
+```

--- a/e2store/src/e2store/memory.rs
+++ b/e2store/src/e2store/memory.rs
@@ -66,8 +66,9 @@ impl E2StoreMemory {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use ethportal_api::utils::bytes::{hex_decode, hex_encode};
+
+    use super::*;
 
     // test cases sourced from: https://github.com/ethereum/go-ethereum/pull/26621/
 

--- a/e2store/src/e2store/stream.rs
+++ b/e2store/src/e2store/stream.rs
@@ -65,9 +65,8 @@ mod tests {
     use rand::Rng;
     use trin_utils::dir::create_temp_test_dir;
 
-    use crate::e2store::types::VersionEntry;
-
     use super::*;
+    use crate::e2store::types::VersionEntry;
 
     #[test]
     fn test_e2store_stream_write_and_read() -> anyhow::Result<()> {

--- a/e2store/src/era.rs
+++ b/e2store/src/era.rs
@@ -1,15 +1,17 @@
-use crate::e2store::{
-    memory::E2StoreMemory,
-    types::{Entry, Header, VersionEntry},
+use std::{
+    fs,
+    io::{Read, Write},
 };
+
 use anyhow::{anyhow, ensure};
 use ethportal_api::consensus::{
     beacon_block::SignedBeaconBlock, beacon_state::BeaconState, fork::ForkName,
 };
 use ssz::Encode;
-use std::{
-    fs,
-    io::{Read, Write},
+
+use crate::e2store::{
+    memory::E2StoreMemory,
+    types::{Entry, Header, VersionEntry},
 };
 
 pub const SLOTS_PER_HISTORICAL_ROOT: usize = 8192;

--- a/e2store/src/era1.rs
+++ b/e2store/src/era1.rs
@@ -1,19 +1,21 @@
-use crate::{
-    e2store::{
-        memory::E2StoreMemory,
-        types::{Entry, VersionEntry},
-    },
-    types::HeaderEntry,
+use std::{
+    fs,
+    io::{Read, Write},
 };
+
 use alloy::{
     primitives::{B256, U256},
     rlp::Decodable,
 };
 use anyhow::ensure;
 use ethportal_api::types::execution::{block_body::BlockBody, receipts::Receipts};
-use std::{
-    fs,
-    io::{Read, Write},
+
+use crate::{
+    e2store::{
+        memory::E2StoreMemory,
+        types::{Entry, VersionEntry},
+    },
+    types::HeaderEntry,
 };
 
 // <config-name>-<era-number>-<era-count>-<short-historical-root>.era

--- a/e2store/src/era2.rs
+++ b/e2store/src/era2.rs
@@ -319,9 +319,8 @@ mod tests {
     use alloy::primitives::{Address, Bloom, B64};
     use trin_utils::dir::create_temp_test_dir;
 
-    use crate::e2store::types::VersionEntry;
-
     use super::*;
+    use crate::e2store::types::VersionEntry;
 
     #[test]
     fn test_era2_stream_write_and_read() -> anyhow::Result<()> {

--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -1,3 +1,7 @@
+use alloy::primitives::B256;
+use discv5::enr::NodeId;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
 use crate::{
     consensus::header::BeaconBlockHeader,
     light_client::store::LightClientStore,
@@ -12,9 +16,6 @@ use crate::{
     },
     RawContentValue, RoutingTableInfo,
 };
-use alloy::primitives::B256;
-use discv5::enr::NodeId;
-use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Portal Beacon JSON-RPC endpoints
 #[rpc(client, server, namespace = "portal")]

--- a/ethportal-api/src/dashboard/grafana.rs
+++ b/ethportal-api/src/dashboard/grafana.rs
@@ -1,7 +1,8 @@
+use std::fs;
+
 use base64;
 use nanotemplate::template;
 use serde::Deserialize;
-use std::fs;
 use ureq;
 
 pub const DASHBOARD_TEMPLATES: &[&str] =

--- a/ethportal-api/src/discv5.rs
+++ b/ethportal-api/src/discv5.rs
@@ -1,9 +1,10 @@
+use discv5::enr::NodeId;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
 use crate::types::{
     discv5::{NodeInfo, RoutingTableInfo},
     enr::Enr,
 };
-use discv5::enr::NodeId;
-use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Discv5 JSON-RPC endpoints
 #[rpc(client, server, namespace = "discv5")]

--- a/ethportal-api/src/history.rs
+++ b/ethportal-api/src/history.rs
@@ -1,3 +1,6 @@
+use discv5::enr::NodeId;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
 use crate::{
     types::{
         content_key::history::HistoryContentKey,
@@ -10,8 +13,6 @@ use crate::{
     },
     RawContentValue, RoutingTableInfo,
 };
-use discv5::enr::NodeId;
-use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Portal History JSON-RPC endpoints
 #[rpc(client, server, namespace = "portal")]

--- a/ethportal-api/src/lib.rs
+++ b/ethportal-api/src/lib.rs
@@ -24,9 +24,9 @@ pub use beacon::{BeaconNetworkApiClient, BeaconNetworkApiServer};
 pub use discv5::{Discv5ApiClient, Discv5ApiServer};
 pub use eth::{EthApiClient, EthApiServer};
 pub use history::{HistoryNetworkApiClient, HistoryNetworkApiServer};
+// Re-exports jsonrpsee crate
+pub use jsonrpsee;
 pub use state::{StateNetworkApiClient, StateNetworkApiServer};
-pub use web3::{Web3ApiClient, Web3ApiServer};
-
 pub use types::{
     consensus,
     consensus::light_client,
@@ -47,8 +47,6 @@ pub use types::{
     node_id::*,
     portal::{RawContentKey, RawContentValue},
 };
-
-// Re-exports jsonrpsee crate
-pub use jsonrpsee;
+pub use web3::{Web3ApiClient, Web3ApiServer};
 
 shadow_rs::shadow!(build_info);

--- a/ethportal-api/src/state.rs
+++ b/ethportal-api/src/state.rs
@@ -1,3 +1,6 @@
+use discv5::enr::NodeId;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
 use crate::{
     types::{
         content_key::state::StateContentKey,
@@ -10,8 +13,6 @@ use crate::{
     },
     RawContentValue, RoutingTableInfo,
 };
-use discv5::enr::NodeId;
-use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Portal State JSON-RPC endpoints
 #[rpc(client, server, namespace = "portal")]

--- a/ethportal-api/src/types/bootnodes.rs
+++ b/ethportal-api/src/types/bootnodes.rs
@@ -143,9 +143,10 @@ impl FromStr for Bootnodes {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
+    use rstest::rstest;
+
     use super::*;
     use crate::types::cli::TrinConfig;
-    use rstest::rstest;
 
     #[test_log::test]
     fn test_bootnodes_default_with_default_bootnodes() {

--- a/ethportal-api/src/types/cli.rs
+++ b/ethportal-api/src/types/cli.rs
@@ -1,3 +1,5 @@
+use std::{env, ffi::OsString, fmt, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
+
 use alloy::primitives::B256;
 use clap::{
     arg,
@@ -5,7 +7,6 @@ use clap::{
     error::{Error, ErrorKind},
     Args, Parser, Subcommand,
 };
-use std::{env, ffi::OsString, fmt, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
 use url::Url;
 
 use crate::{
@@ -24,9 +25,8 @@ pub const DEFAULT_NETWORK: &str = "mainnet";
 pub const DEFAULT_STORAGE_CAPACITY_MB: &str = "1000";
 pub const DEFAULT_WEB3_TRANSPORT: &str = "ipc";
 
-use crate::dashboard::grafana::{GrafanaAPI, DASHBOARD_TEMPLATES};
-
 use super::portal_wire::{NetworkSpec, ANGELFOOD, MAINNET};
+use crate::dashboard::grafana::{GrafanaAPI, DASHBOARD_TEMPLATES};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Web3TransportType {
@@ -555,6 +555,7 @@ pub fn create_dashboard(
 #[cfg(test)]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
+
     use test_log::test;
 
     use super::*;

--- a/ethportal-api/src/types/consensus/beacon_block.rs
+++ b/ethportal-api/src/types/consensus/beacon_block.rs
@@ -1,8 +1,3 @@
-use crate::consensus::{
-    body::{BeaconBlockBodyBellatrix, BeaconBlockBodyCapella, BeaconBlockBodyDeneb},
-    fork::ForkName,
-    signature::BlsSignature,
-};
 use alloy::primitives::B256;
 use jsonrpsee::core::Serialize;
 use rs_merkle::{algorithms::Sha256, MerkleTree};
@@ -13,6 +8,12 @@ use ssz_derive::{Decode, Encode};
 use superstruct::superstruct;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
+
+use crate::consensus::{
+    body::{BeaconBlockBodyBellatrix, BeaconBlockBodyCapella, BeaconBlockBodyDeneb},
+    fork::ForkName,
+    signature::BlsSignature,
+};
 
 /// A block of the `BeaconChain`.
 #[superstruct(
@@ -190,12 +191,14 @@ impl SignedBeaconBlock {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
-    use crate::consensus::fork::ForkName;
+    use std::str::FromStr;
+
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
-    use std::str::FromStr;
+
+    use super::*;
+    use crate::consensus::fork::ForkName;
 
     #[rstest]
     #[case("case_0")]

--- a/ethportal-api/src/types/consensus/beacon_state.rs
+++ b/ethportal-api/src/types/consensus/beacon_state.rs
@@ -1,3 +1,19 @@
+use std::sync::Arc;
+
+use alloy::primitives::B256;
+use discv5::enr::k256::elliptic_curve::consts::{U1099511627776, U2048, U4, U65536, U8192};
+use jsonrpsee::core::Serialize;
+use rs_merkle::{algorithms::Sha256, MerkleTree};
+use serde::Deserialize;
+use serde_this_or_that::as_u64;
+use serde_utils;
+use ssz::{Decode, DecodeError, Encode};
+use ssz_derive::{Decode, Encode};
+use ssz_types::{typenum::U16777216, BitVector, FixedVector, VariableList};
+use superstruct::superstruct;
+use tree_hash::{Hash256, TreeHash};
+use tree_hash_derive::TreeHash;
+
 use crate::consensus::{
     body::{Checkpoint, Eth1Data},
     execution_payload::{
@@ -10,20 +26,6 @@ use crate::consensus::{
     pubkey::PubKey,
     sync_committee::SyncCommittee,
 };
-use alloy::primitives::B256;
-use discv5::enr::k256::elliptic_curve::consts::{U1099511627776, U2048, U4, U65536, U8192};
-use jsonrpsee::core::Serialize;
-use rs_merkle::{algorithms::Sha256, MerkleTree};
-use serde::Deserialize;
-use serde_this_or_that::as_u64;
-use serde_utils;
-use ssz::{Decode, DecodeError, Encode};
-use ssz_derive::{Decode, Encode};
-use ssz_types::{typenum::U16777216, BitVector, FixedVector, VariableList};
-use std::sync::Arc;
-use superstruct::superstruct;
-use tree_hash::{Hash256, TreeHash};
-use tree_hash_derive::TreeHash;
 
 type SlotsPerHistoricalRoot = U8192; // uint64(2**13) (= 8,192)
 type HistoricalRootsLimit = U16777216; // uint64(2**24) (= 16,777,216)
@@ -342,11 +344,13 @@ impl HistoricalBatch {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
+    use std::str::FromStr;
+
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
-    use std::str::FromStr;
+
+    use super::*;
 
     #[rstest]
     #[case("case_0")]

--- a/ethportal-api/src/types/consensus/body.rs
+++ b/ethportal-api/src/types/consensus/body.rs
@@ -1,14 +1,3 @@
-use crate::{
-    consensus::{
-        beacon_state::Epoch,
-        execution_payload::{
-            ExecutionPayloadBellatrix, ExecutionPayloadCapella, ExecutionPayloadDeneb,
-        },
-        fork::ForkName,
-        kzg_commitment::KzgCommitment,
-    },
-    types::bytes::ByteList1G,
-};
 use alloy::primitives::{Address, B256};
 use discv5::enr::k256::elliptic_curve::consts::U16;
 use rs_merkle::{algorithms::Sha256, MerkleTree};
@@ -26,6 +15,17 @@ use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
 use super::{header::BeaconBlockHeader, pubkey::PubKey, signature::BlsSignature};
+use crate::{
+    consensus::{
+        beacon_state::Epoch,
+        execution_payload::{
+            ExecutionPayloadBellatrix, ExecutionPayloadCapella, ExecutionPayloadDeneb,
+        },
+        fork::ForkName,
+        kzg_commitment::KzgCommitment,
+    },
+    types::bytes::ByteList1G,
+};
 
 type MaxBlobCommitmentsPerBlock = U4096;
 type MaxBlsToExecutionChanges = U16;
@@ -238,11 +238,13 @@ pub struct BlsToExecutionChange {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
+    use std::str::FromStr;
+
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
-    use std::str::FromStr;
+
+    use super::*;
 
     /// Test vectors sourced from:
     /// https://github.com/ethereum/consensus-spec-tests/commit/c6e69469a75392b35169bc6234d4d3e6c4e288da

--- a/ethportal-api/src/types/consensus/execution_payload.rs
+++ b/ethportal-api/src/types/consensus/execution_payload.rs
@@ -1,11 +1,3 @@
-use super::serde::{de_hex_to_txs, de_number_to_u256, se_hex_to_number, se_txs_to_hex};
-use crate::{
-    types::{
-        bytes::ByteList32,
-        consensus::{body::Transactions, fork::ForkName},
-    },
-    utils::serde::{hex_fixed_vec, hex_var_list},
-};
 use alloy::primitives::{Address, B256, U256};
 use rs_merkle::{algorithms::Sha256, MerkleTree};
 use serde::{Deserialize, Serialize};
@@ -16,6 +8,15 @@ use ssz_types::{typenum, typenum::U16, FixedVector, VariableList};
 use superstruct::superstruct;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
+
+use super::serde::{de_hex_to_txs, de_number_to_u256, se_hex_to_number, se_txs_to_hex};
+use crate::{
+    types::{
+        bytes::ByteList32,
+        consensus::{body::Transactions, fork::ForkName},
+    },
+    utils::serde::{hex_fixed_vec, hex_var_list},
+};
 
 pub type Bloom = FixedVector<u8, typenum::U256>;
 pub type ExtraData = ByteList32;
@@ -217,11 +218,13 @@ impl ExecutionPayloadHeader {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
+    use std::str::FromStr;
+
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
-    use std::str::FromStr;
+
+    use super::*;
 
     #[rstest]
     #[case("case_0")]

--- a/ethportal-api/src/types/consensus/fork.rs
+++ b/ethportal-api/src/types/consensus/fork.rs
@@ -1,10 +1,12 @@
-use crate::utils::bytes::hex_encode;
 use std::{
     fmt,
     fmt::{Display, Formatter},
     str::FromStr,
 };
+
 use thiserror::Error;
+
+use crate::utils::bytes::hex_encode;
 
 /// Error thrown when failed to parse a valid [`ForkName`].
 #[derive(Debug, Clone, PartialEq, Eq, Error)]

--- a/ethportal-api/src/types/consensus/header.rs
+++ b/ethportal-api/src/types/consensus/header.rs
@@ -22,10 +22,11 @@ pub struct BeaconBlockHeader {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
+
+    use super::*;
 
     /// Test vectors sourced from:
     /// https://github.com/ethereum/consensus-spec-tests/commit/c6e69469a75392b35169bc6234d4d3e6c4e288da

--- a/ethportal-api/src/types/consensus/historical_summaries.rs
+++ b/ethportal-api/src/types/consensus/historical_summaries.rs
@@ -29,12 +29,13 @@ pub struct HistoricalSummariesWithProof {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
+    use serde_json::Value;
+    use ssz::{Decode, Encode};
+
     use crate::consensus::{
         beacon_state::BeaconStateDeneb,
         historical_summaries::{HistoricalSummariesStateProof, HistoricalSummariesWithProof},
     };
-    use serde_json::Value;
-    use ssz::{Decode, Encode};
 
     #[test]
     fn test_historical_summaries_with_proof_deneb() {

--- a/ethportal-api/src/types/consensus/kzg_commitment.rs
+++ b/ethportal-api/src/types/consensus/kzg_commitment.rs
@@ -1,4 +1,9 @@
-use crate::utils::bytes::{hex_decode, hex_encode};
+use std::{
+    fmt,
+    fmt::{Debug, Display, Formatter},
+    str::FromStr,
+};
+
 use c_kzg::BYTES_PER_COMMITMENT;
 use ethereum_hashing::hash_fixed;
 use serde::{
@@ -6,12 +11,9 @@ use serde::{
     ser::{Serialize, Serializer},
 };
 use ssz_derive::{Decode, Encode};
-use std::{
-    fmt,
-    fmt::{Debug, Display, Formatter},
-    str::FromStr,
-};
 use tree_hash::{Hash256, PackedEncoding, TreeHash};
+
+use crate::utils::bytes::{hex_decode, hex_encode};
 
 pub const VERSIONED_HASH_VERSION_KZG: u8 = 0x01;
 

--- a/ethportal-api/src/types/consensus/light_client/bootstrap.rs
+++ b/ethportal-api/src/types/consensus/light_client/bootstrap.rs
@@ -1,3 +1,10 @@
+use alloy::primitives::B256;
+use serde::{Deserialize, Serialize};
+use ssz::Decode;
+use ssz_derive::{Decode, Encode};
+use ssz_types::{typenum::U5, FixedVector};
+use superstruct::superstruct;
+
 use crate::{
     consensus::header::BeaconBlockHeader,
     light_client::header::LightClientHeaderDeneb,
@@ -7,12 +14,6 @@ use crate::{
         sync_committee::SyncCommittee,
     },
 };
-use alloy::primitives::B256;
-use serde::{Deserialize, Serialize};
-use ssz::Decode;
-use ssz_derive::{Decode, Encode};
-use ssz_types::{typenum::U5, FixedVector};
-use superstruct::superstruct;
 
 pub type CurrentSyncCommitteeProofLen = U5;
 
@@ -67,10 +68,11 @@ impl LightClientBootstrap {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
+
+    use super::*;
 
     #[rstest]
     #[case("case_0")]

--- a/ethportal-api/src/types/consensus/light_client/finality_update.rs
+++ b/ethportal-api/src/types/consensus/light_client/finality_update.rs
@@ -1,3 +1,11 @@
+use alloy::primitives::B256;
+use serde::{Deserialize, Serialize};
+use serde_this_or_that::as_u64;
+use ssz::Decode;
+use ssz_derive::{Decode, Encode};
+use ssz_types::FixedVector;
+use superstruct::superstruct;
+
 use crate::{
     light_client::header::LightClientHeaderDeneb,
     types::consensus::{
@@ -9,13 +17,6 @@ use crate::{
         },
     },
 };
-use alloy::primitives::B256;
-use serde::{Deserialize, Serialize};
-use serde_this_or_that::as_u64;
-use ssz::Decode;
-use ssz_derive::{Decode, Encode};
-use ssz_types::FixedVector;
-use superstruct::superstruct;
 
 /// A LightClientFinalityUpdate is the update that
 /// signal a new finalized beacon block header for the light client sync protocol.
@@ -71,10 +72,11 @@ impl LightClientFinalityUpdate {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
+
+    use super::*;
 
     #[rstest]
     #[case("case_0")]

--- a/ethportal-api/src/types/consensus/light_client/header.rs
+++ b/ethportal-api/src/types/consensus/light_client/header.rs
@@ -1,9 +1,3 @@
-use crate::{
-    consensus::execution_payload::ExecutionPayloadHeaderDeneb,
-    types::consensus::{
-        execution_payload::ExecutionPayloadHeaderCapella, fork::ForkName, header::BeaconBlockHeader,
-    },
-};
 use alloy::primitives::B256;
 use serde::{Deserialize, Serialize};
 use ssz::Decode;
@@ -11,6 +5,13 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum::U4, FixedVector};
 use superstruct::superstruct;
 use tree_hash_derive::TreeHash;
+
+use crate::{
+    consensus::execution_payload::ExecutionPayloadHeaderDeneb,
+    types::consensus::{
+        execution_payload::ExecutionPayloadHeaderCapella, fork::ForkName, header::BeaconBlockHeader,
+    },
+};
 
 pub type ExecutionBranchLen = U4;
 
@@ -65,10 +66,11 @@ impl LightClientHeader {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
+
+    use super::*;
 
     #[rstest]
     #[case("case_0")]

--- a/ethportal-api/src/types/consensus/light_client/optimistic_update.rs
+++ b/ethportal-api/src/types/consensus/light_client/optimistic_update.rs
@@ -1,3 +1,9 @@
+use serde::{Deserialize, Serialize};
+use serde_this_or_that::as_u64;
+use ssz::Decode;
+use ssz_derive::{Decode, Encode};
+use superstruct::superstruct;
+
 use crate::{
     light_client::header::LightClientHeaderDeneb,
     types::consensus::{
@@ -6,11 +12,6 @@ use crate::{
         light_client::header::{LightClientHeaderBellatrix, LightClientHeaderCapella},
     },
 };
-use serde::{Deserialize, Serialize};
-use serde_this_or_that::as_u64;
-use ssz::Decode;
-use ssz_derive::{Decode, Encode};
-use superstruct::superstruct;
 
 /// A LightClientOptimisticUpdate is the update we receive on each slot,
 /// it is based off the current unfinalized epoch and it is verified only against BLS signature.
@@ -57,10 +58,11 @@ impl LightClientOptimisticUpdate {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
+
+    use super::*;
 
     #[rstest]
     #[case("case_0")]

--- a/ethportal-api/src/types/consensus/light_client/store.rs
+++ b/ethportal-api/src/types/consensus/light_client/store.rs
@@ -1,5 +1,6 @@
-use crate::consensus::{header::BeaconBlockHeader, sync_committee::SyncCommittee};
 use serde::{Deserialize, Serialize};
+
+use crate::consensus::{header::BeaconBlockHeader, sync_committee::SyncCommittee};
 
 /// `LightClientStore` object for the light client sync protocol.
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]

--- a/ethportal-api/src/types/consensus/light_client/update.rs
+++ b/ethportal-api/src/types/consensus/light_client/update.rs
@@ -1,12 +1,3 @@
-use crate::{
-    light_client::header::LightClientHeaderDeneb,
-    types::consensus::{
-        body::SyncAggregate,
-        fork::ForkName,
-        light_client::header::{LightClientHeaderBellatrix, LightClientHeaderCapella},
-        sync_committee::SyncCommittee,
-    },
-};
 use alloy::primitives::B256;
 use serde::{Deserialize, Serialize};
 use serde_this_or_that::as_u64;
@@ -17,6 +8,16 @@ use ssz_types::{
     FixedVector,
 };
 use superstruct::superstruct;
+
+use crate::{
+    light_client::header::LightClientHeaderDeneb,
+    types::consensus::{
+        body::SyncAggregate,
+        fork::ForkName,
+        light_client::header::{LightClientHeaderBellatrix, LightClientHeaderCapella},
+        sync_committee::SyncCommittee,
+    },
+};
 
 type NextSyncCommitteeProofLen = U5;
 pub type FinalizedRootProofLen = U6;
@@ -73,10 +74,11 @@ impl LightClientUpdate {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ::ssz::Encode;
     use rstest::rstest;
     use serde_json::Value;
+
+    use super::*;
 
     #[rstest]
     #[case("case_0")]

--- a/ethportal-api/src/types/consensus/pubkey.rs
+++ b/ethportal-api/src/types/consensus/pubkey.rs
@@ -1,7 +1,8 @@
+use std::ops::Deref;
+
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ssz::{Decode, Encode};
 use ssz_types::{typenum, FixedVector};
-use std::ops::Deref;
 use tree_hash_derive::TreeHash;
 
 use crate::utils::bytes::{hex_decode, hex_encode};

--- a/ethportal-api/src/types/consensus/sync_committee.rs
+++ b/ethportal-api/src/types/consensus/sync_committee.rs
@@ -1,8 +1,9 @@
-use crate::types::consensus::pubkey::PubKey;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum::U512, FixedVector};
 use tree_hash_derive::TreeHash;
+
+use crate::types::consensus::pubkey::PubKey;
 
 type SyncCommitteeSize = U512;
 

--- a/ethportal-api/src/types/content_key/beacon.rs
+++ b/ethportal-api/src/types/content_key/beacon.rs
@@ -1,13 +1,15 @@
+use std::{fmt, hash::Hash};
+
+use bytes::{BufMut, BytesMut};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use ssz::{Decode, DecodeError, Encode};
+use ssz_derive::{Decode, Encode};
+
 use crate::{
     types::content_key::{error::ContentKeyError, overlay::OverlayContentKey},
     utils::bytes::hex_encode_compact,
     RawContentKey,
 };
-use bytes::{BufMut, BytesMut};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use ssz::{Decode, DecodeError, Encode};
-use ssz_derive::{Decode, Encode};
-use std::{fmt, hash::Hash};
 
 // Prefixes for the different types of beacon content keys:
 // https://github.com/ethereum/portal-network-specs/blob/638aca50c913a749d0d762264d9a4ac72f1a9966/beacon-chain/beacon-network.md
@@ -207,9 +209,8 @@ impl<'de> Deserialize<'de> for BeaconContentKey {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use crate::utils::bytes::hex_decode;
-
     use super::*;
+    use crate::utils::bytes::hex_decode;
 
     fn test_encode_decode(content_key: &BeaconContentKey) {
         let bytes = content_key.to_bytes();

--- a/ethportal-api/src/types/content_key/history.rs
+++ b/ethportal-api/src/types/content_key/history.rs
@@ -1,9 +1,10 @@
+use std::{fmt, hash::Hash};
+
 use bytes::{BufMut, BytesMut};
 use rand::{seq::SliceRandom, RngCore};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ssz::{Decode, DecodeError, Encode};
 use ssz_derive::{Decode, Encode};
-use std::{fmt, hash::Hash};
 
 use crate::{
     types::content_key::{error::ContentKeyError, overlay::OverlayContentKey},

--- a/ethportal-api/src/types/content_key/overlay.rs
+++ b/ethportal-api/src/types/content_key/overlay.rs
@@ -1,4 +1,4 @@
-use std::{fmt, hash::Hash, ops::Deref};
+use std::{fmt, hash::Hash, ops::Deref, str::FromStr};
 
 use quickcheck::{Arbitrary, Gen};
 use sha2::{Digest, Sha256};
@@ -8,7 +8,6 @@ use crate::{
     utils::bytes::{hex_encode, hex_encode_compact},
     RawContentKey,
 };
-use std::str::FromStr;
 
 /// Types whose values represent keys to lookup content items in an overlay network.
 ///

--- a/ethportal-api/src/types/content_key/state.rs
+++ b/ethportal-api/src/types/content_key/state.rs
@@ -1,9 +1,10 @@
+use std::{fmt, hash::Hash};
+
 use alloy::primitives::B256;
 use bytes::{BufMut, BytesMut};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ssz::{Decode, DecodeError, Encode};
 use ssz_derive::{Decode, Encode};
-use std::{fmt, hash::Hash};
 
 use crate::{
     types::{content_key::overlay::OverlayContentKey, state_trie::nibbles::Nibbles},
@@ -175,9 +176,8 @@ mod test {
     use rstest::rstest;
     use serde_yaml::Value;
 
-    use crate::{test_utils::read_file_from_tests_submodule, utils::bytes::hex_decode};
-
     use super::*;
+    use crate::{test_utils::read_file_from_tests_submodule, utils::bytes::hex_decode};
 
     const TEST_DATA_DIRECTORY: &str = "tests/mainnet/state/serialization";
 

--- a/ethportal-api/src/types/content_value/beacon.rs
+++ b/ethportal-api/src/types/content_value/beacon.rs
@@ -1,3 +1,9 @@
+use std::ops::Deref;
+
+use serde::{Serialize, Serializer};
+use ssz::{Decode, DecodeError, Encode};
+use ssz_types::{typenum::U128, VariableList};
+
 use crate::{
     light_client::{
         bootstrap::LightClientBootstrapDeneb, finality_update::LightClientFinalityUpdateDeneb,
@@ -29,10 +35,6 @@ use crate::{
     utils::bytes::hex_encode,
     BeaconContentKey, ContentValueError, RawContentValue,
 };
-use serde::{Serialize, Serializer};
-use ssz::{Decode, DecodeError, Encode};
-use ssz_types::{typenum::U128, VariableList};
-use std::ops::Deref;
 
 /// A wrapper type including a `ForkName` and `LightClientBootstrap`
 #[derive(Clone, Debug, PartialEq)]

--- a/ethportal-api/src/types/content_value/error.rs
+++ b/ethportal-api/src/types/content_value/error.rs
@@ -1,5 +1,6 @@
-use crate::types::network::Subnetwork;
 use thiserror::Error;
+
+use crate::types::network::Subnetwork;
 
 /// An error decoding a portal network content value.
 #[derive(Clone, Debug, Error, PartialEq)]

--- a/ethportal-api/src/types/content_value/history.rs
+++ b/ethportal-api/src/types/content_value/history.rs
@@ -1,3 +1,5 @@
+use ssz::{Decode, Encode};
+
 use crate::{
     types::{
         content_value::ContentValue, execution::header_with_proof::HeaderWithProof,
@@ -6,7 +8,6 @@ use crate::{
     utils::bytes::hex_encode,
     BlockBody, ContentValueError, HistoryContentKey, RawContentValue, Receipts,
 };
-use ssz::{Decode, Encode};
 
 /// A Portal History content value.
 #[derive(Clone, Debug, PartialEq)]
@@ -56,12 +57,12 @@ impl ContentValue for HistoryContentValue {
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use std::fs;
 
     use serde_json::Value;
 
+    use super::*;
     use crate::{utils::bytes::hex_decode, HistoryContentValue};
-    use std::fs;
 
     #[test]
     fn header_with_proof_encode_decode_fluffy() {

--- a/ethportal-api/src/types/content_value/state.rs
+++ b/ethportal-api/src/types/content_value/state.rs
@@ -125,9 +125,8 @@ mod test {
     use serde::Deserialize;
     use serde_yaml::Value;
 
-    use crate::test_utils::read_file_from_tests_submodule;
-
     use super::*;
+    use crate::test_utils::read_file_from_tests_submodule;
 
     const TEST_DATA_DIRECTORY: &str = "tests/mainnet/state/serialization";
 

--- a/ethportal-api/src/types/discv5.rs
+++ b/ethportal-api/src/types/discv5.rs
@@ -1,7 +1,7 @@
-use super::enr::Enr;
+use discv5::enr::NodeId;
 use serde::{Deserialize, Serialize};
 
-use discv5::enr::NodeId;
+use super::enr::Enr;
 
 /// Discv5 bucket
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/ethportal-api/src/types/distance.rs
+++ b/ethportal-api/src/types/distance.rs
@@ -81,10 +81,10 @@ impl Metric for XorMetric {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-
     use quickcheck::{quickcheck, Arbitrary, Gen, TestResult};
     use test_log::test;
+
+    use super::*;
 
     /// Wrapper type around a 256-bit identifier in the DHT key space.
     ///

--- a/ethportal-api/src/types/enr.rs
+++ b/ethportal-api/src/types/enr.rs
@@ -1,14 +1,15 @@
+use std::{
+    net::Ipv4Addr,
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
+
 use discv5::enr::{CombinedKey, Enr as Discv5Enr};
 use rand::Rng;
 use rlp::Encodable;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use ssz::DecodeError;
-use std::{
-    net::Ipv4Addr,
-    ops::{Deref, DerefMut},
-    str::FromStr,
-};
 use validator::ValidationError;
 
 pub type Enr = Discv5Enr<CombinedKey>;
@@ -100,12 +101,13 @@ pub fn generate_random_remote_enr() -> (CombinedKey, Enr) {
 
 #[cfg(test)]
 mod test {
+    use discv5::enr::NodeId;
+    use test_log::test;
+
     use crate::{
         generate_random_node_id,
         types::distance::{Metric, XorMetric},
     };
-    use discv5::enr::NodeId;
-    use test_log::test;
 
     #[test]
     fn test_generate_random_node_id_1() {

--- a/ethportal-api/src/types/execution/block_body.rs
+++ b/ethportal-api/src/types/execution/block_body.rs
@@ -471,11 +471,11 @@ impl ssz::Decode for BlockBodyShanghai {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
     use alloy::primitives::U256;
     use rstest::rstest;
     use ssz::{Decode, Encode};
 
+    use super::*;
     use crate::utils::bytes::{hex_decode, hex_encode};
 
     // tx data from: https://etherscan.io/txs?block=14764013

--- a/ethportal-api/src/types/execution/header.rs
+++ b/ethportal-api/src/types/execution/header.rs
@@ -335,10 +335,11 @@ impl<'de> Deserialize<'de> for TxHashes {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
     use std::str::FromStr;
 
     use serde_json::{json, Value};
+
+    use super::*;
 
     #[test_log::test]
     fn decode_and_encode_header() {

--- a/ethportal-api/src/types/execution/header_with_proof.rs
+++ b/ethportal-api/src/types/execution/header_with_proof.rs
@@ -1,10 +1,11 @@
-use crate::{types::bytes::ByteList2048, Header};
 use alloy::{primitives::B256, rlp::Decodable};
 use jsonrpsee::core::Serialize;
 use serde::Deserialize;
 use ssz::{Encode, SszDecoderBuilder, SszEncoder};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum, FixedVector};
+
+use crate::{types::bytes::ByteList2048, Header};
 
 /// A block header with accumulator proof.
 /// Type definition:
@@ -183,11 +184,13 @@ impl ssz::Encode for SszNone {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
-    use crate::utils::bytes::{hex_decode, hex_encode};
+    use std::fs;
+
     use serde_json::Value;
     use ssz::Decode;
-    use std::fs;
+
+    use super::*;
+    use crate::utils::bytes::{hex_decode, hex_encode};
 
     #[test_log::test]
     fn decode_encode_header_with_proofs() {

--- a/ethportal-api/src/types/execution/receipts.rs
+++ b/ethportal-api/src/types/execution/receipts.rs
@@ -552,13 +552,13 @@ impl DerefMut for Receipt {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
     use std::{str::FromStr, vec};
 
     use alloy::primitives::U256;
     use serde_json::json;
     use ssz::{Decode, Encode};
 
+    use super::*;
     use crate::utils::bytes::hex_encode;
 
     //

--- a/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -1,8 +1,9 @@
+use discv5::enr::NodeId;
+
 use crate::{
     types::enr::Enr, BeaconContentKey, BeaconContentValue, HistoryContentKey, HistoryContentValue,
     StateContentKey, StateContentValue,
 };
-use discv5::enr::NodeId;
 
 /// Discv5 JSON-RPC endpoints. Start with "discv5_" prefix
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/ethportal-api/src/types/jsonrpc/params.rs
+++ b/ethportal-api/src/types/jsonrpc/params.rs
@@ -26,8 +26,9 @@ impl From<Params> for Value {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use rstest::rstest;
+
+    use super::*;
 
     fn expected_map() -> Map<String, Value> {
         let mut expected_map = serde_json::Map::new();

--- a/ethportal-api/src/types/jsonrpc/request.rs
+++ b/ethportal-api/src/types/jsonrpc/request.rs
@@ -74,8 +74,9 @@ fn validate_jsonrpc_version(jsonrpc: &str) -> Result<(), ValidationError> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use validator::ValidationErrors;
+
+    use super::*;
 
     #[test_log::test]
     fn test_json_validator_accepts_valid_json() {

--- a/ethportal-api/src/types/portal.rs
+++ b/ethportal-api/src/types/portal.rs
@@ -2,9 +2,8 @@ use alloy::primitives::{Bytes, U256};
 use serde::{Deserialize, Serialize};
 use ssz_types::{typenum, BitList};
 
-use crate::{types::enr::Enr, OverlayContentKey};
-
 use super::query_trace::QueryTrace;
+use crate::{types::enr::Enr, OverlayContentKey};
 
 /// The SSZ encoded representation of content key.
 ///

--- a/ethportal-api/src/types/portal_wire.rs
+++ b/ethportal-api/src/types/portal_wire.rs
@@ -586,14 +586,16 @@ impl From<Accept> for Value {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
+    use std::str::FromStr;
+
     use alloy::{
         hex::FromHex,
         primitives::{bytes, Bytes},
     };
     use ssz_types::Error::OutOfBounds;
-    use std::str::FromStr;
     use test_log::test;
+
+    use super::*;
 
     #[test]
     fn subnetwork_invalid() {

--- a/ethportal-api/src/types/query_trace.rs
+++ b/ethportal-api/src/types/query_trace.rs
@@ -222,7 +222,6 @@ mod tests {
     use ureq::json;
 
     use super::*;
-
     use crate::types::enr::generate_random_remote_enr;
 
     fn new_node() -> (NodeId, Enr) {

--- a/ethportal-api/src/utils/serde/hex_fixed_vec.rs
+++ b/ethportal-api/src/utils/serde/hex_fixed_vec.rs
@@ -1,7 +1,8 @@
-use crate::utils::bytes::hex_encode;
 use serde::{Deserializer, Serializer};
 use serde_utils::hex::PrefixedHexVisitor;
 use ssz_types::{typenum::Unsigned, FixedVector};
+
+use crate::utils::bytes::hex_encode;
 
 pub fn serialize<S, U>(bytes: &FixedVector<u8, U>, serializer: S) -> Result<S::Ok, S::Error>
 where

--- a/ethportal-peertest/src/scenarios/basic.rs
+++ b/ethportal-peertest/src/scenarios/basic.rs
@@ -1,4 +1,3 @@
-use crate::{utils::fixture_header_by_hash, Peertest, PeertestNode};
 use alloy::primitives::{B256, U256};
 use ethportal_api::{
     types::{distance::Distance, network::Subnetwork},
@@ -9,6 +8,8 @@ use ethportal_api::{
 use jsonrpsee::async_client::Client;
 use ssz::Encode;
 use tracing::info;
+
+use crate::{utils::fixture_header_by_hash, Peertest, PeertestNode};
 
 pub async fn test_web3_client_version(target: &Client) {
     info!("Testing web3_clientVersion");

--- a/ethportal-peertest/src/scenarios/bridge.rs
+++ b/ethportal-peertest/src/scenarios/bridge.rs
@@ -1,7 +1,3 @@
-use crate::{
-    utils::{fixture_header_by_hash_1000010, wait_for_beacon_content, wait_for_history_content},
-    Peertest,
-};
 use ethportal_api::{
     jsonrpsee::http_client::HttpClient, BeaconContentKey, BeaconContentValue, ContentValue,
     RawContentValue,
@@ -17,6 +13,11 @@ use serde_json::Value;
 use tokio::time::{sleep, Duration};
 use trin_validation::oracle::HeaderOracle;
 use url::Url;
+
+use crate::{
+    utils::{fixture_header_by_hash_1000010, wait_for_beacon_content, wait_for_history_content},
+    Peertest,
+};
 
 pub async fn test_history_bridge(peertest: &Peertest, portal_client: &HttpClient) {
     let header_oracle = HeaderOracle::default();

--- a/ethportal-peertest/src/scenarios/eth_rpc.rs
+++ b/ethportal-peertest/src/scenarios/eth_rpc.rs
@@ -1,7 +1,6 @@
 use alloy::primitives::U256;
-use tracing::info;
-
 use ethportal_api::EthApiClient;
+use tracing::info;
 use trin_validation::constants::CHAIN_ID;
 
 use crate::Peertest;

--- a/ethportal-peertest/src/scenarios/find.rs
+++ b/ethportal-peertest/src/scenarios/find.rs
@@ -1,16 +1,16 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use discv5::enr::NodeId;
-use jsonrpsee::async_client::Client;
-use tracing::info;
-
-use crate::{utils::fixture_header_by_hash, Peertest};
 use ethportal_api::{
     types::{network::Subnetwork, portal::FindContentInfo},
     utils::bytes::hex_decode,
     BeaconNetworkApiClient, ContentValue, Enr, HistoryNetworkApiClient, OverlayContentKey,
     StateNetworkApiClient,
 };
+use jsonrpsee::async_client::Client;
+use tracing::info;
+
+use crate::{utils::fixture_header_by_hash, Peertest};
 
 pub async fn test_recursive_find_nodes_self(subnetwork: Subnetwork, peertest: &Peertest) {
     info!("Testing recursive find nodes self for {subnetwork}");

--- a/ethportal-peertest/src/scenarios/gossip.rs
+++ b/ethportal-peertest/src/scenarios/gossip.rs
@@ -1,5 +1,9 @@
 use std::net::{IpAddr, Ipv4Addr};
 
+use ethportal_api::{
+    jsonrpsee::async_client::Client, types::cli::TrinConfig, ContentValue, Discv5ApiClient,
+    HistoryNetworkApiClient,
+};
 use tracing::info;
 
 use crate::{
@@ -9,10 +13,6 @@ use crate::{
         fixture_receipts_15040641, wait_for_history_content,
     },
     Peertest,
-};
-use ethportal_api::{
-    jsonrpsee::async_client::Client, types::cli::TrinConfig, ContentValue, Discv5ApiClient,
-    HistoryNetworkApiClient,
 };
 pub async fn test_gossip_with_trace(peertest: &Peertest, target: &Client) {
     info!("Testing Gossip with tracing");

--- a/ethportal-peertest/src/scenarios/offer_accept.rs
+++ b/ethportal-peertest/src/scenarios/offer_accept.rs
@@ -1,6 +1,17 @@
 use std::{fs, str::FromStr};
 
 use alloy::primitives::Bytes;
+use e2store::era1::Era1;
+use ethportal_api::{
+    jsonrpsee::{async_client::Client, http_client::HttpClient},
+    types::{
+        cli::DEFAULT_UTP_TRANSFER_LIMIT, enr::Enr, execution::accumulator::EpochAccumulator,
+        portal_wire::OfferTrace,
+    },
+    utils::bytes::hex_encode,
+    ContentValue, Discv5ApiClient, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
+};
+use portal_bridge::api::execution::construct_proof;
 use ssz::Decode;
 use tracing::info;
 
@@ -13,17 +24,6 @@ use crate::{
     },
     Peertest,
 };
-use e2store::era1::Era1;
-use ethportal_api::{
-    jsonrpsee::{async_client::Client, http_client::HttpClient},
-    types::{
-        cli::DEFAULT_UTP_TRANSFER_LIMIT, enr::Enr, execution::accumulator::EpochAccumulator,
-        portal_wire::OfferTrace,
-    },
-    utils::bytes::hex_encode,
-    ContentValue, Discv5ApiClient, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
-};
-use portal_bridge::api::execution::construct_proof;
 
 pub async fn test_offer(peertest: &Peertest, target: &Client) {
     info!("Testing Offer/ACCEPT flow");

--- a/ethportal-peertest/src/scenarios/state.rs
+++ b/ethportal-peertest/src/scenarios/state.rs
@@ -1,10 +1,3 @@
-use crate::{
-    utils::{
-        fixtures_state_account_trie_node, fixtures_state_contract_bytecode,
-        fixtures_state_contract_storage_trie_node, wait_for_state_content, StateFixture,
-    },
-    Peertest, PeertestNode,
-};
 use ethportal_api::{
     jsonrpsee::async_client::Client,
     types::execution::header_with_proof::{BlockHeaderProof, HeaderWithProof, SszNone},
@@ -12,6 +5,14 @@ use ethportal_api::{
     StateNetworkApiClient,
 };
 use tracing::info;
+
+use crate::{
+    utils::{
+        fixtures_state_account_trie_node, fixtures_state_contract_bytecode,
+        fixtures_state_contract_storage_trie_node, wait_for_state_content, StateFixture,
+    },
+    Peertest, PeertestNode,
+};
 
 pub async fn test_state_offer_account_trie_node(peertest: &Peertest, target: &Client) {
     for fixture in fixtures_state_account_trie_node() {

--- a/ethportal-peertest/src/scenarios/utp.rs
+++ b/ethportal-peertest/src/scenarios/utp.rs
@@ -1,13 +1,14 @@
-use crate::{
-    utils::{fixture_block_body, fixture_header_by_hash},
-    Peertest,
-};
 use discv5::enr::NodeId;
 use ethportal_api::{
     types::portal::{GetContentInfo, TraceContentInfo},
     ContentValue, HistoryNetworkApiClient,
 };
 use tracing::info;
+
+use crate::{
+    utils::{fixture_block_body, fixture_header_by_hash},
+    Peertest,
+};
 
 pub async fn test_recursive_utp(peertest: &Peertest) {
     info!("Test recursive utp");

--- a/ethportal-peertest/src/scenarios/validation.rs
+++ b/ethportal-peertest/src/scenarios/validation.rs
@@ -1,17 +1,19 @@
-use crate::{
-    utils::{
-        fixture_block_body, fixture_header_by_hash, fixture_header_by_number, fixture_receipts,
-    },
-    Peertest,
-};
+use std::str::FromStr;
+
 use alloy::primitives::B256;
 use ethportal_api::{
     jsonrpsee::async_client::Client,
     types::{enr::Enr, portal::FindContentInfo},
     ContentValue, HistoryContentKey, HistoryNetworkApiClient,
 };
-use std::str::FromStr;
 use tracing::info;
+
+use crate::{
+    utils::{
+        fixture_block_body, fixture_header_by_hash, fixture_header_by_number, fixture_receipts,
+    },
+    Peertest,
+};
 
 pub async fn test_validate_pre_merge_header_by_hash(peertest: &Peertest, target: &Client) {
     info!("Test validating a pre-merge header by block hash");

--- a/ethportal-peertest/src/utils.rs
+++ b/ethportal-peertest/src/utils.rs
@@ -4,15 +4,7 @@ use std::{
 };
 
 use alloy::{primitives::Bytes, rlp::Decodable};
-use futures::{Future, TryFutureExt};
-use serde::Deserializer;
-use ssz::Decode;
-use tracing::error;
-
 use anyhow::Result;
-use serde_yaml::Value;
-use ureq::serde::Deserialize;
-
 use ethportal_api::{
     types::{
         content_key::history::{BlockHeaderByHashKey, BlockHeaderByNumberKey},
@@ -22,6 +14,12 @@ use ethportal_api::{
     ContentValue, Header, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
     RawContentValue, StateContentKey, StateContentValue, StateNetworkApiClient,
 };
+use futures::{Future, TryFutureExt};
+use serde::Deserializer;
+use serde_yaml::Value;
+use ssz::Decode;
+use tracing::error;
+use ureq::serde::Deserialize;
 
 pub async fn wait_for_successful_result<Fut, O>(f: impl Fn() -> Fut) -> O
 where

--- a/light-client/src/client.rs
+++ b/light-client/src/client.rs
@@ -1,22 +1,18 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use anyhow::{anyhow, Result};
-
-use crate::consensus::ConsensusLightClient;
+use ethportal_api::{consensus::header::BeaconBlockHeader, light_client::store::LightClientStore};
 use log::{error, info, warn};
-use tokio::sync::RwLock;
+use tokio::{spawn, sync::RwLock, time::sleep};
 
 use crate::{
     config::{client_config::Config, CheckpointFallback, Network},
-    consensus::{errors::ConsensusError, rpc::ConsensusRpc},
+    consensus::{errors::ConsensusError, rpc::ConsensusRpc, ConsensusLightClient},
+    database::Database,
+    errors::NodeError,
+    node::Node,
+    rpc::Rpc,
 };
-use ethportal_api::{consensus::header::BeaconBlockHeader, light_client::store::LightClientStore};
-use std::path::PathBuf;
-use tokio::{spawn, time::sleep};
-
-use crate::{database::Database, errors::NodeError, node::Node};
-
-use crate::rpc::Rpc;
 
 #[derive(Default)]
 pub struct ClientBuilder {

--- a/light-client/src/config/client_config.rs
+++ b/light-client/src/config/client_config.rs
@@ -1,9 +1,10 @@
+use std::{path::PathBuf, process::exit};
+
 use figment::{
     providers::{Format, Serialized, Toml},
     Figment,
 };
 use serde::Deserialize;
-use std::{path::PathBuf, process::exit};
 
 use crate::config::{
     networks,

--- a/light-client/src/consensus/consensus_client.rs
+++ b/light-client/src/consensus/consensus_client.rs
@@ -1,23 +1,12 @@
-use std::{cmp, sync::Arc};
+use std::{
+    cmp,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use alloy::primitives::B256;
 use anyhow::{anyhow, ensure, Result};
 use chrono::Duration;
-use milagro_bls::PublicKey;
-use ssz_rs::prelude::*;
-use tracing::{debug, info, warn};
-
-use super::{rpc::ConsensusRpc, types::*, utils::*};
-
-use super::errors::ConsensusError;
-use crate::{
-    config::client_config::Config,
-    consensus::{
-        constants::MAX_REQUEST_LIGHT_CLIENT_UPDATES, rpc::portal_rpc::expected_current_slot,
-    },
-    types::Bytes32,
-    utils::bytes_to_bytes32,
-};
 use ethportal_api::{
     consensus::{header::BeaconBlockHeader, signature::BlsSignature},
     light_client::{
@@ -29,9 +18,21 @@ use ethportal_api::{
     },
     utils::bytes::hex_encode,
 };
+use milagro_bls::PublicKey;
+use ssz_rs::prelude::*;
 use ssz_types::{typenum, BitVector, FixedVector};
-use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::{debug, info, warn};
 use tree_hash::TreeHash;
+
+use super::{errors::ConsensusError, rpc::ConsensusRpc, types::*, utils::*};
+use crate::{
+    config::client_config::Config,
+    consensus::{
+        constants::MAX_REQUEST_LIGHT_CLIENT_UPDATES, rpc::portal_rpc::expected_current_slot,
+    },
+    types::Bytes32,
+    utils::bytes_to_bytes32,
+};
 
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/sync-protocol.md
 // does not implement force updates

--- a/light-client/src/consensus/rpc/mock_rpc.rs
+++ b/light-client/src/consensus/rpc/mock_rpc.rs
@@ -1,12 +1,13 @@
 use std::{fs::read_to_string, path::PathBuf};
 
+use anyhow::Result;
+use async_trait::async_trait;
+
 use super::ConsensusRpc;
 use crate::consensus::types::{
     LightClientBootstrapDeneb, LightClientFinalityUpdateDeneb, LightClientOptimisticUpdateDeneb,
     LightClientUpdateDeneb,
 };
-use anyhow::Result;
-use async_trait::async_trait;
 
 #[derive(Clone, Debug)]
 pub struct MockRpc {

--- a/light-client/src/consensus/rpc/mod.rs
+++ b/light-client/src/consensus/rpc/mod.rs
@@ -2,12 +2,13 @@ pub mod mock_rpc;
 pub mod nimbus_rpc;
 pub mod portal_rpc;
 
+use anyhow::Result;
+use async_trait::async_trait;
+
 use super::types::{
     LightClientBootstrapDeneb, LightClientFinalityUpdateDeneb, LightClientOptimisticUpdateDeneb,
     LightClientUpdateDeneb,
 };
-use anyhow::Result;
-use async_trait::async_trait;
 
 // implements https://github.com/ethereum/beacon-APIs/tree/master/apis/beacon/light_client
 #[async_trait]

--- a/light-client/src/consensus/rpc/nimbus_rpc.rs
+++ b/light-client/src/consensus/rpc/nimbus_rpc.rs
@@ -1,14 +1,14 @@
-use crate::consensus::types::u64_deserialize;
+use std::cmp;
+
 use anyhow::Result;
 use async_trait::async_trait;
-use std::cmp;
 
 use super::ConsensusRpc;
 use crate::{
     consensus::{
         constants::MAX_REQUEST_LIGHT_CLIENT_UPDATES,
         types::{
-            LightClientBootstrapDeneb, LightClientFinalityUpdateDeneb,
+            u64_deserialize, LightClientBootstrapDeneb, LightClientFinalityUpdateDeneb,
             LightClientOptimisticUpdateDeneb, LightClientUpdateDeneb,
         },
     },

--- a/light-client/src/consensus/rpc/portal_rpc.rs
+++ b/light-client/src/consensus/rpc/portal_rpc.rs
@@ -1,4 +1,5 @@
-use crate::consensus::rpc::ConsensusRpc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
 use ethportal_api::{
@@ -19,9 +20,10 @@ use ethportal_api::{
 };
 use futures::channel::oneshot;
 use portalnet::overlay::command::OverlayCommand;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::warn;
+
+use crate::consensus::rpc::ConsensusRpc;
 
 pub const BEACON_GENESIS_TIME: u64 = 1606824023;
 

--- a/light-client/src/consensus/utils.rs
+++ b/light-client/src/consensus/utils.rs
@@ -1,9 +1,10 @@
-use crate::{types::Bytes32, utils::bytes32_to_node};
 use anyhow::Result;
 use ethportal_api::consensus::{header::BeaconBlockHeader, signature::BlsSignature};
 use milagro_bls::{AggregateSignature, PublicKey};
 use ssz_rs::prelude::*;
 use tree_hash::TreeHash;
+
+use crate::{types::Bytes32, utils::bytes32_to_node};
 
 pub fn calc_sync_period(slot: u64) -> u64 {
     let epoch = slot / 32; // 32 slots per epoch

--- a/light-client/src/database.rs
+++ b/light-client/src/database.rs
@@ -4,8 +4,9 @@ use std::{
     path::PathBuf,
 };
 
-use crate::config::client_config::Config;
 use anyhow::Result;
+
+use crate::config::client_config::Config;
 
 pub trait Database {
     fn new(config: &Config) -> Result<Self>

--- a/light-client/src/main.rs
+++ b/light-client/src/main.rs
@@ -1,9 +1,10 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use light_client::{
     config::networks, consensus::rpc::nimbus_rpc::NimbusRpc, database::FileDB, Client,
     ClientBuilder,
 };
-use std::path::PathBuf;
 use tracing::info;
 
 const CONSENSUS_RPC_URL: &str = "http://testing.mainnet.beacon-api.nimbus.team";

--- a/light-client/src/node.rs
+++ b/light-client/src/node.rs
@@ -1,13 +1,13 @@
 use std::{sync::Arc, time::Duration};
 
-use crate::{
-    config::client_config::Config,
-    consensus::{rpc::ConsensusRpc, ConsensusLightClient},
-};
 use anyhow::{Error, Result};
 use ethportal_api::{consensus::header::BeaconBlockHeader, light_client::store::LightClientStore};
 
-use crate::errors::NodeError;
+use crate::{
+    config::client_config::Config,
+    consensus::{rpc::ConsensusRpc, ConsensusLightClient},
+    errors::NodeError,
+};
 
 pub struct Node<R: ConsensusRpc> {
     pub consensus: ConsensusLightClient<R>,

--- a/light-client/src/rpc.rs
+++ b/light-client/src/rpc.rs
@@ -1,19 +1,16 @@
-use anyhow::Result;
-use log::info;
 use std::{net::SocketAddr, sync::Arc};
-use tokio::sync::RwLock;
 
-use crate::consensus::rpc::ConsensusRpc;
+use anyhow::Result;
 use jsonrpsee::{
     core::{async_trait, RpcResult},
     proc_macros::rpc,
     server::{Server, ServerHandle},
     Methods,
 };
+use log::info;
+use tokio::sync::RwLock;
 
-use crate::node::Node;
-
-use crate::utils::u64_to_hex_string;
+use crate::{consensus::rpc::ConsensusRpc, node::Node, utils::u64_to_hex_string};
 
 #[derive(Clone)]
 pub struct Rpc<R: ConsensusRpc> {

--- a/light-client/src/utils.rs
+++ b/light-client/src/utils.rs
@@ -1,6 +1,7 @@
-use crate::types::Bytes32;
 use anyhow::Result;
 use ssz_rs::{Node, Vector};
+
+use crate::types::Bytes32;
 
 pub fn bytes_to_bytes32(bytes: &[u8]) -> Bytes32 {
     Vector::from_iter(bytes.to_vec())

--- a/portal-bridge/src/bridge/beacon.rs
+++ b/portal-bridge/src/bridge/beacon.rs
@@ -1,27 +1,11 @@
-use std::sync::Mutex as StdMutex;
+use std::{
+    cmp::Ordering,
+    path::PathBuf,
+    sync::{Arc, Mutex as StdMutex},
+    time::SystemTime,
+};
 
 use anyhow::{bail, ensure};
-use jsonrpsee::http_client::HttpClient;
-use serde_json::Value;
-use ssz_types::VariableList;
-use std::{cmp::Ordering, path::PathBuf, sync::Arc, time::SystemTime};
-use tokio::{
-    sync::Mutex,
-    time::{interval, sleep, Duration, MissedTickBehavior},
-};
-use tracing::{info, warn, Instrument};
-use trin_metrics::bridge::BridgeMetricsReporter;
-
-use crate::{
-    api::consensus::ConsensusApi,
-    constants::BEACON_GENESIS_TIME,
-    gossip::gossip_beacon_content,
-    stats::{BeaconSlotStats, StatsReporter},
-    types::mode::BridgeMode,
-    utils::{
-        duration_until_next_update, expected_current_slot, read_test_assets_from_file, TestAssets,
-    },
-};
 use ethportal_api::{
     consensus::{
         beacon_state::BeaconStateDeneb,
@@ -46,6 +30,26 @@ use ethportal_api::{
     },
     utils::bytes::hex_decode,
     BeaconContentKey, BeaconContentValue, LightClientBootstrapKey, LightClientUpdatesByRangeKey,
+};
+use jsonrpsee::http_client::HttpClient;
+use serde_json::Value;
+use ssz_types::VariableList;
+use tokio::{
+    sync::Mutex,
+    time::{interval, sleep, Duration, MissedTickBehavior},
+};
+use tracing::{info, warn, Instrument};
+use trin_metrics::bridge::BridgeMetricsReporter;
+
+use crate::{
+    api::consensus::ConsensusApi,
+    constants::BEACON_GENESIS_TIME,
+    gossip::gossip_beacon_content,
+    stats::{BeaconSlotStats, StatsReporter},
+    types::mode::BridgeMode,
+    utils::{
+        duration_until_next_update, expected_current_slot, read_test_assets_from_file, TestAssets,
+    },
 };
 
 /// The number of slots in an epoch.

--- a/portal-bridge/src/bridge/era1.rs
+++ b/portal-bridge/src/bridge/era1.rs
@@ -10,6 +10,10 @@ use e2store::{
     era1::{BlockTuple, Era1},
     utils::get_shuffled_era1_files,
 };
+use ethportal_api::{
+    jsonrpsee::http_client::HttpClient, types::execution::accumulator::EpochAccumulator,
+    HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
+};
 use futures::future::join_all;
 use rand::{seq::SliceRandom, thread_rng};
 use reqwest::{
@@ -23,6 +27,9 @@ use tokio::{
 };
 use tracing::{debug, error, info, warn};
 use trin_metrics::bridge::BridgeMetricsReporter;
+use trin_validation::{
+    constants::EPOCH_SIZE, header_validator::HeaderValidator, oracle::HeaderOracle,
+};
 
 use crate::{
     api::execution::{construct_proof, ExecutionApi},
@@ -33,13 +40,6 @@ use crate::{
     gossip::gossip_history_content,
     stats::{HistoryBlockStats, StatsReporter},
     types::mode::{BridgeMode, FourFoursMode},
-};
-use ethportal_api::{
-    jsonrpsee::http_client::HttpClient, types::execution::accumulator::EpochAccumulator,
-    HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
-};
-use trin_validation::{
-    constants::EPOCH_SIZE, header_validator::HeaderValidator, oracle::HeaderOracle,
 };
 
 pub struct Era1Bridge {

--- a/portal-bridge/src/bridge/history.rs
+++ b/portal-bridge/src/bridge/history.rs
@@ -3,6 +3,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use ethportal_api::{
+    jsonrpsee::http_client::HttpClient, types::execution::accumulator::EpochAccumulator,
+    HistoryContentKey,
+};
 use futures::future::join_all;
 use tokio::{
     sync::{OwnedSemaphorePermit, Semaphore},
@@ -11,6 +15,10 @@ use tokio::{
 };
 use tracing::{debug, error, info, warn, Instrument};
 use trin_metrics::bridge::BridgeMetricsReporter;
+use trin_validation::{
+    constants::{EPOCH_SIZE, MERGE_BLOCK_NUMBER},
+    oracle::HeaderOracle,
+};
 
 use crate::{
     api::execution::ExecutionApi,
@@ -19,14 +27,6 @@ use crate::{
     stats::{HistoryBlockStats, StatsReporter},
     types::{full_header::FullHeader, mode::BridgeMode},
     utils::{read_test_assets_from_file, TestAssets},
-};
-use ethportal_api::{
-    jsonrpsee::http_client::HttpClient, types::execution::accumulator::EpochAccumulator,
-    HistoryContentKey,
-};
-use trin_validation::{
-    constants::{EPOCH_SIZE, MERGE_BLOCK_NUMBER},
-    oracle::HeaderOracle,
 };
 
 // todo: calculate / test optimal saturation delay

--- a/portal-bridge/src/bridge/utils.rs
+++ b/portal-bridge/src/bridge/utils.rs
@@ -1,7 +1,8 @@
+use std::{fs, path::Path};
+
 use anyhow::anyhow;
 use ethportal_api::{types::execution::accumulator::EpochAccumulator, utils::bytes::hex_encode};
 use ssz::Decode;
-use std::{fs, path::Path};
 use trin_validation::accumulator::PreMergeAccumulator;
 
 /// Lookup the epoch accumulator & epoch hash for the given epoch index.

--- a/portal-bridge/src/census/mod.rs
+++ b/portal-bridge/src/census/mod.rs
@@ -6,12 +6,12 @@ use ethportal_api::{
     types::{network::Subnetwork, portal_wire::OfferTrace},
     Enr,
 };
+use network::{Network, NetworkAction, NetworkInitializationConfig, NetworkManager};
 use thiserror::Error;
 use tokio::task::JoinHandle;
 use tracing::{error, info, Instrument};
 
 use crate::cli::BridgeConfig;
-use network::{Network, NetworkAction, NetworkInitializationConfig, NetworkManager};
 
 mod network;
 mod peer;

--- a/portal-bridge/src/census/network.rs
+++ b/portal-bridge/src/census/network.rs
@@ -16,14 +16,13 @@ use tokio::{
 };
 use tracing::{debug, error, info, warn};
 
-use crate::{
-    census::CensusError,
-    cli::{BridgeConfig, ClientType},
-};
-
 use super::{
     peers::Peers,
     scoring::{AdditiveWeight, PeerSelector},
+};
+use crate::{
+    census::CensusError,
+    cli::{BridgeConfig, ClientType},
 };
 
 /// The result of the liveness check.

--- a/portal-bridge/src/cli.rs
+++ b/portal-bridge/src/cli.rs
@@ -2,6 +2,18 @@ use std::{env, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
 
 use alloy::primitives::B256;
 use clap::Parser;
+use ethportal_api::{
+    types::{
+        cli::{
+            check_private_key_length, network_parser, DEFAULT_DISCOVERY_PORT, DEFAULT_NETWORK,
+            DEFAULT_WEB3_HTTP_PORT,
+        },
+        network::Subnetwork,
+        portal_wire::NetworkSpec,
+    },
+    Enr,
+};
+use portalnet::discovery::ENR_PORTAL_CLIENT_KEY;
 use reqwest::{
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},
     Client, IntoUrl, Request, Response,
@@ -19,18 +31,6 @@ use crate::{
     DEFAULT_BASE_CL_ENDPOINT, DEFAULT_BASE_EL_ENDPOINT, FALLBACK_BASE_CL_ENDPOINT,
     FALLBACK_BASE_EL_ENDPOINT,
 };
-use ethportal_api::{
-    types::{
-        cli::{
-            check_private_key_length, network_parser, DEFAULT_DISCOVERY_PORT, DEFAULT_NETWORK,
-            DEFAULT_WEB3_HTTP_PORT,
-        },
-        network::Subnetwork,
-        portal_wire::NetworkSpec,
-    },
-    Enr,
-};
-use portalnet::discovery::ENR_PORTAL_CLIENT_KEY;
 
 const DEFAULT_SUBNETWORK: &str = "history";
 const DEFAULT_EXECUTABLE_PATH: &str = "./target/debug/trin";

--- a/portal-bridge/src/gossip.rs
+++ b/portal-bridge/src/gossip.rs
@@ -1,15 +1,15 @@
 use std::sync::{Arc, Mutex};
 
-use jsonrpsee::http_client::HttpClient;
-use tokio::time::{sleep, Duration};
-use tracing::{debug, warn, Instrument};
-
-use crate::stats::{BeaconSlotStats, HistoryBlockStats, StatsReporter};
 use ethportal_api::{
     types::portal::TraceGossipInfo, BeaconContentKey, BeaconContentValue, BeaconNetworkApiClient,
     ContentValue, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
     OverlayContentKey,
 };
+use jsonrpsee::http_client::HttpClient;
+use tokio::time::{sleep, Duration};
+use tracing::{debug, warn, Instrument};
+
+use crate::stats::{BeaconSlotStats, HistoryBlockStats, StatsReporter};
 
 const GOSSIP_RETRY_COUNT: u64 = 3;
 const RETRY_AFTER: Duration = Duration::from_secs(15);

--- a/portal-bridge/src/handle.rs
+++ b/portal-bridge/src/handle.rs
@@ -1,9 +1,9 @@
 use std::collections::HashSet;
 
+use ethportal_api::{types::network::Subnetwork, utils::bytes::hex_encode};
 use tokio::process::{Child, Command};
 
 use crate::cli::BridgeConfig;
-use ethportal_api::{types::network::Subnetwork, utils::bytes::hex_encode};
 
 pub fn build_trin(bridge_config: &BridgeConfig) -> anyhow::Result<Child> {
     if !bridge_config.executable_path.is_file() {

--- a/portal-bridge/src/main.rs
+++ b/portal-bridge/src/main.rs
@@ -1,7 +1,4 @@
 use clap::Parser;
-use tokio::time::{sleep, Duration};
-use tracing::Instrument;
-
 use ethportal_api::{
     jsonrpsee::http_client::{HttpClient, HttpClientBuilder},
     types::network::Subnetwork,
@@ -14,6 +11,8 @@ use portal_bridge::{
     handle::build_trin,
     types::mode::BridgeMode,
 };
+use tokio::time::{sleep, Duration};
+use tracing::Instrument;
 use trin_utils::log::init_tracing_logger;
 use trin_validation::oracle::HeaderOracle;
 

--- a/portal-bridge/src/stats.rs
+++ b/portal-bridge/src/stats.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashSet, str::FromStr};
 
+use ethportal_api::{types::enr::Enr, BeaconContentKey, HistoryContentKey};
 use tracing::{debug, info};
 
 use crate::gossip::GossipReport;
-use ethportal_api::{types::enr::Enr, BeaconContentKey, HistoryContentKey};
 
 // Trait for tracking / reporting gossip stats
 pub trait StatsReporter<TContentKey> {

--- a/portal-bridge/src/types/full_header.rs
+++ b/portal-bridge/src/types/full_header.rs
@@ -2,15 +2,14 @@ use std::sync::Arc;
 
 use alloy::primitives::B256;
 use anyhow::{anyhow, ensure};
-use serde::{Deserialize, Deserializer};
-use serde_json::Value;
-
 use ethportal_api::types::execution::{
     accumulator::EpochAccumulator,
     header::{Header, TxHashes},
     transaction::Transaction,
     withdrawal::Withdrawal,
 };
+use serde::{Deserialize, Deserializer};
+use serde_json::Value;
 use trin_validation::constants::{EPOCH_SIZE, MERGE_BLOCK_NUMBER};
 
 /// Helper type to deserialize a response from a batched Header request.
@@ -112,12 +111,13 @@ impl FullHeader {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use ethportal_api::types::execution::block_body::{
         BlockBody, BlockBodyLegacy, BlockBodyShanghai,
     };
     use serde_json::Value;
     use ssz::{Decode, Encode};
+
+    use super::*;
 
     #[test]
     fn full_header_from_get_block_response() {

--- a/portal-bridge/src/types/mode.rs
+++ b/portal-bridge/src/types/mode.rs
@@ -1,7 +1,6 @@
 use std::{ops::Range, path::PathBuf, str::FromStr};
 
 use anyhow::anyhow;
-
 use trin_validation::constants::EPOCH_SIZE;
 
 /// Used to help decode cli args identifying the desired bridge mode.
@@ -302,8 +301,9 @@ impl FromStr for FourFoursMode {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case("latest", BridgeMode::Latest)]

--- a/portal-bridge/src/utils.rs
+++ b/portal-bridge/src/utils.rs
@@ -8,12 +8,11 @@ use alloy::primitives::B256;
 use anyhow::{anyhow, bail};
 use chrono::Duration;
 use discv5::enr::{CombinedKey, Enr, NodeId};
-use serde::{Deserialize, Serialize};
-
 use ethportal_api::{
     utils::bytes::hex_encode, BeaconContentKey, BeaconContentValue, ContentValue,
     HistoryContentKey, HistoryContentValue, RawContentValue,
 };
+use serde::{Deserialize, Serialize};
 
 /// Generates a set of N private keys, with node ids that are equally spaced
 /// around the 256-bit keys space.
@@ -187,10 +186,6 @@ fn slot_timestamp(slot: u64, genesis_time: u64) -> u64 {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
-    use crate::constants::{
-        BEACON_GENESIS_TIME, HEADER_WITH_PROOF_CONTENT_KEY, HEADER_WITH_PROOF_CONTENT_VALUE,
-    };
     use chrono::{DateTime, TimeZone, Utc};
     use ethportal_api::{
         types::distance::{Metric, XorMetric},
@@ -198,6 +193,11 @@ mod tests {
     };
     use rstest::rstest;
     use serde_json::json;
+
+    use super::*;
+    use crate::constants::{
+        BEACON_GENESIS_TIME, HEADER_WITH_PROOF_CONTENT_KEY, HEADER_WITH_PROOF_CONTENT_VALUE,
+    };
 
     #[rstest]
     #[case(2)]

--- a/portalnet/src/accept_queue.rs
+++ b/portalnet/src/accept_queue.rs
@@ -108,8 +108,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use ethportal_api::{types::enr::generate_random_remote_enr, IdentityContentKey};
+
+    use super::*;
 
     #[tokio::test]
     async fn test_remove_key() {

--- a/portalnet/src/discovery.rs
+++ b/portalnet/src/discovery.rs
@@ -15,6 +15,12 @@ use discv5::{
     enr::{CombinedKey, Enr as Discv5Enr, NodeId},
     ConfigBuilder, Discv5, Event, ListenConfig, RequestError, TalkRequest,
 };
+use ethportal_api::{
+    types::{discv5::RoutingTableInfo, enr::Enr, network::Subnetwork, portal_wire::NetworkSpec},
+    utils::bytes::hex_decode,
+    version::get_trin_version,
+    NodeInfo,
+};
 use lru::LruCache;
 use parking_lot::RwLock;
 use tokio::sync::{mpsc, RwLock as TokioRwLock};
@@ -24,12 +30,6 @@ use utp_rs::{cid::ConnectionPeer, udp::AsyncUdpSocket};
 
 use super::config::PortalnetConfig;
 use crate::socket;
-use ethportal_api::{
-    types::{discv5::RoutingTableInfo, enr::Enr, network::Subnetwork, portal_wire::NetworkSpec},
-    utils::bytes::hex_decode,
-    version::get_trin_version,
-    NodeInfo,
-};
 
 /// Size of the buffer of the Discv5 TALKREQ channel.
 const TALKREQ_CHANNEL_BUFFER: usize = 100;

--- a/portalnet/src/events.rs
+++ b/portalnet/src/events.rs
@@ -4,15 +4,14 @@ use std::{
 };
 
 use discv5::TalkRequest;
-use futures::stream::{select_all, StreamExt};
-use tokio::sync::{broadcast, mpsc};
-use tokio_stream::wrappers::BroadcastStream;
-use tracing::{debug, error, trace, warn};
-
 use ethportal_api::{
     types::{network::Subnetwork, portal_wire::NetworkSpec},
     utils::bytes::{hex_encode, hex_encode_upper},
 };
+use futures::stream::{select_all, StreamExt};
+use tokio::sync::{broadcast, mpsc};
+use tokio_stream::wrappers::BroadcastStream;
+use tracing::{debug, error, trace, warn};
 
 /// Handles for communication between the main event handler and an overlay.
 pub struct OverlayHandle {
@@ -305,8 +304,9 @@ pub fn millis_to_epoch(time: SystemTime) -> i64 {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use std::time::SystemTime;
+
+    use super::*;
 
     #[test]
     fn test_timestamp_creation() {

--- a/portalnet/src/find/iterators/findcontent.rs
+++ b/portalnet/src/find/iterators/findcontent.rs
@@ -492,13 +492,15 @@ where
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
+    use std::{cmp::min, time::Duration};
+
     use discv5::enr::NodeId;
     use quickcheck::*;
     use rand::{thread_rng, Rng};
-    use std::{cmp::min, time::Duration};
     use test_log::test;
     use tracing::trace;
+
+    use super::*;
 
     type TestQuery = FindContentQuery<NodeId>;
 

--- a/portalnet/src/find/iterators/findnodes.rs
+++ b/portalnet/src/find/iterators/findnodes.rs
@@ -21,15 +21,16 @@
 // This basis of this file has been taken from the rust-libp2p codebase:
 // https://github.com/libp2p/rust-libp2p
 
-use super::{
-    super::query_pool::QueryState,
-    query::{Query, QueryConfig, QueryPeer, QueryPeerState, QueryProgress},
-};
-
-use discv5::kbucket::{Distance, Key};
 use std::{
     collections::btree_map::{BTreeMap, Entry},
     time::Instant,
+};
+
+use discv5::kbucket::{Distance, Key};
+
+use super::{
+    super::query_pool::QueryState,
+    query::{Query, QueryConfig, QueryPeer, QueryPeerState, QueryProgress},
 };
 
 #[derive(Debug, Clone)]
@@ -334,12 +335,14 @@ where
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
+    use std::time::Duration;
+
     use discv5::enr::NodeId;
     use quickcheck::*;
     use rand::{thread_rng, Rng};
-    use std::time::Duration;
     use test_log::test;
+
+    use super::*;
 
     type TestQuery = FindNodeQuery<NodeId>;
 

--- a/portalnet/src/find/query_info.rs
+++ b/portalnet/src/find/query_info.rs
@@ -1,8 +1,4 @@
 use discv5::{enr::NodeId, kbucket::Key, Enr};
-use futures::channel::oneshot;
-use smallvec::SmallVec;
-
-use crate::{find::query_pool::TargetKey, overlay::errors::OverlayRequestError};
 use ethportal_api::{
     types::{
         portal_wire::{Content, FindContent, FindNodes, Request},
@@ -10,6 +6,10 @@ use ethportal_api::{
     },
     OverlayContentKey, RawContentValue,
 };
+use futures::channel::oneshot;
+use smallvec::SmallVec;
+
+use crate::{find::query_pool::TargetKey, overlay::errors::OverlayRequestError};
 
 /// Information about a query.
 #[derive(Debug)]
@@ -130,8 +130,9 @@ fn findnode_log2distance(target: NodeId, peer: NodeId, size: usize) -> Option<Ve
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
     use test_log::test;
+
+    use super::*;
 
     #[test]
     fn test_log2distance() {

--- a/portalnet/src/find/query_pool.rs
+++ b/portalnet/src/find/query_pool.rs
@@ -21,12 +21,13 @@
 // This basis of this file has been taken from the rust-libp2p codebase:
 // https://github.com/libp2p/rust-libp2p
 
-use super::{iterators::query::Query, query_info::QueryInfo};
-use ethportal_api::OverlayContentKey;
+use std::{marker::PhantomData, time::Instant};
 
 use discv5::kbucket::Key;
+use ethportal_api::OverlayContentKey;
 use fnv::FnvHashMap;
-use std::{marker::PhantomData, time::Instant};
+
+use super::{iterators::query::Query, query_info::QueryInfo};
 
 pub trait TargetKey<TNodeId> {
     fn key(&self) -> Key<TNodeId>;

--- a/portalnet/src/gossip.rs
+++ b/portalnet/src/gossip.rs
@@ -1,5 +1,15 @@
 use std::{collections::HashMap, sync::Arc};
 
+use ethportal_api::{
+    types::{
+        distance::Metric,
+        enr::Enr,
+        portal::MAX_CONTENT_KEYS_PER_OFFER,
+        portal_wire::{OfferTrace, PopulatedOffer, PopulatedOfferWithResult, Request, Response},
+    },
+    utils::bytes::{hex_encode, hex_encode_compact},
+    OverlayContentKey, RawContentValue,
+};
 use futures::channel::oneshot;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -13,16 +23,6 @@ use crate::{
     },
     types::kbucket::SharedKBucketsTable,
     utp_controller::UtpController,
-};
-use ethportal_api::{
-    types::{
-        distance::Metric,
-        enr::Enr,
-        portal::MAX_CONTENT_KEYS_PER_OFFER,
-        portal_wire::{OfferTrace, PopulatedOffer, PopulatedOfferWithResult, Request, Response},
-    },
-    utils::bytes::{hex_encode, hex_encode_compact},
-    OverlayContentKey, RawContentValue,
 };
 
 /// Datatype to store the result of a gossip request.
@@ -249,12 +249,11 @@ fn select_gossip_recipients<TMetric: Metric>(
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
-
+    use ethportal_api::types::{distance::XorMetric, enr::generate_random_remote_enr};
     use rand::random;
     use rstest::rstest;
 
-    use ethportal_api::types::{distance::XorMetric, enr::generate_random_remote_enr};
+    use super::*;
 
     #[allow(clippy::zero_repeat_side_effects)]
     #[rstest]

--- a/portalnet/src/overlay/command.rs
+++ b/portalnet/src/overlay/command.rs
@@ -1,10 +1,10 @@
 use discv5::enr::NodeId;
+use ethportal_api::types::enr::Enr;
 use futures::channel::oneshot;
 use tokio::sync::broadcast;
 
 use super::{config::FindContentConfig, request::OverlayRequest};
 use crate::{events::EventEnvelope, find::query_info::RecursiveFindContentResult};
-use ethportal_api::types::enr::Enr;
 
 /// A network-based action that the overlay may perform.
 ///

--- a/portalnet/src/overlay/config.rs
+++ b/portalnet/src/overlay/config.rs
@@ -3,9 +3,9 @@
 use std::time::Duration;
 
 use discv5::kbucket::{Filter, MAX_NODES_PER_BUCKET};
+use ethportal_api::types::{cli::DEFAULT_UTP_TRANSFER_LIMIT, enr::Enr};
 
 use crate::{constants::DEFAULT_QUERY_TIMEOUT, types::node::Node};
-use ethportal_api::types::{cli::DEFAULT_UTP_TRANSFER_LIMIT, enr::Enr};
 
 /// Configuration parameters for the overlay network.
 #[derive(Clone)]

--- a/portalnet/src/overlay/errors.rs
+++ b/portalnet/src/overlay/errors.rs
@@ -1,6 +1,5 @@
-use thiserror::Error;
-
 use ethportal_api::types::query_trace::QueryTrace;
+use thiserror::Error;
 
 /// An overlay request error.
 #[derive(Clone, Error, Debug)]

--- a/portalnet/src/overlay/protocol.rs
+++ b/portalnet/src/overlay/protocol.rs
@@ -14,30 +14,6 @@ use discv5::{
     kbucket::{FailureReason, InsertResult, KBucketsTable, NodeStatus},
     ConnectionDirection, ConnectionState, TalkRequest,
 };
-use futures::channel::oneshot;
-use parking_lot::RwLock;
-use ssz::Encode;
-use tokio::sync::{broadcast, mpsc::UnboundedSender};
-use tracing::{debug, error, info, warn};
-use utp_rs::socket::UtpSocket;
-
-use crate::{
-    discovery::{Discovery, UtpEnr},
-    find::query_info::{FindContentResult, RecursiveFindContentResult},
-    gossip::{propagate_gossip_cross_thread, trace_propagate_gossip_cross_thread, GossipResult},
-    overlay::{
-        command::OverlayCommand,
-        config::{FindContentConfig, OverlayConfig},
-        errors::OverlayRequestError,
-        request::{OverlayRequest, RequestDirection},
-        service::OverlayService,
-    },
-    types::{
-        kbucket::{Entry, SharedKBucketsTable},
-        node::Node,
-    },
-    utp_controller::UtpController,
-};
 use ethportal_api::{
     types::{
         bootnodes::Bootnode,
@@ -53,11 +29,34 @@ use ethportal_api::{
     utils::bytes::hex_encode,
     OverlayContentKey, RawContentKey, RawContentValue,
 };
+use futures::channel::oneshot;
+use parking_lot::RwLock;
+use ssz::Encode;
+use tokio::sync::{broadcast, mpsc::UnboundedSender};
+use tracing::{debug, error, info, warn};
 use trin_metrics::{overlay::OverlayMetricsReporter, portalnet::PORTALNET_METRICS};
 use trin_storage::ContentStore;
 use trin_validation::validator::{ValidationResult, Validator};
+use utp_rs::socket::UtpSocket;
 
-use crate::events::EventEnvelope;
+use crate::{
+    discovery::{Discovery, UtpEnr},
+    events::EventEnvelope,
+    find::query_info::{FindContentResult, RecursiveFindContentResult},
+    gossip::{propagate_gossip_cross_thread, trace_propagate_gossip_cross_thread, GossipResult},
+    overlay::{
+        command::OverlayCommand,
+        config::{FindContentConfig, OverlayConfig},
+        errors::OverlayRequestError,
+        request::{OverlayRequest, RequestDirection},
+        service::OverlayService,
+    },
+    types::{
+        kbucket::{Entry, SharedKBucketsTable},
+        node::Node,
+    },
+    utp_controller::UtpController,
+};
 
 /// Overlay protocol is a layer on top of discv5 that handles all requests from the overlay networks
 /// (state, history etc.) and dispatch them to the discv5 protocol TalkReq. Each network should
@@ -737,8 +736,9 @@ fn validate_find_nodes_distances(distances: &[u16]) -> Result<(), OverlayRequest
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case(vec![0u16])]

--- a/portalnet/src/overlay/request.rs
+++ b/portalnet/src/overlay/request.rs
@@ -1,15 +1,15 @@
 use std::fmt::Debug;
 
 use discv5::{enr::NodeId, rpc::RequestId};
+use ethportal_api::types::{
+    enr::Enr,
+    portal_wire::{Request, Response},
+};
 use futures::channel::oneshot;
 use tokio::sync::OwnedSemaphorePermit;
 
 use super::errors::OverlayRequestError;
 use crate::find::query_pool::QueryId;
-use ethportal_api::types::{
-    enr::Enr,
-    portal_wire::{Request, Response},
-};
 
 /// An incoming or outgoing request.
 #[derive(Debug, PartialEq)]

--- a/portalnet/src/socket.rs
+++ b/portalnet/src/socket.rs
@@ -3,6 +3,7 @@ use std::{
     net::{IpAddr, SocketAddr, TcpStream, UdpSocket},
     thread,
 };
+
 use tracing::{debug, info, warn};
 
 // This stun server is part of the mainnet infrastructure.

--- a/portalnet/src/utils/db.rs
+++ b/portalnet/src/utils/db.rs
@@ -6,7 +6,6 @@ use std::{
 use alloy::primitives::B256;
 use anyhow::{anyhow, bail};
 use discv5::enr::{CombinedKey, Enr, NodeId};
-
 use ethportal_api::{
     types::network::Network,
     utils::bytes::{hex_decode, hex_encode},
@@ -80,10 +79,10 @@ fn get_application_private_key(trin_data_dir: &Path) -> anyhow::Result<CombinedK
 
 #[cfg(test)]
 pub mod test {
-    use super::*;
-
     use serial_test::serial;
     use trin_utils::dir::create_temp_test_dir;
+
+    use super::*;
 
     #[test]
     #[serial]

--- a/portalnet/src/utils/portal_wire.rs
+++ b/portalnet/src/utils/portal_wire.rs
@@ -1,6 +1,7 @@
+use std::io::{Read, Write};
+
 use anyhow::anyhow;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use std::io::{Read, Write};
 
 /// Decode content values from uTP payload. All content values are encoded with a LEB128 varint
 /// prefix which indicates the length in bytes of the consecutive content item.
@@ -72,9 +73,10 @@ pub fn read_varint(buf: &[u8]) -> anyhow::Result<(usize, u32)> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ethportal_api::utils::bytes::hex_decode;
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case(u8::MIN as u32)]

--- a/portalnet/src/utp_controller.rs
+++ b/portalnet/src/utp_controller.rs
@@ -1,8 +1,8 @@
-use crate::discovery::UtpEnr;
+use std::{sync::Arc, time::Duration};
+
 use anyhow::anyhow;
 use bytes::Bytes;
 use lazy_static::lazy_static;
-use std::{sync::Arc, time::Duration};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::debug;
 use trin_metrics::{
@@ -10,6 +10,8 @@ use trin_metrics::{
     overlay::OverlayMetricsReporter,
 };
 use utp_rs::{cid::ConnectionId, conn::ConnectionConfig, socket::UtpSocket};
+
+use crate::discovery::UtpEnr;
 /// UtpController is meant to be a container which contains all code related to/for managing uTP
 /// streams We are implementing this because we want the utils of controlling uTP connection to be
 /// as contained as it can, instead of extending overlay_service even more.

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -1,12 +1,5 @@
 use alloy::primitives::B256;
 use discv5::enr::NodeId;
-use tokio::sync::mpsc;
-
-use crate::{
-    errors::RpcServeError,
-    fetch::proxy_to_subnet,
-    jsonrpsee::core::{async_trait, RpcResult},
-};
 use ethportal_api::{
     consensus::header::BeaconBlockHeader,
     light_client::store::LightClientStore,
@@ -22,6 +15,13 @@ use ethportal_api::{
     },
     BeaconContentKey, BeaconContentValue, BeaconNetworkApiServer, ContentValue, RawContentValue,
     RoutingTableInfo,
+};
+use tokio::sync::mpsc;
+
+use crate::{
+    errors::RpcServeError,
+    fetch::proxy_to_subnet,
+    jsonrpsee::core::{async_trait, RpcResult},
 };
 
 pub struct BeaconNetworkApi {

--- a/rpc/src/builder.rs
+++ b/rpc/src/builder.rs
@@ -1,9 +1,9 @@
-use crate::{
-    errors::{RpcError, WsHttpSamePortError},
-    jsonrpsee::{Methods, RpcModule},
-    rpc_server::{RpcServerConfig, RpcServerHandle},
-    BeaconNetworkApi, Discv5Api, EthApi, HistoryNetworkApi, StateNetworkApi, Web3Api,
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    sync::Arc,
 };
+
 use ethportal_api::{
     types::jsonrpc::request::{BeaconJsonRpcRequest, HistoryJsonRpcRequest, StateJsonRpcRequest},
     BeaconNetworkApiServer, Discv5ApiServer, EthApiServer, HistoryNetworkApiServer,
@@ -11,13 +11,15 @@ use ethportal_api::{
 };
 use portalnet::discovery::Discovery;
 use serde::Deserialize;
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-    sync::Arc,
-};
 use strum::{AsRefStr, EnumString, VariantNames};
 use tokio::sync::mpsc;
+
+use crate::{
+    errors::{RpcError, WsHttpSamePortError},
+    jsonrpsee::{Methods, RpcModule},
+    rpc_server::{RpcServerConfig, RpcServerHandle},
+    BeaconNetworkApi, Discv5Api, EthApi, HistoryNetworkApi, StateNetworkApi, Web3Api,
+};
 
 /// Represents RPC modules that are supported by Trin
 #[derive(

--- a/rpc/src/discv5_rpc.rs
+++ b/rpc/src/discv5_rpc.rs
@@ -1,10 +1,13 @@
-use crate::errors::RpcServeError;
+use std::sync::Arc;
 
-use crate::jsonrpsee::core::{async_trait, RpcResult};
 use discv5::enr::NodeId;
 use ethportal_api::{types::enr::Enr, Discv5ApiServer, NodeInfo, RoutingTableInfo};
 use portalnet::discovery::Discovery;
-use std::sync::Arc;
+
+use crate::{
+    errors::RpcServeError,
+    jsonrpsee::core::{async_trait, RpcResult},
+};
 
 pub struct Discv5Api {
     discv5: Arc<Discovery>,

--- a/rpc/src/errors.rs
+++ b/rpc/src/errors.rs
@@ -1,3 +1,9 @@
+use std::io;
+
+use ethportal_api::{types::query_trace::QueryTrace, ContentValueError};
+use reth_ipc::server::IpcServerStartError;
+use serde::{Deserialize, Serialize};
+
 use crate::{
     jsonrpsee::{
         server::AlreadyStoppedError,
@@ -6,10 +12,6 @@ use crate::{
     rpc_server::ServerKind,
     PortalRpcModule,
 };
-use ethportal_api::{types::query_trace::QueryTrace, ContentValueError};
-use reth_ipc::server::IpcServerStartError;
-use serde::{Deserialize, Serialize};
-use std::io;
 
 /// Rpc Errors.
 #[derive(Debug, thiserror::Error)]

--- a/rpc/src/fetch.rs
+++ b/rpc/src/fetch.rs
@@ -1,7 +1,6 @@
+use ethportal_api::types::jsonrpc::{endpoints::SubnetworkEndpoint, request::JsonRpcRequest};
 use serde_json::Value;
 use tokio::sync::mpsc;
-
-use ethportal_api::types::jsonrpc::{endpoints::SubnetworkEndpoint, request::JsonRpcRequest};
 
 use crate::{
     errors::{ContentNotFoundJsonError, RpcServeError},

--- a/rpc/src/history_rpc.rs
+++ b/rpc/src/history_rpc.rs
@@ -1,6 +1,4 @@
 use discv5::enr::NodeId;
-use tokio::sync::mpsc;
-
 use ethportal_api::{
     types::{
         enr::Enr,
@@ -15,6 +13,7 @@ use ethportal_api::{
     ContentValue, HistoryContentKey, HistoryContentValue, HistoryNetworkApiServer, RawContentValue,
     RoutingTableInfo,
 };
+use tokio::sync::mpsc;
 
 use crate::{
     errors::RpcServeError,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -15,8 +15,11 @@ mod serde;
 mod state_rpc;
 mod web3_rpc;
 
-use crate::jsonrpsee::server::ServerBuilder;
-pub use crate::rpc_server::RpcServerHandle;
+use std::{
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    sync::Arc,
+};
+
 use beacon_rpc::BeaconNetworkApi;
 pub use builder::{PortalRpcModule, RpcModuleBuilder, TransportRpcModuleConfig};
 use discv5_rpc::Discv5Api;
@@ -31,17 +34,14 @@ use ethportal_api::{
     },
 };
 use history_rpc::HistoryNetworkApi;
-use state_rpc::StateNetworkApi;
-use web3_rpc::Web3Api;
-
-use crate::rpc_server::RpcServerConfig;
 use portalnet::discovery::Discovery;
 use reth_ipc::server::Builder as IpcServerBuilder;
-use std::{
-    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
-    sync::Arc,
-};
+use state_rpc::StateNetworkApi;
 use tokio::sync::mpsc;
+use web3_rpc::Web3Api;
+
+pub use crate::rpc_server::RpcServerHandle;
+use crate::{jsonrpsee::server::ServerBuilder, rpc_server::RpcServerConfig};
 
 pub async fn launch_jsonrpc_server(
     trin_config: TrinConfig,

--- a/rpc/src/rpc_server.rs
+++ b/rpc/src/rpc_server.rs
@@ -1,3 +1,17 @@
+use std::{
+    fmt,
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+};
+
+use ethportal_api::{
+    jsonrpsee::server::IdProvider,
+    types::cli::{DEFAULT_WEB3_HTTP_PORT, DEFAULT_WEB3_IPC_PATH, DEFAULT_WEB3_WS_PORT},
+};
+use reth_ipc::server::{Builder as IpcServerBuilder, IpcServer};
+use tower::layer::util::{Identity, Stack};
+use tower_http::cors::CorsLayer;
+use tracing::instrument;
+
 use crate::{
     builder::TransportRpcModules,
     cors,
@@ -10,18 +24,6 @@ use crate::{
     },
     RpcError, TransportRpcModuleConfig,
 };
-use ethportal_api::{
-    jsonrpsee::server::IdProvider,
-    types::cli::{DEFAULT_WEB3_HTTP_PORT, DEFAULT_WEB3_IPC_PATH, DEFAULT_WEB3_WS_PORT},
-};
-use reth_ipc::server::{Builder as IpcServerBuilder, IpcServer};
-use std::{
-    fmt,
-    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
-};
-use tower::layer::util::{Identity, Stack};
-use tower_http::cors::CorsLayer;
-use tracing::instrument;
 
 /// Container type for each transport ie. http, ws, and ipc server
 pub struct RpcServer {
@@ -619,11 +621,13 @@ impl WsHttpServerKind {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
-    use crate::{builder::RpcModuleSelection, PortalRpcModule, RpcModuleBuilder};
+    use std::{io, sync::Arc};
+
     use ethportal_api::types::portal_wire::MAINNET;
     use portalnet::discovery::Discovery;
-    use std::{io, sync::Arc};
+
+    use super::*;
+    use crate::{builder::RpcModuleSelection, PortalRpcModule, RpcModuleBuilder};
 
     /// Localhost with port 0 so a free port is used.
     pub fn test_address() -> SocketAddr {

--- a/rpc/src/serde.rs
+++ b/rpc/src/serde.rs
@@ -1,5 +1,6 @@
-use crate::errors::RpcServeError;
 use serde_json::{from_value as serde_json_from_value, Value};
+
+use crate::errors::RpcServeError;
 
 // Required for the ContentNotFound error type
 #[allow(clippy::result_large_err)]

--- a/rpc/src/state_rpc.rs
+++ b/rpc/src/state_rpc.rs
@@ -1,6 +1,4 @@
 use discv5::enr::NodeId;
-use tokio::sync::mpsc;
-
 use ethportal_api::{
     types::{
         enr::Enr,
@@ -15,6 +13,7 @@ use ethportal_api::{
     ContentValue, RawContentValue, RoutingTableInfo, StateContentKey, StateContentValue,
     StateNetworkApiServer,
 };
+use tokio::sync::mpsc;
 
 use crate::{
     errors::RpcServeError,

--- a/rpc/src/web3_rpc.rs
+++ b/rpc/src/web3_rpc.rs
@@ -1,5 +1,6 @@
-use crate::jsonrpsee::core::{async_trait, RpcResult};
 use ethportal_api::{version::get_trin_version, Web3ApiServer};
+
+use crate::jsonrpsee::core::{async_trait, RpcResult};
 
 pub struct Web3Api;
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,5 @@
 imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
 comment_width = 100
 wrap_comments = true
 format_code_in_doc_comments = true

--- a/src/bin/historical_batch.rs
+++ b/src/bin/historical_batch.rs
@@ -1,14 +1,15 @@
+use std::{
+    fs::{File, OpenOptions},
+    io,
+    io::{BufRead, Write},
+};
+
 use anyhow::ensure;
 use e2store::era::Era;
 use ethportal_api::{consensus::beacon_state::HistoricalBatch, utils::bytes::hex_encode};
 use regex::Regex;
 use reqwest::get;
 use ssz::Encode;
-use std::{
-    fs::{File, OpenOptions},
-    io,
-    io::{BufRead, Write},
-};
 use tree_hash::TreeHash;
 
 const _BELLATRIX_SLOT: u64 = 4700013;

--- a/src/bin/poll_latest.rs
+++ b/src/bin/poll_latest.rs
@@ -1,3 +1,9 @@
+use std::{
+    str::FromStr,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+
 use alloy::{
     primitives::B256,
     providers::{Provider, ProviderBuilder, WsConnect},
@@ -10,16 +16,10 @@ use ethportal_api::{
     HistoryContentKey, HistoryNetworkApiClient,
 };
 use futures::StreamExt;
-use std::{
-    str::FromStr,
-    sync::{Arc, Mutex},
-    time::Instant,
-};
 use tokio::time::{sleep, Duration};
 use tracing::{debug, info, warn};
-use url::Url;
-
 use trin_utils::log::init_tracing_logger;
+use url::Url;
 
 // tldr;
 // to poll latest blocks

--- a/src/bin/purge_invalid_history_content.rs
+++ b/src/bin/purge_invalid_history_content.rs
@@ -2,13 +2,12 @@ use alloy::primitives::B256;
 use anyhow::Result;
 use clap::Parser;
 use discv5::enr::{CombinedKey, Enr};
-use tracing::info;
-
 use ethportal_api::types::{
     cli::StorageCapacityConfig,
     network::{Network, Subnetwork},
 };
 use portalnet::utils::db::{configure_node_data_dir, configure_trin_data_dir};
+use tracing::info;
 use trin_storage::{
     versioned::{ContentType, IdIndexedV1StoreConfig},
     PortalStorageConfigFactory,

--- a/src/bin/sample_range.rs
+++ b/src/bin/sample_range.rs
@@ -10,17 +10,16 @@ use alloy::{
 };
 use anyhow::Result;
 use clap::Parser;
-use futures::StreamExt;
-use rand::seq::SliceRandom;
-use tracing::{debug, info, warn};
-use url::Url;
-
 use ethportal_api::{
     jsonrpsee::http_client::{HttpClient, HttpClientBuilder},
     HistoryContentKey, HistoryNetworkApiClient,
 };
+use futures::StreamExt;
+use rand::seq::SliceRandom;
+use tracing::{debug, info, warn};
 use trin_utils::log::init_tracing_logger;
 use trin_validation::constants::MERGE_BLOCK_NUMBER;
+use url::Url;
 
 // tldr
 // to sample 5 blocks from the shanghai fork:

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,8 @@
 
 use ethportal_api::types::cli::TrinConfig;
 use tracing::error;
-use trin_utils::log::init_tracing_logger;
-
 use trin::run_trin;
+use trin_utils::log::init_tracing_logger;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/self_peertest.rs
+++ b/tests/self_peertest.rs
@@ -1,5 +1,4 @@
 #![cfg(unix)]
-use rpc::RpcServerHandle;
 use std::{
     env,
     net::{IpAddr, Ipv4Addr},
@@ -12,6 +11,7 @@ use ethportal_api::types::{
 use ethportal_peertest as peertest;
 use ethportal_peertest::Peertest;
 use jsonrpsee::{async_client::Client, http_client::HttpClient};
+use rpc::RpcServerHandle;
 use serial_test::serial;
 use tokio::time::{sleep, Duration};
 

--- a/trin-beacon/src/events.rs
+++ b/trin-beacon/src/events.rs
@@ -1,9 +1,11 @@
-use crate::network::BeaconNetwork;
+use std::sync::Arc;
+
 use ethportal_api::types::portal_wire::Message;
 use portalnet::events::OverlayRequest;
-use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{error, warn, Instrument};
+
+use crate::network::BeaconNetwork;
 
 pub struct BeaconEvents {
     pub network: Arc<BeaconNetwork>,

--- a/trin-beacon/src/lib.rs
+++ b/trin-beacon/src/lib.rs
@@ -11,23 +11,24 @@ mod test_utils;
 pub mod validation;
 
 use std::sync::Arc;
-use tokio::{
-    sync::{broadcast, mpsc, RwLock},
-    task::JoinHandle,
-    time::{interval, Duration},
-};
-use tracing::info;
-use utp_rs::socket::UtpSocket;
 
-use crate::{events::BeaconEvents, jsonrpc::BeaconRequestHandler, network::BeaconNetwork};
 use ethportal_api::types::jsonrpc::request::BeaconJsonRpcRequest;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
     events::{EventEnvelope, OverlayRequest},
 };
+use tokio::{
+    sync::{broadcast, mpsc, RwLock},
+    task::JoinHandle,
+    time::{interval, Duration},
+};
+use tracing::info;
 use trin_storage::PortalStorageConfig;
 use trin_validation::oracle::HeaderOracle;
+use utp_rs::socket::UtpSocket;
+
+use crate::{events::BeaconEvents, jsonrpc::BeaconRequestHandler, network::BeaconNetwork};
 
 type BeaconHandler = Option<BeaconRequestHandler>;
 type BeaconNetworkTask = Option<JoinHandle<()>>;

--- a/trin-beacon/src/network.rs
+++ b/trin-beacon/src/network.rs
@@ -1,23 +1,24 @@
-use alloy::primitives::B256;
-use parking_lot::RwLock as PLRwLock;
 use std::sync::Arc;
-use tokio::sync::{Mutex, RwLock};
-use tracing::{error, info};
-use utp_rs::socket::UtpSocket;
 
-use crate::{storage::BeaconStorage, sync::BeaconSync, validation::BeaconValidator};
+use alloy::primitives::B256;
 use ethportal_api::{
     types::{distance::XorMetric, network::Subnetwork},
     BeaconContentKey,
 };
 use light_client::{consensus::rpc::portal_rpc::PortalRpc, database::FileDB, Client};
+use parking_lot::RwLock as PLRwLock;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
     overlay::{config::OverlayConfig, protocol::OverlayProtocol},
 };
+use tokio::sync::{Mutex, RwLock};
+use tracing::{error, info};
 use trin_storage::PortalStorageConfig;
 use trin_validation::oracle::HeaderOracle;
+use utp_rs::socket::UtpSocket;
+
+use crate::{storage::BeaconStorage, sync::BeaconSync, validation::BeaconValidator};
 
 /// Beacon network layer on top of the overlay protocol. Encapsulates beacon network specific data
 /// and logic.

--- a/trin-beacon/src/storage.rs
+++ b/trin-beacon/src/storage.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use alloy::primitives::B256;
 use ethportal_api::{
     consensus::fork::ForkName,
@@ -18,7 +20,6 @@ use r2d2_sqlite::{rusqlite, SqliteConnectionManager};
 use rusqlite::params;
 use ssz::{Decode, Encode};
 use ssz_types::{typenum::U128, VariableList};
-use std::path::PathBuf;
 use tracing::debug;
 use tree_hash::TreeHash;
 use trin_metrics::storage::StorageMetricsReporter;
@@ -663,8 +664,6 @@ impl BeaconStorage {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
-    use crate::test_utils;
     use ethportal_api::{
         types::content_key::beacon::{
             HistoricalSummariesWithProofKey, LightClientFinalityUpdateKey,
@@ -674,6 +673,9 @@ mod test {
     };
     use tree_hash::TreeHash;
     use trin_storage::test_utils::create_test_portal_storage_config_with_capacity;
+
+    use super::*;
+    use crate::test_utils;
 
     #[test]
     fn test_beacon_storage_get_put_bootstrap() {

--- a/trin-beacon/src/sync.rs
+++ b/trin-beacon/src/sync.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use alloy::primitives::B256;
 use ethportal_api::BeaconContentKey;
 use light_client::{
@@ -5,7 +7,6 @@ use light_client::{
     ClientBuilder,
 };
 use portalnet::overlay::command::OverlayCommand;
-use std::path::PathBuf;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{error, info};
 

--- a/trin-beacon/src/validation.rs
+++ b/trin-beacon/src/validation.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use alloy::primitives::B256;
 use anyhow::anyhow;
 use chrono::Duration;
@@ -24,7 +26,6 @@ use light_client::{
     },
 };
 use ssz::Decode;
-use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::debug;
 use tree_hash::TreeHash;
@@ -342,8 +343,6 @@ impl BeaconValidator {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
-    use crate::test_utils;
     use ethportal_api::{
         types::{
             content_key::beacon::{
@@ -356,6 +355,9 @@ mod tests {
     };
     use ssz::Encode;
     use ssz_types::VariableList;
+
+    use super::*;
+    use crate::test_utils;
 
     #[tokio::test]
     async fn test_validate_light_client_bootstrap() {

--- a/trin-evm/src/tx_env_modifier.rs
+++ b/trin-evm/src/tx_env_modifier.rs
@@ -152,9 +152,10 @@ impl TxEnvModifier for TransactionRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use alloy::primitives::{bytes::Bytes, U64};
     use revm_primitives::TxEnv;
+
+    use super::*;
 
     #[test]
     fn test_legacy_tx_env_modifier() {

--- a/trin-execution/src/era/manager.rs
+++ b/trin-execution/src/era/manager.rs
@@ -12,14 +12,13 @@ use reqwest::{
 use tokio::task::JoinHandle;
 use tracing::info;
 
-use crate::era::{
-    constants::FIRST_ERA_EPOCH_WITH_EXECUTION_PAYLOAD,
-    utils::{download_raw_era, process_era1_file, process_era_file},
-};
-
 use super::{
     binary_search::EraBinarySearch,
     types::{EraType, ProcessedBlock, ProcessedEra},
+};
+use crate::era::{
+    constants::FIRST_ERA_EPOCH_WITH_EXECUTION_PAYLOAD,
+    utils::{download_raw_era, process_era1_file, process_era_file},
 };
 
 pub struct EraManager {

--- a/trin-execution/src/era/utils.rs
+++ b/trin-execution/src/era/utils.rs
@@ -12,12 +12,11 @@ use reqwest::Client;
 use tokio::time::sleep;
 use tracing::{info, warn};
 
+use super::types::ProcessedEra;
 use crate::era::{
     beacon::ProcessBeaconBlock,
     types::{EraType, ProcessedBlock, TransactionsWithSender},
 };
-
-use super::types::ProcessedEra;
 
 pub fn process_era1_file(raw_era1: Vec<u8>, epoch_index: u64) -> anyhow::Result<ProcessedEra> {
     let mut blocks = Vec::with_capacity(BLOCK_TUPLE_COUNT);

--- a/trin-execution/src/evm/block_executor.rs
+++ b/trin-execution/src/evm/block_executor.rs
@@ -24,6 +24,7 @@ use trin_evm::{
     create_block_env, create_evm_with_tracer, spec_id::get_spec_id, tx_env_modifier::TxEnvModifier,
 };
 
+use super::post_block_beneficiaries::get_post_block_beneficiaries;
 use crate::{
     era::types::{ProcessedBlock, TransactionsWithSender},
     evm::pre_block_contracts::apply_pre_block_contracts,
@@ -33,8 +34,6 @@ use crate::{
     },
     storage::evm_db::EvmDB,
 };
-
-use super::post_block_beneficiaries::get_post_block_beneficiaries;
 
 pub const BLOCKHASH_SERVE_WINDOW: u64 = 256;
 const GENESIS_STATE_FILE: &str = "trin-execution/resources/genesis/mainnet.json";

--- a/trin-execution/src/evm/post_block_beneficiaries.rs
+++ b/trin-execution/src/evm/post_block_beneficiaries.rs
@@ -8,9 +8,8 @@ use revm::{db::State, Evm};
 use revm_primitives::SpecId;
 use trin_evm::spec_id::get_spec_block_number;
 
-use crate::{era::types::ProcessedBlock, storage::evm_db::EvmDB};
-
 use super::dao_fork::{DAO_HARDFORK_BENEFICIARY, DAO_HARDKFORK_ACCOUNTS};
+use crate::{era::types::ProcessedBlock, storage::evm_db::EvmDB};
 
 // Calculate block reward
 // https://github.com/paradigmxyz/reth/blob/v0.2.0-beta.6/crates/consensus/common/src/calc.rs

--- a/trin-execution/src/execution.rs
+++ b/trin-execution/src/execution.rs
@@ -1,23 +1,23 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
 use alloy::primitives::B256;
 use anyhow::ensure;
 use eth_trie::{RootWithTrieDiff, Trie};
 use ethportal_api::{types::execution::transaction::Transaction, Header};
 use revm::inspectors::TracerEip3155;
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
 use tokio::sync::{oneshot::Receiver, Mutex};
 use tracing::{info, warn};
 
+use super::config::StateConfig;
 use crate::{
     era::manager::EraManager,
     evm::block_executor::BlockExecutor,
     metrics::{start_timer_vec, stop_timer, BLOCK_PROCESSING_TIMES},
     storage::{evm_db::EvmDB, execution_position::ExecutionPosition, utils::setup_rocksdb},
 };
-
-use super::config::StateConfig;
 
 pub struct TrinExecution {
     pub database: EvmDB,
@@ -166,9 +166,8 @@ mod tests {
 
     use trin_utils::dir::create_temp_test_dir;
 
-    use crate::era::utils::process_era1_file;
-
     use super::*;
+    use crate::era::utils::process_era1_file;
 
     #[tokio::test]
     #[ignore = "This test downloads data from a remote server"]

--- a/trin-execution/src/storage/account_db.rs
+++ b/trin-execution/src/storage/account_db.rs
@@ -61,11 +61,11 @@ impl DB for AccountDB {
 #[cfg(test)]
 mod test_account_db {
 
-    use crate::storage::utils::setup_rocksdb;
-
-    use super::*;
     use eth_trie::DB;
     use trin_utils::dir::create_temp_test_dir;
+
+    use super::*;
+    use crate::storage::utils::setup_rocksdb;
 
     #[test]
     fn test_account_db_get() {

--- a/trin-execution/src/storage/evm_db.rs
+++ b/trin-execution/src/storage/evm_db.rs
@@ -1,12 +1,5 @@
 use std::sync::Arc;
 
-use crate::{
-    config::StateConfig,
-    metrics::{
-        start_timer_vec, stop_timer, BUNDLE_COMMIT_PROCESSING_TIMES, TRANSACTION_PROCESSING_TIMES,
-    },
-    storage::error::EVMError,
-};
 use alloy::{
     consensus::EMPTY_ROOT_HASH,
     primitives::{keccak256, map::FbHashMap, Address, B256, U256},
@@ -26,6 +19,13 @@ use rocksdb::DB as RocksDB;
 use tracing::info;
 
 use super::{account_db::AccountDB, execution_position::ExecutionPosition, trie_db::TrieRocksDB};
+use crate::{
+    config::StateConfig,
+    metrics::{
+        start_timer_vec, stop_timer, BUNDLE_COMMIT_PROCESSING_TIMES, TRANSACTION_PROCESSING_TIMES,
+    },
+    storage::error::EVMError,
+};
 
 fn start_commit_timer(name: &str) -> HistogramTimer {
     start_timer_vec(&BUNDLE_COMMIT_PROCESSING_TIMES, &[name])

--- a/trin-execution/src/trie_walker/mod.rs
+++ b/trin-execution/src/trie_walker/mod.rs
@@ -160,14 +160,14 @@ impl<DB: TrieWalkerDb> Iterator for TrieWalker<DB> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::{str::FromStr, sync::Arc};
 
     use alloy::primitives::{keccak256, Address, B256, U256};
     use eth_trie::{EthTrie, RootWithTrieDiff, Trie};
-    use std::{str::FromStr, sync::Arc};
     use tracing_test::traced_test;
     use trin_utils::dir::create_temp_test_dir;
 
+    use super::*;
     use crate::{
         config::StateConfig,
         execution::TrinExecution,

--- a/trin-history/src/events.rs
+++ b/trin-history/src/events.rs
@@ -1,9 +1,11 @@
-use crate::network::HistoryNetwork;
+use std::sync::Arc;
+
 use ethportal_api::types::portal_wire::Message;
 use portalnet::events::OverlayRequest;
-use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{error, warn, Instrument};
+
+use crate::network::HistoryNetwork;
 
 pub struct HistoryEvents {
     pub network: Arc<HistoryNetwork>,

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -9,24 +9,24 @@ pub mod validation;
 
 use std::sync::Arc;
 
+use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
 use network::HistoryNetwork;
+use portalnet::{
+    config::PortalnetConfig,
+    discovery::{Discovery, UtpEnr},
+    events::{EventEnvelope, OverlayRequest},
+};
 use tokio::{
     sync::{broadcast, mpsc, RwLock},
     task::JoinHandle,
     time::{interval, Duration},
 };
 use tracing::info;
+use trin_storage::PortalStorageConfig;
+use trin_validation::oracle::HeaderOracle;
 use utp_rs::socket::UtpSocket;
 
 use crate::{events::HistoryEvents, jsonrpc::HistoryRequestHandler};
-use ethportal_api::types::jsonrpc::request::HistoryJsonRpcRequest;
-use portalnet::{
-    config::PortalnetConfig,
-    discovery::{Discovery, UtpEnr},
-    events::{EventEnvelope, OverlayRequest},
-};
-use trin_storage::PortalStorageConfig;
-use trin_validation::oracle::HeaderOracle;
 
 type HistoryHandler = Option<HistoryRequestHandler>;
 type HistoryNetworkTask = Option<JoinHandle<()>>;

--- a/trin-history/src/network.rs
+++ b/trin-history/src/network.rs
@@ -1,23 +1,21 @@
 use std::sync::Arc;
 
-use parking_lot::RwLock as PLRwLock;
-use tokio::sync::RwLock;
-use utp_rs::socket::UtpSocket;
-
-use crate::storage::HistoryStorage;
 use ethportal_api::{
     types::{distance::XorMetric, network::Subnetwork},
     HistoryContentKey,
 };
+use parking_lot::RwLock as PLRwLock;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
     overlay::{config::OverlayConfig, protocol::OverlayProtocol},
 };
-use trin_validation::oracle::HeaderOracle;
-
-use crate::validation::ChainHistoryValidator;
+use tokio::sync::RwLock;
 use trin_storage::PortalStorageConfig;
+use trin_validation::oracle::HeaderOracle;
+use utp_rs::socket::UtpSocket;
+
+use crate::{storage::HistoryStorage, validation::ChainHistoryValidator};
 
 /// Gossip content as it gets dropped from local storage,
 /// enabled by default for the history network.

--- a/trin-history/src/validation.rs
+++ b/trin-history/src/validation.rs
@@ -2,9 +2,6 @@ use std::sync::Arc;
 
 use alloy::primitives::B256;
 use anyhow::{anyhow, ensure};
-use ssz::Decode;
-use tokio::sync::RwLock;
-
 use ethportal_api::{
     types::execution::{
         block_body::BlockBody, header::Header, header_with_proof::HeaderWithProof,
@@ -13,6 +10,8 @@ use ethportal_api::{
     utils::bytes::hex_encode,
     HistoryContentKey,
 };
+use ssz::Decode;
+use tokio::sync::RwLock;
 use trin_validation::{
     oracle::HeaderOracle,
     validator::{ValidationResult, Validator},
@@ -123,14 +122,14 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
     use std::fs;
 
     use alloy::primitives::U256;
+    use ethportal_api::utils::bytes::hex_decode;
     use serde_json::Value;
     use ssz::Encode;
 
-    use ethportal_api::utils::bytes::hex_decode;
+    use super::*;
 
     fn get_header_with_proof_ssz() -> Vec<u8> {
         let file =

--- a/trin-metrics/src/overlay.rs
+++ b/trin-metrics/src/overlay.rs
@@ -1,3 +1,4 @@
+use ethportal_api::types::portal_wire::{Request, Response};
 use prometheus_exporter::{
     self,
     prometheus::{
@@ -7,7 +8,6 @@ use prometheus_exporter::{
 };
 
 use crate::labels::{MessageDirectionLabel, MessageLabel, UtpDirectionLabel, UtpOutcomeLabel};
-use ethportal_api::types::portal_wire::{Request, Response};
 
 /// Contains metrics reporters for use in the overlay network
 /// (eg. `portalnet/src/overlay.rs` & `portalnet/src/overlay_service.rs`).

--- a/trin-metrics/src/portalnet.rs
+++ b/trin-metrics/src/portalnet.rs
@@ -1,6 +1,7 @@
-use crate::{bridge::BridgeMetrics, overlay::OverlayMetrics, storage::StorageMetrics};
 use lazy_static::lazy_static;
 use prometheus_exporter::prometheus::default_registry;
+
+use crate::{bridge::BridgeMetrics, overlay::OverlayMetrics, storage::StorageMetrics};
 
 // We use lazy_static to ensure that the metrics registry is initialized only once, for each
 // runtime. This is important because the registry is a global singleton, and if it is

--- a/trin-state/src/events.rs
+++ b/trin-state/src/events.rs
@@ -1,9 +1,11 @@
-use crate::network::StateNetwork;
+use std::sync::Arc;
+
 use ethportal_api::types::portal_wire::Message;
 use portalnet::events::OverlayRequest;
-use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{error, warn, Instrument};
+
+use crate::network::StateNetwork;
 
 pub struct StateEvents {
     pub network: Arc<StateNetwork>,

--- a/trin-state/src/jsonrpc.rs
+++ b/trin-state/src/jsonrpc.rs
@@ -1,13 +1,6 @@
 use std::{fmt::Debug, sync::Arc};
 
 use discv5::{enr::NodeId, Enr};
-use portalnet::overlay::{config::FindContentConfig, errors::OverlayRequestError};
-use serde_json::{json, Value};
-use tokio::sync::mpsc;
-use tracing::error;
-use trin_storage::ContentStore;
-
-use crate::network::StateNetwork;
 use ethportal_api::{
     jsonrpsee::core::Serialize,
     types::{
@@ -20,6 +13,13 @@ use ethportal_api::{
     utils::bytes::hex_encode,
     ContentValue, OverlayContentKey, RawContentValue, StateContentKey, StateContentValue,
 };
+use portalnet::overlay::{config::FindContentConfig, errors::OverlayRequestError};
+use serde_json::{json, Value};
+use tokio::sync::mpsc;
+use tracing::error;
+use trin_storage::ContentStore;
+
+use crate::network::StateNetwork;
 
 /// Handles State network JSON-RPC requests
 pub struct StateRequestHandler {

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -7,24 +7,24 @@ use std::{
 };
 
 use cpu_time::ProcessTime;
+use ethportal_api::types::jsonrpc::request::StateJsonRpcRequest;
 use network::StateNetwork;
+use portalnet::{
+    config::PortalnetConfig,
+    discovery::{Discovery, UtpEnr},
+    events::{EventEnvelope, OverlayRequest},
+};
 use tokio::{
     sync::{broadcast, mpsc, RwLock},
     task::JoinHandle,
     time::interval,
 };
 use tracing::info;
+use trin_storage::PortalStorageConfig;
+use trin_validation::oracle::HeaderOracle;
 use utp_rs::socket::UtpSocket;
 
 use crate::{events::StateEvents, jsonrpc::StateRequestHandler};
-use ethportal_api::types::jsonrpc::request::StateJsonRpcRequest;
-use portalnet::{
-    config::PortalnetConfig,
-    discovery::{Discovery, UtpEnr},
-    events::{EventEnvelope, OverlayRequest},
-};
-use trin_storage::PortalStorageConfig;
-use trin_validation::oracle::HeaderOracle;
 
 pub mod events;
 mod jsonrpc;

--- a/trin-state/src/network.rs
+++ b/trin-state/src/network.rs
@@ -1,23 +1,22 @@
-use parking_lot::RwLock as PLRwLock;
 use std::sync::Arc;
-use tokio::sync::RwLock;
-use tracing::debug;
-use utp_rs::socket::UtpSocket;
 
-use crate::storage::StateStorage;
 use ethportal_api::{
     types::{distance::XorMetric, network::Subnetwork},
     StateContentKey,
 };
+use parking_lot::RwLock as PLRwLock;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
     overlay::{config::OverlayConfig, protocol::OverlayProtocol},
 };
-use trin_validation::oracle::HeaderOracle;
-
-use crate::validation::StateValidator;
+use tokio::sync::RwLock;
+use tracing::debug;
 use trin_storage::PortalStorageConfig;
+use trin_validation::oracle::HeaderOracle;
+use utp_rs::socket::UtpSocket;
+
+use crate::{storage::StateStorage, validation::StateValidator};
 
 /// State network layer on top of the overlay protocol. Encapsulates state network specific data and
 /// logic.

--- a/trin-storage/src/lib.rs
+++ b/trin-storage/src/lib.rs
@@ -5,7 +5,10 @@ pub mod test_utils;
 pub mod utils;
 pub mod versioned;
 
+use std::{ops::Deref, str::FromStr};
+
 use alloy::primitives::{Bytes, B256};
+pub use config::{PortalStorageConfig, PortalStorageConfigFactory};
 use discv5::enr::NodeId;
 use error::ContentStoreError;
 use ethportal_api::{
@@ -16,9 +19,6 @@ use ethportal_api::{
     RawContentValue,
 };
 use rusqlite::types::{FromSql, FromSqlError, ValueRef};
-use std::{ops::Deref, str::FromStr};
-
-pub use config::{PortalStorageConfig, PortalStorageConfigFactory};
 
 pub const DATABASE_NAME: &str = "trin.sqlite";
 
@@ -207,9 +207,10 @@ pub struct DataSize {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 pub mod test {
-    use super::*;
     use alloy::primitives::{bytes, B512};
     use ethportal_api::IdentityContentKey;
+
+    use super::*;
 
     #[test]
     fn memory_store_contains_key() {

--- a/trin-storage/src/utils.rs
+++ b/trin-storage/src/utils.rs
@@ -1,3 +1,9 @@
+use std::{fs, path::Path};
+
+use r2d2::Pool;
+use r2d2_sqlite::SqliteConnectionManager;
+use tracing::info;
+
 use crate::{
     error::ContentStoreError,
     sql::{
@@ -7,10 +13,6 @@ use crate::{
     versioned::sql::STORE_INFO_CREATE_TABLE,
     DATABASE_NAME,
 };
-use r2d2::Pool;
-use r2d2_sqlite::SqliteConnectionManager;
-use std::{fs, path::Path};
-use tracing::info;
 
 /// Helper function for opening a SQLite connection.
 pub fn setup_sql(node_data_dir: &Path) -> Result<Pool<SqliteConnectionManager>, ContentStoreError> {

--- a/trin-storage/src/versioned/id_indexed_v1/config.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/config.rs
@@ -5,9 +5,8 @@ use ethportal_api::types::network::Subnetwork;
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 
-use crate::{versioned::ContentType, DistanceFunction, PortalStorageConfig};
-
 use super::pruning_strategy::PruningConfig;
+use crate::{versioned::ContentType, DistanceFunction, PortalStorageConfig};
 
 /// The config for the IdIndexedV1Store
 #[derive(Clone, Debug)]

--- a/trin-storage/src/versioned/id_indexed_v1/migration.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/migration.rs
@@ -1,11 +1,10 @@
 use tracing::{debug, info};
 
+use super::IdIndexedV1StoreConfig;
 use crate::{
     error::ContentStoreError,
     versioned::{id_indexed_v1::sql, ContentType},
 };
-
-use super::IdIndexedV1StoreConfig;
 
 pub fn migrate_legacy_history_store(
     config: &IdIndexedV1StoreConfig,
@@ -55,12 +54,11 @@ mod tests {
     };
     use rand::Rng;
 
+    use super::*;
     use crate::{
         test_utils::{create_test_portal_storage_config_with_capacity, generate_random_bytes},
         versioned::{usage_stats::UsageStats, IdIndexedV1Store, VersionedContentStore},
     };
-
-    use super::*;
 
     const STORAGE_CAPACITY_MB: u32 = 10;
 

--- a/trin-storage/src/versioned/id_indexed_v1/pruning_strategy.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/pruning_strategy.rs
@@ -2,9 +2,8 @@ use std::{fmt::Debug, ops::Range, time::Duration};
 
 use tracing::debug;
 
-use crate::versioned::usage_stats::UsageStats;
-
 use super::IdIndexedV1StoreConfig;
+use crate::versioned::usage_stats::UsageStats;
 
 /// The configuration parameters used by [PruningStrategy].
 #[derive(Clone, Debug)]
@@ -202,9 +201,8 @@ mod tests {
     use r2d2_sqlite::SqliteConnectionManager;
     use rstest::rstest;
 
-    use crate::{versioned::ContentType, DistanceFunction};
-
     use super::*;
+    use crate::{versioned::ContentType, DistanceFunction};
 
     const DEFAULT_STORAGE_CAPACITY_BYTES: u64 = 1_000_000;
 

--- a/trin-storage/src/versioned/id_indexed_v1/store.rs
+++ b/trin-storage/src/versioned/id_indexed_v1/store.rs
@@ -1,9 +1,11 @@
 use std::marker::PhantomData;
 
+use ethportal_api::{types::distance::Distance, OverlayContentKey, RawContentValue};
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::{named_params, types::Type, OptionalExtension};
 use tracing::{debug, error, warn};
+use trin_metrics::storage::StorageMetricsReporter;
 
 use super::{
     migration::migrate_legacy_history_store, pruning_strategy::PruningStrategy, sql,
@@ -15,8 +17,6 @@ use crate::{
     versioned::{usage_stats::UsageStats, ContentType, StoreVersion, VersionedContentStore},
     ContentId,
 };
-use ethportal_api::{types::distance::Distance, OverlayContentKey, RawContentValue};
-use trin_metrics::storage::StorageMetricsReporter;
 
 /// The result of looking for the farthest content.
 struct FarthestQueryResult {
@@ -548,12 +548,11 @@ mod tests {
     use rand::Rng;
     use tempfile::TempDir;
 
+    use super::*;
     use crate::{
         test_utils::generate_random_bytes, utils::setup_sql,
         versioned::id_indexed_v1::pruning_strategy::PruningConfig, DistanceFunction,
     };
-
-    use super::*;
 
     const CONTENT_DEFAULT_SIZE_BYTES: u64 = 100;
 

--- a/trin-storage/src/versioned/mod.rs
+++ b/trin-storage/src/versioned/mod.rs
@@ -4,11 +4,10 @@ pub mod store;
 mod usage_stats;
 mod utils;
 
-use rusqlite::types::{FromSql, FromSqlError, ValueRef};
-use strum::{AsRefStr, Display, EnumString};
-
 pub use id_indexed_v1::{IdIndexedV1Store, IdIndexedV1StoreConfig};
+use rusqlite::types::{FromSql, FromSqlError, ValueRef};
 pub use store::VersionedContentStore;
+use strum::{AsRefStr, Display, EnumString};
 pub use utils::create_store;
 
 /// The type of the content that is stored.

--- a/trin-storage/src/versioned/store.rs
+++ b/trin-storage/src/versioned/store.rs
@@ -1,6 +1,5 @@
-use crate::error::ContentStoreError;
-
 use super::{ContentType, StoreVersion};
+use crate::error::ContentStoreError;
 
 /// A trait for the versioned content store. Instance of it should be created using
 /// `create_store` function.

--- a/trin-storage/src/versioned/utils.rs
+++ b/trin-storage/src/versioned/utils.rs
@@ -2,9 +2,8 @@ use r2d2::{Pool, PooledConnection};
 use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::{named_params, OptionalExtension};
 
-use crate::error::ContentStoreError;
-
 use super::{sql, store::VersionedContentStore, ContentType, StoreVersion};
+use crate::error::ContentStoreError;
 
 /// Ensures that the correct version of the content store is used (by migrating the content if
 /// that's not the case).
@@ -87,9 +86,8 @@ fn update_store_info(
 pub mod test {
     use anyhow::Result;
 
-    use crate::{test_utils::create_test_portal_storage_config_with_capacity, PortalStorageConfig};
-
     use super::*;
+    use crate::{test_utils::create_test_portal_storage_config_with_capacity, PortalStorageConfig};
 
     const STORAGE_CAPACITY_MB: u32 = 10;
 

--- a/trin-utils/src/log.rs
+++ b/trin-utils/src/log.rs
@@ -1,4 +1,5 @@
 use std::env;
+
 use tracing_subscriber::EnvFilter;
 
 pub fn init_tracing_logger() {

--- a/trin-validation/src/accumulator.rs
+++ b/trin-validation/src/accumulator.rs
@@ -1,7 +1,8 @@
-use alloy::primitives::{B256, U256};
 use std::path::PathBuf;
 
+use alloy::primitives::{B256, U256};
 use anyhow::anyhow;
+use ethportal_api::types::execution::{accumulator::EpochAccumulator, header::Header};
 use serde::{Deserialize, Serialize};
 use ssz::Decode;
 use ssz_derive::{Decode, Encode};
@@ -13,7 +14,6 @@ use crate::{
     merkle::proof::MerkleTree,
     TrinValidationAssets,
 };
-use ethportal_api::types::execution::{accumulator::EpochAccumulator, header::Header};
 
 /// SSZ List[Hash256, max_length = MAX_HISTORICAL_EPOCHS]
 /// List of historical epoch accumulator merkle roots preceding current epoch.

--- a/trin-validation/src/header_validator.rs
+++ b/trin-validation/src/header_validator.rs
@@ -1,11 +1,3 @@
-use crate::{
-    accumulator::PreMergeAccumulator,
-    constants::{
-        CAPELLA_FORK_EPOCH, EPOCH_SIZE, MERGE_BLOCK_NUMBER, SHANGHAI_BLOCK_NUMBER, SLOTS_PER_EPOCH,
-    },
-    historical_roots_acc::HistoricalRootsAccumulator,
-    merkle::proof::verify_merkle_proof,
-};
 use alloy::primitives::B256;
 use anyhow::anyhow;
 use ethportal_api::{
@@ -15,6 +7,15 @@ use ethportal_api::{
         HistoricalSummariesBlockProof,
     },
     Header,
+};
+
+use crate::{
+    accumulator::PreMergeAccumulator,
+    constants::{
+        CAPELLA_FORK_EPOCH, EPOCH_SIZE, MERGE_BLOCK_NUMBER, SHANGHAI_BLOCK_NUMBER, SLOTS_PER_EPOCH,
+    },
+    historical_roots_acc::HistoricalRootsAccumulator,
+    merkle::proof::verify_merkle_proof,
 };
 
 /// HeaderValidator is responsible for validating pre-merge and post-merge headers with their
@@ -220,19 +221,12 @@ fn calculate_generalized_index(header: &Header) -> u64 {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use std::{fs, str::FromStr};
 
     use alloy::{
         primitives::{Address, Bloom, B256, U256},
         rlp::Decodable,
     };
-    use rstest::*;
-    use serde_json::Value;
-    use ssz::{Decode, Encode};
-    use tree_hash::TreeHash;
-
-    use crate::constants::DEFAULT_PRE_MERGE_ACC_HASH;
     use ethportal_api::{
         types::execution::{
             accumulator::EpochAccumulator,
@@ -243,6 +237,13 @@ mod test {
         utils::bytes::{hex_decode, hex_encode},
         HistoryContentKey, OverlayContentKey,
     };
+    use rstest::*;
+    use serde_json::Value;
+    use ssz::{Decode, Encode};
+    use tree_hash::TreeHash;
+
+    use super::*;
+    use crate::constants::DEFAULT_PRE_MERGE_ACC_HASH;
 
     #[rstest]
     #[case(1_000_001)]

--- a/trin-validation/src/historical_roots_acc.rs
+++ b/trin-validation/src/historical_roots_acc.rs
@@ -1,7 +1,8 @@
-use crate::TrinValidationAssets;
 use ethportal_api::consensus::beacon_state::HistoricalRoots;
 use ssz::{Decode, Encode};
 use tree_hash::{Hash256, PackedEncoding, TreeHash, TreeHashType};
+
+use crate::TrinValidationAssets;
 
 /// The frozen historical roots accumulator from beacon state. It is used to verify the
 /// canonicalness of the post-merge/pre-Capella execution headers.
@@ -73,10 +74,11 @@ impl TreeHash for HistoricalRootsAccumulator {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use ethportal_api::utils::bytes::hex_encode;
     use ssz::Encode;
     use tree_hash::TreeHash;
+
+    use super::*;
 
     #[test]
     fn test_default_historical_roots_acc() {

--- a/trin-validation/src/merkle/proof.rs
+++ b/trin-validation/src/merkle/proof.rs
@@ -1,10 +1,11 @@
+use alloy::primitives::B256;
+use ethereum_hashing::{hash, hash32_concat, ZERO_HASHES};
+use lazy_static::lazy_static;
+
 ///
 /// Code sourced from:
 /// https://github.com/sigp/lighthouse/blob/bf533c8e42/consensus/merkle_proof/src/lib.rs
 use crate::merkle::safe_arith::ArithError;
-use alloy::primitives::B256;
-use ethereum_hashing::{hash, hash32_concat, ZERO_HASHES};
-use lazy_static::lazy_static;
 
 const MAX_TREE_DEPTH: usize = 32;
 const EMPTY_SLICE: &[B256] = &[];
@@ -407,10 +408,11 @@ impl From<InvalidSnapshot> for MerkleTreeError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use alloy::primitives::U256;
     use quickcheck::TestResult;
     use quickcheck_macros::quickcheck;
+
+    use super::*;
 
     /// Check that we can:
     /// 1. Build a MerkleTree from arbitrary leaves and an arbitrary depth.

--- a/trin-validation/src/oracle.rs
+++ b/trin-validation/src/oracle.rs
@@ -1,10 +1,6 @@
 use alloy::primitives::B256;
 use anyhow::anyhow;
 use enr::NodeId;
-use serde_json::Value;
-use tokio::sync::mpsc;
-
-use crate::header_validator::HeaderValidator;
 use ethportal_api::{
     consensus::header::BeaconBlockHeader,
     light_client::store::LightClientStore,
@@ -18,6 +14,10 @@ use ethportal_api::{
     },
     ContentValue, Enr, HistoryContentKey, HistoryContentValue,
 };
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use crate::header_validator::HeaderValidator;
 
 /// Responsible for dispatching cross-overlay-network requests
 /// for data to perform validation.
@@ -216,11 +216,11 @@ impl HeaderOracle {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::*;
     use std::str::FromStr;
 
     use tree_hash::TreeHash;
 
+    use super::*;
     use crate::constants::DEFAULT_PRE_MERGE_ACC_HASH;
 
     #[tokio::test]

--- a/utp-testing/src/bin/test_app.rs
+++ b/utp-testing/src/bin/test_app.rs
@@ -1,10 +1,9 @@
-use clap::Parser;
 use std::{net::SocketAddr, str::FromStr};
+
+use clap::Parser;
 use tracing::info;
 use trin_utils::log::init_tracing_logger;
-use utp_testing::run_test_app;
-
-use utp_testing::cli::TestAppConfig;
+use utp_testing::{cli::TestAppConfig, run_test_app};
 
 /// uTP test app, used for creation of a `test-app` docker image
 #[tokio::main]

--- a/utp-testing/src/bin/test_suite.rs
+++ b/utp-testing/src/bin/test_suite.rs
@@ -1,10 +1,9 @@
-use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
-use rand::{thread_rng, Rng};
-use trin_utils::log::init_tracing_logger;
-
 use std::time::Duration;
 
 use ethportal_api::utils::bytes::hex_encode;
+use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
+use rand::{thread_rng, Rng};
+use trin_utils::log::init_tracing_logger;
 
 const SERVER_ADDR: &str = "193.167.100.100:9041";
 const CLIENT_ADDR: &str = "193.167.0.100:9042";

--- a/utp-testing/src/lib.rs
+++ b/utp-testing/src/lib.rs
@@ -5,7 +5,8 @@ extern crate core;
 pub mod cli;
 pub mod rpc;
 
-use crate::rpc::RpcServer;
+use std::{io::ErrorKind, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
+
 use discv5::TalkRequest;
 use ethportal_api::{
     types::{enr::Enr, network::Subnetwork, portal_wire::MAINNET},
@@ -20,13 +21,14 @@ use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpEnr},
 };
-use std::{io::ErrorKind, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 use tokio::sync::{
     mpsc::{self, Receiver},
     RwLock,
 };
 use trin_validation::oracle::HeaderOracle;
 use utp_rs::{conn::ConnectionConfig, socket::UtpSocket};
+
+use crate::rpc::RpcServer;
 
 /// uTP test app
 pub struct TestApp {


### PR DESCRIPTION
### What was wrong?

We don't have the fmt linting option for the import format we all use.

The format we normally use as a team is

-1 std imports grouped up
-2 external imports grouped up
-3 crates imports grouped up

### How was it fixed?

It turns out fmt has a flag for enabling this formatting so I enabled the lint option in rustfmt.toml