### PR TITLE
feat: update beacon jsonrpc endpoints

### DIFF
--- a/ethportal-api/src/beacon.rs
+++ b/ethportal-api/src/beacon.rs
@@ -6,6 +6,10 @@ use crate::{
     consensus::header::BeaconBlockHeader,
     light_client::store::LightClientStore,
     types::{
+        consensus::light_client::{
+            finality_update::LightClientFinalityUpdate,
+            optimistic_update::LightClientOptimisticUpdate,
+        },
         content_key::beacon::BeaconContentKey,
         enr::Enr,
         portal::{
@@ -59,6 +63,14 @@ pub trait BeaconNetworkApi {
     /// Get the finalized beacon header
     #[method(name = "beaconFinalizedHeader")]
     async fn finalized_header(&self) -> RpcResult<BeaconBlockHeader>;
+
+    /// Get the finality update
+    #[method(name = "beaconFinalityUpdate")]
+    async fn finality_update(&self) -> RpcResult<LightClientFinalityUpdate>;
+
+    /// Get the optimistic update
+    #[method(name = "beaconOptimisticUpdate")]
+    async fn optimistic_update(&self) -> RpcResult<LightClientOptimisticUpdate>;
 
     /// Send a FINDNODES request for nodes that fall within the given set of distances, to the
     /// designated peer and wait for a response

--- a/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -118,6 +118,10 @@ pub enum BeaconEndpoint {
     FinalizedHeader,
     /// params: None
     FinalizedStateRoot,
+    /// params: None
+    FinalityUpdate,
+    /// params: None
+    OptimisticUpdate,
     /// params: node_id
     GetEnr(NodeId),
     /// params: None

--- a/light-client/src/client.rs
+++ b/light-client/src/client.rs
@@ -1,7 +1,13 @@
 use std::{path::PathBuf, sync::Arc};
 
 use anyhow::{anyhow, Result};
-use ethportal_api::{consensus::header::BeaconBlockHeader, light_client::store::LightClientStore};
+use ethportal_api::{
+    consensus::header::BeaconBlockHeader,
+    light_client::store::LightClientStore,
+    types::consensus::light_client::{
+        finality_update::LightClientFinalityUpdate, optimistic_update::LightClientOptimisticUpdate,
+    },
+};
 use log::{error, info, warn};
 use tokio::{spawn, sync::RwLock, time::sleep};
 
@@ -457,6 +463,14 @@ impl<DB: Database, R: ConsensusRpc + 'static> Client<DB, R> {
 
     pub async fn get_finalized_header(&self) -> Result<BeaconBlockHeader> {
         self.node.read().await.get_finalized_header()
+    }
+
+    pub async fn get_optimistic_update(&self) -> Result<LightClientOptimisticUpdate> {
+        self.node.read().await.get_optimistic_update().await
+    }
+
+    pub async fn get_finality_update(&self) -> Result<LightClientFinalityUpdate> {
+        self.node.read().await.get_finality_update().await
     }
 
     pub async fn get_light_client_store(&self) -> Result<LightClientStore> {

--- a/light-client/src/consensus/consensus_client.rs
+++ b/light-client/src/consensus/consensus_client.rs
@@ -11,8 +11,8 @@ use ethportal_api::{
     consensus::{header::BeaconBlockHeader, signature::BlsSignature},
     light_client::{
         bootstrap::CurrentSyncCommitteeProofLen,
-        finality_update::LightClientFinalityUpdateDeneb,
-        optimistic_update::LightClientOptimisticUpdateDeneb,
+        finality_update::{LightClientFinalityUpdate, LightClientFinalityUpdateDeneb},
+        optimistic_update::{LightClientOptimisticUpdate, LightClientOptimisticUpdateDeneb},
         store::LightClientStore,
         update::{FinalizedRootProofLen, LightClientUpdateDeneb},
     },
@@ -89,6 +89,20 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
 
     pub fn get_finalized_header(&self) -> &BeaconBlockHeader {
         &self.store.finalized_header
+    }
+
+    pub async fn get_finality_update(&self) -> Result<LightClientFinalityUpdate> {
+        self.rpc
+            .get_finality_update()
+            .await
+            .map(|update| update.into())
+    }
+
+    pub async fn get_optimistic_update(&self) -> Result<LightClientOptimisticUpdate> {
+        self.rpc
+            .get_optimistic_update()
+            .await
+            .map(|update| update.into())
     }
 
     pub fn get_light_client_store(&self) -> &LightClientStore {

--- a/light-client/src/node.rs
+++ b/light-client/src/node.rs
@@ -1,7 +1,13 @@
 use std::{sync::Arc, time::Duration};
 
 use anyhow::{Error, Result};
-use ethportal_api::{consensus::header::BeaconBlockHeader, light_client::store::LightClientStore};
+use ethportal_api::{
+    consensus::header::BeaconBlockHeader,
+    light_client::store::LightClientStore,
+    types::consensus::light_client::{
+        finality_update::LightClientFinalityUpdate, optimistic_update::LightClientOptimisticUpdate,
+    },
+};
 
 use crate::{
     config::client_config::Config,
@@ -91,6 +97,14 @@ impl<R: ConsensusRpc> Node<R> {
 
     pub fn get_last_checkpoint(&self) -> Option<Vec<u8>> {
         self.consensus.last_checkpoint.clone()
+    }
+
+    pub async fn get_optimistic_update(&self) -> Result<LightClientOptimisticUpdate> {
+        self.consensus.get_optimistic_update().await
+    }
+
+    pub async fn get_finality_update(&self) -> Result<LightClientFinalityUpdate> {
+        self.consensus.get_finality_update().await
     }
 
     fn check_head_age(&self) -> Result<(), NodeError> {

--- a/rpc/src/beacon_rpc.rs
+++ b/rpc/src/beacon_rpc.rs
@@ -4,6 +4,10 @@ use ethportal_api::{
     consensus::header::BeaconBlockHeader,
     light_client::store::LightClientStore,
     types::{
+        consensus::light_client::{
+            finality_update::LightClientFinalityUpdate,
+            optimistic_update::LightClientOptimisticUpdate,
+        },
         enr::Enr,
         jsonrpc::{endpoints::BeaconEndpoint, request::BeaconJsonRpcRequest},
         portal::{
@@ -113,6 +117,18 @@ impl BeaconNetworkApiServer for BeaconNetworkApi {
     /// Get the finalized beacon header.
     async fn finalized_header(&self) -> RpcResult<BeaconBlockHeader> {
         let endpoint = BeaconEndpoint::FinalizedHeader;
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
+    }
+
+    /// Get the optimistic update.
+    async fn optimistic_update(&self) -> RpcResult<LightClientOptimisticUpdate> {
+        let endpoint = BeaconEndpoint::OptimisticUpdate;
+        Ok(proxy_to_subnet(&self.network, endpoint).await?)
+    }
+
+    /// Get the finality update.
+    async fn finality_update(&self) -> RpcResult<LightClientFinalityUpdate> {
+        let endpoint = BeaconEndpoint::FinalityUpdate;
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 

--- a/trin-beacon/src/jsonrpc.rs
+++ b/trin-beacon/src/jsonrpc.rs
@@ -119,6 +119,32 @@ async fn complete_request(network: Arc<BeaconNetwork>, request: BeaconJsonRpcReq
                 None => Err("Beacon client not initialized".to_string()),
             }
         }
+        BeaconEndpoint::FinalityUpdate => {
+            let beacon_client = network.beacon_client.lock().await;
+            match beacon_client.as_ref() {
+                Some(client) => {
+                    let update = client.get_finality_update().await;
+                    match update {
+                        Ok(update) => Ok(json!((update))),
+                        Err(err) => Err(err.to_string()),
+                    }
+                }
+                None => Err("Beacon client not initialized".to_string()),
+            }
+        }
+        BeaconEndpoint::OptimisticUpdate => {
+            let beacon_client = network.beacon_client.lock().await;
+            match beacon_client.as_ref() {
+                Some(client) => {
+                    let update = client.get_optimistic_update().await;
+                    match update {
+                        Ok(update) => Ok(json!((update))),
+                        Err(err) => Err(err.to_string()),
+                    }
+                }
+                None => Err("Beacon client not initialized".to_string()),
+            }
+        }
     };
     let _ = request.resp.send(response);
 }

--- a/trin-utils/src/dir.rs
+++ b/trin-utils/src/dir.rs
@@ -35,7 +35,7 @@ pub fn setup_data_dir(
 /// - Unix-like: `$HOME/.local/share/{app_name}`
 ///
 /// It returns `None` if no valid home directory path could be retrieved from the operating system.
-pub fn get_default_data_dir_path(app_name: &str) -> Option<PathBuf> {
+fn get_default_data_dir_path(app_name: &str) -> Option<PathBuf> {
     ProjectDirs::from("", "", app_name).map(|proj_dirs| proj_dirs.data_local_dir().to_path_buf())
 }
 


### PR DESCRIPTION
### What was wrong?
Exposing the updates rather than the headers themselves is more useful for displaying information in `trin-desktop`.

### How was it fixed?
- Added jsonrpc endpoints to expose the finality/optimistic updates

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
