### PR TITLE
chore: bump ethportal-api to v0.4.0

### DIFF
--- a/ethportal-api/Cargo.toml
+++ b/ethportal-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethportal-api"
-version = "0.3.0"
+version = "0.4.0"
 description = "Definitions for various Ethereum Portal Network JSONRPC APIs"
 build = "build.rs"
 authors.workspace = true


### PR DESCRIPTION
The only change is the new beacon endpoints merged in e18427e8db833259b8af8238fc6453b4fb7b152a
via
https://github.com/ethereum/trin/pull/1604