### PR TITLE
refactor: update docker images to use cargo-chef

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - run:
           name: Build Docker image
           no_output_timeout: 30m
-          command: docker build -f ./docker/Dockerfile -t $IMAGE_NAME:latest --build-arg GIT_HASH=$CIRCLE_SHA1 .
+          command: docker build -f ./docker/Dockerfile -t $IMAGE_NAME:latest
       - run:
           name: Check that Docker container has no defects
           command: docker run $IMAGE_NAME:latest -h
@@ -103,7 +103,7 @@ jobs:
       - run:
           name: Build Docker bridge image
           no_output_timeout: 30m
-          command: docker build -f ./docker/Dockerfile.bridge -t $IMAGE_NAME:latest-bridge --build-arg GIT_HASH=$CIRCLE_SHA1 .
+          command: docker build -f ./docker/Dockerfile.bridge -t $IMAGE_NAME:latest-bridge
       - run:
           name: Archive Docker image
           command: docker save -o bridge-image.tar $IMAGE_NAME

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - run:
           name: Build Docker image
           no_output_timeout: 30m
-          command: docker build -f ./docker/Dockerfile -t $IMAGE_NAME:latest
+          command: docker build -f ./docker/Dockerfile -t $IMAGE_NAME:latest .
       - run:
           name: Check that Docker container has no defects
           command: docker run $IMAGE_NAME:latest -h
@@ -103,7 +103,7 @@ jobs:
       - run:
           name: Build Docker bridge image
           no_output_timeout: 30m
-          command: docker build -f ./docker/Dockerfile.bridge -t $IMAGE_NAME:latest-bridge
+          command: docker build -f ./docker/Dockerfile.bridge -t $IMAGE_NAME:latest-bridge .
       - run:
           name: Archive Docker image
           command: docker save -o bridge-image.tar $IMAGE_NAME

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,30 @@
-.git
-.env
-venv
-target
-/book
+# exclude everything
+*
+
+# include source files
+!Cargo.lock
+!Cargo.toml
+!/e2store
+!/ethportal-api
+!/ethportal-peertest
+!/light-client
+!/portalnet
+!/portal-bridge
+!/rpc
+!/src
+!/trin-beacon
+!/trin-evm
+!/trin-execution
+!/trin-history
+!/trin-metrics
+!/trin-state
+!/trin-storage
+!/trin-utils
+!/trin-validation
+!/utp-testing
+
+# include for vergen constants
+!/.git
+
+# include portal-accumulators, which is used in the portal-bridge Dockerfile
+!/portal-accumulators

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,50 +1,32 @@
-# select build image
-FROM rust:1.81.0 AS builder
-
-# create a new empty shell project
-RUN USER=root cargo new --bin trin
-WORKDIR /trin
-
-# Docker build command *SHOULD* include --build-arg GIT_HASH=...
-# eg. --build-arg GIT_HASH=$(git rev-parse HEAD)
-ARG GIT_HASH=unknown
-ENV GIT_HASH=$GIT_HASH
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
 
 RUN apt-get update && apt-get install clang -y
 
-# copy over manifests and source to build image
-COPY ./Cargo.lock ./Cargo.lock
-COPY ./Cargo.toml ./Cargo.toml
-COPY ./e2store ./e2store
-COPY ./ethportal-api ./ethportal-api
-COPY ./ethportal-peertest ./ethportal-peertest
-COPY ./light-client ./light-client
-COPY ./portalnet ./portalnet
-COPY ./portal-bridge ./portal-bridge
-COPY ./rpc ./rpc
-COPY ./src ./src 
-COPY ./trin-beacon ./trin-beacon
-COPY ./trin-evm ./trin-evm
-COPY ./trin-execution ./trin-execution
-COPY ./trin-history ./trin-history
-COPY ./trin-metrics ./trin-metrics
-COPY ./trin-state ./trin-state
-COPY ./trin-storage ./trin-storage
-COPY ./trin-utils ./trin-utils
-COPY ./trin-validation ./trin-validation 
-COPY ./utp-testing ./utp-testing
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# build for release
-RUN cargo build -p trin --release
+FROM chef AS builder 
+COPY --from=planner /app/recipe.json recipe.json
 
-# final base
-FROM ubuntu:22.04
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Build application
+COPY . .
+RUN cargo build --release --locked --bin trin
+
+# We do not need the Rust toolchain to run the binary!
+FROM ubuntu AS runtime
+WORKDIR /app
 
 # copy build artifacts from build stage
-COPY --from=builder /trin/target/release/trin /usr/bin/
-COPY --from=builder /trin/target/release/poll_latest /usr/bin/
-COPY --from=builder /trin/target/release/purge_invalid_history_content /usr/bin/
-COPY --from=builder /trin/target/release/sample_range /usr/bin/
+COPY --from=builder /app/target/release/trin /usr/bin/
+COPY --from=builder /app/target/release/poll_latest /usr/bin/
+COPY --from=builder /app/target/release/purge_invalid_history_content /usr/bin/
+COPY --from=builder /app/target/release/sample_range /usr/bin/
+
 
 ENV RUST_LOG=debug
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,7 @@ COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 # Build application
+# Copy over all project folders specified in the .dockerignore
 COPY . .
 RUN cargo build --release --locked --bin trin
 
@@ -26,7 +27,6 @@ COPY --from=builder /app/target/release/trin /usr/bin/
 COPY --from=builder /app/target/release/poll_latest /usr/bin/
 COPY --from=builder /app/target/release/purge_invalid_history_content /usr/bin/
 COPY --from=builder /app/target/release/sample_range /usr/bin/
-
 
 ENV RUST_LOG=debug
 

--- a/docker/Dockerfile.bridge
+++ b/docker/Dockerfile.bridge
@@ -1,5 +1,5 @@
 # init final base
-FROM ubuntu:22.04 AS final_base
+FROM ubuntu AS final_base
 # These steps copy over the epoch accumulators repo for the bridge to use
 # This data is too large to be kept inside trin-source code
 # It must be downloaded separately and moved to the correct location
@@ -9,54 +9,36 @@ FROM ubuntu:22.04 AS final_base
 RUN mkdir /portal-accumulators
 COPY ./portal-accumulators /portal-accumulators
 
-# select build image
-FROM rust:1.81.0 AS builder
-
-# create a new empty shell project
-RUN USER=root cargo new --bin trin
-WORKDIR /trin
-
-# Docker build command *SHOULD* include --build-arg GIT_HASH=...
-# eg. --build-arg GIT_HASH=$(git rev-parse HEAD)
-ARG GIT_HASH=unknown
-ENV GIT_HASH=$GIT_HASH
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
 
 RUN apt-get update && apt-get install clang -y
 
-# copy over manifests and source to build image
-COPY ./Cargo.lock ./Cargo.lock
-COPY ./Cargo.toml ./Cargo.toml
-COPY ./e2store ./e2store
-COPY ./ethportal-api ./ethportal-api
-COPY ./ethportal-peertest ./ethportal-peertest
-COPY ./light-client ./light-client
-COPY ./portalnet ./portalnet
-COPY ./portal-bridge ./portal-bridge
-COPY ./rpc ./rpc
-COPY ./src ./src 
-COPY ./trin-beacon ./trin-beacon
-COPY ./trin-evm ./trin-evm
-COPY ./trin-execution ./trin-execution
-COPY ./trin-history ./trin-history
-COPY ./trin-metrics ./trin-metrics
-COPY ./trin-state ./trin-state
-COPY ./trin-storage ./trin-storage
-COPY ./trin-utils ./trin-utils
-COPY ./trin-validation ./trin-validation 
-COPY ./utp-testing ./utp-testing
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# build for release
-RUN cargo build -p trin -p portal-bridge --release
+FROM chef AS builder 
+COPY --from=planner /app/recipe.json recipe.json
 
-# final base
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Build application
+COPY . .
+RUN cargo build --release --locked -p trin -p portal-bridge
+
+# We do not need the Rust toolchain to run the binary!
 FROM final_base
+WORKDIR /app
 
 # copy build artifacts from build stage
-COPY --from=builder /trin/target/release/trin /usr/bin/
-COPY --from=builder /trin/trin-execution/resources /resources
-COPY --from=builder /trin/target/release/portal-bridge /usr/bin/
-COPY --from=builder /trin/target/release/sample_range /usr/bin/
-COPY --from=builder /trin/target/release/poll_latest /usr/bin/
+
+COPY --from=builder /app/target/release/trin /usr/bin/
+COPY --from=builder /app/trin-execution/resources /resources
+COPY --from=builder /app/target/release/portal-bridge /usr/bin/
+COPY --from=builder /app/target/release/sample_range /usr/bin/
+COPY --from=builder /app/target/release/poll_latest /usr/bin/
 
 RUN apt-get update && apt-get install libcurl4 -y
 

--- a/docker/Dockerfile.bridge
+++ b/docker/Dockerfile.bridge
@@ -25,6 +25,7 @@ COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 # Build application
+# Copy over all project folders specified in the .dockerignore
 COPY . .
 RUN cargo build --release --locked -p trin -p portal-bridge
 
@@ -33,7 +34,6 @@ FROM final_base
 WORKDIR /app
 
 # copy build artifacts from build stage
-
 COPY --from=builder /app/target/release/trin /usr/bin/
 COPY --from=builder /app/trin-execution/resources /resources
 COPY --from=builder /app/target/release/portal-bridge /usr/bin/


### PR DESCRIPTION
### What was wrong?

@njgheorghita brought up a concern that https://github.com/ethereum/trin/pull/1615#discussion_r1904266409 with my PR to update how we get the client info, to use vergen instead of shadow-rs https://github.com/ethereum/trin/pull/1615 that our docker images would no longer get the right git commitment.

He brought up a very good point! The way our dockerfiles were setup vergen wouldn't work properly. 

### How was it fixed?

Remove the requirement to pass `GITHASH` to the docker build, by copying the whole working directory, since then the working directory has access to the .git folder, we no longer need to pass it in.

Another thing is now we don't need to update our dockerfile everytime we add a new crate, which will improve maintainability.

Because we are now copying the whole workspace, to not lose caching performance I added cargo-chef (which reth uses) which will changes more info can be found at https://github.com/LukeMathWalker/cargo-chef


I tested these changes locally with https://github.com/ethereum/trin/pull/1615 and it works
![image](https://github.com/user-attachments/assets/1947aa66-9fe1-46f1-82f2-0e5a32f6f1f4)

