### PR TITLE
chore(ci): enable docker build ci on PR's

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,20 +304,14 @@ jobs:
 workflows:
   merge-test:
     jobs:
-      - docker-build:
-          filters:
-            branches:
-              only: master
+      - docker-build
       - docker-publish:
           requires:
             - docker-build
           filters:
             branches:
               only: master
-      - docker-build-bridge:
-          filters:
-            branches:
-              only: master
+      - docker-build-bridge
       - docker-publish-bridge:
           requires:
             - docker-build-bridge


### PR DESCRIPTION
### What was wrong?
When we merged a PR our docker build CI would only build on master

This has lead to CI on master failing a few times in 2024 after we update crates


### How was it fixed?

When something like this fails, it is a good sign we should update our systems to prevent it.

So I enabled running the docker build CI on PR's which will prevent this from happening again in the future
