### PR TITLE
chore(ci): fix CI from failing by updating actions versions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Rust
         run: |
@@ -30,7 +30,6 @@ jobs:
 
       - name: Install mdbook
         run: |
-          mkdir bin
           curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
           echo "$(pwd)/bin" >> $GITHUB_PATH
 
@@ -42,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Install dependencies
         run: cargo install mdbook
@@ -58,7 +57,7 @@ jobs:
         run: mdbook build
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./book/book
 
@@ -80,4 +79,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install required dependencies

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -32,7 +32,7 @@ jobs:
     name: Update
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
       - name: cargo update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     needs: extract-version
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get latest version of stable Rust
         run: rustup update stable
       - name: Install target
@@ -118,13 +118,13 @@ jobs:
       # This is required to share artifacts between different jobs
       # =======================================================================
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: trin-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
           path: trin-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
 
       - name: Upload signature
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: trin-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz.asc
           path: trin-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz.asc
@@ -141,7 +141,7 @@ jobs:
     steps:
       # This is necessary for generating the changelog. It has to come before "Download Artifacts" or else it deletes the artifacts.
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -149,7 +149,7 @@ jobs:
       #       Download artifacts
       # ==============================
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       # ==============================
       #       Create release draft


### PR DESCRIPTION
### What was wrong?

CI is failing with https://github.com/ethereum/trin/actions/runs/12695272279/job/35386819592?pr=1624

```rust
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

### How was it fixed?

updating the version from v3 to v4
