### PR TITLE
fix: update submodule and missing workspace member

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/evm",
     "crates/light-client",
     "crates/metrics",
+    "crates/portalnet",
     "crates/rpc",
     "crates/storage",
     "crates/subnetworks/beacon",


### PR DESCRIPTION
### What was wrong?
I'm chasing down a bug in hive, and noticed that trin doesn't have the latest version of `portal-spec-tests`

On another note, I think we lost a lot of test coverage (at the very least `ethportal-peertest` doesn't seem to be running) with the recent refactor in #1624 ... but I'm still chasing that down and will address it in a future pr. 


### How was it fixed?
- Updated submodule
- Added missing workspace member

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
