### PR TITLE
chore: bump discv5 to 0.9 includes NAT fixes + other improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,36 +19,35 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aead"
-version = "0.4.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
+ "crypto-common",
  "generic-array",
 ]
 
 [[package]]
 name = "aes"
-version = "0.7.5"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "ctr 0.8.0",
- "opaque-debug",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",
  "cipher",
- "ctr 0.7.0",
+ "ctr",
  "ghash",
  "subtle",
 ]
@@ -1346,11 +1345,12 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "generic-array",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1578,6 +1578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -1606,18 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.7.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
-dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "ctr"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
 ]
@@ -1865,31 +1857,31 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac33cb3f99889a57e56a8c6ccb77aaf0cfc7787602b7af09783f736d77314e1"
+version = "0.9.0"
+source = "git+https://github.com/kolbyml/discv5?rev=7dcd74031aa98c220c2984bbc2274c414b6f709f#7dcd74031aa98c220c2984bbc2274c414b6f709f"
 dependencies = [
  "aes",
  "aes-gcm",
+ "alloy-rlp",
  "arrayvec",
- "delay_map 0.3.0",
+ "ctr",
+ "delay_map 0.4.0",
  "enr",
  "fnv",
  "futures",
- "hashlink 0.8.4",
+ "hashlink",
  "hex",
  "hkdf",
  "lazy_static",
  "lru 0.12.5",
  "more-asserts",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.3",
  "rand",
- "rlp",
  "smallvec",
- "socket2 0.4.10",
+ "socket2",
  "tokio",
  "tracing",
- "uint",
+ "uint 0.10.0",
  "zeroize",
 ]
 
@@ -2061,18 +2053,18 @@ dependencies = [
 
 [[package]]
 name = "enr"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
+checksum = "851bd664a3d3a3c175cff92b2f0df02df3c541b4895d0ae307611827aae46152"
 dependencies = [
- "base64 0.21.7",
+ "alloy-rlp",
+ "base64 0.22.1",
  "bytes",
  "ed25519-dalek",
  "hex",
  "k256",
  "log",
  "rand",
- "rlp",
  "serde",
  "sha3 0.10.8",
  "zeroize",
@@ -2237,7 +2229,6 @@ dependencies = [
  "once_cell",
  "quickcheck",
  "rand",
- "rlp",
  "rs_merkle",
  "rstest",
  "secp256k1",
@@ -2592,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -2717,15 +2708,6 @@ dependencies = [
  "equivalent",
  "foldhash",
  "serde",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
-dependencies = [
- "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2955,7 +2937,7 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3188,6 +3170,15 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "instant"
@@ -4364,9 +4355,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polyval"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4498,7 +4489,7 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -5168,7 +5159,7 @@ dependencies = [
  "bitflags 2.7.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink 0.9.1",
+ "hashlink",
  "libsqlite3-sys",
  "smallvec",
 ]
@@ -5823,16 +5814,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
@@ -6321,7 +6302,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.8",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -7002,6 +6983,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7042,11 +7035,11 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "generic-array",
+ "crypto-common",
  "subtle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ chrono = "0.4.38"
 clap = { version = "4.2.1", features = ["derive"] }
 delay_map = "0.4.0"
 directories = "3.0"
-discv5 = { version = "0.4.1", features = ["serde"] }
+discv5 = { git = "https://github.com/kolbyml/discv5", rev = "7dcd74031aa98c220c2984bbc2274c414b6f709f", features = ["serde"] }
 env_logger = "0.9.0"
 eth_trie = "0.5.0"
 ethereum_hashing = "0.7.0"

--- a/bin/portal-bridge/src/cli.rs
+++ b/bin/portal-bridge/src/cli.rs
@@ -267,8 +267,8 @@ impl FromStr for ClientType {
 impl From<&Enr> for ClientType {
     fn from(enr: &Enr) -> Self {
         let client_id = enr
-            .get(ENR_PORTAL_CLIENT_KEY)
-            .and_then(|v| String::from_utf8(v.to_vec()).ok());
+            .get_decodable::<String>(ENR_PORTAL_CLIENT_KEY)
+            .and_then(|v| v.ok());
         if let Some(client_id) = client_id {
             if client_id.starts_with("t") {
                 ClientType::Trin

--- a/crates/ethportal-api/Cargo.toml
+++ b/crates/ethportal-api/Cargo.toml
@@ -34,7 +34,6 @@ lazy_static.workspace = true
 once_cell = "1.17"
 quickcheck.workspace = true
 rand.workspace = true
-rlp = "0.5.0"
 rs_merkle = "1.4.2"
 secp256k1 = { version = "0.29.0", features = ["global-context", "recovery", "rand"] }
 serde = { workspace = true, features = ["rc"] }

--- a/crates/ethportal-api/src/types/enr.rs
+++ b/crates/ethportal-api/src/types/enr.rs
@@ -4,9 +4,9 @@ use std::{
     str::FromStr,
 };
 
+use alloy_rlp::{Encodable, RlpDecodableWrapper, RlpEncodableWrapper};
 use discv5::enr::{CombinedKey, Enr as Discv5Enr};
 use rand::Rng;
-use rlp::Encodable;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use ssz::DecodeError;
@@ -14,7 +14,9 @@ use validator::ValidationError;
 
 pub type Enr = Discv5Enr<CombinedKey>;
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(
+    Debug, PartialEq, Clone, Serialize, Deserialize, RlpEncodableWrapper, RlpDecodableWrapper,
+)]
 pub struct SszEnr(pub Enr);
 
 impl SszEnr {
@@ -76,11 +78,13 @@ impl ssz::Encode for SszEnr {
     }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
-        buf.append(&mut self.rlp_bytes().to_vec());
+        self.encode(buf);
     }
 
     fn ssz_bytes_len(&self) -> usize {
-        self.rlp_bytes().to_vec().ssz_bytes_len()
+        let mut buf = vec![];
+        self.encode(&mut buf);
+        buf.ssz_bytes_len()
     }
 }
 

--- a/crates/portalnet/src/discovery.rs
+++ b/crates/portalnet/src/discovery.rs
@@ -213,7 +213,7 @@ impl Discovery {
                         // TODO: this is a temporary fix to prevent caching of eth2 nodes
                         // and will be updated to a more stable solution as soon as it
                         // validates the theory of what is causing the issue on mainnet.
-                        if enr.get(ENR_PORTAL_CLIENT_KEY).is_none() {
+                        if enr.get_decodable::<String>(ENR_PORTAL_CLIENT_KEY).is_none() {
                             debug!(
                                 enr = ?enr,
                                 "discv5 session established with node that does not have a portal client key, not caching"
@@ -416,8 +416,8 @@ impl UtpEnr {
 
     pub fn client(&self) -> Option<String> {
         self.0
-            .get(ENR_PORTAL_CLIENT_KEY)
-            .and_then(|v| String::from_utf8(v.to_vec()).ok())
+            .get_decodable::<String>(ENR_PORTAL_CLIENT_KEY)
+            .and_then(|v| v.ok())
     }
 }
 

--- a/crates/validation/Cargo.toml
+++ b/crates/validation/Cargo.toml
@@ -14,7 +14,7 @@ version.workspace = true
 [dependencies]
 alloy.workspace = true
 anyhow.workspace = true
-enr = "0.10.0"
+enr = "0.13.0"
 ethereum_hashing = "0.7.0"
 ethereum_ssz.workspace = true
 ethereum_ssz_derive.workspace = true


### PR DESCRIPTION
### What was wrong?

We are using a fairly old version of discv5 0.4.1 there has been quote a few improvements

- Automatic Firewall/NAT Detection
- Increase default vote duration to 2 minutes
- Respond to requests from peers with invalid ENRs
- Remove unused event EnrAdded
- Prevent storing non-contactable ENRs

### How was it fixed?

by bumping the version and updating what is required

sigp/discv5 had a regression when updating from 0.4.1 to 0.5.0 when upgrading from parity rlp to alloy_rlp. I made a fix here, https://github.com/sigp/discv5/pull/276 I have set the cargo.toml to point to my PR for now, we can update to a release when it is merge in. These improvements seem pretty big so I think they are worth getting in
