### PR TITLE
fix: cross build ci required for releases + remove const_format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,27 +1440,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const_format"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
-dependencies = [
- "const_format_proc_macros",
- "konst",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,7 +2193,6 @@ dependencies = [
  "bimap",
  "bytes",
  "c-kzg",
- "const_format",
  "discv5",
  "env_logger 0.9.3",
  "eth_trie",
@@ -3514,21 +3492,6 @@ dependencies = [
  "primitive-types",
  "tiny-keccak",
 ]
-
-[[package]]
-name = "konst"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330f0e13e6483b8c34885f7e6c9f19b1a7bd449c673fbb948a51c99d66ef74f4"
-dependencies = [
- "konst_macro_rules",
-]
-
-[[package]]
-name = "konst_macro_rules"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"

--- a/crates/ethportal-api/Cargo.toml
+++ b/crates/ethportal-api/Cargo.toml
@@ -20,7 +20,6 @@ base64 = "0.13.0"
 bimap = "0.6.3"
 bytes.workspace = true
 c-kzg = "1.0.0"
-const_format = {version = "0.2.0", features = ["rust_1_64"]}
 discv5.workspace = true
 eth_trie.workspace = true
 ethereum_hashing.workspace = true

--- a/crates/ethportal-api/build.rs
+++ b/crates/ethportal-api/build.rs
@@ -1,4 +1,4 @@
-use std::error::Error;
+use std::{env, error::Error};
 
 use vergen::EmitBuilder;
 
@@ -10,6 +10,40 @@ fn main() -> Result<(), Box<dyn Error>> {
         .rustc_semver()
         .cargo_features()
         .cargo_target_triple()
-        .emit()?;
+        .emit_and_set()?;
+
+    // Set short SHA
+    let sha = env::var("VERGEN_GIT_SHA")?;
+    let short_sha = &sha[0..7];
+    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={short_sha}");
+
+    // Trin's version is the same as the git tag.
+    let git_describe = env::var("VERGEN_GIT_DESCRIBE")?;
+    let trin_version = git_describe.split('-').collect::<Vec<&str>>()[0];
+    println!("cargo:rustc-env=TRIN_VERSION={}", trin_version);
+
+    let cargo_target_triple = env::var("VERGEN_CARGO_TARGET_TRIPLE")?;
+    let target_triple = cargo_target_triple.split('-').collect::<Vec<&str>>();
+    let build_architecture = target_triple[0];
+    let build_operating_system = target_triple[2];
+
+    // The operating system of the build, linux, macos, windows etc.
+    println!("cargo:rustc-env=TRIN_BUILD_OPERATING_SYSTEM={build_operating_system}");
+
+    // The architecture of the build, x86_64, aarch64, etc.
+    println!("cargo:rustc-env=TRIN_BUILD_ARCHITECTURE={build_architecture}");
+
+    println!(
+        "cargo:rustc-env=TRIN_FULL_VERSION={}",
+        format_args!(
+            "{version}-{hash} {build_os}-{build_arch} rustc{rust_version}",
+            version = trin_version,
+            hash = short_sha,
+            build_os = build_operating_system,
+            build_arch = build_architecture,
+            rust_version = env::var("VERGEN_RUSTC_SEMVER")?
+        )
+    );
+
     Ok(())
 }

--- a/crates/ethportal-api/src/version.rs
+++ b/crates/ethportal-api/src/version.rs
@@ -1,29 +1,22 @@
+use std::env;
+
 /// The latest git commit hash of the build.
 pub const TRIN_FULL_COMMIT: &str = env!("VERGEN_GIT_SHA");
-pub const TRIN_SHORT_COMMIT: &str = const_format::str_index!(TRIN_FULL_COMMIT, ..8);
+pub const TRIN_SHORT_COMMIT: &str = env!("VERGEN_GIT_SHA_SHORT");
 
 /// Trin's version is the same as the git tag.
-pub const TRIN_VERSION: &str = const_format::str_split!(env!("VERGEN_GIT_DESCRIBE"), '-')[0];
+pub const TRIN_VERSION: &str = env!("TRIN_VERSION");
 
 /// The operating system of the build, linux, macos, windows etc.
-pub const BUILD_OPERATING_SYSTEM: &str =
-    const_format::str_split!(env!("VERGEN_CARGO_TARGET_TRIPLE"), "-")[2];
+pub const BUILD_OPERATING_SYSTEM: &str = env!("TRIN_BUILD_OPERATING_SYSTEM");
 
 /// The architecture of the build, x86_64, aarch64, etc.
-pub const BUILD_ARCHITECTURE: &str =
-    const_format::str_split!(env!("VERGEN_CARGO_TARGET_TRIPLE"), "-")[0];
+pub const BUILD_ARCHITECTURE: &str = env!("TRIN_BUILD_ARCHITECTURE");
 
 // /// The version of the programming language used to build the binary.
 pub const PROGRAMMING_LANGUAGE_VERSION: &str = env!("VERGEN_RUSTC_SEMVER");
 
-pub const FULL_VERSION: &str = const_format::formatcp!(
-    "{version}-{hash} {build_os}-{build_arch} rustc{rust_version}",
-    version = TRIN_VERSION,
-    hash = TRIN_SHORT_COMMIT,
-    build_os = BUILD_OPERATING_SYSTEM,
-    build_arch = BUILD_ARCHITECTURE,
-    rust_version = PROGRAMMING_LANGUAGE_VERSION
-);
+pub const FULL_VERSION: &str = env!("TRIN_FULL_VERSION");
 
 /// Returns the trin version and git revision.
 pub const fn get_trin_version() -> &'static str {


### PR DESCRIPTION
### What was wrong?

There was a bug in https://github.com/ethereum/trin/pull/1615 which caused https://github.com/ethereum/trin/actions/runs/12834319209/job/35791388762 release ci to fail, on trying to build.

### How was it fixed?

I removed const_format cause it wasn't needed and also fixed some indexing

I tested on my forked github repo and it works

release: https://github.com/KolbyML/trin/releases
release branch: https://github.com/KolbyML/trin/tree/fix-cross-build
ci working: https://github.com/KolbyML/trin/actions/runs/12835484962/job/35796339052

![image](https://github.com/user-attachments/assets/0f7942e4-85f8-49c0-b891-1d8cb8fa8c86)

I tested the binary built locally

![image](https://github.com/user-attachments/assets/5edcbc43-2578-4c09-ae5c-37f709326c6a)

and the short commit matches