### PR TITLE
feat: add uTP duration metrics

### DIFF
--- a/crates/portalnet/src/lib.rs
+++ b/crates/portalnet/src/lib.rs
@@ -13,4 +13,4 @@ pub mod put_content;
 pub mod socket;
 pub mod types;
 pub mod utils;
-pub mod utp_controller;
+pub mod utp;

--- a/crates/portalnet/src/overlay/protocol.rs
+++ b/crates/portalnet/src/overlay/protocol.rs
@@ -59,7 +59,7 @@ use crate::{
         kbucket::{Entry, SharedKBucketsTable},
         node::Node,
     },
-    utp_controller::UtpController,
+    utp::controller::UtpController,
 };
 
 /// Overlay protocol is a layer on top of discv5 that handles all requests from the overlay networks

--- a/crates/portalnet/src/overlay/request.rs
+++ b/crates/portalnet/src/overlay/request.rs
@@ -6,10 +6,9 @@ use ethportal_api::types::{
     portal_wire::{Request, Response},
 };
 use futures::channel::oneshot;
-use tokio::sync::OwnedSemaphorePermit;
 
 use super::errors::OverlayRequestError;
-use crate::find::query_pool::QueryId;
+use crate::{find::query_pool::QueryId, utp::timed_semaphore::OwnedTimedSemaphorePermit};
 
 /// An incoming or outgoing request.
 #[derive(Debug, PartialEq)]
@@ -44,7 +43,7 @@ pub struct OverlayRequest {
     /// Will be None for requests that are not associated with a query.
     pub query_id: Option<QueryId>,
     /// An optional permit to allow for transfer caps
-    pub request_permit: Option<OwnedSemaphorePermit>,
+    pub request_permit: Option<OwnedTimedSemaphorePermit>,
 }
 
 impl OverlayRequest {
@@ -54,7 +53,7 @@ impl OverlayRequest {
         direction: RequestDirection,
         responder: Option<OverlayResponder>,
         query_id: Option<QueryId>,
-        request_permit: Option<OwnedSemaphorePermit>,
+        request_permit: Option<OwnedTimedSemaphorePermit>,
     ) -> Self {
         OverlayRequest {
             id: rand::random(),
@@ -77,7 +76,7 @@ pub struct ActiveOutgoingRequest {
     /// An optional QueryID for the query that this request is associated with.
     pub query_id: Option<QueryId>,
     /// An optional permit to allow for transfer caps
-    pub request_permit: Option<OwnedSemaphorePermit>,
+    pub request_permit: Option<OwnedTimedSemaphorePermit>,
 }
 
 /// A response for a particular overlay request.

--- a/crates/portalnet/src/put_content.rs
+++ b/crates/portalnet/src/put_content.rs
@@ -22,7 +22,7 @@ use crate::{
         request::{OverlayRequest, RequestDirection},
     },
     types::kbucket::SharedKBucketsTable,
-    utp_controller::UtpController,
+    utp::controller::UtpController,
 };
 
 /// Datatype to store the result of a put content request.

--- a/crates/portalnet/src/utp/mod.rs
+++ b/crates/portalnet/src/utp/mod.rs
@@ -1,0 +1,2 @@
+pub mod controller;
+pub mod timed_semaphore;

--- a/crates/portalnet/src/utp/timed_semaphore.rs
+++ b/crates/portalnet/src/utp/timed_semaphore.rs
@@ -1,0 +1,17 @@
+use tokio::sync::OwnedSemaphorePermit;
+use trin_metrics::timer::DiscardOnDropHistogramTimer;
+
+/// A owned semaphore which records the time it has been alive from initialization to when drop() is
+/// called.
+#[derive(Debug)]
+pub struct OwnedTimedSemaphorePermit {
+    pub permit: OwnedSemaphorePermit,
+    pub histogram_timer: DiscardOnDropHistogramTimer,
+}
+
+impl OwnedTimedSemaphorePermit {
+    pub fn drop(self) {
+        self.histogram_timer.stop_and_record();
+        drop(self.permit);
+    }
+}


### PR DESCRIPTION
### What was wrong?
For the most part we have no idea into how uTP is performing, are things working right? Idk lets add some metrics
### How was it fixed?

add a timer attached to the semaphore. This metric won't include uTP transfers initiated over json-rpc, but I am not really concerned with the uTP transfers over json-rpc


