### PR TITLE
feat: add max-radius param with 5% default

### DIFF
--- a/bin/trin/src/cli.rs
+++ b/bin/trin/src/cli.rs
@@ -9,6 +9,7 @@ use clap::{
 };
 use ethportal_api::{
     types::{
+        distance::Distance,
         network::Subnetwork,
         portal_wire::{NetworkSpec, MAINNET},
     },
@@ -25,11 +26,14 @@ use portalnet::{
 use rpc::config::RpcConfig;
 use trin_storage::config::StorageCapacityConfig;
 use trin_utils::cli::{
-    check_private_key_length, network_parser, subnetwork_parser, Web3TransportType,
+    check_private_key_length, max_radius_parser, network_parser, subnetwork_parser,
+    Web3TransportType,
 };
 use url::Url;
 
 const DEFAULT_SUBNETWORKS: &str = "history";
+/// Default max radius value percentage out of 100.
+const DEFAULT_MAX_RADIUS: &str = "5";
 pub const DEFAULT_STORAGE_CAPACITY_MB: &str = "1000";
 pub const DEFAULT_WEB3_TRANSPORT: &str = "ipc";
 
@@ -205,6 +209,14 @@ pub struct TrinConfig {
         default_value_t = DEFAULT_UTP_TRANSFER_LIMIT,
     )]
     pub utp_transfer_limit: usize,
+
+    #[arg(
+        long,
+        help = "The maximum radius our node will use. The default is 5% of the network size. The max is 100%",
+        default_value = DEFAULT_MAX_RADIUS,
+        value_parser = max_radius_parser,
+    )]
+    pub max_radius: Distance,
 }
 
 impl Default for TrinConfig {
@@ -236,6 +248,8 @@ impl Default for TrinConfig {
             ws_port: DEFAULT_WEB3_WS_PORT,
             utp_transfer_limit: DEFAULT_UTP_TRANSFER_LIMIT,
             network: MAINNET.clone(),
+            max_radius: max_radius_parser(DEFAULT_MAX_RADIUS)
+                .expect("Parsing static DEFAULT_MAX_RADIUS to work"),
         }
     }
 }

--- a/bin/trin/src/lib.rs
+++ b/bin/trin/src/lib.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 
 use cli::TrinConfig;
 use ethportal_api::{
-    types::network::Subnetwork, utils::bytes::hex_encode, version::get_trin_version,
+    types::{distance::Distance, network::Subnetwork},
+    utils::bytes::hex_encode,
+    version::get_trin_version,
 };
 use portalnet::{
     discovery::{Discovery, Discv5UdpSocket},
@@ -103,7 +105,7 @@ pub async fn run_trin(
                 &discovery,
                 utp_socket.clone(),
                 portalnet_config.clone(),
-                storage_config_factory.create(&Subnetwork::State)?,
+                storage_config_factory.create(&Subnetwork::State, trin_config.max_radius)?,
                 header_oracle.clone(),
             )
             .await?
@@ -123,7 +125,7 @@ pub async fn run_trin(
             &discovery,
             utp_socket.clone(),
             portalnet_config.clone(),
-            storage_config_factory.create(&Subnetwork::Beacon)?,
+            storage_config_factory.create(&Subnetwork::Beacon, Distance::MAX)?,
             header_oracle.clone(),
         )
         .await?
@@ -146,7 +148,7 @@ pub async fn run_trin(
             &discovery,
             utp_socket.clone(),
             portalnet_config.clone(),
-            storage_config_factory.create(&Subnetwork::History)?,
+            storage_config_factory.create(&Subnetwork::History, trin_config.max_radius)?,
             header_oracle.clone(),
         )
         .await?

--- a/crates/storage/src/test_utils.rs
+++ b/crates/storage/src/test_utils.rs
@@ -1,5 +1,5 @@
 use discv5::enr::NodeId;
-use ethportal_api::types::network::Subnetwork;
+use ethportal_api::types::{distance::Distance, network::Subnetwork};
 use tempfile::TempDir;
 
 use crate::{
@@ -21,7 +21,7 @@ pub fn create_test_portal_storage_config_with_capacity(
         temp_dir.path().to_path_buf(),
     )
     .unwrap()
-    .create(&Subnetwork::History)
+    .create(&Subnetwork::History, Distance::MAX)
     .unwrap();
     Ok((temp_dir, config))
 }

--- a/crates/storage/src/versioned/id_indexed_v1/config.rs
+++ b/crates/storage/src/versioned/id_indexed_v1/config.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use discv5::enr::NodeId;
-use ethportal_api::types::network::Subnetwork;
+use ethportal_api::types::{distance::Distance, network::Subnetwork};
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 
@@ -19,6 +19,7 @@ pub struct IdIndexedV1StoreConfig {
     pub sql_connection_pool: Pool<SqliteConnectionManager>,
     pub distance_fn: DistanceFunction,
     pub pruning_config: PruningConfig,
+    pub max_radius: Distance,
 }
 
 impl IdIndexedV1StoreConfig {
@@ -37,6 +38,7 @@ impl IdIndexedV1StoreConfig {
             distance_fn: config.distance_fn,
             // consider making this a parameter if we start using non-default value
             pruning_config: PruningConfig::default(),
+            max_radius: config.max_radius,
         }
     }
 }

--- a/crates/storage/src/versioned/id_indexed_v1/pruning_strategy.rs
+++ b/crates/storage/src/versioned/id_indexed_v1/pruning_strategy.rs
@@ -196,7 +196,7 @@ mod tests {
     use std::path::PathBuf;
 
     use discv5::enr::NodeId;
-    use ethportal_api::types::network::Subnetwork;
+    use ethportal_api::types::{distance::Distance, network::Subnetwork};
     use r2d2::Pool;
     use r2d2_sqlite::SqliteConnectionManager;
     use rstest::rstest;
@@ -220,6 +220,7 @@ mod tests {
             sql_connection_pool: Pool::new(SqliteConnectionManager::memory()).unwrap(),
             distance_fn: DistanceFunction::Xor,
             pruning_config: PruningConfig::default(),
+            max_radius: Distance::MAX,
         };
         PruningStrategy::new(config)
     }

--- a/crates/storage/src/versioned/id_indexed_v1/store.rs
+++ b/crates/storage/src/versioned/id_indexed_v1/store.rs
@@ -84,12 +84,12 @@ impl<TContentKey: OverlayContentKey> VersionedContentStore for IdIndexedV1Store<
         let pruning_strategy = PruningStrategy::new(config.clone());
 
         let mut store = Self {
-            config,
-            radius: Distance::MAX,
+            radius: config.max_radius,
             pruning_strategy,
             usage_stats: UsageStats::default(),
             metrics: StorageMetricsReporter::new(subnetwork),
             _phantom_content_key: PhantomData,
+            config,
         };
         store.init()?;
         Ok(store)
@@ -133,11 +133,12 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
         } else {
             debug!(
                 Db = %self.config.content_type,
-                "Used capacity ({}) is below target capacity ({}) -> Using MAX radius",
+                "Used capacity ({}) is below target capacity ({}) -> Using MAX radius ({})",
                 self.usage_stats.total_entry_size_bytes,
-                self.pruning_strategy.target_capacity_bytes()
+                self.pruning_strategy.target_capacity_bytes(),
+                self.config.max_radius,
             );
-            self.radius = Distance::MAX;
+            self.radius = self.config.max_radius;
             self.metrics.report_radius(self.radius);
         }
 
@@ -420,7 +421,7 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
 
     /// Sets `self.radius` to the distance to the farthest stored content.
     ///
-    /// If no content is found, it sets radius to `Distance::MAX`.
+    /// If no content is found, it sets radius to `config.max_radius`.
     fn set_radius_to_farthest(&mut self) -> Result<(), ContentStoreError> {
         match self.lookup_farthest()? {
             None => {
@@ -432,7 +433,7 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
                     self.radius = Distance::ZERO;
                 } else {
                     error!(Db = %self.config.content_type, "Farthest not found!");
-                    self.radius = Distance::MAX;
+                    self.radius = self.config.max_radius;
                 }
             }
             Some(farthest) => {
@@ -572,6 +573,7 @@ mod tests {
             sql_connection_pool: setup_sql(temp_dir.path()).unwrap(),
             storage_capacity_bytes,
             pruning_config: PruningConfig::default(),
+            max_radius: Distance::MAX,
         }
     }
 

--- a/crates/storage/src/versioned/id_indexed_v1/store.rs
+++ b/crates/storage/src/versioned/id_indexed_v1/store.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{cmp::min, marker::PhantomData};
 
 use ethportal_api::{types::distance::Distance, OverlayContentKey, RawContentValue};
 use r2d2::Pool;
@@ -437,7 +437,10 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
                 }
             }
             Some(farthest) => {
-                self.radius = self.distance_to_content_id(&farthest.content_id);
+                self.radius = min(
+                    self.distance_to_content_id(&farthest.content_id),
+                    self.config.max_radius,
+                );
             }
         }
         self.metrics.report_radius(self.radius);

--- a/crates/utils/src/cli.rs
+++ b/crates/utils/src/cli.rs
@@ -90,8 +90,8 @@ pub fn max_radius_parser(max_radius_str: &str) -> Result<Distance, String> {
         ));
     }
 
-    // If the max radius is 100%, return the maximum distance as without it we will be 35 less than
-    // the maximum distance.
+    // If the max radius is 100% return it, as arithmetic multiplication loses precision and will be
+    // off by 5.
     if max_radius_percentage == U256::from(100) {
         return Ok(Distance::MAX);
     }

--- a/crates/utils/src/cli.rs
+++ b/crates/utils/src/cli.rs
@@ -1,8 +1,9 @@
 use core::fmt;
 use std::{str::FromStr, sync::Arc};
 
-use alloy::primitives::B256;
+use alloy::primitives::{B256, U256};
 use ethportal_api::types::{
+    distance::Distance,
     network::Subnetwork,
     portal_wire::{NetworkSpec, ANGELFOOD, MAINNET},
 };
@@ -71,4 +72,31 @@ pub fn subnetwork_parser(subnetwork_string: &str) -> Result<Arc<Vec<Subnetwork>>
     }
 
     Ok(Arc::new(subnetworks))
+}
+
+pub fn max_radius_parser(max_radius_str: &str) -> Result<Distance, String> {
+    let max_radius_percentage = match max_radius_str.parse::<U256>() {
+        Ok(val) => val,
+        Err(err) => {
+            return Err(format!(
+                "Invalid max radius percentage, expected a number, received: {err}"
+            ))
+        }
+    };
+
+    if max_radius_percentage > U256::from(100) {
+        return Err(format!(
+            "Invalid max radius percentage, expected 0 to 100, received: {max_radius_percentage}"
+        ));
+    }
+
+    // If the max radius is 100%, return the maximum distance as without it we will be 35 less than
+    // the maximum distance.
+    if max_radius_percentage == U256::from(100) {
+        return Ok(Distance::MAX);
+    }
+
+    Ok(Distance::from(
+        U256::MAX / U256::from(100) * max_radius_percentage,
+    ))
 }

--- a/testing/ethportal-peertest/src/lib.rs
+++ b/testing/ethportal-peertest/src/lib.rs
@@ -107,6 +107,8 @@ fn generate_trin_config(
         "--unsafe-private-key",
         private_key.as_str(),
         "--ephemeral",
+        "--max-radius",
+        "100",
     ];
     TrinConfig::new_from(trin_config_args).unwrap()
 }

--- a/testing/ethportal-peertest/src/scenarios/put_content.rs
+++ b/testing/ethportal-peertest/src/scenarios/put_content.rs
@@ -364,6 +364,8 @@ fn fresh_node_config() -> (String, TrinConfig) {
         test_discovery_port.to_string().as_ref(),
         "--bootnodes",
         "none",
+        "--max-radius",
+        "100",
         "--unsafe-private-key",
         // node id: 0x27128939ed60d6f4caef0374da15361a2c1cd6baa1a5bccebac1acd18f485900
         "0x9ca7889c09ef1162132251b6284bd48e64bd3e71d75ea33b959c37be0582a2fd",

--- a/testing/ethportal-peertest/tests/rpc_server.rs
+++ b/testing/ethportal-peertest/tests/rpc_server.rs
@@ -50,6 +50,8 @@ async fn setup_web3_server() -> (RpcServerHandle, RootProvider<PubSubFrontend>, 
         &test_discovery_port.to_string(),
         "--bootnodes",
         "none",
+        "--max-radius",
+        "100",
     ])
     .unwrap();
 
@@ -86,6 +88,8 @@ async fn test_batch_call() {
         &test_discovery_port.to_string(),
         "--bootnodes",
         "none",
+        "--max-radius",
+        "100",
     ])
     .unwrap();
 

--- a/testing/ethportal-peertest/tests/self_peertest.rs
+++ b/testing/ethportal-peertest/tests/self_peertest.rs
@@ -339,6 +339,8 @@ async fn peertest_ping_cross_discv5_protocol_id() {
         test_discovery_port.to_string().as_ref(),
         "--bootnodes",
         "none",
+        "--max-radius",
+        "100",
     ])
     .unwrap();
     let mainnet_handle = trin::run_trin(trin_config).await.unwrap();
@@ -392,6 +394,8 @@ async fn setup_peertest(
         test_discovery_port.to_string().as_ref(),
         "--bootnodes",
         "none",
+        "--max-radius",
+        "100",
     ])
     .unwrap();
 
@@ -446,6 +450,8 @@ async fn setup_peertest_bridge(
         test_discovery_port.to_string().as_ref(),
         "--bootnodes",
         &peertest.bootnode.enr.to_base64(),
+        "--max-radius",
+        "100",
     ])
     .unwrap();
 


### PR DESCRIPTION
### What was wrong?

For a larger description of the problem can be viewed here https://github.com/ethereum/trin/issues/1574

The TL:DR is currently we start at 100 percent radius when the node will end up at 1-3%. This means we download and purge content our node won't end up storing which wastes a lot of CPU cycles, but also takes our uTP transfer limit which could be used for content within our final 1-3% final radius.

This is a big issue as on the state network, currently we are trying to bridge latest state, but our nodes uTP limit is always full so often `trin-execution` offer's of state diffs are declined as all State nodes are at transfer capacity.

![image](https://github.com/user-attachments/assets/845b6737-7551-4ef2-b5ef-ec520c5ef3d7)
^ here is a picture I took awhile ago, at the bottom you can see we successfully offered to 0 peers and the content was declined 8 times. This is due to the State nodes being at uTP transfer capacity (or in other words hitting our rate limit)

Recently this issue has gotten worse, but even if it didn't this PR is required if we want to bridge latest state. Bridging state content is very expensive, because there is just so much state to gossip. If we want Portal and the State network to be successful we need a 10x performance improvement at least in Trin as currently Trin can only handle 5 Mbps up and down which is way to slow, we won't be able to take a load on the network with this.

So this PR is the first step in a road of changes which will hopefully greatly increase the performance in Trin. I don't think we have a choice we need to be performent if we want users.

### How was it fixed?

Add a cli called `max-radius`, by default the max radius is 5 percent, assuming we have a network of over 20 nodes we should have max coverage. Since the nodes radius's should end up below 3% especially as the network storage requirements will keep growing over time. So I don't think we should have a default bigger then 5%

For testing on hive we will use `--max-radius 100`

I think this solution is the best one for the foreseeable future, we could do a more complex scheme but that wouldn't be worth it right now, instead we should focus on finding other bottlenecks in Trin as this PR is good enough and gets us most of want we want for the foreseeable future. A more complex scheme would give diminishing returns, so I wouldn't expect us to look into it until Trin is very optimized so it is a very low priority to further optimize this with a complex solution.