### PR TITLE
fix: docker portal-bridge can't find genesis.json

### DIFF
--- a/bin/trin-execution/src/evm/block_executor.rs
+++ b/bin/trin-execution/src/evm/block_executor.rs
@@ -1,12 +1,9 @@
 use std::{
     collections::HashMap,
-    fs::File,
-    io::BufReader,
-    path::Path,
     time::{Duration, Instant},
 };
 
-use anyhow::{bail, ensure};
+use anyhow::ensure;
 use eth_trie::{RootWithTrieDiff, Trie};
 use ethportal_api::{
     types::{execution::transaction::Transaction, state_trie::account_state::AccountState},
@@ -36,8 +33,6 @@ use crate::{
 };
 
 pub const BLOCKHASH_SERVE_WINDOW: u64 = 256;
-const GENESIS_STATE_FILE: &str = "trin-execution/resources/genesis/mainnet.json";
-const TEST_GENESIS_STATE_FILE: &str = "resources/genesis/mainnet.json";
 
 #[derive(Debug, Serialize, Deserialize)]
 struct AllocBalance {
@@ -132,14 +127,8 @@ impl<'a> BlockExecutor<'a> {
     }
 
     fn process_genesis(&mut self) -> anyhow::Result<()> {
-        let genesis_file = if Path::new(GENESIS_STATE_FILE).is_file() {
-            File::open(GENESIS_STATE_FILE)?
-        } else if Path::new(TEST_GENESIS_STATE_FILE).is_file() {
-            File::open(TEST_GENESIS_STATE_FILE)?
-        } else {
-            bail!("Genesis file not found")
-        };
-        let genesis: GenesisConfig = serde_json::from_reader(BufReader::new(genesis_file))?;
+        let genesis: GenesisConfig =
+            serde_json::from_str(include_str!("../../resources/genesis/mainnet.json"))?;
 
         for (address, alloc_balance) in genesis.alloc {
             let address_hash = keccak256(address);

--- a/docker/Dockerfile.bridge
+++ b/docker/Dockerfile.bridge
@@ -35,7 +35,6 @@ WORKDIR /app
 
 # copy build artifacts from build stage
 COPY --from=builder /app/target/release/trin /usr/bin/
-COPY --from=builder /app/bin/trin-execution/resources /resources
 COPY --from=builder /app/target/release/portal-bridge /usr/bin/
 
 RUN apt-get update && apt-get install libcurl4 -y


### PR DESCRIPTION
### What was wrong?
Milos noticed that the 1M state bridges weren't running after the refactor
![image](https://github.com/user-attachments/assets/8121b361-b430-4d9b-bbbf-9902a4c9473d)

### How was it fixed?

Stop reading the genesis file and use `include_str!` I am using this upstream for trin-execution and it is also common practice in reth for the genesis file.

Just to point out we can't use a const I believe, `include_str` errored saying we must use a string literal
