### PR TITLE
fix: set gas_price when handling eth_call

### DIFF
--- a/crates/rpc/src/eth_rpc.rs
+++ b/crates/rpc/src/eth_rpc.rs
@@ -126,6 +126,13 @@ impl EthApiServer for EthApi {
         if transaction.gas.is_none() {
             transaction.gas = Some(evm_block_state.block_header().gas_limit.to());
         }
+        // If gas price is not set, set it to base fee
+        if transaction.gas_price.is_none() {
+            transaction.gas_price = evm_block_state
+                .block_header()
+                .base_fee_per_gas
+                .map(|base_fee| base_fee.to());
+        }
 
         let result_and_state = execute_transaction(
             create_block_env(evm_block_state.block_header()),

--- a/crates/rpc/src/evm_state.rs
+++ b/crates/rpc/src/evm_state.rs
@@ -17,10 +17,11 @@ use ethportal_api::{
             trie_traversal::{NodeTraversal, TraversalError, TraversalResult},
         },
     },
-    ContentValue, ContentValueError, Header, StateContentKey, StateContentValue,
+    ContentValue, ContentValueError, Header, OverlayContentKey, StateContentKey, StateContentValue,
 };
 use revm::primitives::{AccountInfo, Bytecode, KECCAK_EMPTY};
 use tokio::sync::mpsc;
+use tracing::debug;
 use trin_evm::async_db::AsyncDatabase;
 
 use crate::{errors::RpcServeError, fetch::proxy_to_subnet};
@@ -161,6 +162,10 @@ impl EvmBlockState {
             return Ok(value.clone());
         }
 
+        debug!(
+            content_id = ?Bytes::from(content_key.content_id()),
+            content_key = ?content_key.to_bytes(),
+            "Fetching state content");
         let endpoint = StateEndpoint::GetContent(content_key.clone());
         let GetContentInfo { content, .. } =
             proxy_to_subnet(&self.state_network, endpoint)


### PR DESCRIPTION
### What was wrong?

We can't execute transaction post EIP-1559 without setting gas price. And gas price has to be at least base fee.

### How was it fixed?

If unset, set the gas price to base fee.

Also added `debug` logging for easier debugging eth_call requests.

