### PR TITLE
fix: temporarily pin crunchy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,9 +1535,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,3 +114,9 @@ trin-state = { path = "crates/subnetworks/state" }
 trin-storage = { path = "crates/storage" }
 trin-utils = { path = "crates/utils" }
 trin-validation = { path = "crates/validation" }
+
+# TODO: When we build for a windows target on an ubuntu runner, crunchy tries to
+# get the wrong path, update this when the workflow has been updated
+#
+# See: https://github.com/eira-fransham/crunchy/issues/13
+crunchy = "=0.2.2"


### PR DESCRIPTION
### What was wrong?

our depend ci updated crunchy and the latest release breaks cross building the windows binary https://github.com/eira-fransham/crunchy/issues/13

### How was it fixed?

temporarily pin crunchy to a working version
