### PR TITLE
chore: switch discv5 to pull from crates.io again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,8 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.9.0"
-source = "git+https://github.com/kolbyml/discv5?rev=7dcd74031aa98c220c2984bbc2274c414b6f709f#7dcd74031aa98c220c2984bbc2274c414b6f709f"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4b4e7798d2ff74e29cee344dc490af947ae657d6ab5273dde35d58ce06a4d71"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ chrono = "0.4.38"
 clap = { version = "4.2.1", features = ["derive"] }
 delay_map = "0.4.0"
 directories = "3.0"
-discv5 = { git = "https://github.com/kolbyml/discv5", rev = "7dcd74031aa98c220c2984bbc2274c414b6f709f", features = ["serde"] }
+discv5 = { version = "0.9.1", features = ["serde"] }
 env_logger = "0.9.0"
 eth_trie = "0.5.0"
 ethereum_hashing = "0.7.0"


### PR DESCRIPTION
### What was wrong?
fixes https://github.com/ethereum/trin/issues/1642
### How was it fixed?

switch it back now that the fix is merged and published in a release
