### PR TITLE
feat: implement Debug for PingError so messages display

### DIFF
--- a/crates/ethportal-api/src/types/ping_extensions/extensions/type_65535.rs
+++ b/crates/ethportal-api/src/types/ping_extensions/extensions/type_65535.rs
@@ -1,12 +1,14 @@
+use std::fmt::Debug;
+
 use anyhow::anyhow;
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum::U300, VariableList};
 
-use crate::types::portal_wire::CustomPayload;
+use crate::{types::portal_wire::CustomPayload, utils::bytes::hex_encode};
 
 /// Used to respond to pings which the node can't handle
-#[derive(PartialEq, Debug, Clone, Encode, Decode)]
+#[derive(Eq, PartialEq, Clone, Encode, Decode)]
 pub struct PingError {
     pub error_code: u16,
     pub message: VariableList<u8, U300>,
@@ -27,6 +29,18 @@ impl PingError {
                 anyhow!("PingError can only handle messages up to 300 bytes, received {err:?}")
             })?,
         })
+    }
+}
+
+impl Debug for PingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = String::from_utf8(self.message.to_vec())
+            .unwrap_or_else(|_| format!("Invalid utf8 string: {}", hex_encode(&*self.message)));
+
+        f.debug_struct("PingError")
+            .field("error_code", &self.error_code)
+            .field("message", &message)
+            .finish()
     }
 }
 

--- a/crates/ethportal-api/src/types/ping_extensions/extensions/type_65535.rs
+++ b/crates/ethportal-api/src/types/ping_extensions/extensions/type_65535.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{borrow::Cow, fmt::Debug, ops::Deref, str};
 
 use anyhow::anyhow;
 use ssz::Encode;
@@ -34,8 +34,14 @@ impl PingError {
 
 impl Debug for PingError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let message = String::from_utf8(self.message.to_vec())
-            .unwrap_or_else(|_| format!("Invalid utf8 string: {}", hex_encode(&*self.message)));
+        let message = str::from_utf8(self.message.deref())
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|_| {
+                Cow::Owned(format!(
+                    "Invalid utf8 string: {}",
+                    hex_encode(self.message.deref())
+                ))
+            });
 
         f.debug_struct("PingError")
             .field("error_code", &self.error_code)


### PR DESCRIPTION
### What was wrong?

The default derived Debug implementation printed the message as bytes

### How was it fixed?

Implement Debug manually to decode the Ping Message, there is no point in decoding it unless we print it so I think this strikes a pretty good balance.