### PR TITLE
feat: enable WAL mode on sqlite 1.39-1.9xing Trin performance

### DIFF
--- a/crates/storage/src/sql.rs
+++ b/crates/storage/src/sql.rs
@@ -77,3 +77,6 @@ pub const HISTORICAL_SUMMARIES_EPOCH_LOOKUP_QUERY: &str =
 
 // todo: remove this in the future
 pub const DROP_USAGE_STATS_DB: &str = "DROP TABLE IF EXISTS usage_stats;";
+
+/// Benchmarking with WAL mode enabled 1.4 to 1.9x's Trin performance
+pub const ENABLE_WAL_MODE: &str = "PRAGMA journal_mode = WAL;PRAGMA synchronous = NORMAL;";

--- a/crates/storage/src/utils.rs
+++ b/crates/storage/src/utils.rs
@@ -7,8 +7,8 @@ use tracing::info;
 use crate::{
     error::ContentStoreError,
     sql::{
-        DROP_USAGE_STATS_DB, HISTORICAL_SUMMARIES_CREATE_TABLE, LC_BOOTSTRAP_CREATE_TABLE,
-        LC_UPDATE_CREATE_TABLE,
+        DROP_USAGE_STATS_DB, ENABLE_WAL_MODE, HISTORICAL_SUMMARIES_CREATE_TABLE,
+        LC_BOOTSTRAP_CREATE_TABLE, LC_UPDATE_CREATE_TABLE,
     },
     versioned::sql::STORE_INFO_CREATE_TABLE,
     DATABASE_NAME,
@@ -22,10 +22,7 @@ pub fn setup_sql(node_data_dir: &Path) -> Result<Pool<SqliteConnectionManager>, 
     let manager = SqliteConnectionManager::file(sql_path);
     let pool = Pool::new(manager)?;
     let conn = pool.get()?;
-    // Set WAL mode for better performance, it makes R/W operations faster as they don't block each
-    // other 3.8x's Trin performance
-    conn.execute_batch("PRAGMA journal_mode = WAL;")?;
-    conn.execute_batch("PRAGMA synchronous = NORMAL;")?;
+    conn.execute_batch(ENABLE_WAL_MODE)?;
     conn.execute_batch(LC_BOOTSTRAP_CREATE_TABLE)?;
     conn.execute_batch(LC_UPDATE_CREATE_TABLE)?;
     conn.execute_batch(HISTORICAL_SUMMARIES_CREATE_TABLE)?;

--- a/crates/storage/src/utils.rs
+++ b/crates/storage/src/utils.rs
@@ -22,6 +22,10 @@ pub fn setup_sql(node_data_dir: &Path) -> Result<Pool<SqliteConnectionManager>, 
     let manager = SqliteConnectionManager::file(sql_path);
     let pool = Pool::new(manager)?;
     let conn = pool.get()?;
+    // Set WAL mode for better performance, it makes R/W operations faster as they don't block each
+    // other 3.8x's Trin performance
+    conn.execute_batch("PRAGMA journal_mode = WAL;")?;
+    conn.execute_batch("PRAGMA synchronous = NORMAL;")?;
     conn.execute_batch(LC_BOOTSTRAP_CREATE_TABLE)?;
     conn.execute_batch(LC_UPDATE_CREATE_TABLE)?;
     conn.execute_batch(HISTORICAL_SUMMARIES_CREATE_TABLE)?;


### PR DESCRIPTION
### What was wrong?

I ran https://github.com/ethereum/trin/pull/1660 without profiling

Before using WAL
`INFO trin_bench: Finished gossiping blocks in 16m 11s, with 270336 offers`
After enabling WAL
`INFO trin_bench: Finished gossiping blocks in 11m 40s, with 270336 offers`

I am testing with era1 files 1000 to 1010

### How was it fixed?

So after enabling WAL the benchmark finish 1.39 times faster or enabling WAL resulted in approximately a 27.91% reduction in time
