### PR TITLE
chore: remove state nodes from standard release process

### DIFF
--- a/book/src/developers/contributing/releases/deployment.md
+++ b/book/src/developers/contributing/releases/deployment.md
@@ -61,11 +61,8 @@ This step directs Ansible to use the current master version of trin. Read [about
 - Run the deployment:
     - Trin nodes:
         - `ansible-playbook playbook.yml --tags trin`
-    - State network nodes (check with the team if there is a reason not to update them):
-        - Recently, we don't regularly deploy state bridge nodes (because they run for a long time and we don't want to restart them). To deploy all other state nodes, use following command:
-            - `ansible-playbook playbook.yml --tags state-network --limit state_stun,state_bootnode,state_regular`
-        - To deploy to all state network nodes:
-            - `ansible-playbook playbook.yml --tags state-network`
+    <!-- - State network nodes (check with the team if there is a reason not to update them):
+            - `ansible-playbook playbook.yml --tags state-network` -->
 - Run Glados deployment: updates glados + portal client (currently configured as trin, but this could change)
     - `cd ../../glados/ansible`
     - `ansible-playbook playbook.yml --tags glados`


### PR DESCRIPTION
### What was wrong?
In todays Trin meeting it was agreed to take State nodes out of the standard release process for the time being.

The reason for this is the State Network is not ready for production and being able to iterate quicker should help us launch quicker as we will know if there is an issue quick and hence fix them quicker
### How was it fixed?

Comment out the state network code, if someone wants I can remove it, but I thought to keep it as one day the state nodes will join the standard deployment process again

