### PR TITLE
chore: pin crunchy for Windows compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,9 +1535,8 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+version = "0.2.2"
+source = "git+https://github.com/eira-fransham/crunchy?rev=1bf90cf2d0a8cfcb2c5592275a23ab028dff6468#1bf90cf2d0a8cfcb2c5592275a23ab028dff6468"
 
 [[package]]
 name = "crypto-bigint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,13 +115,16 @@ trin-storage = { path = "crates/storage" }
 trin-utils = { path = "crates/utils" }
 trin-validation = { path = "crates/validation" }
 
+crunchy = "=0.2.2"
+
+[patch.crates-io]
+# TODO: remove this when our other dependencies update to getrandom 0.3 as it is a breaking change
+tempfile = { git = "https://github.com/Stebalien/tempfile", tag = "v3.15.0" }
+# TODO: remove this when our other dependencies update to getrandom 0.3 as it is a breaking change
+uuid = { git = "https://github.com/uuid-rs/uuid", tag = "1.12.1" }
+
 # TODO: When we build for a windows target on an ubuntu runner, crunchy tries to
 # get the wrong path, update this when the workflow has been updated
 #
 # See: https://github.com/eira-fransham/crunchy/issues/13
-crunchy = "=0.2.2"
-
-# todo: remove this when our other dependencies update to getrandom 0.3 as it is a breaking change
-[patch.crates-io]
-tempfile = { git = "https://github.com/Stebalien/tempfile", tag = "v3.15.0" }
-uuid = { git = "https://github.com/uuid-rs/uuid", tag = "1.12.1" }
+crunchy = { git = "https://github.com/eira-fransham/crunchy", rev = "1bf90cf2d0a8cfcb2c5592275a23ab028dff6468" }


### PR DESCRIPTION
### What was wrong?

Windows build is failing: https://github.com/ethereum/trin/actions/runs/13189513029/job/36819458339

### How was it fixed?

Pin crunchy for all dependencies