### PR TITLE
chore: remove ssz_rs dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
  "derive_more 1.0.0",
  "once_cell",
  "serde",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -2162,7 +2162,7 @@ dependencies = [
  "ed25519",
  "rand_core",
  "serde",
- "sha2 0.10.8",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -2340,7 +2340,7 @@ checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
 dependencies = [
  "cpufeatures",
  "ring",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -2413,7 +2413,7 @@ dependencies = [
  "serde-this-or-that",
  "serde_json",
  "serde_yaml",
- "sha2 0.10.8",
+ "sha2",
  "sha3 0.9.1",
  "snap",
  "ssz_types",
@@ -3659,7 +3659,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.8",
+ "sha2",
  "signature",
 ]
 
@@ -3791,6 +3791,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "ethereum_ssz",
  "ethportal-api",
  "figment",
  "futures",
@@ -3804,7 +3805,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "snowbridge-milagro-bls",
- "ssz-rs",
  "ssz_types",
  "strum",
  "thiserror 1.0.69",
@@ -3812,6 +3812,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.19",
  "tree_hash",
+ "tree_hash_derive",
+ "trin-validation",
 ]
 
 [[package]]
@@ -5157,7 +5159,7 @@ dependencies = [
  "revm-primitives",
  "ripemd",
  "secp256k1",
- "sha2 0.10.8",
+ "sha2",
  "substrate-bn",
 ]
 
@@ -5272,7 +5274,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b241d2e59b74ef9e98d94c78c47623d04c8392abaf82014dfd372a16041128f"
 dependencies = [
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -5380,7 +5382,7 @@ version = "7.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d38ff6bf570dc3bb7100fce9f7b60c33fa71d80e88da3f2580df4ff2bdded74"
 dependencies = [
- "sha2 0.10.8",
+ "sha2",
  "walkdir",
 ]
 
@@ -5853,19 +5855,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
@@ -6041,31 +6030,6 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
-]
-
-[[package]]
-name = "ssz-rs"
-version = "0.8.0"
-source = "git+https://github.com/ralexstokes/ssz-rs?rev=d09f55b4f8554491e3431e01af1c32347a8781cd#d09f55b4f8554491e3431e01af1c32347a8781cd"
-dependencies = [
- "bitvec",
- "hex",
- "lazy_static",
- "num-bigint",
- "serde",
- "sha2 0.9.9",
- "ssz-rs-derive",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ssz-rs-derive"
-version = "0.8.0"
-source = "git+https://github.com/ralexstokes/ssz-rs?rev=d09f55b4f8554491e3431e01af1c32347a8781cd#d09f55b4f8554491e3431e01af1c32347a8781cd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
  "derive_more 1.0.0",
  "once_cell",
  "serde",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]

--- a/crates/light-client/Cargo.toml
+++ b/crates/light-client/Cargo.toml
@@ -17,6 +17,8 @@ anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
 ethportal-api.workspace = true
+trin-validation.workspace = true
+ethereum_ssz.workspace = true
 figment = { version = "0.10.7", features = ["toml", "env"] }
 futures.workspace = true
 hex.workspace = true
@@ -29,7 +31,6 @@ serde.workspace = true
 serde-this-or-that.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
-ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "d09f55b4f8554491e3431e01af1c32347a8781cd" }
 ssz_types.workspace = true
 strum.workspace = true
 thiserror.workspace = true
@@ -37,6 +38,7 @@ tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tree_hash.workspace = true
+tree_hash_derive.workspace = true
 
 [lib]
 name = "light_client"

--- a/crates/light-client/Cargo.toml
+++ b/crates/light-client/Cargo.toml
@@ -17,7 +17,6 @@ anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
 ethportal-api.workspace = true
-trin-validation.workspace = true
 ethereum_ssz.workspace = true
 figment = { version = "0.10.7", features = ["toml", "env"] }
 futures.workspace = true
@@ -39,6 +38,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 tree_hash.workspace = true
 tree_hash_derive.workspace = true
+trin-validation.workspace = true
 
 [lib]
 name = "light_client"

--- a/crates/light-client/Cargo.toml
+++ b/crates/light-client/Cargo.toml
@@ -16,8 +16,8 @@ alloy.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
-ethportal-api.workspace = true
 ethereum_ssz.workspace = true
+ethportal-api.workspace = true
 figment = { version = "0.10.7", features = ["toml", "env"] }
 futures.workspace = true
 hex.workspace = true

--- a/crates/light-client/src/consensus/consensus_client.rs
+++ b/crates/light-client/src/consensus/consensus_client.rs
@@ -19,7 +19,6 @@ use ethportal_api::{
     utils::bytes::hex_encode,
 };
 use milagro_bls::PublicKey;
-use ssz_rs::prelude::*;
 use ssz_types::{typenum, BitVector, FixedVector};
 use tracing::{debug, info, warn};
 use tree_hash::TreeHash;
@@ -583,12 +582,12 @@ fn compute_committee_sign_root(
     genesis_root: &[u8],
     header: Bytes32,
     fork_version: &[u8],
-) -> Result<Node> {
+) -> Result<B256> {
     let genesis_root = genesis_root.to_vec().try_into()?;
     let domain_type = &hex::decode("07000000")?[..];
-    let fork_version = Vector::from_iter(fork_version.to_vec());
+    let fork_version = FixedVector::from(fork_version.to_vec());
     let domain = compute_domain(domain_type, fork_version, genesis_root)?;
-    compute_signing_root(header, domain)
+    Ok(compute_signing_root(header, domain))
 }
 
 fn get_participating_keys(
@@ -632,7 +631,7 @@ fn verify_sync_committee_signature(
 
         Ok(is_aggregate_valid(
             signature,
-            signing_root.r#as_bytes(),
+            signing_root.as_slice(),
             &public_keys,
         ))
     })();

--- a/crates/light-client/src/consensus/consensus_client.rs
+++ b/crates/light-client/src/consensus/consensus_client.rs
@@ -583,7 +583,7 @@ fn compute_committee_sign_root(
     header: Bytes32,
     fork_version: &[u8],
 ) -> Result<B256> {
-    let genesis_root = genesis_root.to_vec().try_into()?;
+    let genesis_root = genesis_root.to_vec().into();
     let domain_type = &hex::decode("07000000")?[..];
     let fork_version = FixedVector::from(fork_version.to_vec());
     let domain = compute_domain(domain_type, fork_version, genesis_root)?;

--- a/crates/light-client/src/consensus/consensus_client.rs
+++ b/crates/light-client/src/consensus/consensus_client.rs
@@ -642,7 +642,7 @@ fn is_finality_proof_valid(
     finality_header: &mut BeaconBlockHeader,
     finality_branch: &FixedVector<B256, FinalizedRootProofLen>,
 ) -> bool {
-    is_proof_valid(attested_header, finality_header, &finality_branch, 6, 41)
+    is_proof_valid(attested_header, finality_header, finality_branch, 6, 41)
 }
 
 fn is_next_committee_proof_valid(
@@ -653,7 +653,7 @@ fn is_next_committee_proof_valid(
     is_proof_valid(
         attested_header,
         next_committee,
-        &next_committee_branch,
+        next_committee_branch,
         5,
         23,
     )
@@ -667,7 +667,7 @@ fn is_current_committee_proof_valid(
     is_proof_valid(
         attested_header,
         current_committee,
-        &current_committee_branch,
+        current_committee_branch,
         5,
         22,
     )

--- a/crates/light-client/src/consensus/utils.rs
+++ b/crates/light-client/src/consensus/utils.rs
@@ -32,18 +32,12 @@ pub fn is_proof_valid<L: TreeHash>(
 ) -> bool {
     let res: Result<bool> = (move || {
         let leaf_hash = leaf_object.tree_hash_root();
-        let state_root = bytes32_to_node(
-            &Bytes32::try_from(attested_header.state_root.0.to_vec())
-                .expect("Unable to convert state root to bytes"),
-        )?;
+        let state_root = bytes32_to_node(&Bytes32::from(attested_header.state_root.0.to_vec()))?;
         let branches = branch_to_nodes(branch.to_vec())?;
 
         leaf_hash.ssz_append(&mut branches.as_ssz_bytes());
 
         let root = merkle_root_from_branch(leaf_hash, &branches, depth, index);
-
-        println!("state root >>> {:?}", state_root);
-        println!("calculated root >>> {:?}", root);
 
         Ok(root == state_root)
     })();
@@ -80,7 +74,7 @@ pub fn compute_domain(
     let start = domain_type;
     let end = &fork_data_root.as_slice()[..28];
     let d = [start, end].concat();
-    Ok(d.to_vec().try_into()?)
+    Ok(d.to_vec().into())
 }
 
 fn compute_fork_data_root(

--- a/crates/light-client/src/consensus/utils.rs
+++ b/crates/light-client/src/consensus/utils.rs
@@ -7,8 +7,6 @@ use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 use trin_validation::merkle::proof::merkle_root_from_branch;
 
-use crate::{types::Bytes32, utils::bytes32_to_node};
-
 pub fn calc_sync_period(slot: u64) -> u64 {
     let epoch = slot / 32; // 32 slots per epoch
     epoch / 256 // 256 epochs per sync committee
@@ -25,14 +23,13 @@ pub fn is_aggregate_valid(sig_bytes: &BlsSignature, msg: &[u8], pks: &[&PublicKe
 pub fn is_proof_valid<L: TreeHash>(
     attested_header: &BeaconBlockHeader,
     leaf_object: &L,
-    branch: &[Bytes32],
+    branch: &[B256],
     depth: usize,
     index: usize,
 ) -> bool {
     let res: Result<bool> = (move || {
         let leaf_hash = leaf_object.tree_hash_root();
-        let state_root = bytes32_to_node(&Bytes32::from(attested_header.state_root.0.to_vec()))?;
-        let branch = branch_to_nodes(branch.to_vec())?;
+        let state_root = attested_header.state_root;
 
         let root = merkle_root_from_branch(leaf_hash, &branch, depth, index);
 
@@ -44,17 +41,17 @@ pub fn is_proof_valid<L: TreeHash>(
 
 #[derive(Default, Debug, TreeHash)]
 struct SigningData {
-    object_root: Bytes32,
-    domain: Bytes32,
+    object_root: B256,
+    domain: B256,
 }
 
 #[derive(Default, Debug, TreeHash)]
 struct ForkData {
     current_version: FixedVector<u8, U4>,
-    genesis_validator_root: Bytes32,
+    genesis_validator_root: B256,
 }
 
-pub fn compute_signing_root(object_root: Bytes32, domain: Bytes32) -> B256 {
+pub fn compute_signing_root(object_root: B256, domain: B256) -> B256 {
     let data = SigningData {
         object_root,
         domain,
@@ -65,29 +62,22 @@ pub fn compute_signing_root(object_root: Bytes32, domain: Bytes32) -> B256 {
 pub fn compute_domain(
     domain_type: &[u8],
     fork_version: FixedVector<u8, U4>,
-    genesis_root: Bytes32,
-) -> Result<Bytes32> {
+    genesis_root: B256,
+) -> Result<B256> {
     let fork_data_root = compute_fork_data_root(fork_version, genesis_root);
     let start = domain_type;
     let end = &fork_data_root.as_slice()[..28];
     let d = [start, end].concat();
-    Ok(d.to_vec().into())
+    Ok(B256::from_slice(&d))
 }
 
 fn compute_fork_data_root(
     current_version: FixedVector<u8, U4>,
-    genesis_validator_root: Bytes32,
+    genesis_validator_root: B256,
 ) -> B256 {
     let fork_data = ForkData {
         current_version,
         genesis_validator_root,
     };
     fork_data.tree_hash_root()
-}
-
-pub fn branch_to_nodes(branch: Vec<Bytes32>) -> Result<Vec<B256>> {
-    branch
-        .iter()
-        .map(bytes32_to_node)
-        .collect::<Result<Vec<B256>>>()
 }

--- a/crates/light-client/src/consensus/utils.rs
+++ b/crates/light-client/src/consensus/utils.rs
@@ -2,7 +2,6 @@ use alloy::primitives::B256;
 use anyhow::Result;
 use ethportal_api::consensus::{header::BeaconBlockHeader, signature::BlsSignature};
 use milagro_bls::{AggregateSignature, PublicKey};
-use ssz::Encode;
 use ssz_types::{typenum::U4, FixedVector};
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
@@ -33,11 +32,9 @@ pub fn is_proof_valid<L: TreeHash>(
     let res: Result<bool> = (move || {
         let leaf_hash = leaf_object.tree_hash_root();
         let state_root = bytes32_to_node(&Bytes32::from(attested_header.state_root.0.to_vec()))?;
-        let branches = branch_to_nodes(branch.to_vec())?;
+        let branch = branch_to_nodes(branch.to_vec())?;
 
-        leaf_hash.ssz_append(&mut branches.as_ssz_bytes());
-
-        let root = merkle_root_from_branch(leaf_hash, &branches, depth, index);
+        let root = merkle_root_from_branch(leaf_hash, &branch, depth, index);
 
         Ok(root == state_root)
     })();

--- a/crates/light-client/src/consensus/utils.rs
+++ b/crates/light-client/src/consensus/utils.rs
@@ -27,16 +27,12 @@ pub fn is_proof_valid<L: TreeHash>(
     depth: usize,
     index: usize,
 ) -> bool {
-    let res: Result<bool> = (move || {
-        let leaf_hash = leaf_object.tree_hash_root();
-        let state_root = attested_header.state_root;
+    let leaf_hash = leaf_object.tree_hash_root();
+    let state_root = attested_header.state_root;
 
-        let root = merkle_root_from_branch(leaf_hash, &branch, depth, index);
+    let root = merkle_root_from_branch(leaf_hash, branch, depth, index);
 
-        Ok(root == state_root)
-    })();
-
-    res.unwrap_or_default()
+    root == state_root
 }
 
 #[derive(Default, Debug, TreeHash)]

--- a/crates/light-client/src/consensus/utils.rs
+++ b/crates/light-client/src/consensus/utils.rs
@@ -1,8 +1,12 @@
+use alloy::primitives::B256;
 use anyhow::Result;
 use ethportal_api::consensus::{header::BeaconBlockHeader, signature::BlsSignature};
 use milagro_bls::{AggregateSignature, PublicKey};
-use ssz_rs::prelude::*;
+use ssz::Encode;
+use ssz_types::{typenum::U4, FixedVector};
 use tree_hash::TreeHash;
+use tree_hash_derive::TreeHash;
+use trin_validation::merkle::proof::merkle_root_from_branch;
 
 use crate::{types::Bytes32, utils::bytes32_to_node};
 
@@ -21,72 +25,78 @@ pub fn is_aggregate_valid(sig_bytes: &BlsSignature, msg: &[u8], pks: &[&PublicKe
 
 pub fn is_proof_valid<L: TreeHash>(
     attested_header: &BeaconBlockHeader,
-    leaf_object: &mut L,
+    leaf_object: &L,
     branch: &[Bytes32],
     depth: usize,
     index: usize,
 ) -> bool {
     let res: Result<bool> = (move || {
-        let leaf_hash = Node::from_bytes(<[u8; 32]>::from(leaf_object.tree_hash_root()));
+        let leaf_hash = leaf_object.tree_hash_root();
         let state_root = bytes32_to_node(
             &Bytes32::try_from(attested_header.state_root.0.to_vec())
                 .expect("Unable to convert state root to bytes"),
         )?;
-        let branch = branch_to_nodes(branch.to_vec())?;
+        let branches = branch_to_nodes(branch.to_vec())?;
 
-        let is_valid = is_valid_merkle_branch(&leaf_hash, branch.iter(), depth, index, &state_root);
-        Ok(is_valid)
+        leaf_hash.ssz_append(&mut branches.as_ssz_bytes());
+
+        let root = merkle_root_from_branch(leaf_hash, &branches, depth, index);
+
+        println!("state root >>> {:?}", state_root);
+        println!("calculated root >>> {:?}", root);
+
+        Ok(root == state_root)
     })();
 
     res.unwrap_or_default()
 }
 
-#[derive(SimpleSerialize, Default, Debug)]
+#[derive(Default, Debug, TreeHash)]
 struct SigningData {
     object_root: Bytes32,
     domain: Bytes32,
 }
 
-#[derive(SimpleSerialize, Default, Debug)]
+#[derive(Default, Debug, TreeHash)]
 struct ForkData {
-    current_version: Vector<u8, 4>,
+    current_version: FixedVector<u8, U4>,
     genesis_validator_root: Bytes32,
 }
 
-pub fn compute_signing_root(object_root: Bytes32, domain: Bytes32) -> Result<Node> {
-    let mut data = SigningData {
+pub fn compute_signing_root(object_root: Bytes32, domain: Bytes32) -> B256 {
+    let data = SigningData {
         object_root,
         domain,
     };
-    Ok(data.hash_tree_root()?)
+    data.tree_hash_root()
 }
 
 pub fn compute_domain(
     domain_type: &[u8],
-    fork_version: Vector<u8, 4>,
+    fork_version: FixedVector<u8, U4>,
     genesis_root: Bytes32,
 ) -> Result<Bytes32> {
-    let fork_data_root = compute_fork_data_root(fork_version, genesis_root)?;
+    let fork_data_root = compute_fork_data_root(fork_version, genesis_root);
     let start = domain_type;
-    let end = &fork_data_root.as_bytes()[..28];
+    let end = &fork_data_root.as_slice()[..28];
     let d = [start, end].concat();
     Ok(d.to_vec().try_into()?)
 }
 
 fn compute_fork_data_root(
-    current_version: Vector<u8, 4>,
+    current_version: FixedVector<u8, U4>,
     genesis_validator_root: Bytes32,
-) -> Result<Node> {
-    let mut fork_data = ForkData {
+) -> B256 {
+    let fork_data = ForkData {
         current_version,
         genesis_validator_root,
     };
-    Ok(fork_data.hash_tree_root()?)
+    fork_data.tree_hash_root()
 }
 
-pub fn branch_to_nodes(branch: Vec<Bytes32>) -> Result<Vec<Node>> {
+pub fn branch_to_nodes(branch: Vec<Bytes32>) -> Result<Vec<B256>> {
     branch
         .iter()
         .map(bytes32_to_node)
-        .collect::<Result<Vec<Node>>>()
+        .collect::<Result<Vec<B256>>>()
 }

--- a/crates/light-client/src/lib.rs
+++ b/crates/light-client/src/lib.rs
@@ -9,5 +9,4 @@ pub mod database;
 pub mod errors;
 pub mod node;
 pub mod rpc;
-pub mod types;
 pub mod utils;

--- a/crates/light-client/src/types.rs
+++ b/crates/light-client/src/types.rs
@@ -1,3 +1,3 @@
-use ssz_rs::Vector;
+use ssz_types::{typenum::U32, FixedVector};
 
-pub type Bytes32 = Vector<u8, 32>;
+pub type Bytes32 = FixedVector<u8, U32>;

--- a/crates/light-client/src/types.rs
+++ b/crates/light-client/src/types.rs
@@ -1,3 +1,0 @@
-use ssz_types::{typenum::U32, FixedVector};
-
-pub type Bytes32 = FixedVector<u8, U32>;

--- a/crates/light-client/src/utils.rs
+++ b/crates/light-client/src/utils.rs
@@ -1,11 +1,3 @@
-// pub fn bytes_to_bytes32(bytes: &[u8]) -> Bytes32 {
-//     FixedVector::from(bytes.to_vec())
-// }
-
-// pub fn bytes32_to_node(bytes: &Bytes32) -> Result<B256> {
-//     Ok(B256::from_slice(bytes.iter().as_slice()))
-// }
-
 pub fn u64_to_hex_string(val: u64) -> String {
     format!("0x{val:x}")
 }

--- a/crates/light-client/src/utils.rs
+++ b/crates/light-client/src/utils.rs
@@ -9,7 +9,7 @@ pub fn bytes_to_bytes32(bytes: &[u8]) -> Bytes32 {
 }
 
 pub fn bytes32_to_node(bytes: &Bytes32) -> Result<B256> {
-    Ok(B256::from_slice(bytes.iter().as_slice().try_into()?))
+    Ok(B256::from_slice(bytes.iter().as_slice()))
 }
 
 pub fn u64_to_hex_string(val: u64) -> String {

--- a/crates/light-client/src/utils.rs
+++ b/crates/light-client/src/utils.rs
@@ -1,16 +1,10 @@
-use alloy::primitives::B256;
-use anyhow::Result;
-use ssz_types::FixedVector;
+// pub fn bytes_to_bytes32(bytes: &[u8]) -> Bytes32 {
+//     FixedVector::from(bytes.to_vec())
+// }
 
-use crate::types::Bytes32;
-
-pub fn bytes_to_bytes32(bytes: &[u8]) -> Bytes32 {
-    FixedVector::from(bytes.to_vec())
-}
-
-pub fn bytes32_to_node(bytes: &Bytes32) -> Result<B256> {
-    Ok(B256::from_slice(bytes.iter().as_slice()))
-}
+// pub fn bytes32_to_node(bytes: &Bytes32) -> Result<B256> {
+//     Ok(B256::from_slice(bytes.iter().as_slice()))
+// }
 
 pub fn u64_to_hex_string(val: u64) -> String {
     format!("0x{val:x}")

--- a/crates/light-client/src/utils.rs
+++ b/crates/light-client/src/utils.rs
@@ -1,14 +1,15 @@
+use alloy::primitives::B256;
 use anyhow::Result;
-use ssz_rs::{Node, Vector};
+use ssz_types::FixedVector;
 
 use crate::types::Bytes32;
 
 pub fn bytes_to_bytes32(bytes: &[u8]) -> Bytes32 {
-    Vector::from_iter(bytes.to_vec())
+    FixedVector::from(bytes.to_vec())
 }
 
-pub fn bytes32_to_node(bytes: &Bytes32) -> Result<Node> {
-    Ok(Node::from_bytes(bytes.as_slice().try_into()?))
+pub fn bytes32_to_node(bytes: &Bytes32) -> Result<B256> {
+    Ok(B256::from_slice(bytes.iter().as_slice().try_into()?))
 }
 
 pub fn u64_to_hex_string(val: u64) -> String {


### PR DESCRIPTION
### What was wrong?
FIxes #1417 

light-client crate used ssz-rs crate for SSZ handling instead of ethereum-ssz crate

### How was it fixed?

This PR removes the ssz-rs dependency and uses ethereum-ssz instead 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
