### PR TITLE
feat: improve estimated disk usage

### DIFF
--- a/crates/storage/src/versioned/id_indexed_v1/store.rs
+++ b/crates/storage/src/versioned/id_indexed_v1/store.rs
@@ -535,6 +535,10 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
         Ok(deleted_content)
     }
 
+    /// Calculates the raw content size, that is stored in `content_size` column.
+    ///
+    /// Represents the raw size (in bytes) of the content id, key and value. This is used in
+    /// combination with [extra_disk_usage_per_content_bytes]  to estimate disk usage.
     fn calculate_content_size(
         raw_content_id: &[u8],
         raw_content_key: &[u8],

--- a/crates/storage/src/versioned/usage_stats.rs
+++ b/crates/storage/src/versioned/usage_stats.rs
@@ -1,77 +1,141 @@
 use trin_metrics::storage::StorageMetricsReporter;
 
 /// Contains information about number and size of entries that is stored.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UsageStats {
     /// The total count of stored entries
-    pub entry_count: u64,
+    entry_count: u64,
     /// The total sum of sizes of stored entries
-    pub total_entry_size_bytes: u64,
+    total_entry_size_bytes: u64,
+    /// The estimated additional disk usage per content. There is always some extra disk usage on
+    /// top of entry size that should be taken into consideration when estimating total disk usage.
+    extra_disk_usage_per_content: u64,
 }
 
 impl UsageStats {
-    pub fn new(entry_count: u64, total_entry_size_bytes: u64) -> Self {
+    pub fn new(
+        entry_count: u64,
+        total_entry_size_bytes: u64,
+        extra_disk_usage_per_content: u64,
+    ) -> Self {
         Self {
             entry_count,
             total_entry_size_bytes,
+            extra_disk_usage_per_content,
         }
     }
 
-    /// Returns the average entry size, or `None` when empty.
-    pub fn average_entry_size_bytes(&self) -> Option<f64> {
+    /// Returns the total count of stored entries
+    pub fn entry_count(&self) -> u64 {
+        self.entry_count
+    }
+
+    /// Returns the sum of sizes of stored entries. For estimated disk usage,
+    /// [UsageStats::estimated_disk_usage_bytes] should be used instead.
+    pub fn total_entry_size_bytes(&self) -> u64 {
+        self.total_entry_size_bytes
+    }
+
+    /// Returns the estimated total disk usage
+    pub fn estimated_disk_usage_bytes(&self) -> u64 {
+        self.total_entry_size_bytes + self.entry_count * self.extra_disk_usage_per_content
+    }
+
+    /// Returns the average disk usage per entry, or `None` when empty.
+    pub fn average_entry_disk_usage_bytes(&self) -> Option<f64> {
         if self.entry_count == 0 {
             Option::None
         } else {
-            Option::Some(self.total_entry_size_bytes as f64 / self.entry_count as f64)
+            let average_entry_size = self.total_entry_size_bytes as f64 / self.entry_count as f64;
+            Option::Some(average_entry_size + self.extra_disk_usage_per_content as f64)
         }
     }
 
     /// Returns whether total entry size is above provided value
-    pub fn is_above(&self, size_bytes: u64) -> bool {
-        self.total_entry_size_bytes > size_bytes
+    pub fn is_estimated_disk_usage_above(&self, size_bytes: u64) -> bool {
+        self.estimated_disk_usage_bytes() > size_bytes
+    }
+
+    /// Should be called when new entry is stored
+    pub fn on_store(&mut self, entry_size_bytes: u64) {
+        self.entry_count += 1;
+        self.total_entry_size_bytes += entry_size_bytes;
+    }
+
+    /// Should be called when entry is deleted
+    pub fn on_delete(&mut self, entry_size_bytes: u64) {
+        self.on_multi_delete(1, entry_size_bytes);
+    }
+
+    /// Should be called when multiple entries are deleted
+    pub fn on_multi_delete(
+        &mut self,
+        deleted_entry_count: u64,
+        deleted_total_entry_size_bytes: u64,
+    ) {
+        self.entry_count -= deleted_entry_count;
+        self.total_entry_size_bytes -= deleted_total_entry_size_bytes;
     }
 
     /// Reports entry count and content data storage to the metrics reporter
     pub fn report_metrics(&self, metrics: &StorageMetricsReporter) {
         metrics.report_entry_count(self.entry_count);
-        metrics.report_content_data_storage_bytes(self.total_entry_size_bytes as f64);
+        metrics.report_content_data_storage_bytes(self.estimated_disk_usage_bytes() as f64);
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use anyhow::Result;
+    use rstest::rstest;
 
     use super::*;
 
     #[test]
-    fn average_entry_size_bytes() -> Result<()> {
-        assert_eq!(UsageStats::default().average_entry_size_bytes(), None);
-
+    fn average_entry_disk_usage_bytes_no_usage() {
         assert_eq!(
-            UsageStats::new(/* entry_count= */ 1, /* total_entry_size= */ 100)
-                .average_entry_size_bytes(),
-            Some(100.0)
+            UsageStats::new(0, 0, 100).average_entry_disk_usage_bytes(),
+            None
         );
+    }
 
+    #[rstest]
+    #[case::single_content_no_extra(1, 100, 0, 100.0)]
+    #[case::single_content_with_extra(1, 100, 100, 200.0)]
+    #[case::multi_content_no_extra(1_000, 123456, 0, 123.456)]
+    #[case::multi_content_with_extra(1_000, 123456, 100, 223.456)]
+    fn average_entry_disk_usage_bytes(
+        #[case] entry_count: u64,
+        #[case] total_entry_size: u64,
+        #[case] extra_disk_usage_per_content: u64,
+        #[case] expected_average_entry_disk_usage_bytes: f64,
+    ) {
+        let usage_stats =
+            UsageStats::new(entry_count, total_entry_size, extra_disk_usage_per_content);
+        let average_entry_disk_usage_bytes = usage_stats.average_entry_disk_usage_bytes().unwrap();
+        assert!(
+            (average_entry_disk_usage_bytes - expected_average_entry_disk_usage_bytes).abs()
+                < 0.000001
+        );
+    }
+
+    #[rstest]
+    #[case::no_usage_no_extra(0, 0, 0, 0)]
+    #[case::no_usage_with_extra(0, 0, 100, 0)]
+    #[case::single_content_no_extra(1, 100, 0, 100)]
+    #[case::single_content_with_extra(1, 100, 100, 200)]
+    #[case::multi_content_no_extra(1_000, 123456, 0, 123456)]
+    #[case::multi_content_with_extra(1_000, 123456, 100, 223456)]
+    fn estimated_disk_usage_bytes(
+        #[case] entry_count: u64,
+        #[case] total_entry_size: u64,
+        #[case] extra_disk_usage_per_content: u64,
+        #[case] expected_estimated_disk_usage_bytes: u64,
+    ) {
+        let usage_stats =
+            UsageStats::new(entry_count, total_entry_size, extra_disk_usage_per_content);
         assert_eq!(
-            UsageStats::new(/* entry_count= */ 2, /* total_entry_size= */ 300)
-                .average_entry_size_bytes(),
-            Some(150.0)
-        );
-
-        assert_eq!(
-            UsageStats::new(/* entry_count= */ 3, /* total_entry_size= */ 600)
-                .average_entry_size_bytes(),
-            Some(200.0)
-        );
-
-        assert_eq!(
-            UsageStats::new(/* entry_count= */ 1_200, /* total_entry_size= */ 98_070)
-                .average_entry_size_bytes(),
-            Some(81.725)
-        );
-
-        Ok(())
+            usage_stats.estimated_disk_usage_bytes(),
+            expected_estimated_disk_usage_bytes,
+        )
     }
 }


### PR DESCRIPTION
### What was wrong?

We underestimate the disk usage. See #1653 for details.

### How was it fixed?

Based on the analysis in #1653, I added fixed number of bytes per content item that should be used when estimating disk usage (together with already counted number of bytes for content_id, content_key and content_value).

This way, the data that is actually store in the db (`content_size = content_id.len() + content_key.len() + content_value.len()`) doesn't have to change and we can easily update our estimate in the future if we need to.

### How was it tested?

I had local trin client that was running for some time (~20h) last week. Storage was configured to use 1GB of data, and all 3 subnetworks are enabled (state and history had 500MB capacity each). The actual size of the DB was 1447 MB (45% than desired).

Starting trin client with this PR would trigger pruning at startup. Pruning would run until our estimated disk usage is below 1GB. This however doesn't affect the actual disk usage. To do so, we would have to run "VACUUM".

Before running this code, I made a copy of db. That way I was able to re-run the code, and confirm that results are stable.

#### Run 1: Prune + Vacuum

I started new trin client (with this PR) and observed that:

- estimated disk usage was:
    - 1063 MB for state + 526 MB for history (compared to 500 MB each before) = 1590 MB (compared to actual 1447 MB)
- pruning executed at startup
- estimated disk usage after pruning: 498 MB for state + 495 MB for history (both under specified capacity)
    - the actual DB size didn't decrease because we don't use Vacuum
- I stop trin and run Vacuum manually
    - the db size decreased to 785 MB

#### Run 2: Vacuum + Prune + Vacuum

I run Vacuum on the original DB which decreased db size to 1154 MB.
Then I repeated steps from the first run and observed that:

- The estimated disk usage was the same (as expected)
- Pruning ended with the same estimated usage
- DB size after pruning was still 1.154 MB (expected, again because of the vacuum)
- DB size after vacuum was also 785 MB.

### Conclusion

It's worth observing that running Vacuum on the original db decreased it's size from 1447 MB to 1154 MB. That means that defragmentation added ~25% disk usage.  If we assume the same defragmentation, resulting db would occupy 984 MB (instead of 785 MB), which would leave us under close to the target capacity (with a bit of room).

This defragmentation ratio is not fixed. It depends on the content that is stored (it's different between state and history content) and how long client is running (longer running client tends to have higher defragmentation, but probably there is a limit). The original DB had radius between 2% and 4% for both history and state network, which implies that there was significant defragmentataion (if I remember correctly, I run the code before the max 5% radius PR was merged), which would imply that defragmentation might not be significantly higher even in the worse case.

### Things to consider

This would result in all our nodes (or at least the ones that reached their capacity) to trim content at startup. Different nodes are affected differently:

- history nodes - they wouldn't be significantly affected, as disk usage estimate wasn't as bad (in comparison to state)
    - in my local example, I deleted only ~6% of history content
- regular state nodes - Since they were restarted recently with 5% max radius, they didn't reach they capacity yet. This change would just change how much capacity they estimated they use, but they wouldn't prune anything (unless they get full by the time this PR is deployed)
- big storage nodes - These would be impacted the most because their defragmentation is very low (so far they only insert and never delete content). Running this PR would cause them to delete 1/3 of their content, which would:
    - run pruning very long (making them unresponsive for quite some time)
    - leave it with significant overestimated disk usage (I believe good in the long run)
    
    
    