### PR TITLE
refactor: remove unused Distance type

### DIFF
--- a/crates/ethportal-api/src/types/portal.rs
+++ b/crates/ethportal-api/src/types/portal.rs
@@ -46,7 +46,6 @@ pub type RawContentKey = Bytes;
 pub type RawContentValue = Bytes;
 
 pub type DataRadius = U256;
-pub type Distance = U256;
 
 /// Response for Ping endpoint
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
### What was wrong?

The `ethportal_api::types::portal::Distance` type is not used.

My auto complete confuses it frequently with `ethportal_api::types::distance::Distance` (the actual type that we use).

### How was it fixed?

Removed the type.
