### PR TITLE
fix: remove debug logs from OverlayService::find_enr

### DIFF
--- a/crates/portalnet/src/overlay/service/manager.rs
+++ b/crates/portalnet/src/overlay/service/manager.rs
@@ -2282,13 +2282,11 @@ impl<
 
         // Check whether this node id is in our discv5 routing table
         if let Some(enr) = self.discovery.find_enr(node_id) {
-            debug!(node_id=%node_id, enr=%enr, "#1596: discv5 routing table");
             return Some(enr);
         }
 
         // Check whether this node id is in our discovery ENR cache
         if let Some(node_addr) = self.discovery.cached_node_addr(node_id) {
-            debug!(node_id=%node_id, enr=?node_addr, "#1596: cached node addr");
             return Some(node_addr.enr);
         }
 
@@ -2299,7 +2297,6 @@ impl<
                 .iter()
                 .find(|v| v.node_id() == *node_id)
             {
-                debug!(node_id=%node_id, enr=%enr, "#1596: node query_pool");
                 return Some(enr.clone());
             }
         }
@@ -2311,12 +2308,10 @@ impl<
                 .iter()
                 .find(|v| v.node_id() == *node_id)
             {
-                debug!(node_id=%node_id, enr=%enr, "#1596: content query_pool");
                 return Some(enr.clone());
             }
         }
 
-        debug!(node_id=%node_id, "#1596: none");
         None
     }
 


### PR DESCRIPTION
### What was wrong?

I added some debug logs in #1600 in order to debug #1596.

Issue is now fix and these debug logs are no longer needed.

### How was it fixed?

I deleted debug logs.