### PR TITLE
chore: add cross-compile checks to every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,61 @@ jobs:
 
       - name: Validate PR commits with commitlint
         run: sudo npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose
+
+  check-cross-build:
+    # This is a stripped-down version of the full release build in .github/workflows/release.yml
+    # Some key changes:
+    # - No need to extract the version of the build
+    # - No need to upload artifacts
+    # - Fewer architectures, just to verify that some custom cases work
+    name: Verify cross-compilation
+    strategy:
+      matrix:
+        arch:
+          [
+            x86_64-unknown-linux-gnu,
+            aarch64-apple-darwin,
+            x86_64-pc-windows-gnu,
+          ]
+        include:
+          - arch: x86_64-unknown-linux-gnu
+            platform: ubuntu-20.04
+            profile: release
+          - arch: aarch64-apple-darwin
+            platform: macos-latest
+            profile: release
+          - arch: x86_64-pc-windows-gnu
+            platform: ubuntu-20.04
+            profile: release
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Get latest version of stable Rust
+        run: rustup update stable
+      - name: Install target
+        run: rustup target add ${{ matrix.arch }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      # ==============================
+      # Apple M1 SDK setup
+      # ==============================
+
+      - name: Apple M1 setup
+        if: ${{ matrix.job.target == 'aarch64-apple-darwin' }}
+        run: |
+          echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
+
+      # ==============================
+      #       Builds
+      # ==============================
+
+      # This is the main thing being tested, looking for a `make` failure
+      - name: Build trin for ${{ matrix.arch }}
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
+          env PROFILE=${{ matrix.profile }} make build-${{ matrix.arch }}


### PR DESCRIPTION
Recently, cross was not working because of a dependency conflict. See #1670 

We only found out at the moment of release, which caused a bunch of downstream issues. For example:
- Either way that you try to trigger the follow-up release will cause
  the Release Draft to be missing all the real changes (Tried repushing
  the tag, and skipping the version into the next one)
- There's no other good way to test if whatever was broken the first
  time is fixed. You don't want to test your change by pushing to
  master.
- It makes a messy list of commits on master.

This change tests cross compiles at every PR, to reduce the chances of a similar issue happening again.

~I don't know a good way to test this locally. Any suggestions besides merging and finding out?~ Ah, great, it runs immediately in this PR.