### PR TITLE
feat: create fn for history content migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6957,6 +6957,7 @@ dependencies = [
  "quickcheck",
  "rand",
  "rstest",
+ "rusqlite",
  "serde_json",
  "serial_test",
  "ssz_types",

--- a/crates/storage/src/versioned/id_indexed_v1/store.rs
+++ b/crates/storage/src/versioned/id_indexed_v1/store.rs
@@ -553,7 +553,9 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
 const fn extra_disk_usage_per_content_bytes(content_type: &ContentType) -> u64 {
     match content_type {
         ContentType::History => 750,
+        ContentType::HistoryEternal => 750,
         ContentType::State => 500,
+        ContentType::HistoryEphemeral => panic!("HistoryEphemeral is not supported"),
     }
 }
 

--- a/crates/storage/src/versioned/mod.rs
+++ b/crates/storage/src/versioned/mod.rs
@@ -18,8 +18,17 @@ pub use utils::create_store;
 #[derive(Clone, Debug, Display, Eq, PartialEq, AsRefStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum ContentType {
+    /// Corresponds to the history network content.
+    ///
+    /// This type is deprecated and  `HistoryEternal` or should be used instead.
+    /// See https://github.com/ethereum/trin/issues/1666".
     History,
+    /// Corresponds to the state network content.
     State,
+    /// Corresponds to the non-ephemeral history network content.
+    HistoryEternal,
+    /// Corresponds to the ephemeral history network content.
+    HistoryEphemeral,
 }
 
 /// The version of the store. There should be exactly one implementation of the

--- a/crates/subnetworks/history/Cargo.toml
+++ b/crates/subnetworks/history/Cargo.toml
@@ -19,6 +19,7 @@ ethereum_ssz.workspace = true
 ethportal-api.workspace = true
 parking_lot.workspace = true
 portalnet.workspace = true
+rusqlite.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/subnetworks/history/src/lib.rs
+++ b/crates/subnetworks/history/src/lib.rs
@@ -6,6 +6,7 @@ mod jsonrpc;
 pub mod network;
 mod ping_extensions;
 mod storage;
+mod storage_migration;
 pub mod validation;
 
 use std::sync::Arc;

--- a/crates/subnetworks/history/src/storage_migration.rs
+++ b/crates/subnetworks/history/src/storage_migration.rs
@@ -1,0 +1,173 @@
+use ethportal_api::{
+    types::{
+        content_value::{
+            history::HistoryContentValue as OldHistoryContentValue,
+            history_new::HistoryContentValue as NewHistoryContentValue,
+        },
+        execution::{header_with_proof as old_hwp, header_with_proof_new as new_hwp},
+        network::Subnetwork,
+    },
+    ContentValue, HistoryContentKey, OverlayContentKey, RawContentValue,
+};
+use rusqlite::{named_params, types::Type};
+use tracing::{debug, error, info};
+use trin_storage::{
+    error::ContentStoreError,
+    versioned::{create_store, ContentType, IdIndexedV1Store, IdIndexedV1StoreConfig},
+    PortalStorageConfig,
+};
+
+mod sql {
+    pub const TABLE_EXISTS: &str =
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='ii1_history';";
+
+    pub const BATCH_DELETE: &str = "
+        DELETE FROM ii1_history
+        WHERE rowid IN (
+            SELECT rowid
+            FROM ii1_history
+            ORDER BY content_id
+            LIMIT :limit
+        )
+        RETURNING content_key, content_value;
+    ";
+
+    pub const DROP_TABLE: &str = "DROP TABLE ii1_history;";
+}
+
+const BATCH_DELETE_LIMIT: usize = 100;
+
+#[allow(unused)]
+pub fn maybe_migrate(config: &PortalStorageConfig) -> Result<(), ContentStoreError> {
+    let conn = config.sql_connection_pool.get()?;
+
+    if !conn.prepare(sql::TABLE_EXISTS)?.exists(())? {
+        info!("Legacy history table doesn't exist!");
+        return Ok(());
+    }
+
+    info!("Legacy history table exists. Starting migration.");
+
+    let config = IdIndexedV1StoreConfig::new(
+        ContentType::HistoryEternal,
+        Subnetwork::History,
+        config.clone(),
+    );
+
+    let mut store: IdIndexedV1Store<HistoryContentKey> = create_store(
+        ContentType::HistoryEternal,
+        config.clone(),
+        config.sql_connection_pool,
+    )?;
+
+    let mut batch_delete_query = conn.prepare(sql::BATCH_DELETE)?;
+
+    loop {
+        let deleted = batch_delete_query
+            .query_map(named_params! { ":limit": BATCH_DELETE_LIMIT }, |row| {
+                let key_bytes: Vec<u8> = row.get("content_key")?;
+                let value_bytes: Vec<u8> = row.get("content_value")?;
+                let value = RawContentValue::from(value_bytes);
+                HistoryContentKey::try_from_bytes(key_bytes)
+                    .map(|key| (key, value))
+                    .map_err(|e| rusqlite::Error::FromSqlConversionFailure(0, Type::Blob, e.into()))
+            })?
+            .collect::<Result<Vec<(HistoryContentKey, RawContentValue)>, rusqlite::Error>>()?;
+
+        if deleted.is_empty() {
+            break;
+        }
+
+        for (content_key, old_content_value) in deleted {
+            match convert_content_value(&content_key, old_content_value) {
+                Ok(Some(new_content_value)) => {
+                    store.insert(&content_key, new_content_value)?;
+                }
+                Ok(None) => {
+                    debug!(
+                        key=%content_key.to_bytes(),
+                        "Not migrating content item",
+                    )
+                }
+                Err(err) => {
+                    error!(
+                        key=%content_key.to_bytes(),
+                        err=%err,
+                        "Error converting content item",
+                    );
+                }
+            }
+        }
+    }
+
+    conn.execute_batch(sql::DROP_TABLE)?;
+
+    info!("Migration finished!");
+
+    Ok(())
+}
+
+fn convert_content_value(
+    content_key: &HistoryContentKey,
+    raw_content_value: RawContentValue,
+) -> Result<Option<RawContentValue>, ContentStoreError> {
+    let old_content_value = OldHistoryContentValue::decode(content_key, &raw_content_value)?;
+    match old_content_value {
+        OldHistoryContentValue::BlockHeaderWithProof(old_hwp) => {
+            let proof = match old_hwp.proof {
+                old_hwp::BlockHeaderProof::None(_) => return Ok(None),
+                old_hwp::BlockHeaderProof::PreMergeAccumulatorProof(
+                    pre_merge_accumulator_proof,
+                ) => {
+                    let proof = new_hwp::BlockProofHistoricalHashesAccumulator::new(
+                        pre_merge_accumulator_proof.proof.to_vec(),
+                    )
+                    .map_err(|err| ContentStoreError::InvalidData {
+                        message: format!("Invalid HistoricalHashes proof: {err:?}"),
+                    })?;
+                    new_hwp::BlockHeaderProof::HistoricalHashes(proof)
+                }
+                old_hwp::BlockHeaderProof::HistoricalRootsBlockProof(historical_roots_proof) => {
+                    // Note: there is inconsistency between field names because old types are not
+                    // in sync with most recent spec.
+                    let proof = new_hwp::BlockProofHistoricalRoots {
+                        beacon_block_proof: historical_roots_proof.historical_roots_proof,
+                        beacon_block_root: historical_roots_proof.beacon_block_root,
+                        execution_block_proof: historical_roots_proof.beacon_block_proof,
+                        slot: historical_roots_proof.slot,
+                    };
+                    new_hwp::BlockHeaderProof::HistoricalRoots(proof)
+                }
+                old_hwp::BlockHeaderProof::HistoricalSummariesBlockProof(
+                    historical_summaries_proof,
+                ) => {
+                    // Note: there is inconsistency between field names because old types are not
+                    // in sync with most recent spec.
+                    let execution_block_proof = new_hwp::ExecutionBlockProofCapella::new(
+                        historical_summaries_proof.beacon_block_proof.to_vec(),
+                    )
+                    .map_err(|err| ContentStoreError::InvalidData {
+                        message: format!("Invalid ExecutionBlockProofCapella proof: {err:?}"),
+                    })?;
+                    let proof = new_hwp::BlockProofHistoricalSummaries {
+                        beacon_block_proof: historical_summaries_proof.historical_summaries_proof,
+                        beacon_block_root: historical_summaries_proof.beacon_block_root,
+                        execution_block_proof,
+                        slot: historical_summaries_proof.slot,
+                    };
+                    new_hwp::BlockHeaderProof::HistoricalSummaries(proof)
+                }
+            };
+            let new_content_value =
+                NewHistoryContentValue::BlockHeaderWithProof(new_hwp::HeaderWithProof {
+                    header: old_hwp.header,
+                    proof,
+                });
+            Ok(Some(new_content_value.encode()))
+        }
+        OldHistoryContentValue::BlockBody(_) | OldHistoryContentValue::Receipts(_) => {
+            // TODO: consider whether to filter post-merge bodies and receipts
+            Ok(Some(raw_content_value))
+        }
+    }
+}


### PR DESCRIPTION
### What was wrong?

We need logic for history content migration. See #1666 for details.

### How was it fixed?

Created new `ContentType`s that will be used for new content types.
This way, we can use the same implementation of content store, because new type will correspond to the new sql table.

This also makes the migration simple: we have to delete content from original table, and either discard or insert into new table.

### To-Do

The migration function is not used at the moment, so this PR can be merged as is.
The followup work, that can be done either as part of this PR or as a followup PR (depending on the review status of this PR and when I finish it):
- Add tests for migration
- Add migration metrics/stats that can be printed periodically
- Decide what we do regarding post-merge bodies and receipts

