### PR TITLE
fix(ci): make dependencies update bot commit under github-actions account instead of users

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -31,6 +31,9 @@ jobs:
   update:
     name: Update
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -57,6 +60,7 @@ jobs:
         with:
           add-paths: ./Cargo.lock
           commit-message: ${{ steps.msg.outputs.commit_message }}
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           title: ${{ env.TITLE }}
           body: ${{ steps.msg.outputs.body }}
           branch: ${{ env.BRANCH }}

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -31,9 +31,6 @@ jobs:
   update:
     name: Update
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
### What was wrong?
![image](https://github.com/user-attachments/assets/7358bcf1-2ec7-48f1-8756-d48652b59943)
Currently every time our CI dependencies bot runs it commits under a user account, instead of github actions bot.

This PR and commit isn't being made by a user, it is being made by github actions bot account, so we probably shouldn't be comitting it under a user's account
### How was it fixed?

I tested this locally on my fork https://github.com/KolbyML/trin/pull/5

![image](https://github.com/user-attachments/assets/ab2eeb06-feeb-4fa7-99f9-4cd636d350af)


Now it commits the update dependencies commit under the bots account
