### PR TITLE
feat(beacon): enable pruning for outdated light client bootstrap data

### DIFF
--- a/crates/storage/src/sql.rs
+++ b/crates/storage/src/sql.rs
@@ -26,6 +26,10 @@ pub const LC_BOOTSTRAP_LOOKUP_QUERY: &str =
 pub const LC_BOOTSTRAP_LATEST_BLOCK_ROOT_QUERY: &str =
     "SELECT block_root FROM lc_bootstrap ORDER BY slot DESC LIMIT 1";
 
+/// Query to prune the lc_bootstrap table by deleting all records with slot less than the given
+/// slot.
+pub const LC_BOOTSTRAP_PRUNE_QUERY: &str = "DELETE FROM lc_bootstrap WHERE slot < (?1)";
+
 /// Total beacon data size is the combination of lc_bootstrap, lc_update and historical_summaries
 /// tables
 pub const TOTAL_DATA_SIZE_QUERY_BEACON: &str = "SELECT

--- a/crates/subnetworks/beacon/src/network.rs
+++ b/crates/subnetworks/beacon/src/network.rs
@@ -58,6 +58,7 @@ impl BeaconNetwork {
             ..Default::default()
         };
         let storage = Arc::new(PLRwLock::new(BeaconStorage::new(storage_config)?));
+        storage.write().spawn_pruning_task(); // Spawn pruning task to clean up expired content.
         let storage_clone = Arc::clone(&storage);
         let validator = Arc::new(BeaconValidator::new(header_oracle));
         let ping_extensions = Arc::new(BeaconPingExtensions {});


### PR DESCRIPTION
### What was wrong?
The beacon node keeps all the light client bootstrap data in the DB, but we want to serve and retain only bootstraps that are within the weak subjectivity period ~= 4 months old.

### How was it fixed?
Add a pruning task for light client bootstrap data that runs on every start, and once a day when the client is running.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
