### PR TITLE
chore: bump ethportal-api version to v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "ethportal-api"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "alloy",
  "alloy-rlp",

--- a/crates/ethportal-api/Cargo.toml
+++ b/crates/ethportal-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethportal-api"
-version = "0.4.1"
+version = "0.4.2"
 description = "Definitions for various Ethereum Portal Network JSONRPC APIs"
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
Bump `ethportal-api` version as part of the release process.
