### PR TITLE
perf: switch store from RwLock to Mutex 1.74x performance increase ~98.8% error rate decrease

### DIFF
--- a/crates/portalnet/src/overlay/service/mod.rs
+++ b/crates/portalnet/src/overlay/service/mod.rs
@@ -7,7 +7,7 @@ use delay_map::HashSetDelay;
 use discv5::enr::NodeId;
 use ethportal_api::{types::network::Subnetwork, OverlayContentKey};
 use manager::QueryTraceEvent;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use tokio::sync::{
     broadcast,
     mpsc::{UnboundedReceiver, UnboundedSender},
@@ -38,7 +38,8 @@ where
     /// The underlying Discovery v5 protocol.
     discovery: Arc<Discovery>,
     /// The content database of the local node.
-    store: Arc<RwLock<TStore>>,
+    store: Arc<Mutex<TStore>>,
+
     /// The routing table of the local node.
     kbuckets: SharedKBucketsTable,
     /// The protocol identifier.

--- a/crates/portalnet/tests/overlay.rs
+++ b/crates/portalnet/tests/overlay.rs
@@ -15,7 +15,7 @@ use ethportal_api::{
     utils::bytes::hex_encode_upper,
     OverlayContentKey,
 };
-use parking_lot::RwLock;
+use parking_lot::Mutex;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, Discv5UdpSocket},
@@ -47,7 +47,7 @@ async fn init_overlay(
 
     let node_id = discovery.local_enr().node_id();
     let store = MemoryContentStore::new(node_id, DistanceFunction::Xor);
-    let store = Arc::new(RwLock::new(store));
+    let store = Arc::new(Mutex::new(store));
 
     let header_oracle = HeaderOracle::default();
     let header_oracle = Arc::new(TokioRwLock::new(header_oracle));
@@ -256,7 +256,7 @@ async fn overlay() {
     let content = vec![0xef];
     overlay_three
         .store
-        .write()
+        .lock()
         .put(content_key.clone(), &content)
         .expect("Unable to store content");
     let (found_content, utp_transfer, _) = overlay_one

--- a/crates/subnetworks/beacon/src/jsonrpc.rs
+++ b/crates/subnetworks/beacon/src/jsonrpc.rs
@@ -215,7 +215,7 @@ async fn local_content(
     network: Arc<BeaconNetwork>,
     content_key: BeaconContentKey,
 ) -> Result<Value, String> {
-    let response = match network.overlay.store.read().get(&content_key)
+    let response = match network.overlay.store.lock().get(&content_key)
         {
             Ok(val) => match val {
                 Some(val) => {
@@ -236,7 +236,7 @@ async fn paginate_local_content_keys(
     offset: u64,
     limit: u64,
 ) -> Result<Value, String> {
-    let response = match network.overlay.store.read().paginate(&offset, &limit)
+    let response = match network.overlay.store.lock().paginate(&offset, &limit)
         {
             Ok(val) => Ok(json!(val)),
             Err(err) => Err(format!(
@@ -256,7 +256,7 @@ async fn store(
     let response = match network
         .overlay
         .store
-        .write()
+        .lock()
         .put::<Vec<u8>>(content_key, data)
     {
         Ok(_) => Ok(Value::Bool(true)),

--- a/crates/subnetworks/beacon/src/lib.rs
+++ b/crates/subnetworks/beacon/src/lib.rs
@@ -119,7 +119,7 @@ pub fn spawn_beacon_heartbeat(network: Arc<BeaconNetwork>) {
             // this wait at the top. Otherwise, we get two log lines immediately on startup.
             heart_interval.tick().await;
 
-            let storage_log = network.overlay.store.read().get_summary_info();
+            let storage_log = network.overlay.store.lock().get_summary_info();
             let message_log = network.overlay.get_message_summary();
             let utp_log = network.overlay.get_utp_summary();
             info!("reports~ data: {storage_log}; msgs: {message_log}");

--- a/crates/subnetworks/history/src/jsonrpc.rs
+++ b/crates/subnetworks/history/src/jsonrpc.rs
@@ -150,7 +150,7 @@ async fn local_content(
     network: Arc<HistoryNetwork>,
     content_key: HistoryContentKey,
 ) -> Result<Value, String> {
-    let response = match network.overlay.store.read().get(&content_key)
+    let response = match network.overlay.store.lock().get(&content_key)
         {
             Ok(val) => match val {
                 Some(val) => {
@@ -176,7 +176,7 @@ async fn paginate_local_content_keys(
     offset: u64,
     limit: u64,
 ) -> Result<Value, String> {
-    let response = match network.overlay.store.read().paginate(offset, limit)
+    let response = match network.overlay.store.lock().paginate(offset, limit)
         {
             Ok(val) => Ok(json!(val)),
             Err(err) => Err(format!(
@@ -196,7 +196,7 @@ async fn store(
     let response = match network
         .overlay
         .store
-        .write()
+        .lock()
         .put::<Vec<u8>>(content_key, data)
     {
         Ok(_) => Ok(Value::Bool(true)),

--- a/crates/subnetworks/history/src/lib.rs
+++ b/crates/subnetworks/history/src/lib.rs
@@ -118,7 +118,7 @@ pub fn spawn_history_heartbeat(network: Arc<HistoryNetwork>) {
             // this wait at the top. Otherwise, we get two log lines immediately on startup.
             heart_interval.tick().await;
 
-            let storage_log = network.overlay.store.read().get_summary_info();
+            let storage_log = network.overlay.store.lock().get_summary_info();
             let message_log = network.overlay.get_message_summary();
             let utp_log = network.overlay.get_utp_summary();
             info!("reports~ data: {storage_log}; msgs: {message_log}");

--- a/crates/subnetworks/history/src/network.rs
+++ b/crates/subnetworks/history/src/network.rs
@@ -4,7 +4,7 @@ use ethportal_api::{
     types::{distance::XorMetric, network::Subnetwork},
     HistoryContentKey,
 };
-use parking_lot::RwLock as PLRwLock;
+use parking_lot::Mutex;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpPeer},
@@ -55,7 +55,7 @@ impl HistoryNetwork {
             utp_transfer_limit: portal_config.utp_transfer_limit,
             ..Default::default()
         };
-        let storage = Arc::new(PLRwLock::new(HistoryStorage::new(
+        let storage = Arc::new(Mutex::new(HistoryStorage::new(
             storage_config,
             disable_history_storage,
         )?));

--- a/crates/subnetworks/state/src/jsonrpc.rs
+++ b/crates/subnetworks/state/src/jsonrpc.rs
@@ -172,7 +172,7 @@ fn local_storage_lookup(
     network
         .overlay
         .store
-        .read()
+        .lock()
         .get(content_key)
         .map_err(|err| err.to_string())
 }
@@ -285,7 +285,7 @@ async fn store(
         network
             .overlay
             .store
-            .write()
+            .lock()
             .put(content_key, content_value.encode())
             .map(|_| true),
     )
@@ -352,7 +352,7 @@ async fn put_content(
 fn paginate(network: Arc<StateNetwork>, offset: u64, limit: u64) -> Result<Value, String> {
     to_json_result(
         "PaginateLocalContentKeys",
-        network.overlay.store.read().paginate(offset, limit),
+        network.overlay.store.lock().paginate(offset, limit),
     )
 }
 

--- a/crates/subnetworks/state/src/lib.rs
+++ b/crates/subnetworks/state/src/lib.rs
@@ -127,7 +127,7 @@ pub fn spawn_state_heartbeat(network: Arc<StateNetwork>) {
             let cpu_percent =
                 100.0 * process_time.elapsed().as_secs_f64() / clock_time.elapsed().as_secs_f64();
 
-            let storage_log = network.overlay.store.read().get_summary_info();
+            let storage_log = network.overlay.store.lock().get_summary_info();
             let message_log = network.overlay.get_message_summary();
             let utp_log = network.overlay.get_utp_summary();
             info!("reports~ data: {storage_log}; msgs: {message_log}; cpu={cpu_percent:.1}%");

--- a/crates/subnetworks/state/src/network.rs
+++ b/crates/subnetworks/state/src/network.rs
@@ -4,7 +4,7 @@ use ethportal_api::{
     types::{distance::XorMetric, network::Subnetwork},
     StateContentKey,
 };
-use parking_lot::RwLock as PLRwLock;
+use parking_lot::Mutex;
 use portalnet::{
     config::PortalnetConfig,
     discovery::{Discovery, UtpPeer},
@@ -60,7 +60,7 @@ impl StateNetwork {
             utp_transfer_limit: portal_config.utp_transfer_limit,
             ..Default::default()
         };
-        let storage = Arc::new(PLRwLock::new(StateStorage::new(storage_config)?));
+        let storage = Arc::new(Mutex::new(StateStorage::new(storage_config)?));
         let validator = Arc::new(StateValidator { header_oracle });
         let ping_extensions = Arc::new(StatePingExtensions {});
         let overlay = OverlayProtocol::new(


### PR DESCRIPTION
### What was wrong?

Currently the performance of Trin is very poor as in we can only handle around 2-5 Megabits per second. This is insanely low, inorder to get the state network live we need to massively increase performance of Trin hopefully by at least 10-100x more ideally. Ideally Trin can saturate a computers network card. To put 2-5 megabits into prospective that isn't even 1 megabyte per a second, Trin is insanely slow, and due to this slowness Trin has a high error rate, especially under under small load. Last I checked only 90% of Trin Execution state diff bridges made it onto the network. The state is massive, having an error rate that high makes it hard to have a reliable network.

In short
- trin performance is bad
- trin performance isn't good enough to onboard users, the network would die under any real load by users

### How was it fixed?

This is the first improvement of many. I used the benchmark I wrote and found an big bottleneck around our database code, if I commented out a few database calls I was able to get 2x performance which was the theoretical target for my optimizations for this specific bottleneck.

![image](https://github.com/user-attachments/assets/2ca558b5-010d-49ff-af60-76c6e248c44a)

I ended up finding the `parking_lot::RwLock` would block readers to "ensure" fairness to writers, the issue with this is it greatly limits performance of Trin. When I switched the read's to write's the performance bottleneck I was trying to debug went away.

 |       | Time    | Errors/Transfer Failures |
|-------|---------|--------------------------|
| Run 1 | 15m 27s | 5539                     |
| Run 2 | 15m 9s  | 969                      |
| Run 3 | 13m 5s  | 13139                    |
| Run 4 | 8m 27s  | 89                       |
| Run 5 | 8m 26s  | 72                       |
| Run 6 | 8m 11s  | 76                       |

![graph](https://github.com/user-attachments/assets/3a99b10c-452e-4421-a78c-1d73911df1af)


Here is a chart, the first 3 runs are before this PR. The last 3 runs are with this PR.

If you notice there is a speed up of 1.74x and there are ~98.8% fewer errors. This is significant and confirms my belief that in order to increase the reliability of State transfers, we must increase the performance of Trin itself, as currently Trin can't handle any reasonable load before throwing errors and such.

### For more information on the benchmark
I kinda hijacked my benchmark PR to benchmark stuff https://github.com/ethereum/trin/pull/1660

But the basic idea is we send a range of era1 files through offers from nodeA to nodeB, we send all headers first, then bodies, then receipts. This way we won't have validation/complexity issues, as if we did 1 block at a time.

I am sending era1 1000 to 1010 inclusive which is around 6.7GB of data

## Todo in follow up PR's

This change doesn't really change our performance for small transfers like for headers and state, but now that this bottleneck is fixed others should become easier to find (it is like a game of wack a mole, where you get rid of the some and new ones take their place). Currently we can only handle around 20-30k packets sending or receiving (when sending headers, for bodies and receipts our rate is significantly higher especially with this fix) I am assuming a good chunk of those are wasted packets because currently all talk_responses are empty, so https://github.com/ethereum/devp2p/issues/229 would probably help significantly with that, but I am sure I can find another bottleneck which should give another significant performance gain, they shouldn't be too hard to find as currently Trin's performance is unbelievably bad.