### PR TITLE
chore: improve ping extension decode errors

### DIFF
--- a/crates/ethportal-api/src/types/ping_extensions/decode.rs
+++ b/crates/ethportal-api/src/types/ping_extensions/decode.rs
@@ -8,7 +8,7 @@ use super::{
         type_65535::PingError,
     },
 };
-use crate::types::portal_wire::CustomPayload;
+use crate::{types::portal_wire::CustomPayload, utils::bytes::hex_encode};
 
 #[derive(Debug, Clone)]
 pub enum DecodedExtension {
@@ -41,7 +41,7 @@ impl DecodedExtension {
                     .map_err(|err| {
                     anyhow!(
                         "Failed to decode ClientInfoRadiusCapabilities: {err:?}, payload: {:?}",
-                        hex::encode(&*payload.payload)
+                        hex_encode(&*payload.payload)
                     )
                 })?;
                 Ok(DecodedExtension::Capabilities(capabilities))
@@ -51,7 +51,7 @@ impl DecodedExtension {
                     BasicRadius::from_ssz_bytes(&payload.payload).map_err(|err| {
                         anyhow!(
                             "Failed to decode BasicRadius: {err:?}, payload: {:?}",
-                            hex::encode(&*payload.payload)
+                            hex_encode(&*payload.payload)
                         )
                     })?;
                 Ok(DecodedExtension::BasicRadius(basic_radius))
@@ -61,7 +61,7 @@ impl DecodedExtension {
                     HistoryRadius::from_ssz_bytes(&payload.payload).map_err(|err| {
                         anyhow!(
                             "Failed to decode HistoryRadius: {err:?}, payload: {:?}",
-                            hex::encode(&*payload.payload)
+                            hex_encode(&*payload.payload)
                         )
                     })?;
                 Ok(DecodedExtension::HistoryRadius(history_radius))
@@ -70,7 +70,7 @@ impl DecodedExtension {
                 let error = PingError::from_ssz_bytes(&payload.payload).map_err(|err| {
                     anyhow!(
                         "Failed to decode PingError: {err:?}, payload: {:?}",
-                        hex::encode(&*payload.payload)
+                        hex_encode(&*payload.payload)
                     )
                 })?;
                 Ok(DecodedExtension::Error(error))

--- a/crates/ethportal-api/src/types/ping_extensions/decode.rs
+++ b/crates/ethportal-api/src/types/ping_extensions/decode.rs
@@ -39,23 +39,40 @@ impl DecodedExtension {
             Extensions::Capabilities => {
                 let capabilities = ClientInfoRadiusCapabilities::from_ssz_bytes(&payload.payload)
                     .map_err(|err| {
-                    anyhow!("Failed to decode ClientInfoRadiusCapabilities: {err:?}")
+                    anyhow!(
+                        "Failed to decode ClientInfoRadiusCapabilities: {err:?}, payload: {:?}",
+                        hex::encode(&*payload.payload)
+                    )
                 })?;
                 Ok(DecodedExtension::Capabilities(capabilities))
             }
             Extensions::BasicRadius => {
-                let basic_radius = BasicRadius::from_ssz_bytes(&payload.payload)
-                    .map_err(|err| anyhow!("Failed to decode BasicRadius: {err:?}"))?;
+                let basic_radius =
+                    BasicRadius::from_ssz_bytes(&payload.payload).map_err(|err| {
+                        anyhow!(
+                            "Failed to decode BasicRadius: {err:?}, payload: {:?}",
+                            hex::encode(&*payload.payload)
+                        )
+                    })?;
                 Ok(DecodedExtension::BasicRadius(basic_radius))
             }
             Extensions::HistoryRadius => {
-                let history_radius = HistoryRadius::from_ssz_bytes(&payload.payload)
-                    .map_err(|err| anyhow!("Failed to decode HistoryRadius: {err:?}"))?;
+                let history_radius =
+                    HistoryRadius::from_ssz_bytes(&payload.payload).map_err(|err| {
+                        anyhow!(
+                            "Failed to decode HistoryRadius: {err:?}, payload: {:?}",
+                            hex::encode(&*payload.payload)
+                        )
+                    })?;
                 Ok(DecodedExtension::HistoryRadius(history_radius))
             }
             Extensions::Error => {
-                let error = PingError::from_ssz_bytes(&payload.payload)
-                    .map_err(|err| anyhow!("Failed to decode PingError: {err:?}"))?;
+                let error = PingError::from_ssz_bytes(&payload.payload).map_err(|err| {
+                    anyhow!(
+                        "Failed to decode PingError: {err:?}, payload: {:?}",
+                        hex::encode(&*payload.payload)
+                    )
+                })?;
                 Ok(DecodedExtension::Error(error))
             }
         }

--- a/crates/portalnet/src/overlay/service/ping/mod.rs
+++ b/crates/portalnet/src/overlay/service/ping/mod.rs
@@ -219,7 +219,7 @@ impl<
                         warn!(
                             protocol = %self.protocol,
                             request.source = %source,
-                            "Failed to decode custom payload during process_ping: {err:?}",
+                            "Failed to decode custom payload during process_pong: {err:?}",
                         );
                         return;
                     }


### PR DESCRIPTION
### What was wrong?

We have `process_ping` in the `process_pong` function log, also it is a little hard to debug decode failures if the hex isn't included

### How was it fixed?

fixed the error message and added the hex(payload) if decode fails