### PR TITLE
feat: add block header by number content value

### DIFF
--- a/crates/ethportal-api/src/types/content_value/history.rs
+++ b/crates/ethportal-api/src/types/content_value/history.rs
@@ -16,6 +16,7 @@ pub enum HistoryContentValue {
     BlockHeaderWithProof(HeaderWithProof),
     BlockBody(BlockBody),
     Receipts(Receipts),
+    BlockHeaderByNumber(HeaderWithProof),
 }
 
 impl ContentValue for HistoryContentValue {
@@ -26,6 +27,7 @@ impl ContentValue for HistoryContentValue {
             Self::BlockHeaderWithProof(value) => value.as_ssz_bytes().into(),
             Self::BlockBody(value) => value.as_ssz_bytes().into(),
             Self::Receipts(value) => value.as_ssz_bytes().into(),
+            Self::BlockHeaderByNumber(value) => value.as_ssz_bytes().into(),
         }
     }
 

--- a/crates/ethportal-api/src/types/content_value/history_new.rs
+++ b/crates/ethportal-api/src/types/content_value/history_new.rs
@@ -16,6 +16,7 @@ pub enum HistoryContentValue {
     BlockHeaderWithProof(HeaderWithProof),
     BlockBody(BlockBody),
     Receipts(Receipts),
+    BlockHeaderByNumber(HeaderWithProof),
 }
 
 impl ContentValue for HistoryContentValue {
@@ -26,6 +27,7 @@ impl ContentValue for HistoryContentValue {
             Self::BlockHeaderWithProof(value) => value.as_ssz_bytes().into(),
             Self::BlockBody(value) => value.as_ssz_bytes().into(),
             Self::Receipts(value) => value.as_ssz_bytes().into(),
+            Self::BlockHeaderByNumber(value) => value.as_ssz_bytes().into(),
         }
     }
 

--- a/crates/metrics/src/history_migration.rs
+++ b/crates/metrics/src/history_migration.rs
@@ -60,7 +60,8 @@ impl HistoryMigrationMetrics {
 
     pub fn get_content_value_label(&self, content_value: &HistoryContentValue) -> &str {
         match content_value {
-            HistoryContentValue::BlockHeaderWithProof(header_with_proof) => {
+            HistoryContentValue::BlockHeaderWithProof(header_with_proof)
+            | HistoryContentValue::BlockHeaderByNumber(header_with_proof) => {
                 match &header_with_proof.proof {
                     BlockHeaderProof::None(_) => "header_no_proof",
                     BlockHeaderProof::PreMergeAccumulatorProof(_) => "header_pre_merge_accumulator",


### PR DESCRIPTION
### What was wrong?
Block Header by Number content value implementation is missing. Here are the [specs](https://github.com/ethereum/portal-network-specs/blob/master/history/history-network.md#block-header-by-number).

To reserve the **0x03** selector, we have to implement this for `HistoryContentValue` before ephemeral headers.

### How was it fixed?
Add `BlockHeaderByNumber` history content value variant and update the db migration code.

It seems the `BlockHeaderWithProof`  variant should be renamed to `BlockHeaderByHash` but we can discuss this and it is for another PR.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
