### PR TITLE
feat: remove old store ContentType::History

### DIFF
--- a/crates/storage/src/versioned/id_indexed_v1/store.rs
+++ b/crates/storage/src/versioned/id_indexed_v1/store.rs
@@ -552,7 +552,6 @@ impl<TContentKey: OverlayContentKey> IdIndexedV1Store<TContentKey> {
 /// See https://github.com/ethereum/trin/issues/1653 for details.
 const fn extra_disk_usage_per_content_bytes(content_type: &ContentType) -> u64 {
     match content_type {
-        ContentType::History => 750,
         ContentType::HistoryEternal => 750,
         ContentType::State => 500,
         ContentType::HistoryEphemeral => panic!("HistoryEphemeral is not supported"),

--- a/crates/storage/src/versioned/mod.rs
+++ b/crates/storage/src/versioned/mod.rs
@@ -18,11 +18,6 @@ pub use utils::create_store;
 #[derive(Clone, Debug, Display, Eq, PartialEq, AsRefStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum ContentType {
-    /// Corresponds to the history network content.
-    ///
-    /// This type is deprecated and  `HistoryEternal` or should be used instead.
-    /// See https://github.com/ethereum/trin/issues/1666".
-    History,
     /// Corresponds to the state network content.
     State,
     /// Corresponds to the non-ephemeral history network content.

--- a/crates/storage/src/versioned/utils.rs
+++ b/crates/storage/src/versioned/utils.rs
@@ -103,7 +103,10 @@ pub mod test {
             create_test_portal_storage_config_with_capacity(STORAGE_CAPACITY_MB)?;
         let conn = config.sql_connection_pool.get()?;
 
-        assert_eq!(get_store_version(&ContentType::History, &conn)?, None);
+        assert_eq!(
+            get_store_version(&ContentType::HistoryEternal, &conn)?,
+            None
+        );
         Ok(())
     }
 
@@ -197,14 +200,14 @@ pub mod test {
         let sql_connection_pool = config.sql_connection_pool.clone();
 
         update_store_info(
-            &ContentType::History,
+            &ContentType::HistoryEternal,
             StoreVersion::IdIndexedV1,
             &sql_connection_pool.get().unwrap(),
         )
         .unwrap();
 
         // Should panic - MockContentStore doesn't support migration.
-        create_store::<MockContentStore>(ContentType::History, config, sql_connection_pool)
+        create_store::<MockContentStore>(ContentType::HistoryEternal, config, sql_connection_pool)
             .unwrap();
     }
 }


### PR DESCRIPTION
### What was wrong?

The old history content type (`ContentType::History`) used for storage is no longer needed.

Instead, we should use either `ContentType::HistoryEternal` or `ContentType::HistoryEphemeral`.

### How was it fixed?

Removed no longer used type.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
