### PR TITLE
docs: release ethportal using verification

### DIFF
--- a/book/src/developers/contributing/releases/deployment.md
+++ b/book/src/developers/contributing/releases/deployment.md
@@ -79,6 +79,7 @@ This step directs Ansible to use the current master version of trin. Read [about
         - regular nodes: all remaining ips
     - `ssh ubuntu@$IP_ADDR`
     - check logs, ignoring DEBUG: `sudo docker logs trin -n 1000 | grep -v DEBUG`
+    - for glados logins, use `ssh devops@$IP_ADDR` instead
 - Check monitoring tools to see if network health is the same or better as before deployment. Glados might lag for 10-15 minutes, so keep checking back.
 
 ### Communicate

--- a/book/src/developers/contributing/releases/release_checklist.md
+++ b/book/src/developers/contributing/releases/release_checklist.md
@@ -21,9 +21,14 @@ group discussion and decision.
 
 ## Release dependencies
 
-For now, that's just ethportal-api. Manually bump the version in the
-Cargo.toml, and run `cargo update` to update the workspace lockfile. Commit and
-merge these changes to trin. Then run:
+For now, that's just ethportal-api, plus the whole workspace. Steps to release:
+
+1. Bump the version in that crate's Cargo.toml (pay attention to whether there are any API changes that require a major version bump)
+2. Bump the version in the workspace Cargo.toml
+3. Run `cargo update` to update the workspace lockfile
+4. Get a review on whether the version number changes are appropriate
+5. Merge the combined PR into master
+6. Publish the ethportal-api release with:
 
 ```bash
 cargo publish -p ethportal-api

--- a/book/src/developers/contributing/releases/release_checklist.md
+++ b/book/src/developers/contributing/releases/release_checklist.md
@@ -26,14 +26,8 @@ Cargo.toml, and run `cargo update` to update the workspace lockfile. Commit and
 merge these changes to trin. Then run:
 
 ```bash
-cd ethportal-api
-cargo publish --no-verify
+cargo publish -p ethportal-api
 ```
-
-We would like to get rid of the no-verify ASAP, but for now Cargo.lock is
-causing issues that we have no other workaround for. `cargo publish` generates
-a new lock file, and then complains that the lockfile is new. See this
-[StackOverflow post](https://stackoverflow.com/questions/79276315/how-to-build-a-cargo-lock-file-for-a-package-within-a-workspace).
 
 ## Release Trin
 

--- a/book/src/developers/contributing/rotation/index.md
+++ b/book/src/developers/contributing/rotation/index.md
@@ -21,15 +21,15 @@ There are some daily tasks, and some transition tasks: Kickoff on Monday & Hando
 
 Unlike your code-heavy weeks, this can be an interruption-heavy week. Although it's often good practice to not get distracted by inbound messages while coding, this week is the opposite: as soon as you see new messages (like on Discord), jump into it.
 
-### Kickoff
+### First time ever as Flamingo
+
+Read through the "Setup" section of the [Deployment Instructions](../releases/deployment.md) and follow the steps to make sure that your PGP and SSH keys are in place and ready for a deployment.
+
+### Kickoff: first day of Flamingo week
 
 Have a discussion with the previous Flamingo on any ongoing issues or in-progress tasks. This is crucial to get a quick understanding of the state of the network and any in-progress tasks to resume.
 
 Make sure your status is "online" in Discord. Make sure you're tagged under the `trin-flamingo` role (ping discord Admin). Put on your favorite pink shirt. Watch a [silly flamingo video](https://www.youtube.com/watch?v=gWNWtbPEWw0). Fly.
-
-### First
-
-Read through the "Setup" section of the [Deployment Instructions](../releases/deployment.md) and follow the steps to make sure that your PGP and SSH keys are in place and ready for a deployment.
 
 ### Daily
 
@@ -90,7 +90,7 @@ When you get to the end of your checklist, here are ideas for what to work on ne
 - Add new integration tools (eg~ portal-hive -> Discord bot?)
 - Scratch your own itch! What do you wish was easier? Now is the time to build it.
 
-### Handoff
+### Handoff: last day of Flamingo week
 
 Look back at your week as Flamingo and summarize it in notes if needed. Prepare for a kickoff discussion with the next Flamingo and update them on your work from previous week.
 


### PR DESCRIPTION
Frankly, I don't know what changed since --no-verify was required. It works without the flag now, so we should definitely not use it. Verification seems good.