### PR TITLE
chore: update docker compose environment variable syntax

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     hostname: trin
     image: portalnetwork/trin:latest
     environment:
-      - RUST_LOG: info
+      - RUST_LOG=info
     command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/"
     network_mode: "host"
     volumes: 


### PR DESCRIPTION
the environment variable section is now be declared according to array syntax described in [docker docs](https://docs.docker.com/reference/compose-file/services/#environment).

the orginal declaration
```yaml
environment:
    - RUST_LOG: info
```
is giving this syntax error
```bash
➜  docker compose up
services.trin.environment.[0]: unexpected type map[string]interface {}
```