### PR TITLE
refactor: read e2store header type as big endian

### DIFF
--- a/crates/e2store/src/e2ss.rs
+++ b/crates/e2store/src/e2ss.rs
@@ -44,6 +44,7 @@ use crate::{
         stream::{E2StoreStreamReader, E2StoreStreamWriter},
         types::{Entry, VersionEntry},
     },
+    entry_types,
     types::HeaderEntry,
     utils::underlying_io_error_kind,
 };
@@ -230,7 +231,7 @@ impl TryFrom<&Entry> for AccountEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x0800,
+            entry.header.type_ == entry_types::COMPRESSED_ACCOUNT,
             "invalid account entry: incorrect account type"
         );
         ensure!(
@@ -257,7 +258,7 @@ impl TryFrom<AccountEntry> for Entry {
             "FrameEncoder should write whole rlp encoding"
         );
         let encoded = encoder.into_inner()?;
-        Ok(Entry::new(0x0800, encoded))
+        Ok(Entry::new(entry_types::COMPRESSED_ACCOUNT, encoded))
     }
 }
 
@@ -283,7 +284,7 @@ impl TryFrom<&Entry> for StorageEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x0900,
+            entry.header.type_ == entry_types::COMPRESSED_STORAGE,
             "invalid storage entry: incorrect storage type"
         );
         ensure!(
@@ -310,7 +311,7 @@ impl TryFrom<StorageEntry> for Entry {
             "FrameEncoder should write whole rlp encoding"
         );
         let encoded = encoder.into_inner()?;
-        Ok(Entry::new(0x0900, encoded))
+        Ok(Entry::new(entry_types::COMPRESSED_STORAGE, encoded))
     }
 }
 

--- a/crates/e2store/src/e2ss.rs
+++ b/crates/e2store/src/e2ss.rs
@@ -12,10 +12,10 @@
 //! e2ss := Version | CompressedHeader | account*
 //! account :=  CompressedAccount | CompressedStorage*
 //!
-//! Version             = { type: 0x3265, data: nil }
-//! CompressedHeader    = { type: 0x03,   data: snappyFramed(rlp(header)) }
-//! CompressedAccount   = { type: 0x08,   data: snappyFramed(rlp(Account)) }
-//! CompressedStorage   = { type: 0x09,   data: snappyFramed(rlp(Vec<StorageItem>)) }
+//! Version             = { type: 0x6532, data: nil }
+//! CompressedHeader    = { type: 0x0300,   data: snappyFramed(rlp(header)) }
+//! CompressedAccount   = { type: 0x0800,   data: snappyFramed(rlp(Account)) }
+//! CompressedStorage   = { type: 0x0900,   data: snappyFramed(rlp(Vec<StorageItem>)) }
 //!
 //! Account             = { address_hash, AccountState, raw_bytecode, storage_entry_count }
 //! AccountState        = { nonce, balance, storage_root, code_hash }
@@ -230,7 +230,7 @@ impl TryFrom<&Entry> for AccountEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x08,
+            entry.header.type_ == 0x0800,
             "invalid account entry: incorrect account type"
         );
         ensure!(
@@ -257,7 +257,7 @@ impl TryFrom<AccountEntry> for Entry {
             "FrameEncoder should write whole rlp encoding"
         );
         let encoded = encoder.into_inner()?;
-        Ok(Entry::new(0x08, encoded))
+        Ok(Entry::new(0x0800, encoded))
     }
 }
 
@@ -283,7 +283,7 @@ impl TryFrom<&Entry> for StorageEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x09,
+            entry.header.type_ == 0x0900,
             "invalid storage entry: incorrect storage type"
         );
         ensure!(
@@ -310,7 +310,7 @@ impl TryFrom<StorageEntry> for Entry {
             "FrameEncoder should write whole rlp encoding"
         );
         let encoded = encoder.into_inner()?;
-        Ok(Entry::new(0x09, encoded))
+        Ok(Entry::new(0x0900, encoded))
     }
 }
 

--- a/crates/e2store/src/e2store/memory.rs
+++ b/crates/e2store/src/e2store/memory.rs
@@ -69,6 +69,7 @@ mod test {
     use ethportal_api::utils::bytes::{hex_decode, hex_encode};
 
     use super::*;
+    use crate::entry_types;
 
     // test cases sourced from: https://github.com/ethereum/go-ethereum/pull/26621/
 
@@ -88,7 +89,7 @@ mod test {
     fn test_entry_beef() {
         let expected = "0x2a00020000000000beef";
         let entry = Entry::deserialize(&hex_decode(expected).unwrap()).unwrap();
-        assert_eq!(entry.header.type_, 0x2a00); // 4200
+        assert_eq!(entry.header.type_, 0x2a00); // 10752
         assert_eq!(entry.header.length, 2);
         assert_eq!(entry.header.reserved, 0);
         assert_eq!(entry.value, vec![0xbe, 0xef]);
@@ -105,7 +106,10 @@ mod test {
         assert_eq!(file.entries[0].header.length, 2);
         assert_eq!(file.entries[0].header.reserved, 0);
         assert_eq!(file.entries[0].value, vec![0xbe, 0xef]);
-        assert_eq!(file.entries[1].header.type_, 0x0900); // 2304
+        assert_eq!(
+            file.entries[1].header.type_,
+            entry_types::COMPRESSED_STORAGE
+        ); // 2304
         assert_eq!(file.entries[1].header.length, 4);
         assert_eq!(file.entries[1].header.reserved, 0);
         assert_eq!(file.entries[1].value, vec![0xab, 0xcd, 0xab, 0xcd]);

--- a/crates/e2store/src/e2store/memory.rs
+++ b/crates/e2store/src/e2store/memory.rs
@@ -88,7 +88,7 @@ mod test {
     fn test_entry_beef() {
         let expected = "0x2a00020000000000beef";
         let entry = Entry::deserialize(&hex_decode(expected).unwrap()).unwrap();
-        assert_eq!(entry.header.type_, 0x2a); // 42
+        assert_eq!(entry.header.type_, 0x2a00); // 4200
         assert_eq!(entry.header.length, 2);
         assert_eq!(entry.header.reserved, 0);
         assert_eq!(entry.value, vec![0xbe, 0xef]);
@@ -101,11 +101,11 @@ mod test {
         let expected = "0x2a00020000000000beef0900040000000000abcdabcd";
         let file = E2StoreMemory::deserialize(&hex_decode(expected).unwrap()).unwrap();
         assert_eq!(file.entries.len(), 2);
-        assert_eq!(file.entries[0].header.type_, 0x2a); // 42
+        assert_eq!(file.entries[0].header.type_, 0x2a00); // 10752
         assert_eq!(file.entries[0].header.length, 2);
         assert_eq!(file.entries[0].header.reserved, 0);
         assert_eq!(file.entries[0].value, vec![0xbe, 0xef]);
-        assert_eq!(file.entries[1].header.type_, 0x09); // 9
+        assert_eq!(file.entries[1].header.type_, 0x0900); // 2304
         assert_eq!(file.entries[1].header.length, 4);
         assert_eq!(file.entries[1].header.reserved, 0);
         assert_eq!(file.entries[1].value, vec![0xab, 0xcd, 0xab, 0xcd]);

--- a/crates/e2store/src/e2store/types.rs
+++ b/crates/e2store/src/e2store/types.rs
@@ -1,6 +1,8 @@
 use anyhow::{anyhow, ensure};
 use ssz_derive::{Decode, Encode};
 
+use crate::entry_types;
+
 /// Represents an e2store `Entry`
 #[derive(Default, Debug, Eq, PartialEq, Clone)]
 pub struct Entry {
@@ -116,7 +118,7 @@ pub struct VersionEntry {
 impl Default for VersionEntry {
     fn default() -> Self {
         Self {
-            version: Entry::new(0x6532, vec![]),
+            version: Entry::new(entry_types::VERSION, vec![]),
         }
     }
 }
@@ -126,7 +128,7 @@ impl TryFrom<&Entry> for VersionEntry {
 
     fn try_from(entry: &Entry) -> anyhow::Result<Self> {
         ensure!(
-            entry.header.type_ == 0x6532,
+            entry.header.type_ == entry_types::VERSION,
             "invalid version entry: incorrect header type"
         );
         ensure!(

--- a/crates/e2store/src/e2store/types.rs
+++ b/crates/e2store/src/e2store/types.rs
@@ -83,7 +83,7 @@ impl Header {
 
     /// Write to a byte slice.
     fn write(&self, buf: &mut [u8]) {
-        buf[0..2].copy_from_slice(&self.type_.to_le_bytes());
+        buf[0..2].copy_from_slice(&self.type_.to_be_bytes());
         buf[2..6].copy_from_slice(&self.length.to_le_bytes());
         buf[6..8].copy_from_slice(&self.reserved.to_le_bytes());
     }
@@ -93,7 +93,7 @@ impl Header {
         if bytes.len() != Header::SERIALIZED_SIZE as usize {
             return Err(anyhow!("invalid header size: {}", bytes.len()));
         }
-        let type_ = u16::from_le_bytes([bytes[0], bytes[1]]);
+        let type_ = u16::from_be_bytes([bytes[0], bytes[1]]);
         let length = u32::from_le_bytes([bytes[2], bytes[3], bytes[4], bytes[5]]);
         let reserved = u16::from_le_bytes([bytes[6], bytes[7]]);
         ensure!(
@@ -116,7 +116,7 @@ pub struct VersionEntry {
 impl Default for VersionEntry {
     fn default() -> Self {
         Self {
-            version: Entry::new(0x3265, vec![]),
+            version: Entry::new(0x6532, vec![]),
         }
     }
 }
@@ -126,7 +126,7 @@ impl TryFrom<&Entry> for VersionEntry {
 
     fn try_from(entry: &Entry) -> anyhow::Result<Self> {
         ensure!(
-            entry.header.type_ == 0x3265,
+            entry.header.type_ == 0x6532,
             "invalid version entry: incorrect header type"
         );
         ensure!(

--- a/crates/e2store/src/entry_types.rs
+++ b/crates/e2store/src/entry_types.rs
@@ -1,0 +1,63 @@
+/// Snappy compressed ssz signed beacon block
+///
+/// data: snappyFramed(ssz(SignedBeaconBlock))
+pub const COMPRESSED_SIGNED_BEACON_BLOCK: u16 = 0x0100;
+
+/// Snappy compressed ssz beacon state
+///
+/// data: snappyFramed(ssz(BeaconState))
+pub const COMPRESSED_BEACON_STATE: u16 = 0x0200;
+
+/// Snappy compressed rlp execution header
+///
+/// data: snappyFramed(rlp(header))
+pub const COMPRESSED_HEADER: u16 = 0x0300;
+
+/// Snappy compressed rlp execution body
+///
+/// data: snappyFramed(rlp(body))
+pub const COMPRESSED_BODY: u16 = 0x0400;
+
+/// Snappy compressed rlp execution receipts
+///
+/// data: snappyFramed(rlp(receipts))
+pub const COMPRESSED_RECEIPTS: u16 = 0x0500;
+
+/// Total difficulty of a block
+///
+/// data: uint256(header.total_difficulty)
+pub const TOTAL_DIFFICULTY: u16 = 0x0600;
+
+/// Accumulator
+///
+/// data: accumulator-root
+/// header-record := { block-hash: Bytes32, total-difficulty: Uint256 }
+/// accumulator-root := hash_tree_root([]header-record, 8192)
+pub const ACCUMULATOR: u16 = 0x0700;
+
+/// CompressedAccount
+///
+/// data: snappyFramed(rlp(Account))
+/// Account = { address_hash, AccountState, raw_bytecode, storage_entry_count }
+/// AccountState = { nonce, balance, storage_root, code_hash }
+pub const COMPRESSED_ACCOUNT: u16 = 0x0800;
+
+/// CompressedStorage
+///
+/// data: snappyFramed(rlp(Vec<StorageItem>))
+/// StorageItem = { storage_index_hash, value }
+pub const COMPRESSED_STORAGE: u16 = 0x0900;
+
+/// BlockIndex
+///
+/// data: block-index
+/// block-index := starting-number | index | index | index ... | count
+pub const BLOCK_INDEX: u16 = 0x6232;
+
+/// Version
+pub const VERSION: u16 = 0x6532;
+
+/// SlotIndex
+///
+/// data: starting-slot | index | index | index ... | count
+pub const SLOT_INDEX: u16 = 0x6932;

--- a/crates/e2store/src/era.rs
+++ b/crates/e2store/src/era.rs
@@ -181,7 +181,7 @@ pub struct CompressedSignedBeaconBlock {
 impl CompressedSignedBeaconBlock {
     pub fn try_from(entry: &Entry, fork: ForkName) -> Result<Self, anyhow::Error> {
         ensure!(
-            entry.header.type_ == 0x01,
+            entry.header.type_ == 0x0100,
             "invalid compressed signed beacon block entry: incorrect header type"
         );
 
@@ -205,8 +205,7 @@ impl TryInto<Entry> for CompressedSignedBeaconBlock {
         let _ = snappy_encoder.write(&ssz_encoded)?;
         let snappy_encoded = snappy_encoder.into_inner()?;
 
-        let header = 0x01;
-        Ok(Entry::new(header, snappy_encoded))
+        Ok(Entry::new(0x0100, snappy_encoded))
     }
 }
 
@@ -218,7 +217,7 @@ pub struct CompressedBeaconState {
 impl CompressedBeaconState {
     fn try_from(entry: &Entry, fork: ForkName) -> Result<Self, anyhow::Error> {
         ensure!(
-            entry.header.type_ == 0x02,
+            entry.header.type_ == 0x0200,
             "invalid compressed beacon state entry: incorrect header type"
         );
 
@@ -242,8 +241,7 @@ impl TryInto<Entry> for CompressedBeaconState {
         let _ = snappy_encoder.write(&ssz_encoded)?;
         let snappy_encoded = snappy_encoder.into_inner()?;
 
-        let header = 0x02;
-        Ok(Entry::new(header, snappy_encoded))
+        Ok(Entry::new(0x0200, snappy_encoded))
     }
 }
 
@@ -263,7 +261,7 @@ impl TryFrom<&Entry> for SlotIndexBlockEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x3269,
+            entry.header.type_ == 0x6932,
             "invalid slot index entry: incorrect header type"
         );
         ensure!(
@@ -296,7 +294,7 @@ impl TryInto<Entry> for SlotIndexBlockEntry {
         }
         buf.extend_from_slice(&self.slot_index.count.to_le_bytes());
 
-        Ok(Entry::new(0x3269, buf))
+        Ok(Entry::new(0x6932, buf))
     }
 }
 
@@ -348,7 +346,7 @@ impl TryFrom<&Entry> for SlotIndexStateEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x3269,
+            entry.header.type_ == 0x6932,
             "invalid slot index entry: incorrect header type"
         );
         ensure!(
@@ -381,7 +379,7 @@ impl TryInto<Entry> for SlotIndexStateEntry {
         }
         buf.extend_from_slice(&self.slot_index.count.to_le_bytes());
 
-        Ok(Entry::new(0x3269, buf))
+        Ok(Entry::new(0x6932, buf))
     }
 }
 

--- a/crates/e2store/src/era.rs
+++ b/crates/e2store/src/era.rs
@@ -9,9 +9,12 @@ use ethportal_api::consensus::{
 };
 use ssz::Encode;
 
-use crate::e2store::{
-    memory::E2StoreMemory,
-    types::{Entry, Header, VersionEntry},
+use crate::{
+    e2store::{
+        memory::E2StoreMemory,
+        types::{Entry, Header, VersionEntry},
+    },
+    entry_types,
 };
 
 pub const SLOTS_PER_HISTORICAL_ROOT: usize = 8192;
@@ -181,7 +184,7 @@ pub struct CompressedSignedBeaconBlock {
 impl CompressedSignedBeaconBlock {
     pub fn try_from(entry: &Entry, fork: ForkName) -> Result<Self, anyhow::Error> {
         ensure!(
-            entry.header.type_ == 0x0100,
+            entry.header.type_ == entry_types::COMPRESSED_SIGNED_BEACON_BLOCK,
             "invalid compressed signed beacon block entry: incorrect header type"
         );
 
@@ -205,7 +208,10 @@ impl TryInto<Entry> for CompressedSignedBeaconBlock {
         let _ = snappy_encoder.write(&ssz_encoded)?;
         let snappy_encoded = snappy_encoder.into_inner()?;
 
-        Ok(Entry::new(0x0100, snappy_encoded))
+        Ok(Entry::new(
+            entry_types::COMPRESSED_SIGNED_BEACON_BLOCK,
+            snappy_encoded,
+        ))
     }
 }
 
@@ -217,7 +223,7 @@ pub struct CompressedBeaconState {
 impl CompressedBeaconState {
     fn try_from(entry: &Entry, fork: ForkName) -> Result<Self, anyhow::Error> {
         ensure!(
-            entry.header.type_ == 0x0200,
+            entry.header.type_ == entry_types::COMPRESSED_BEACON_STATE,
             "invalid compressed beacon state entry: incorrect header type"
         );
 
@@ -241,7 +247,10 @@ impl TryInto<Entry> for CompressedBeaconState {
         let _ = snappy_encoder.write(&ssz_encoded)?;
         let snappy_encoded = snappy_encoder.into_inner()?;
 
-        Ok(Entry::new(0x0200, snappy_encoded))
+        Ok(Entry::new(
+            entry_types::COMPRESSED_BEACON_STATE,
+            snappy_encoded,
+        ))
     }
 }
 
@@ -261,7 +270,7 @@ impl TryFrom<&Entry> for SlotIndexBlockEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x6932,
+            entry.header.type_ == entry_types::SLOT_INDEX,
             "invalid slot index entry: incorrect header type"
         );
         ensure!(
@@ -294,7 +303,7 @@ impl TryInto<Entry> for SlotIndexBlockEntry {
         }
         buf.extend_from_slice(&self.slot_index.count.to_le_bytes());
 
-        Ok(Entry::new(0x6932, buf))
+        Ok(Entry::new(entry_types::SLOT_INDEX, buf))
     }
 }
 
@@ -346,7 +355,7 @@ impl TryFrom<&Entry> for SlotIndexStateEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x6932,
+            entry.header.type_ == entry_types::SLOT_INDEX,
             "invalid slot index entry: incorrect header type"
         );
         ensure!(
@@ -379,7 +388,7 @@ impl TryInto<Entry> for SlotIndexStateEntry {
         }
         buf.extend_from_slice(&self.slot_index.count.to_le_bytes());
 
-        Ok(Entry::new(0x6932, buf))
+        Ok(Entry::new(entry_types::SLOT_INDEX, buf))
     }
 }
 

--- a/crates/e2store/src/era1.rs
+++ b/crates/e2store/src/era1.rs
@@ -15,6 +15,7 @@ use crate::{
         memory::E2StoreMemory,
         types::{Entry, VersionEntry},
     },
+    entry_types,
     types::HeaderEntry,
 };
 
@@ -186,7 +187,7 @@ impl TryFrom<&Entry> for BodyEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x0400,
+            entry.header.type_ == entry_types::COMPRESSED_BODY,
             "invalid body entry: incorrect header type"
         );
         ensure!(
@@ -210,7 +211,7 @@ impl TryInto<Entry> for BodyEntry {
         let mut encoder = snap::write::FrameEncoder::new(buf);
         let _ = encoder.write(&rlp_encoded)?;
         let encoded = encoder.into_inner()?;
-        Ok(Entry::new(0x0400, encoded))
+        Ok(Entry::new(entry_types::COMPRESSED_BODY, encoded))
     }
 }
 
@@ -224,7 +225,7 @@ impl TryFrom<&Entry> for ReceiptsEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x0500,
+            entry.header.type_ == entry_types::COMPRESSED_RECEIPTS,
             "invalid receipts entry: incorrect header type"
         );
         ensure!(
@@ -248,7 +249,7 @@ impl TryInto<Entry> for ReceiptsEntry {
         let mut encoder = snap::write::FrameEncoder::new(buf);
         let _ = encoder.write(&rlp_encoded)?;
         let encoded = encoder.into_inner()?;
-        Ok(Entry::new(0x0500, encoded))
+        Ok(Entry::new(entry_types::COMPRESSED_RECEIPTS, encoded))
     }
 }
 
@@ -262,7 +263,7 @@ impl TryFrom<&Entry> for TotalDifficultyEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x0600,
+            entry.header.type_ == entry_types::TOTAL_DIFFICULTY,
             "invalid total difficulty entry: incorrect header type"
         );
         ensure!(
@@ -286,7 +287,10 @@ impl TryInto<Entry> for TotalDifficultyEntry {
     type Error = anyhow::Error;
 
     fn try_into(self) -> Result<Entry, Self::Error> {
-        Ok(Entry::new(0x0600, self.total_difficulty.to_be_bytes_vec()))
+        Ok(Entry::new(
+            entry_types::TOTAL_DIFFICULTY,
+            self.total_difficulty.to_be_bytes_vec(),
+        ))
     }
 }
 
@@ -300,7 +304,7 @@ impl TryFrom<&Entry> for AccumulatorEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x0700,
+            entry.header.type_ == entry_types::ACCUMULATOR,
             "invalid accumulator entry: incorrect header type"
         );
         ensure!(
@@ -325,7 +329,7 @@ impl TryInto<Entry> for AccumulatorEntry {
 
     fn try_into(self) -> Result<Entry, Self::Error> {
         let value = self.accumulator.as_slice().to_vec();
-        Ok(Entry::new(0x0700, value))
+        Ok(Entry::new(entry_types::ACCUMULATOR, value))
     }
 }
 

--- a/crates/e2store/src/era1.rs
+++ b/crates/e2store/src/era1.rs
@@ -23,13 +23,13 @@ use crate::{
 // era1 := Version | block-tuple* | other-entries* | Accumulator | BlockIndex
 // block-tuple :=  CompressedHeader | CompressedBody | CompressedReceipts | TotalDifficulty
 // -----
-// Version            = { type: 0x3265, data: nil }
-// CompressedHeader   = { type: 0x03,   data: snappyFramed(rlp(header)) }
-// CompressedBody     = { type: 0x04,   data: snappyFramed(rlp(body)) }
-// CompressedReceipts = { type: 0x05,   data: snappyFramed(rlp(receipts)) }
-// TotalDifficulty    = { type: 0x06,   data: uint256(header.total_difficulty) }
-// Accumulator        = { type: 0x07,   data: hash_tree_root(List(HeaderRecord, 8192)) }
-// BlockIndex         = { type: 0x3266, data: block-index }
+// Version            = { type: 0x6532, data: nil }
+// CompressedHeader   = { type: 0x0300,   data: snappyFramed(rlp(header)) }
+// CompressedBody     = { type: 0x0400,   data: snappyFramed(rlp(body)) }
+// CompressedReceipts = { type: 0x0500,   data: snappyFramed(rlp(receipts)) }
+// TotalDifficulty    = { type: 0x0600,   data: uint256(header.total_difficulty) }
+// Accumulator        = { type: 0x0700,   data: hash_tree_root(List(HeaderRecord, 8192)) }
+// BlockIndex         = { type: 0x6632, data: block-index }
 
 pub const BLOCK_TUPLE_COUNT: usize = 8192;
 const ERA1_ENTRY_COUNT: usize = BLOCK_TUPLE_COUNT * 4 + 3;
@@ -186,7 +186,7 @@ impl TryFrom<&Entry> for BodyEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x04,
+            entry.header.type_ == 0x0400,
             "invalid body entry: incorrect header type"
         );
         ensure!(
@@ -210,7 +210,7 @@ impl TryInto<Entry> for BodyEntry {
         let mut encoder = snap::write::FrameEncoder::new(buf);
         let _ = encoder.write(&rlp_encoded)?;
         let encoded = encoder.into_inner()?;
-        Ok(Entry::new(0x04, encoded))
+        Ok(Entry::new(0x0400, encoded))
     }
 }
 
@@ -224,7 +224,7 @@ impl TryFrom<&Entry> for ReceiptsEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x05,
+            entry.header.type_ == 0x0500,
             "invalid receipts entry: incorrect header type"
         );
         ensure!(
@@ -248,7 +248,7 @@ impl TryInto<Entry> for ReceiptsEntry {
         let mut encoder = snap::write::FrameEncoder::new(buf);
         let _ = encoder.write(&rlp_encoded)?;
         let encoded = encoder.into_inner()?;
-        Ok(Entry::new(0x05, encoded))
+        Ok(Entry::new(0x0500, encoded))
     }
 }
 
@@ -262,7 +262,7 @@ impl TryFrom<&Entry> for TotalDifficultyEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x06,
+            entry.header.type_ == 0x0600,
             "invalid total difficulty entry: incorrect header type"
         );
         ensure!(
@@ -286,7 +286,7 @@ impl TryInto<Entry> for TotalDifficultyEntry {
     type Error = anyhow::Error;
 
     fn try_into(self) -> Result<Entry, Self::Error> {
-        Ok(Entry::new(0x06, self.total_difficulty.to_be_bytes_vec()))
+        Ok(Entry::new(0x0600, self.total_difficulty.to_be_bytes_vec()))
     }
 }
 
@@ -300,7 +300,7 @@ impl TryFrom<&Entry> for AccumulatorEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x07,
+            entry.header.type_ == 0x0700,
             "invalid accumulator entry: incorrect header type"
         );
         ensure!(
@@ -325,7 +325,7 @@ impl TryInto<Entry> for AccumulatorEntry {
 
     fn try_into(self) -> Result<Entry, Self::Error> {
         let value = self.accumulator.as_slice().to_vec();
-        Ok(Entry::new(0x07, value))
+        Ok(Entry::new(0x0700, value))
     }
 }
 
@@ -341,7 +341,7 @@ impl TryFrom<&Entry> for BlockIndexEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x3266,
+            entry.header.type_ == 0x6632,
             "invalid block index entry: incorrect header type"
         );
         ensure!(
@@ -376,7 +376,7 @@ impl TryInto<Entry> for BlockIndexEntry {
             .iter()
             .flat_map(|i| i.to_le_bytes().to_vec())
             .collect::<Vec<u8>>();
-        Ok(Entry::new(0x3266, encoded))
+        Ok(Entry::new(0x6632, encoded))
     }
 }
 

--- a/crates/e2store/src/lib.rs
+++ b/crates/e2store/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod e2ss;
 pub mod e2store;
+pub mod entry_types;
 pub mod era;
 pub mod era1;
 pub mod types;

--- a/crates/e2store/src/types.rs
+++ b/crates/e2store/src/types.rs
@@ -4,7 +4,7 @@ use alloy::rlp::Decodable;
 use anyhow::ensure;
 use ethportal_api::Header;
 
-use crate::e2store::types::Entry;
+use crate::{e2store::types::Entry, entry_types};
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct HeaderEntry {
@@ -16,7 +16,7 @@ impl TryFrom<&Entry> for HeaderEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x0300,
+            entry.header.type_ == entry_types::COMPRESSED_HEADER,
             "invalid header entry: incorrect header type"
         );
         ensure!(
@@ -40,6 +40,6 @@ impl TryFrom<HeaderEntry> for Entry {
         let mut encoder = snap::write::FrameEncoder::new(buf);
         let _ = encoder.write(&rlp_encoded)?;
         let encoded = encoder.into_inner()?;
-        Ok(Entry::new(0x0300, encoded))
+        Ok(Entry::new(entry_types::COMPRESSED_HEADER, encoded))
     }
 }

--- a/crates/e2store/src/types.rs
+++ b/crates/e2store/src/types.rs
@@ -16,7 +16,7 @@ impl TryFrom<&Entry> for HeaderEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x03,
+            entry.header.type_ == 0x0300,
             "invalid header entry: incorrect header type"
         );
         ensure!(
@@ -40,6 +40,6 @@ impl TryFrom<HeaderEntry> for Entry {
         let mut encoder = snap::write::FrameEncoder::new(buf);
         let _ = encoder.write(&rlp_encoded)?;
         let encoded = encoder.into_inner()?;
-        Ok(Entry::new(0x03, encoded))
+        Ok(Entry::new(0x0300, encoded))
     }
 }


### PR DESCRIPTION
### What was wrong?
I am creating a repo to formalize all of the e2store formats and to avoid duplicate types with @arnetheduck and @advaita-saha https://github.com/eth-clients/e2store-format-specs

Anyways currently we are reading the type as little endian which doesn't make sense.

For example the type for the `VersionEntry` is a vector [65, 32] which in ascii is `e2`, but we are reading it backwards as `2e`.

Our code is ends up working to the same result, but it is fairly unidle as we also have 0x3265 in our documentation when it should be 0x6532 or [65, 32]


### How was it fixed?

use be and update numbers.
