### PR TITLE
refactor: ownership/from traits in e2store

### DIFF
--- a/bin/e2hs-writer/src/reader.rs
+++ b/bin/e2hs-writer/src/reader.rs
@@ -95,7 +95,7 @@ impl EpochReader {
     fn get_pre_merge_block_data(&self, block_number: u64) -> anyhow::Result<AllBlockData> {
         let raw_era1 = self.era_provider.get_era1_for_block(block_number)?;
         let block_index = block_number % EPOCH_SIZE;
-        let tuple = Era1::get_tuple_by_index(&raw_era1, block_index);
+        let tuple = Era1::get_tuple_by_index(&raw_era1, block_index as usize)?;
         let header = tuple.header.header;
         let Some(epoch_acc) = &self.epoch_accumulator else {
             bail!("Epoch accumulator not found for pre-merge block: {block_number}")

--- a/bin/e2hs-writer/src/writer.rs
+++ b/bin/e2hs-writer/src/writer.rs
@@ -55,7 +55,7 @@ impl EpochWriter {
         let mut indices = vec![];
         for block_tuple in &block_tuples {
             indices.push(offset);
-            let entry: [Entry; 3] = block_tuple.clone().try_into()?;
+            let entry = <[Entry; 3]>::try_from(block_tuple)?;
             let length = entry.iter().map(|entry| entry.length() as u64).sum::<u64>();
             offset += length;
         }

--- a/crates/e2store/src/e2ss.rs
+++ b/crates/e2store/src/e2ss.rs
@@ -78,10 +78,10 @@ impl E2SSWriter {
         let mut writer = E2StoreStreamWriter::create(&path)?;
 
         let version = VersionEntry::default();
-        writer.append_entry(&version.clone().into())?;
+        writer.append_entry(&Entry::from(&version))?;
 
         let header = HeaderEntry { header };
-        writer.append_entry(&header.clone().try_into()?)?;
+        writer.append_entry(&Entry::try_from(&header)?)?;
 
         Ok(Self {
             version,

--- a/crates/e2store/src/e2store/stream.rs
+++ b/crates/e2store/src/e2store/stream.rs
@@ -82,7 +82,7 @@ mod tests {
         let mut e2store_stream_writer = E2StoreStreamWriter::create(&tmp_path)?;
 
         let version = VersionEntry::default();
-        e2store_stream_writer.append_entry(&version.clone().into())?;
+        e2store_stream_writer.append_entry(&Entry::from(&version))?;
 
         let value: Vec<u8> = (0..100).map(|_| rng.gen_range(0..20)).collect();
         let entry = Entry::new(0, value);

--- a/crates/e2store/src/e2store/types.rs
+++ b/crates/e2store/src/e2store/types.rs
@@ -149,8 +149,8 @@ impl TryFrom<&Entry> for VersionEntry {
     }
 }
 
-impl From<VersionEntry> for Entry {
-    fn from(val: VersionEntry) -> Self {
-        val.version
+impl From<&VersionEntry> for Entry {
+    fn from(val: &VersionEntry) -> Self {
+        val.version.clone()
     }
 }

--- a/crates/e2store/src/era.rs
+++ b/crates/e2store/src/era.rs
@@ -152,9 +152,9 @@ impl Era {
         }
         let era_state_entry = Entry::try_from(&self.era_state)?;
         entries.push(era_state_entry);
-        let slot_index_block_entry = Entry::try_from(&self.slot_index_block)?;
+        let slot_index_block_entry = Entry::from(&self.slot_index_block);
         entries.push(slot_index_block_entry);
-        let slot_index_state_entry = Entry::try_from(&self.slot_index_state)?;
+        let slot_index_state_entry = Entry::from(&self.slot_index_state);
         entries.push(slot_index_state_entry);
         let file = E2StoreMemory { entries };
 
@@ -291,10 +291,8 @@ impl TryFrom<&Entry> for SlotIndexBlockEntry {
     }
 }
 
-impl TryFrom<&SlotIndexBlockEntry> for Entry {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &SlotIndexBlockEntry) -> Result<Self, Self::Error> {
+impl From<&SlotIndexBlockEntry> for Entry {
+    fn from(value: &SlotIndexBlockEntry) -> Self {
         let mut buf = vec![];
 
         buf.extend_from_slice(&value.slot_index.starting_slot.to_le_bytes());
@@ -303,7 +301,7 @@ impl TryFrom<&SlotIndexBlockEntry> for Entry {
         }
         buf.extend_from_slice(&value.slot_index.count.to_le_bytes());
 
-        Ok(Entry::new(entry_types::SLOT_INDEX, buf))
+        Entry::new(entry_types::SLOT_INDEX, buf)
     }
 }
 
@@ -376,10 +374,8 @@ impl TryFrom<&Entry> for SlotIndexStateEntry {
     }
 }
 
-impl TryFrom<&SlotIndexStateEntry> for Entry {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &SlotIndexStateEntry) -> Result<Self, Self::Error> {
+impl From<&SlotIndexStateEntry> for Entry {
+    fn from(value: &SlotIndexStateEntry) -> Self {
         let mut buf = vec![];
 
         buf.extend_from_slice(&value.slot_index.starting_slot.to_le_bytes());
@@ -388,7 +384,7 @@ impl TryFrom<&SlotIndexStateEntry> for Entry {
         }
         buf.extend_from_slice(&value.slot_index.count.to_le_bytes());
 
-        Ok(Entry::new(entry_types::SLOT_INDEX, buf))
+        Entry::new(entry_types::SLOT_INDEX, buf)
     }
 }
 

--- a/crates/e2store/src/era.rs
+++ b/crates/e2store/src/era.rs
@@ -144,17 +144,17 @@ impl Era {
     #[allow(dead_code)]
     fn write(&self) -> anyhow::Result<Vec<u8>> {
         let mut entries: Vec<Entry> = vec![];
-        let version_entry: Entry = self.version.clone().into();
+        let version_entry = Entry::from(&self.version);
         entries.push(version_entry);
         for block in &self.blocks {
-            let block_entry: Entry = block.clone().try_into()?;
+            let block_entry = Entry::try_from(block)?;
             entries.push(block_entry);
         }
-        let era_state_entry: Entry = self.era_state.clone().try_into()?;
+        let era_state_entry = Entry::try_from(&self.era_state)?;
         entries.push(era_state_entry);
-        let slot_index_block_entry: Entry = self.slot_index_block.clone().try_into()?;
+        let slot_index_block_entry = Entry::try_from(&self.slot_index_block)?;
         entries.push(slot_index_block_entry);
-        let slot_index_state_entry: Entry = self.slot_index_state.clone().try_into()?;
+        let slot_index_state_entry = Entry::try_from(&self.slot_index_state)?;
         entries.push(slot_index_state_entry);
         let file = E2StoreMemory { entries };
 
@@ -198,11 +198,11 @@ impl CompressedSignedBeaconBlock {
     }
 }
 
-impl TryInto<Entry> for CompressedSignedBeaconBlock {
+impl TryFrom<&CompressedSignedBeaconBlock> for Entry {
     type Error = anyhow::Error;
 
-    fn try_into(self) -> Result<Entry, Self::Error> {
-        let ssz_encoded = self.block.as_ssz_bytes();
+    fn try_from(value: &CompressedSignedBeaconBlock) -> Result<Self, Self::Error> {
+        let ssz_encoded = value.block.as_ssz_bytes();
         let buf: Vec<u8> = vec![];
         let mut snappy_encoder = snap::write::FrameEncoder::new(buf);
         let _ = snappy_encoder.write(&ssz_encoded)?;
@@ -237,11 +237,11 @@ impl CompressedBeaconState {
     }
 }
 
-impl TryInto<Entry> for CompressedBeaconState {
+impl TryFrom<&CompressedBeaconState> for Entry {
     type Error = anyhow::Error;
 
-    fn try_into(self) -> Result<Entry, Self::Error> {
-        let ssz_encoded = self.state.as_ssz_bytes();
+    fn try_from(value: &CompressedBeaconState) -> Result<Self, Self::Error> {
+        let ssz_encoded = value.state.as_ssz_bytes();
         let buf: Vec<u8> = vec![];
         let mut snappy_encoder = snap::write::FrameEncoder::new(buf);
         let _ = snappy_encoder.write(&ssz_encoded)?;
@@ -291,17 +291,17 @@ impl TryFrom<&Entry> for SlotIndexBlockEntry {
     }
 }
 
-impl TryInto<Entry> for SlotIndexBlockEntry {
+impl TryFrom<&SlotIndexBlockEntry> for Entry {
     type Error = anyhow::Error;
 
-    fn try_into(self) -> Result<Entry, Self::Error> {
+    fn try_from(value: &SlotIndexBlockEntry) -> Result<Self, Self::Error> {
         let mut buf = vec![];
 
-        buf.extend_from_slice(&self.slot_index.starting_slot.to_le_bytes());
-        for index in &self.slot_index.indices {
+        buf.extend_from_slice(&value.slot_index.starting_slot.to_le_bytes());
+        for index in &value.slot_index.indices {
             buf.extend_from_slice(&index.to_le_bytes());
         }
-        buf.extend_from_slice(&self.slot_index.count.to_le_bytes());
+        buf.extend_from_slice(&value.slot_index.count.to_le_bytes());
 
         Ok(Entry::new(entry_types::SLOT_INDEX, buf))
     }
@@ -376,17 +376,17 @@ impl TryFrom<&Entry> for SlotIndexStateEntry {
     }
 }
 
-impl TryInto<Entry> for SlotIndexStateEntry {
+impl TryFrom<&SlotIndexStateEntry> for Entry {
     type Error = anyhow::Error;
 
-    fn try_into(self) -> Result<Entry, Self::Error> {
+    fn try_from(value: &SlotIndexStateEntry) -> Result<Self, Self::Error> {
         let mut buf = vec![];
 
-        buf.extend_from_slice(&self.slot_index.starting_slot.to_le_bytes());
-        for index in &self.slot_index.indices {
+        buf.extend_from_slice(&value.slot_index.starting_slot.to_le_bytes());
+        for index in &value.slot_index.indices {
             buf.extend_from_slice(&index.to_le_bytes());
         }
-        buf.extend_from_slice(&self.slot_index.count.to_le_bytes());
+        buf.extend_from_slice(&value.slot_index.count.to_le_bytes());
 
         Ok(Entry::new(entry_types::SLOT_INDEX, buf))
     }

--- a/crates/e2store/src/era1.rs
+++ b/crates/e2store/src/era1.rs
@@ -58,21 +58,14 @@ impl Era1 {
                 .expect("invalid block index entry")
                 .block_index;
         (0..block_index.count).map(move |i| {
-            let mut entries: [Entry; 4] = Default::default();
-            for (j, entry) in entries.iter_mut().enumerate() {
-                file.entries[i as usize * 4 + j + 1].clone_into(entry);
-            }
-            BlockTuple::try_from(&entries).expect("invalid block tuple")
+            BlockTuple::try_from(&file.entries[i as usize * 4 + 1..i as usize * 4 + 5])
+                .expect("invalid block tuple")
         })
     }
 
-    pub fn get_tuple_by_index(raw_era1: &[u8], index: u64) -> BlockTuple {
-        let file = E2StoreMemory::deserialize(raw_era1).expect("invalid era1 file");
-        let mut entries: [Entry; 4] = Default::default();
-        for (j, entry) in entries.iter_mut().enumerate() {
-            file.entries[index as usize * 4 + j + 1].clone_into(entry);
-        }
-        BlockTuple::try_from(&entries).expect("invalid block tuple")
+    pub fn get_tuple_by_index(raw_era1: &[u8], index: usize) -> anyhow::Result<BlockTuple> {
+        let file = E2StoreMemory::deserialize(raw_era1)?;
+        BlockTuple::try_from(&file.entries[index * 4 + 1..index * 4 + 5])
     }
 
     pub fn deserialize(buf: &[u8]) -> anyhow::Result<Self> {
@@ -88,11 +81,7 @@ impl Era1 {
         let mut block_tuples = vec![];
         let block_tuple_count = block_index.block_index.count as usize;
         for count in 0..block_tuple_count {
-            let mut entries: [Entry; 4] = Default::default();
-            for (i, entry) in entries.iter_mut().enumerate() {
-                *entry = file.entries[count * 4 + i + 1].clone();
-            }
-            let block_tuple = BlockTuple::try_from(&entries)?;
+            let block_tuple = BlockTuple::try_from(&file.entries[count * 4 + 1..count * 4 + 5])?;
             block_tuples.push(block_tuple);
         }
         let accumulator_index = (block_tuple_count * 4) + 1;
@@ -108,15 +97,15 @@ impl Era1 {
     #[allow(dead_code)]
     fn write(&self) -> anyhow::Result<Vec<u8>> {
         let mut entries: Vec<Entry> = vec![];
-        let version_entry: Entry = self.version.clone().into();
+        let version_entry = Entry::from(&self.version);
         entries.push(version_entry);
         for block_tuple in &self.block_tuples {
-            let block_tuple_entries: [Entry; 4] = block_tuple.clone().try_into()?;
+            let block_tuple_entries = <[Entry; 4]>::try_from(block_tuple)?;
             entries.extend_from_slice(&block_tuple_entries);
         }
-        let accumulator_entry: Entry = self.accumulator.clone().try_into()?;
+        let accumulator_entry = Entry::try_from(&self.accumulator)?;
         entries.push(accumulator_entry);
-        let block_index_entry: Entry = self.block_index.clone().try_into()?;
+        let block_index_entry = Entry::try_from(&self.block_index)?;
         entries.push(block_index_entry);
         let file = E2StoreMemory { entries };
         ensure!(
@@ -147,10 +136,15 @@ pub struct BlockTuple {
     pub total_difficulty: TotalDifficultyEntry,
 }
 
-impl TryFrom<&[Entry; 4]> for BlockTuple {
+impl TryFrom<&[Entry]> for BlockTuple {
     type Error = anyhow::Error;
 
-    fn try_from(entries: &[Entry; 4]) -> anyhow::Result<Self> {
+    fn try_from(entries: &[Entry]) -> anyhow::Result<Self> {
+        ensure!(
+            entries.len() == 4,
+            "invalid block tuple: incorrect number of entries, found {} expected 4",
+            entries.len()
+        );
         let header = HeaderEntry::try_from(&entries[0])?;
         let body = BodyEntry::try_from(&entries[1])?;
         let receipts = ReceiptsEntry::try_from(&entries[2])?;
@@ -164,16 +158,15 @@ impl TryFrom<&[Entry; 4]> for BlockTuple {
     }
 }
 
-impl TryInto<[Entry; 4]> for BlockTuple {
+impl TryFrom<&BlockTuple> for [Entry; 4] {
     type Error = anyhow::Error;
 
-    fn try_into(self) -> anyhow::Result<[Entry; 4]> {
-        Ok([
-            self.header.try_into()?,
-            self.body.try_into()?,
-            self.receipts.try_into()?,
-            self.total_difficulty.try_into()?,
-        ])
+    fn try_from(value: &BlockTuple) -> anyhow::Result<[Entry; 4]> {
+        let header = Entry::try_from(&value.header)?;
+        let body = Entry::try_from(&value.body)?;
+        let receipts = Entry::try_from(&value.receipts)?;
+        let total_difficulty = Entry::try_from(&value.total_difficulty)?;
+        Ok([header, body, receipts, total_difficulty])
     }
 }
 
@@ -202,11 +195,11 @@ impl TryFrom<&Entry> for BodyEntry {
     }
 }
 
-impl TryInto<Entry> for BodyEntry {
+impl TryFrom<&BodyEntry> for Entry {
     type Error = anyhow::Error;
 
-    fn try_into(self) -> Result<Entry, Self::Error> {
-        let rlp_encoded = alloy::rlp::encode(self.body);
+    fn try_from(value: &BodyEntry) -> Result<Self, Self::Error> {
+        let rlp_encoded = alloy::rlp::encode(&value.body);
         let buf: Vec<u8> = vec![];
         let mut encoder = snap::write::FrameEncoder::new(buf);
         let _ = encoder.write(&rlp_encoded)?;
@@ -240,11 +233,11 @@ impl TryFrom<&Entry> for ReceiptsEntry {
     }
 }
 
-impl TryInto<Entry> for ReceiptsEntry {
+impl TryFrom<&ReceiptsEntry> for Entry {
     type Error = anyhow::Error;
 
-    fn try_into(self) -> Result<Entry, Self::Error> {
-        let rlp_encoded = alloy::rlp::encode(&self.receipts);
+    fn try_from(value: &ReceiptsEntry) -> Result<Self, Self::Error> {
+        let rlp_encoded = alloy::rlp::encode(&value.receipts);
         let buf: Vec<u8> = vec![];
         let mut encoder = snap::write::FrameEncoder::new(buf);
         let _ = encoder.write(&rlp_encoded)?;
@@ -283,14 +276,12 @@ impl TryFrom<&Entry> for TotalDifficultyEntry {
     }
 }
 
-impl TryInto<Entry> for TotalDifficultyEntry {
+impl TryFrom<&TotalDifficultyEntry> for Entry {
     type Error = anyhow::Error;
 
-    fn try_into(self) -> Result<Entry, Self::Error> {
-        Ok(Entry::new(
-            entry_types::TOTAL_DIFFICULTY,
-            self.total_difficulty.to_be_bytes_vec(),
-        ))
+    fn try_from(value: &TotalDifficultyEntry) -> Result<Self, Self::Error> {
+        let value = value.total_difficulty.to_be_bytes_vec();
+        Ok(Entry::new(entry_types::TOTAL_DIFFICULTY, value))
     }
 }
 
@@ -324,11 +315,11 @@ impl TryFrom<&Entry> for AccumulatorEntry {
     }
 }
 
-impl TryInto<Entry> for AccumulatorEntry {
+impl TryFrom<&AccumulatorEntry> for Entry {
     type Error = anyhow::Error;
 
-    fn try_into(self) -> Result<Entry, Self::Error> {
-        let value = self.accumulator.as_slice().to_vec();
+    fn try_from(value: &AccumulatorEntry) -> Result<Entry, Self::Error> {
+        let value = value.accumulator.as_slice().to_vec();
         Ok(Entry::new(entry_types::ACCUMULATOR, value))
     }
 }
@@ -363,19 +354,19 @@ impl TryFrom<&Entry> for Era1BlockIndexEntry {
             "invalid block index entry: incorrect value length"
         );
         Ok(Self {
-            block_index: BlockIndex::try_from(entry.clone())?,
+            block_index: BlockIndex::try_from(entry)?,
         })
     }
 }
 
-impl TryInto<Entry> for Era1BlockIndexEntry {
+impl TryFrom<&Era1BlockIndexEntry> for Entry {
     type Error = anyhow::Error;
 
-    fn try_into(self) -> Result<Entry, Self::Error> {
+    fn try_from(value: &Era1BlockIndexEntry) -> Result<Entry, Self::Error> {
         let mut buf: Vec<u64> = vec![];
-        buf.push(self.block_index.starting_number);
-        buf.extend_from_slice(&self.block_index.indices);
-        buf.push(self.block_index.count);
+        buf.push(value.block_index.starting_number);
+        buf.extend_from_slice(&value.block_index.indices);
+        buf.push(value.block_index.count);
         let encoded = buf
             .iter()
             .flat_map(|i| i.to_le_bytes().to_vec())
@@ -391,10 +382,10 @@ pub struct BlockIndex {
     pub count: u64,
 }
 
-impl TryFrom<Entry> for BlockIndex {
+impl TryFrom<&Entry> for BlockIndex {
     type Error = anyhow::Error;
 
-    fn try_from(entry: Entry) -> Result<Self, Self::Error> {
+    fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         let starting_number = u64::from_le_bytes(entry.value[0..8].try_into()?);
         let block_tuple_count = (entry.value.len() - 16) / 8;
         let mut indices = vec![0; block_tuple_count];

--- a/crates/e2store/src/types.rs
+++ b/crates/e2store/src/types.rs
@@ -31,14 +31,14 @@ impl TryFrom<&Entry> for HeaderEntry {
 }
 
 impl TryFrom<&HeaderEntry> for Entry {
-    type Error = anyhow::Error;
+    type Error = std::io::Error;
 
     fn try_from(value: &HeaderEntry) -> Result<Self, Self::Error> {
         let rlp_encoded = alloy::rlp::encode(&value.header);
         let buf: Vec<u8> = vec![];
         let mut encoder = snap::write::FrameEncoder::new(buf);
         let _ = encoder.write(&rlp_encoded)?;
-        let encoded = encoder.into_inner()?;
+        let encoded = encoder.into_inner().map_err(|e| e.into_error())?;
         Ok(Entry::new(entry_types::COMPRESSED_HEADER, encoded))
     }
 }

--- a/crates/e2store/src/types.rs
+++ b/crates/e2store/src/types.rs
@@ -30,11 +30,11 @@ impl TryFrom<&Entry> for HeaderEntry {
     }
 }
 
-impl TryFrom<HeaderEntry> for Entry {
+impl TryFrom<&HeaderEntry> for Entry {
     type Error = anyhow::Error;
 
-    fn try_from(value: HeaderEntry) -> Result<Self, Self::Error> {
-        let rlp_encoded = alloy::rlp::encode(value.header);
+    fn try_from(value: &HeaderEntry) -> Result<Self, Self::Error> {
+        let rlp_encoded = alloy::rlp::encode(&value.header);
         let buf: Vec<u8> = vec![];
         let mut encoder = snap::write::FrameEncoder::new(buf);
         let _ = encoder.write(&rlp_encoded)?;


### PR DESCRIPTION
### What was wrong?
Addressed some remaining comments from #1727 related to ownership patterns we use in `e2store`

### How was it fixed?
- removed some clones & updated ownership in conversion traits

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
