### PR TITLE
refactor: print debug logs for silent errors in `handle_offer()`

### DIFF
--- a/crates/portalnet/src/overlay/service/manager.rs
+++ b/crates/portalnet/src/overlay/service/manager.rs
@@ -1134,7 +1134,7 @@ impl<
                                     utp_processing,
                                 )
                                 .await {
-                                    debug!(%err, content_key = ?content_key, "Fallback FINDCONTENT task failed, after uTP transfer failed");
+                                    debug!(%err, ?content_key, "Fallback FINDCONTENT task failed, after uTP transfer failed");
                                 }
                             })
                         })
@@ -1150,7 +1150,7 @@ impl<
             let content_values = match decode_and_validate_content_payload(&accepted_keys, data) {
                 Ok(content_values) => content_values,
                 Err(err) => {
-                    debug!(%err, content_keys = ?content_keys_string, "Decoding and validating content payload failed");
+                    debug!(%err, ?content_keys_string, "Decoding and validating content payload failed");
                     let handles: Vec<JoinHandle<_>> = content_keys
                         .into_iter()
                         .map(|content_key| {
@@ -1161,7 +1161,7 @@ impl<
                                     utp_processing,
                                 )
                                 .await {
-                                    debug!(%err, content_key = ?content_key, "Fallback FINDCONTENT task failed, decoding and validating content payload failed");
+                                    debug!(%err, ?content_key, "Fallback FINDCONTENT task failed, decoding and validating content payload failed");
                                 }
                             })
                         })
@@ -1193,10 +1193,10 @@ impl<
                                 // Spawn a fallback FINDCONTENT task for each content key
                                 // that failed individual processing.
                                 if let Err(err) = Self::fallback_find_content(
-                                    key, utp_processing,
+                                    key.clone(), utp_processing,
                                 )
                                 .await {
-                                    debug!(%err, "Fallback FINDCONTENT task failed, after validating and storing content failed");
+                                    debug!(%err, ?key, "Fallback FINDCONTENT task failed, after validating and storing content failed");
                                 }
                                 None
                             }


### PR DESCRIPTION
### What was wrong?
The Samba team has spent days trying to debug why there `put_content` implementation isn't working, Trin wasn't printing any logs so they had no way to tell why Trin was failing to accept their offer
### How was it fixed?

If these functions return error's print them on the debug log
