### PR TITLE
feature: add e2hs mode to portal-bridge

### DIFF
--- a/bin/e2hs-writer/src/provider.rs
+++ b/bin/e2hs-writer/src/provider.rs
@@ -45,8 +45,9 @@ impl EraProvider {
         let first_source = match starting_block < MERGE_BLOCK_NUMBER {
             true => {
                 let era1_paths = get_era1_files(&http_client).await?;
-                let era1_path = era1_paths.get(&starting_block).ok_or(anyhow!(
-                    "Era1 file not found for block number: {starting_block}",
+                let epoch_index = starting_block / EPOCH_SIZE;
+                let era1_path = era1_paths.get(&epoch_index).ok_or(anyhow!(
+                    "Era1 file not found for epoch index: {epoch_index}",
                 ))?;
                 let raw_era1 = fetch_bytes(http_client.clone(), era1_path).await?;
                 EraSource::PreMerge(Arc::new(raw_era1))

--- a/bin/e2hs-writer/src/writer.rs
+++ b/bin/e2hs-writer/src/writer.rs
@@ -6,7 +6,7 @@ use e2store::{
 };
 use ethportal_api::utils::bytes::hex_encode;
 use futures::StreamExt;
-use tracing::{debug, info};
+use tracing::info;
 
 use crate::reader::EpochReader;
 
@@ -27,7 +27,7 @@ impl EpochWriter {
         let mut block_stream = Box::pin(reader.iter_blocks());
 
         while let Some(Ok(block_data)) = block_stream.next().await {
-            debug!(
+            info!(
                 "Writing block {}",
                 block_data.header_with_proof.header.number
             );

--- a/bin/portal-bridge/README.md
+++ b/bin/portal-bridge/README.md
@@ -44,6 +44,12 @@ cargo run -p portal-bridge -- --executable-path ./target/debug/trin --epoch-accu
     - before gossiping a individual piece of content, the bridge will perform a lookup to see if the content is already in the portal network. If it is, the content will not be gossiped.
 - `"--mode fourfours:single_hunter:10:50`: sample size = 10, threshold = 50
     - same as the above hunter mode, but it will only gossip a single era1 file before exiting
+
+#### E2HS Bridge
+
+- `"--mode e2hs --e2hs-range 100-200"`: gossip a block range from #100 to #200 (inclusive) using `E2HS` files as the data source
+- `"--mode e2hs --e2hs-range 1000-10000 --e2hs-randomize"`: randomize the order in which epochs from block range are gossiped
+
 #### Beacon Subnetwork
 
 - `"--mode latest"`: follow the head of the chain and gossip latest blocks

--- a/bin/portal-bridge/src/bridge/e2hs.rs
+++ b/bin/portal-bridge/src/bridge/e2hs.rs
@@ -1,0 +1,439 @@
+use std::{
+    str::FromStr,
+    sync::{Arc, Mutex},
+};
+
+use alloy::primitives::B256;
+use anyhow::{anyhow, ensure};
+use clap::Parser;
+use e2store::e2hs::{BlockTuple, E2HS};
+use ethportal_api::{
+    jsonrpsee::http_client::HttpClient,
+    types::execution::{
+        block_body::BlockBody, header_with_proof::HeaderWithProof, receipts::Receipts,
+    },
+    HistoryContentKey, HistoryContentValue,
+};
+use futures::future::join_all;
+use rand::seq::SliceRandom;
+use tokio::{
+    sync::{OwnedSemaphorePermit, Semaphore},
+    task::JoinHandle,
+    time::{sleep, timeout, Duration},
+};
+use tracing::{debug, error, info, warn};
+use trin_metrics::bridge::BridgeMetricsReporter;
+use trin_validation::header_validator::HeaderValidator;
+
+use crate::{
+    bridge::history::{HEADER_SATURATION_DELAY, SERVE_BLOCK_TIMEOUT},
+    put_content::gossip_history_content,
+    stats::{HistoryBlockStats, StatsReporter},
+    types::range::block_range_to_epochs,
+};
+
+/// Looks for the e2hs file for the given epoch index in a local directory.
+/// TODO: this will need to be updated to fetch files from a hosted
+/// server once we have a proper source for the files.
+fn get_e2hs_file(epoch_index: u64) -> anyhow::Result<String> {
+    let e2hs_dir = "./test-e2hs";
+    let all_files = std::fs::read_dir(e2hs_dir)?;
+    let files: Vec<String> = all_files
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let path = entry.path();
+            let path_str = path.to_str()?;
+            if path_str.contains(&format!("mainnet-{epoch_index:05}")) {
+                Some(path_str.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+    let file_count = files.len();
+    ensure!(
+        file_count == 1,
+        "Expected 1 file for epoch {epoch_index}, found {file_count}"
+    );
+    let file = files.first().expect("to be able to get first file");
+    Ok(file.clone())
+}
+
+#[derive(Debug)]
+pub struct E2HSBridge {
+    portal_client: HttpClient,
+    metrics: BridgeMetricsReporter,
+    gossip_semaphore: Arc<Semaphore>,
+    header_validator: HeaderValidator,
+    block_range: BlockRange,
+    random_fill: bool,
+}
+
+impl E2HSBridge {
+    pub fn new(
+        portal_client: HttpClient,
+        gossip_limit: usize,
+        block_range: BlockRange,
+        random_fill: bool,
+    ) -> anyhow::Result<Self> {
+        let gossip_semaphore = Arc::new(Semaphore::new(gossip_limit));
+        let mode = format!("{}-{}:{}", block_range.start, block_range.end, random_fill);
+        let metrics = BridgeMetricsReporter::new("e2hs".to_string(), &mode);
+        let header_validator = HeaderValidator::new();
+        Ok(Self {
+            portal_client,
+            metrics,
+            gossip_semaphore,
+            header_validator,
+            block_range,
+            random_fill,
+        })
+    }
+
+    pub async fn launch(&self) {
+        info!("Launching E2HS bridge");
+        let epochs = block_range_to_epochs(self.block_range.start, self.block_range.end);
+        let mut epoch_indexes: Vec<u64> = epochs.keys().cloned().collect();
+        if self.random_fill {
+            epoch_indexes.shuffle(&mut rand::thread_rng());
+        }
+        for index in epoch_indexes {
+            let block_range = epochs.get(&index).expect("to be able to get block range");
+            self.gossip_epoch(index, *block_range).await;
+        }
+    }
+
+    async fn gossip_epoch(&self, epoch_index: u64, block_range: Option<(u64, u64)>) {
+        match block_range {
+            Some(_) => {
+                info!("Gossiping block range: {block_range:?} from epoch {epoch_index}",);
+            }
+            None => {
+                info!("Gossiping entire epoch {epoch_index}");
+            }
+        }
+        let Ok(e2hs_path) = get_e2hs_file(epoch_index) else {
+            panic!("Failed to find e2hs file for epoch {epoch_index}");
+        };
+        let raw_e2hs = std::fs::read(e2hs_path).expect("Failed to read e2hs file");
+        let mut serve_block_tuple_handles = vec![];
+        let block_stream = E2HS::iter_tuples(raw_e2hs).expect("to be able to iter tuples");
+        for block_tuple in block_stream {
+            let block_number = block_tuple
+                .header_with_proof
+                .header_with_proof
+                .header
+                .number;
+            if let Some((start, end)) = block_range {
+                if block_number < start || block_number > end {
+                    debug!("Skipping block {block_number} outside of range");
+                    continue;
+                }
+            }
+            if let Err(err) = self.validate_block_tuple(&block_tuple) {
+                error!("Failed to validate block tuple: {err:?}");
+                continue;
+            }
+            let permit = self
+                .gossip_semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .expect("Failed to acquire gossip semaphore");
+            self.metrics.report_current_block(block_number as i64);
+            let handle = Self::spawn_serve_block_tuple(
+                self.portal_client.clone(),
+                block_tuple,
+                permit,
+                self.metrics.clone(),
+            );
+            serve_block_tuple_handles.push(handle);
+        }
+        join_all(serve_block_tuple_handles).await;
+    }
+
+    fn spawn_serve_block_tuple(
+        portal_client: HttpClient,
+        block_tuple: BlockTuple,
+        permit: OwnedSemaphorePermit,
+        metrics: BridgeMetricsReporter,
+    ) -> JoinHandle<()> {
+        let number = block_tuple
+            .header_with_proof
+            .header_with_proof
+            .header
+            .number;
+        info!("Spawning serve block tuple for block {number}");
+        let block_stats = Arc::new(Mutex::new(HistoryBlockStats::new(number)));
+        tokio::spawn(async move {
+            let timer = metrics.start_process_timer("spawn_serve_block_tuple");
+            match timeout(
+                SERVE_BLOCK_TIMEOUT,
+                Self::serve_block_tuple(
+                    portal_client,
+                    block_tuple,
+                    block_stats.clone(),
+                    metrics.clone(),
+                ),
+            )
+            .await
+            {
+                Ok(Ok(())) => {
+                    info!("Served block {number}");
+                }
+                Ok(Err(e)) => {
+                    error!("Failed to serve block {number}: {e:?}");
+                }
+                Err(_) => {
+                    error!("Timed out serving block {number}");
+                }
+            }
+            metrics.stop_process_timer(timer);
+            drop(permit);
+        })
+    }
+
+    async fn serve_block_tuple(
+        portal_client: HttpClient,
+        block_tuple: BlockTuple,
+        block_stats: Arc<Mutex<HistoryBlockStats>>,
+        metrics: BridgeMetricsReporter,
+    ) -> anyhow::Result<()> {
+        let header_number = block_tuple
+            .header_with_proof
+            .header_with_proof
+            .header
+            .number;
+
+        info!("Serving block tuple for block #{header_number}");
+
+        let header_hash = block_tuple
+            .header_with_proof
+            .header_with_proof
+            .header
+            .hash_slow();
+
+        // gossip header by hash
+        let timer = metrics.start_process_timer("gossip_header_by_hash");
+        match Self::gossip_header_by_hash(
+            block_tuple.header_with_proof.header_with_proof.clone(),
+            portal_client.clone(),
+            block_stats.clone(),
+        )
+        .await
+        {
+            Ok(_) => {
+                metrics.report_gossip_success(true, "header_by_hash");
+                info!("Gossiped header by hash: {header_number}");
+            }
+            Err(e) => {
+                metrics.report_gossip_success(false, "header_by_hash");
+                warn!("Failed to gossip header by hash: {header_number} - {e:?}");
+            }
+        }
+        metrics.stop_process_timer(timer);
+        // Sleep for 10 seconds to allow headers to saturate network,
+        // since they must be available for body / receipt validation.
+        sleep(Duration::from_secs(HEADER_SATURATION_DELAY)).await;
+
+        // gossip header by number
+        let timer = metrics.start_process_timer("gossip_header_by_number");
+        match Self::gossip_header_by_number(
+            block_tuple.header_with_proof.header_with_proof.clone(),
+            portal_client.clone(),
+            block_stats.clone(),
+        )
+        .await
+        {
+            Ok(_) => {
+                metrics.report_gossip_success(true, "header_by_number");
+                info!("Gossiped header by number: {header_number}");
+            }
+            Err(e) => {
+                metrics.report_gossip_success(false, "header_by_number");
+                warn!("Failed to gossip header by number: {header_number} - {e:?}");
+            }
+        }
+        metrics.stop_process_timer(timer);
+
+        // gossip body
+        let timer = metrics.start_process_timer("gossip_block_body");
+        match Self::gossip_body(
+            block_tuple.body.body.clone(),
+            header_hash,
+            portal_client.clone(),
+            block_stats.clone(),
+        )
+        .await
+        {
+            Ok(_) => {
+                metrics.report_gossip_success(true, "block_body");
+                info!("Gossiped body: {header_number}");
+            }
+            Err(e) => {
+                metrics.report_gossip_success(false, "block_body");
+                warn!("Failed to gossip body: {header_number} - {e:?}");
+            }
+        }
+        metrics.stop_process_timer(timer);
+
+        // gossip receipts
+        let timer = metrics.start_process_timer("gossip_receipts");
+        match Self::gossip_receipts(
+            block_tuple.receipts.receipts.clone(),
+            header_hash,
+            portal_client.clone(),
+            block_stats.clone(),
+        )
+        .await
+        {
+            Ok(_) => {
+                metrics.report_gossip_success(true, "receipts");
+                info!("Gossiped receipts: {header_number}");
+            }
+            Err(e) => {
+                metrics.report_gossip_success(false, "receipts");
+                warn!("Failed to gossip receipts: {header_number} - {e:?}");
+            }
+        }
+        metrics.stop_process_timer(timer);
+        Ok(())
+    }
+
+    async fn gossip_header_by_hash(
+        header_with_proof: HeaderWithProof,
+        portal_client: HttpClient,
+        block_stats: Arc<Mutex<HistoryBlockStats>>,
+    ) -> anyhow::Result<()> {
+        let header_hash = header_with_proof.header.hash_slow();
+        let hwp_by_hash_content_key = HistoryContentKey::new_block_header_by_hash(header_hash);
+        let hwp_content_value = HistoryContentValue::BlockHeaderWithProof(header_with_proof);
+        if let Err(err) = gossip_history_content(
+            portal_client,
+            hwp_by_hash_content_key.clone(),
+            hwp_content_value,
+            block_stats,
+        )
+        .await
+        {
+            error!(
+                "Failed to gossip history content key: {:?} - {:?}",
+                hwp_by_hash_content_key, err
+            );
+        }
+        Ok(())
+    }
+
+    async fn gossip_header_by_number(
+        header_with_proof: HeaderWithProof,
+        portal_client: HttpClient,
+        block_stats: Arc<Mutex<HistoryBlockStats>>,
+    ) -> anyhow::Result<()> {
+        let header_number = header_with_proof.header.number;
+        let hwp_by_number_content_key =
+            HistoryContentKey::new_block_header_by_number(header_number);
+        let hwp_content_value = HistoryContentValue::BlockHeaderWithProof(header_with_proof);
+        if let Err(err) = gossip_history_content(
+            portal_client,
+            hwp_by_number_content_key.clone(),
+            hwp_content_value,
+            block_stats,
+        )
+        .await
+        {
+            error!(
+                "Failed to gossip history content key: {:?} - {:?}",
+                hwp_by_number_content_key, err
+            );
+        }
+        Ok(())
+    }
+
+    async fn gossip_body(
+        body: BlockBody,
+        header_hash: B256,
+        portal_client: HttpClient,
+        block_stats: Arc<Mutex<HistoryBlockStats>>,
+    ) -> anyhow::Result<()> {
+        let body_content_key = HistoryContentKey::new_block_body(header_hash);
+        let body_content_value = HistoryContentValue::BlockBody(body);
+        if let Err(err) = gossip_history_content(
+            portal_client,
+            body_content_key.clone(),
+            body_content_value,
+            block_stats,
+        )
+        .await
+        {
+            error!(
+                "Failed to gossip history content key: {:?} - {:?}",
+                body_content_key, err
+            );
+        }
+        Ok(())
+    }
+
+    async fn gossip_receipts(
+        receipts: Receipts,
+        header_hash: B256,
+        portal_client: HttpClient,
+        block_stats: Arc<Mutex<HistoryBlockStats>>,
+    ) -> anyhow::Result<()> {
+        let receipts_content_key = HistoryContentKey::new_block_receipts(header_hash);
+        let receipts_content_value = HistoryContentValue::Receipts(receipts);
+        if let Err(err) = gossip_history_content(
+            portal_client,
+            receipts_content_key.clone(),
+            receipts_content_value,
+            block_stats,
+        )
+        .await
+        {
+            error!(
+                "Failed to gossip history content key: {:?} - {:?}",
+                receipts_content_key, err
+            );
+        }
+        Ok(())
+    }
+
+    fn validate_block_tuple(&self, block_tuple: &BlockTuple) -> anyhow::Result<()> {
+        self.header_validator
+            .validate_header_with_proof(&block_tuple.header_with_proof.header_with_proof)?;
+        let receipts = &block_tuple.receipts.receipts;
+        let receipts_root = receipts.root();
+        ensure!(
+            receipts_root
+                == block_tuple
+                    .header_with_proof
+                    .header_with_proof
+                    .header
+                    .receipts_root,
+            "Receipts root mismatch"
+        );
+        let body = &block_tuple.body.body;
+        body.validate_against_header(&block_tuple.header_with_proof.header_with_proof.header)?;
+        Ok(())
+    }
+}
+
+/// BlockRange used specifically for the E2HS bridge
+#[derive(Parser, Debug, Clone)]
+pub struct BlockRange {
+    pub start: u64,
+    pub end: u64,
+}
+
+impl FromStr for BlockRange {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err(anyhow!("Invalid block range format"));
+        }
+        let start = parts[0].parse()?;
+        let end = parts[1].parse()?;
+        Ok(Self { start, end })
+    }
+}

--- a/bin/portal-bridge/src/bridge/era1.rs
+++ b/bin/portal-bridge/src/bridge/era1.rs
@@ -363,8 +363,8 @@ impl Era1Bridge {
             block_tuple.header.header.number
         );
         let mut gossip_header_by_hash = true;
+        let header_hash = block_tuple.header.header.hash_slow();
         if hunt {
-            let header_hash = block_tuple.header.header.hash_slow();
             let header_content_key = HistoryContentKey::new_block_header_by_hash(header_hash);
             let header_content_info = portal_client.get_content(header_content_key.clone()).await;
             if header_content_info.is_ok() {
@@ -456,8 +456,7 @@ impl Era1Bridge {
         }
         let mut gossip_body = true;
         if hunt {
-            let body_hash = block_tuple.header.header.hash_slow();
-            let body_content_key = HistoryContentKey::new_block_body(body_hash);
+            let body_content_key = HistoryContentKey::new_block_body(header_hash);
             let body_content_info = portal_client.get_content(body_content_key.clone()).await;
             if body_content_info.is_ok() {
                 info!(
@@ -495,8 +494,7 @@ impl Era1Bridge {
         }
         let mut gossip_receipts = true;
         if hunt {
-            let receipts_hash = block_tuple.header.header.hash_slow();
-            let receipts_content_key = HistoryContentKey::new_block_receipts(receipts_hash);
+            let receipts_content_key = HistoryContentKey::new_block_receipts(header_hash);
             let receipts_content_info = portal_client
                 .get_content(receipts_content_key.clone())
                 .await;

--- a/bin/portal-bridge/src/bridge/mod.rs
+++ b/bin/portal-bridge/src/bridge/mod.rs
@@ -1,4 +1,5 @@
 pub mod beacon;
+pub mod e2hs;
 pub mod era1;
 pub mod history;
 pub mod state;

--- a/bin/portal-bridge/src/cli.rs
+++ b/bin/portal-bridge/src/cli.rs
@@ -22,6 +22,7 @@ use trin_utils::cli::{check_private_key_length, network_parser};
 use url::Url;
 
 use crate::{
+    bridge::e2hs::BlockRange,
     census::ENR_OFFER_LIMIT,
     constants::{DEFAULT_GOSSIP_LIMIT, DEFAULT_OFFER_LIMIT, DEFAULT_TOTAL_REQUEST_TIMEOUT},
     types::mode::BridgeMode,
@@ -52,6 +53,19 @@ pub struct BridgeConfig {
         default_value = DEFAULT_EPOCH_ACC_PATH
     )]
     pub epoch_acc_path: PathBuf,
+
+    #[arg(
+        long = "e2hs-range",
+        help = "The (inclusive) block range for the E2HS bridge"
+    )]
+    pub e2hs_range: Option<BlockRange>,
+
+    #[arg(
+        long = "e2hs-randomize",
+        help = "Randomize epochs during gossip in E2HS bridge (default: false)",
+        default_value = "false"
+    )]
+    pub e2hs_randomize: bool,
 
     #[arg(
         long = "portal-subnetworks",

--- a/bin/portal-bridge/src/types/mod.rs
+++ b/bin/portal-bridge/src/types/mod.rs
@@ -1,2 +1,3 @@
 pub mod full_header;
 pub mod mode;
+pub mod range;

--- a/bin/portal-bridge/src/types/mode.rs
+++ b/bin/portal-bridge/src/types/mode.rs
@@ -19,6 +19,7 @@ use trin_validation::constants::EPOCH_SIZE;
 pub enum BridgeMode {
     #[default]
     Latest,
+    E2HS,
     FourFours(FourFoursMode),
     Backfill(ModeType),
     Single(ModeType),
@@ -46,6 +47,9 @@ impl BridgeMode {
             }
             BridgeMode::Snapshot(_) => {
                 return Err(anyhow!("BridgeMode `snapshot` does not have a block range"))
+            }
+            BridgeMode::E2HS => {
+                return Err(anyhow!("BridgeMode `e2hs` does not have a block range"))
             }
         };
         let (start, end) = match mode_type.clone() {
@@ -83,6 +87,7 @@ impl FromStr for BridgeMode {
         match s {
             "latest" => Ok(BridgeMode::Latest),
             "fourfours" => Ok(BridgeMode::FourFours(FourFoursMode::Random)),
+            "e2hs" => Ok(BridgeMode::E2HS),
             val => {
                 let index = val
                     .find(':')

--- a/bin/portal-bridge/src/types/range.rs
+++ b/bin/portal-bridge/src/types/range.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use trin_validation::constants::EPOCH_SIZE;
+
 /// Converts a block range into a mapping of epoch indexes to block ranges.
 ///
 /// An epoch is defined as a range of 8192 blocks, starting at 0.
@@ -12,7 +14,6 @@ use std::collections::HashMap;
 /// HashMap mapping epoch indexes to either None or Some((start_block, end_block))
 pub fn block_range_to_epochs(start_block: u64, end_block: u64) -> HashMap<u64, Option<(u64, u64)>> {
     let mut epoch_map = HashMap::new();
-    const EPOCH_SIZE: u64 = 8192;
 
     // Calculate start and end epochs
     let start_epoch = start_block / EPOCH_SIZE;

--- a/bin/portal-bridge/src/types/range.rs
+++ b/bin/portal-bridge/src/types/range.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+
+/// Converts a block range into a mapping of epoch indexes to block ranges.
+///
+/// An epoch is defined as a range of 8192 blocks, starting at 0.
+/// The resulting HashMap contains:
+/// - For epochs that are completely covered by the block range: None
+/// - For epochs that are partially covered: Some((start_block, end_block)) where start_block and
+///   end_block represent the actual block numbers that overlap with the epoch
+///
+/// # Returns
+/// HashMap mapping epoch indexes to either None or Some((start_block, end_block))
+pub fn block_range_to_epochs(start_block: u64, end_block: u64) -> HashMap<u64, Option<(u64, u64)>> {
+    let mut epoch_map = HashMap::new();
+    const EPOCH_SIZE: u64 = 8192;
+
+    // Calculate start and end epochs
+    let start_epoch = start_block / EPOCH_SIZE;
+    let end_epoch = end_block / EPOCH_SIZE;
+
+    // Process each epoch in the range
+    for epoch in start_epoch..=end_epoch {
+        // Calculate the first and last block of the current epoch
+        let epoch_first_block = epoch * EPOCH_SIZE;
+        let epoch_last_block = epoch_first_block + EPOCH_SIZE - 1;
+
+        // Determine if the epoch is fully or partially covered
+        if epoch_first_block >= start_block && epoch_last_block <= end_block {
+            // Epoch is fully covered by the block range
+            epoch_map.insert(epoch, None);
+        } else {
+            // Epoch is partially covered, calculate the overlap
+            let overlap_start = start_block.max(epoch_first_block);
+            let overlap_end = end_block.min(epoch_last_block);
+
+            // Use actual block numbers instead of epoch-relative ones
+            epoch_map.insert(epoch, Some((overlap_start, overlap_end)));
+        }
+    }
+
+    epoch_map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_single_epoch_complete() {
+        // Test a range that completely covers a single epoch
+        let start = 8192; // Start of epoch 1
+        let end = 16383; // End of epoch 1
+        let result = block_range_to_epochs(start, end);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(&1), Some(&None));
+    }
+
+    #[test]
+    fn test_single_epoch_partial() {
+        // Test a range that partially covers a single epoch
+        let start = 8500;
+        let end = 9000;
+        let result = block_range_to_epochs(start, end);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(&1), Some(&Some((8500, 9000))));
+    }
+
+    #[test]
+    fn test_multiple_epochs() {
+        // Test a range spanning multiple epochs
+        let start = 8000; // In epoch 0
+        let end = 17000; // In epoch 2
+        let result = block_range_to_epochs(start, end);
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(result.get(&0), Some(&Some((8000, 8191))));
+        assert_eq!(result.get(&1), Some(&None));
+        assert_eq!(result.get(&2), Some(&Some((16384, 17000))));
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        // Test case where start and end are the same
+        let result = block_range_to_epochs(5000, 5000);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(&0), Some(&Some((5000, 5000))));
+
+        // Test exact epoch boundaries
+        let result = block_range_to_epochs(0, 8191);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(&0), Some(&None));
+    }
+}


### PR DESCRIPTION
### What was wrong?
With the introduction of the new [e2hs](https://github.com/eth-clients/e2store-format-specs/pull/6) file format, we need a bridge mode to support these files.

This is a very basic bridge mode, that won't really work unless you have all necessary `e2hs` files in a local `test-e2hs` dir, inside the root level of the trin dir. But the intention is that this will be updated to use a centralized server that hosts all `e2hs` files, once they are generated and made available. 

The existing `BridgeMode` type has turned into a bit of a frankenstein, as a result of us trying to push too much into a single cli arg. After this new bridge mode matures, I expect a fair amount of legacy bridge code to be deleted, that's why I decided to create new, isolated cli args for the `e2hs` mode to use, rather than try and squeeze them into the old `BridgeMode` type. 

There's another trade-off to consider. I opted to require the user to provide the entire block range, rather than using a live el provider to detect the head of the chain. I'm not married to this, but I think it's easier if a user just wants to casually run the bridge, without an infura / pandaops account. 

But both of these decisions are fairly trivial, and can be changed as new use-cases for the bridge are implemented. 

### Usage
`"--mode e2hs --e2hs-range 1000-10000 --e2hs-randomize"`: randomize the order in which epochs from block range are gossiped

### How was it fixed?
- added `e2hs` mode to portal-bridge

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
