### PR TITLE
fix: update short hash used in e2hs file path

### DIFF
--- a/bin/e2hs-writer/src/writer.rs
+++ b/bin/e2hs-writer/src/writer.rs
@@ -60,7 +60,11 @@ impl EpochWriter {
             offset += length;
         }
         let starting_header = &block_tuples[0].header_with_proof.header_with_proof.header;
-        let short_hash = hex_encode(&starting_header.hash_slow()[..4]);
+        let ending_header_hash = &block_tuples[BLOCK_TUPLE_COUNT - 1]
+            .header_with_proof
+            .header_with_proof
+            .header
+            .hash_slow();
         let block_index = BlockIndex {
             starting_number: starting_header.number,
             indices,
@@ -73,6 +77,8 @@ impl EpochWriter {
             block_index,
         };
         let raw_e2hs = e2hs.write()?;
+
+        let short_hash = hex_encode(&ending_header_hash[..4]);
         let e2hs_path = format!(
             "{}/mainnet-{:05}-{}.e2hs",
             self.target_dir,


### PR DESCRIPTION
### What was wrong?
The [spec](https://github.com/eth-clients/e2store-format-specs/pull/6) for `e2hs` was just updated to to use the final block header hash in a file (as opposed to the first) to be used in the file path. 

### How was it fixed?
- updated the `e2hs-writer`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
