### PR TITLE
chore: bump ethportal-api & e2store minor version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "e2store"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "ethportal-api"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "alloy",
  "alloy-rlp",

--- a/crates/e2store/Cargo.toml
+++ b/crates/e2store/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.2.3"
+version = "0.3.0"
 
 [dependencies]
 alloy = { workspace = true, features = ["rlp", "consensus"] }

--- a/crates/ethportal-api/Cargo.toml
+++ b/crates/ethportal-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethportal-api"
-version = "0.5.1"
+version = "0.6.0"
 description = "Definitions for various Ethereum Portal Network JSONRPC APIs"
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
### What was wrong?
Glados needs a release of `ethportal-api`. Since there was a breaking change we are bumping the minor release
### How was it fixed?

bumping `ethportal-api` and `e2store` crates