### PR TITLE
fix: ensure our ENR cache has enough room for max sessions

### DIFF
--- a/bin/trin/src/cli.rs
+++ b/bin/trin/src/cli.rs
@@ -17,7 +17,7 @@ use ethportal_api::{
 };
 use portalnet::{
     bootnodes::Bootnodes,
-    config::{PortalnetConfig, NODE_ADDR_CACHE_CAPACITY},
+    config::{PortalnetConfig, DISCV5_SESSION_CACHE_CAPACITY},
     constants::{
         DEFAULT_DISCOVERY_PORT, DEFAULT_NETWORK, DEFAULT_UTP_TRANSFER_LIMIT,
         DEFAULT_WEB3_HTTP_ADDRESS, DEFAULT_WEB3_IPC_PATH, DEFAULT_WEB3_WS_PORT,
@@ -433,7 +433,7 @@ impl TrinConfig {
             bootnodes: self.bootnodes.to_enrs(self.network.network()),
             no_stun: self.no_stun,
             no_upnp: self.no_upnp,
-            node_addr_cache_capacity: NODE_ADDR_CACHE_CAPACITY,
+            discv5_session_cache_capacity: DISCV5_SESSION_CACHE_CAPACITY,
             disable_poke: self.disable_poke,
             trusted_block_root: self.trusted_block_root,
             utp_transfer_limit: self.utp_transfer_limit,

--- a/bin/trin/src/lib.rs
+++ b/bin/trin/src/lib.rs
@@ -77,18 +77,7 @@ pub async fn run_trin(
     // Initialize and spawn uTP socket
     let (utp_talk_reqs_tx, utp_talk_reqs_rx) = mpsc::unbounded_channel();
 
-    // Set the enr_cache_capacity to the maximum uTP limit between all active networks. This is
-    // a trade off between memory usage and increased searches from the networks for each Enr.
-    // utp_transfer_limit is 2x as it would be utp_transfer_limit for incoming and
-    // utp_transfer_limit for outgoing
-    let enr_cache_capacity =
-        portalnet_config.utp_transfer_limit * 2 * trin_config.portal_subnetworks.len();
-    let discv5_utp_socket = Discv5UdpSocket::new(
-        Arc::clone(&discovery),
-        utp_talk_reqs_rx,
-        header_oracle.clone(),
-        enr_cache_capacity,
-    );
+    let discv5_utp_socket = Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_reqs_rx);
     let utp_socket = UtpSocket::with_socket(discv5_utp_socket);
     let utp_socket = Arc::new(utp_socket);
 

--- a/crates/portalnet/src/config.rs
+++ b/crates/portalnet/src/config.rs
@@ -5,9 +5,9 @@ use ethportal_api::types::{enr::Enr, network::Network};
 
 use crate::{bootnodes::Bootnodes, constants::DEFAULT_UTP_TRANSFER_LIMIT};
 
-/// Capacity of the cache for observed `NodeAddress` values.
+/// Discv5 session cache capacity.
 /// Provides capacity for 1000 nodes, to match Discv5's default session_cache_capacity value.
-pub const NODE_ADDR_CACHE_CAPACITY: usize = 1000;
+pub const DISCV5_SESSION_CACHE_CAPACITY: usize = 1000;
 
 #[derive(Clone)]
 pub struct PortalnetConfig {
@@ -17,7 +17,7 @@ pub struct PortalnetConfig {
     pub bootnodes: Vec<Enr>,
     pub no_stun: bool,
     pub no_upnp: bool,
-    pub node_addr_cache_capacity: usize,
+    pub discv5_session_cache_capacity: usize,
     pub disable_poke: bool,
     pub trusted_block_root: Option<B256>,
     /// the max number of concurrent utp transfers
@@ -34,7 +34,7 @@ impl Default for PortalnetConfig {
             bootnodes: Bootnodes::default().to_enrs(Network::Mainnet),
             no_stun: false,
             no_upnp: false,
-            node_addr_cache_capacity: NODE_ADDR_CACHE_CAPACITY,
+            discv5_session_cache_capacity: DISCV5_SESSION_CACHE_CAPACITY,
             disable_poke: false,
             trusted_block_root: None,
             utp_transfer_limit: DEFAULT_UTP_TRANSFER_LIMIT,

--- a/crates/portalnet/src/config.rs
+++ b/crates/portalnet/src/config.rs
@@ -6,9 +6,8 @@ use ethportal_api::types::{enr::Enr, network::Network};
 use crate::{bootnodes::Bootnodes, constants::DEFAULT_UTP_TRANSFER_LIMIT};
 
 /// Capacity of the cache for observed `NodeAddress` values.
-/// Provides capacity for 32 full k-buckets. This capacity will be shared among all active portal
-/// subnetworks.
-pub const NODE_ADDR_CACHE_CAPACITY: usize = discv5::kbucket::MAX_NODES_PER_BUCKET * 32;
+/// Provides capacity for 1000 nodes, to match Discv5's default session_cache_capacity value.
+pub const NODE_ADDR_CACHE_CAPACITY: usize = 1000;
 
 #[derive(Clone)]
 pub struct PortalnetConfig {

--- a/crates/portalnet/src/config.rs
+++ b/crates/portalnet/src/config.rs
@@ -20,7 +20,7 @@ pub struct PortalnetConfig {
     pub node_addr_cache_capacity: usize,
     pub disable_poke: bool,
     pub trusted_block_root: Option<B256>,
-    // the max number of concurrent utp transfers
+    /// the max number of concurrent utp transfers
     pub utp_transfer_limit: usize,
 }
 

--- a/crates/portalnet/src/discovery.rs
+++ b/crates/portalnet/src/discovery.rs
@@ -159,6 +159,11 @@ impl Discovery {
 
         let discv5_config = ConfigBuilder::new(listen_config)
             .request_timeout(Duration::from_secs(3))
+            // Set the session cache capacity to match our node address cache capacity. If our cache
+            // is smaller then the session cache capacity, it can lead to problems where we can't
+            // send replies to nodes that we have a session with, as we wouldn't have enough room in
+            // to store all the Enr's from all of our current established connections.
+            .session_cache_capacity(portal_config.node_addr_cache_capacity)
             .build();
         let discv5 = Discv5::new(enr, enr_key, discv5_config)
             .map_err(|e| format!("Failed to create discv5 instance: {e}"))?;

--- a/crates/portalnet/src/overlay/service/manager.rs
+++ b/crates/portalnet/src/overlay/service/manager.rs
@@ -2281,19 +2281,14 @@ impl<
 
     /// Returns an ENR if one is known for the given NodeId.
     pub fn find_enr(&self, node_id: &NodeId) -> Option<Enr> {
-        // Check whether this node id is in our discovery ENR cache
-        if let Some(node_addr) = self.discovery.cached_node_addr(node_id) {
-            return Some(node_addr.enr);
+        // Check whether this node id is in our enr_session_cache or discv5 routing table
+        if let Some(enr) = self.discovery.find_enr(node_id) {
+            return Some(enr);
         }
 
         // Check whether we know this node id in our X's Portal Network's routing table.
         if let Some(node) = self.kbuckets.entry(*node_id).present_or_pending() {
             return Some(node.enr);
-        }
-
-        // Check whether this node id is in our discv5 routing table
-        if let Some(enr) = self.discovery.find_enr(node_id) {
-            return Some(enr);
         }
 
         // Check the existing find node queries for the ENR.

--- a/crates/portalnet/src/overlay/service/manager.rs
+++ b/crates/portalnet/src/overlay/service/manager.rs
@@ -2473,14 +2473,11 @@ mod tests {
     use parking_lot::lock_api::Mutex;
     use rstest::*;
     use serial_test::serial;
-    use tokio::{
-        sync::{mpsc::unbounded_channel, RwLock as TokioRwLock},
-        time::timeout,
-    };
+    use tokio::{sync::mpsc::unbounded_channel, time::timeout};
     use tokio_test::{assert_pending, assert_ready, task};
     use trin_metrics::portalnet::PORTALNET_METRICS;
     use trin_storage::{DistanceFunction, MemoryContentStore};
-    use trin_validation::{oracle::HeaderOracle, validator::MockValidator};
+    use trin_validation::validator::MockValidator;
 
     use super::*;
     use crate::{
@@ -2510,15 +2507,9 @@ mod tests {
         };
         let discovery = Arc::new(Discovery::new(portal_config, MAINNET.clone()).unwrap());
 
-        let header_oracle = HeaderOracle::default();
-        let header_oracle = Arc::new(TokioRwLock::new(header_oracle));
         let (_utp_talk_req_tx, utp_talk_req_rx) = unbounded_channel();
-        let discv5_utp = crate::discovery::Discv5UdpSocket::new(
-            Arc::clone(&discovery),
-            utp_talk_req_rx,
-            header_oracle,
-            50,
-        );
+        let discv5_utp =
+            crate::discovery::Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx);
         let utp_socket = utp_rs::socket::UtpSocket::with_socket(discv5_utp);
         let metrics = OverlayMetricsReporter {
             overlay_metrics: PORTALNET_METRICS.overlay(),

--- a/crates/portalnet/tests/overlay.rs
+++ b/crates/portalnet/tests/overlay.rs
@@ -26,11 +26,11 @@ use portalnet::{
     },
 };
 use tokio::{
-    sync::{mpsc, mpsc::unbounded_channel, RwLock as TokioRwLock},
+    sync::{mpsc, mpsc::unbounded_channel},
     time::{self, Duration},
 };
 use trin_storage::{ContentStore, DistanceFunction, MemoryContentStore};
-use trin_validation::{oracle::HeaderOracle, validator::MockValidator};
+use trin_validation::validator::MockValidator;
 use utp_rs::socket::UtpSocket;
 
 async fn init_overlay(
@@ -49,11 +49,8 @@ async fn init_overlay(
     let store = MemoryContentStore::new(node_id, DistanceFunction::Xor);
     let store = Arc::new(Mutex::new(store));
 
-    let header_oracle = HeaderOracle::default();
-    let header_oracle = Arc::new(TokioRwLock::new(header_oracle));
     let (_utp_talk_req_tx, utp_talk_req_rx) = unbounded_channel();
-    let discv5_utp =
-        Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx, header_oracle, 50);
+    let discv5_utp = Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx);
     let utp_socket = Arc::new(UtpSocket::with_socket(discv5_utp));
 
     let validator = Arc::new(MockValidator {});

--- a/testing/utp/src/lib.rs
+++ b/testing/utp/src/lib.rs
@@ -25,7 +25,6 @@ use tokio::sync::{
     mpsc::{self, Receiver},
     RwLock,
 };
-use trin_validation::oracle::HeaderOracle;
 use utp_rs::{conn::ConnectionConfig, peer::Peer, socket::UtpSocket};
 
 use crate::rpc::RpcServer;
@@ -179,15 +178,9 @@ pub async fn run_test_app(
     let enr = discovery.local_enr();
     let discovery = Arc::new(discovery);
 
-    let header_oracle = HeaderOracle::default();
-    let header_oracle = Arc::new(RwLock::new(header_oracle));
     let (utp_talk_req_tx, utp_talk_req_rx) = mpsc::unbounded_channel();
-    let discv5_utp_socket = portalnet::discovery::Discv5UdpSocket::new(
-        Arc::clone(&discovery),
-        utp_talk_req_rx,
-        header_oracle,
-        50,
-    );
+    let discv5_utp_socket =
+        portalnet::discovery::Discv5UdpSocket::new(Arc::clone(&discovery), utp_talk_req_rx);
     let utp_socket = utp_rs::socket::UtpSocket::with_socket(discv5_utp_socket);
     let utp_socket = Arc::new(utp_socket);
 


### PR DESCRIPTION
### What was wrong?

Discv5 uses an timed LRU cache for all of its sessions. In the past we had bugs where a discv5 session was established, we would try and send a message to the node but it wouldn't be in our ENR cache. From talking to Milos on our call today. The `Discv5.session_capacity` should be less than or equal to our `NodeAddrCache` capacity, to prevent this bug.

### How was it fixed?
- I manually set `session_cache_capacity()` well initializing Discv5, to ensure both of our caches use the same value. I also added a comment for context why we are doing this.
- I updated the `NODE_ADDR_CACHE_CAPACITY` const from 512 Enr's to 1000, to be consistent with Discv5's session capacity default, if we want to save RAM I think it is fine to leave it at 512, but I think matching Discv5's default is a better story then, `32 full k-buckets`. They don't declare a const for `1000`, so I just wrote it.

This fix is important as we need it for the new protocol versioning update. As e.x. before this PR

- node contacts us
- node is flushed from our LRU cache as we are spammed with new connections
- node remains in sessions, due to session capacity being double our Enr capacity
- we try to fetch ENR from NodeID, well trying to figure out which PV they use, but get a cache miss
- **Failure** everything worked, except we weren't able to find the Peer's ENR from their NodeID, so we can't handle their messages

This PR fixes this problem as if our ENRCaches capacity is => then the session capacity, we will always have the ENR's for all the active sessions.
