### PR TITLE
fix: we use invalid BlockIndex type 6232 instead of 6632

### DIFF
--- a/crates/e2store/src/e2hs.rs
+++ b/crates/e2store/src/e2hs.rs
@@ -16,7 +16,7 @@
 //! CompressedHWP      = { type: 0x0301, data: snappyFramed(ssz(header_with_proof)) }
 //! CompressedBody     = { type: 0x0400, data: snappyFramed(rlp(body)) }
 //! CompressedReceipts = { type: 0x0500, data: snappyFramed(rlp(receipts)) }
-//! BlockIndex         = { type: 0x6232, data: block-index }
+//! BlockIndex         = { type: 0x6632, data: block-index }
 //! ```
 //!
 //! E2HS files must each contain a contiguous sequence of 8192 blocks.

--- a/crates/e2store/src/entry_types.rs
+++ b/crates/e2store/src/entry_types.rs
@@ -53,14 +53,14 @@ pub const COMPRESSED_ACCOUNT: u16 = 0x0800;
 /// StorageItem = { storage_index_hash, value }
 pub const COMPRESSED_STORAGE: u16 = 0x0900;
 
+/// Version
+pub const VERSION: u16 = 0x6532;
+
 /// BlockIndex
 ///
 /// data: block-index
 /// block-index := starting-number | index | index | index ... | count
-pub const BLOCK_INDEX: u16 = 0x6232;
-
-/// Version
-pub const VERSION: u16 = 0x6532;
+pub const BLOCK_INDEX: u16 = 0x6632;
 
 /// SlotIndex
 ///

--- a/crates/e2store/src/era1.rs
+++ b/crates/e2store/src/era1.rs
@@ -332,7 +332,7 @@ impl TryFrom<&Entry> for Era1BlockIndexEntry {
 
     fn try_from(entry: &Entry) -> Result<Self, Self::Error> {
         ensure!(
-            entry.header.type_ == 0x6632,
+            entry.header.type_ == entry_types::BLOCK_INDEX,
             "invalid block index entry: incorrect header type"
         );
         ensure!(
@@ -365,7 +365,7 @@ impl From<&Era1BlockIndexEntry> for Entry {
             .iter()
             .flat_map(|i| i.to_le_bytes().to_vec())
             .collect::<Vec<u8>>();
-        Entry::new(0x6632, encoded)
+        Entry::new(entry_types::BLOCK_INDEX, encoded)
     }
 }
 


### PR DESCRIPTION
### What was wrong?

@ScottyPoi noticed we were encoding the `blockIndex` type wrong

### How was it fixed?

fix it
