### PR TITLE
feat: add Protocol Version support

### DIFF
--- a/crates/ethportal-api/src/types/mod.rs
+++ b/crates/ethportal-api/src/types/mod.rs
@@ -12,5 +12,6 @@ pub mod node_id;
 pub mod ping_extensions;
 pub mod portal;
 pub mod portal_wire;
+pub mod protocol_versions;
 pub mod query_trace;
 pub mod state_trie;

--- a/crates/ethportal-api/src/types/portal_wire.rs
+++ b/crates/ethportal-api/src/types/portal_wire.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Arc,
 };
 
-use alloy::primitives::U256;
+use alloy::primitives::{map::HashSet, U256};
 use alloy_rlp::Decodable;
 use anyhow::anyhow;
 use bimap::BiHashMap;
@@ -201,7 +201,10 @@ impl NetworkSpec {
             return Ok(Some(ProtocolVersion::V0));
         };
 
-        // We assume our supported protocol versions are ordered from most old to most recent.
+        // Convert `their_supported_versions` to a HashSet for O(1) lookups.
+        let their_supported_versions = their_supported_versions.iter().collect::<HashSet<_>>();
+
+        // We assume our supported protocol versions are ordered chronologically.
         // Hence, we iterate in reverse order to find the latest common version.
         for version in self.supported_protocol_versions.iter().rev() {
             if their_supported_versions.contains(version) {

--- a/crates/ethportal-api/src/types/protocol_versions.rs
+++ b/crates/ethportal-api/src/types/protocol_versions.rs
@@ -1,0 +1,138 @@
+use std::ops::Deref;
+
+use alloy::primitives::Bytes;
+use alloy_rlp::{Decodable, Encodable};
+use ssz::{Decode, Encode};
+use ssz_derive::{Decode, Encode};
+use ssz_types::{typenum::U8, VariableList};
+
+pub const ENR_PROTOCOL_VERSION_KEY: &str = "pv";
+
+/// Portal Protocol Versions
+///
+/// https://github.com/ethereum/portal-network-specs/blob/master/protocol-version-changelog.md
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProtocolVersion {
+    /// The initial version of the protocol.
+    V0,
+    /// Adds `accept codes` and varint size encoding for find content messages.
+    V1,
+    /// Unspecified version is a version that we don't know about, but the other side does.
+    UnspecifiedVersion(u8),
+}
+
+impl From<ProtocolVersion> for u8 {
+    fn from(version: ProtocolVersion) -> u8 {
+        match version {
+            ProtocolVersion::V0 => 0,
+            ProtocolVersion::V1 => 1,
+            ProtocolVersion::UnspecifiedVersion(version) => version,
+        }
+    }
+}
+
+impl From<u8> for ProtocolVersion {
+    fn from(version: u8) -> ProtocolVersion {
+        match version {
+            0 => ProtocolVersion::V0,
+            1 => ProtocolVersion::V1,
+            version => ProtocolVersion::UnspecifiedVersion(version),
+        }
+    }
+}
+
+impl Encode for ProtocolVersion {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        u8::from(*self).ssz_append(buf);
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        1
+    }
+
+    fn ssz_fixed_len() -> usize {
+        1
+    }
+}
+
+impl Decode for ProtocolVersion {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        let value = u8::from_ssz_bytes(bytes)?;
+        Ok(ProtocolVersion::from(value))
+    }
+
+    fn ssz_fixed_len() -> usize {
+        1
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+#[ssz(struct_behaviour = "transparent")]
+pub struct ProtocolVersionList(pub VariableList<ProtocolVersion, U8>);
+
+impl ProtocolVersionList {
+    pub fn new(versions: Vec<ProtocolVersion>) -> Self {
+        Self(VariableList::from(versions))
+    }
+}
+
+impl Deref for ProtocolVersionList {
+    type Target = [ProtocolVersion];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Encodable for ProtocolVersionList {
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        let ssz_bytes = self.as_ssz_bytes();
+        let bytes = Bytes::from(ssz_bytes);
+        bytes.encode(out);
+    }
+}
+
+impl Decodable for ProtocolVersionList {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let bytes = Bytes::decode(buf)?;
+        let supported_versions = ProtocolVersionList::from_ssz_bytes(&bytes)
+            .map_err(|_| alloy_rlp::Error::Custom("Failed to decode SSZ ProtocolVersionList"))?;
+        Ok(supported_versions)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use discv5::{enr::CombinedKey, Enr};
+
+    use super::*;
+
+    #[test]
+    fn test_encode_decode_protocol_version_key() {
+        let enr = {
+            let mut builder = Enr::builder();
+
+            builder.add_value(
+                ENR_PROTOCOL_VERSION_KEY,
+                &ProtocolVersionList::new(vec![ProtocolVersion::V0]),
+            );
+
+            builder.build(&CombinedKey::generate_secp256k1()).unwrap()
+        };
+
+        assert_eq!(
+            enr.get_decodable::<ProtocolVersionList>(ENR_PROTOCOL_VERSION_KEY)
+                .expect("Protocol Version key doesn't exist")
+                .expect("Failed to decode Protocol Version value"),
+            ProtocolVersionList::new(vec![ProtocolVersion::V0])
+        );
+    }
+}


### PR DESCRIPTION
### What was wrong?
We don't support Protocol versioning https://github.com/ethereum/portal-network-specs/pull/379
### How was it fixed?

By implementing the specification change. Currently Trin on Mainnet is only set to support `v0`. I set Angelfood to `v0, v1` just because, no body uses AngelFood, but this allows us to easily test changes for V1 in Hive potentially. In the future we could probably just pass a custom `NetworkSpec` through the CLI for testing this kind of stuff in hive

`v1` should be added to the `NetworkSpec.supported_protocol_versions` once we support it and want to enable it on the network.

### To-Do in followup PR's

This PR doesn't implement the `V1`

`V1` will be 2 changes
- https://github.com/ethereum/trin/pull/1720 I will rebase this PR and modify it to exist in the `Protocol Versions` context
- https://github.com/ethereum/portal-network-specs/pull/383 varint size prefix for `FindContent/Content request/response`

So I will implement these 2 features in separate PR's, then we can enable `V1` when we want to
