### PR TITLE
feat: implement protocol version 1 findcontent utp varint encoding

### DIFF
--- a/crates/portalnet/src/overlay/service/offer.rs
+++ b/crates/portalnet/src/overlay/service/offer.rs
@@ -9,6 +9,7 @@ use ethportal_api::{
         distance::Metric,
         enr::Enr,
         portal_wire::{Accept, Content, FindContent, Offer, OfferTrace, Request, Response},
+        protocol_versions::ProtocolVersion,
     },
     OverlayContentKey, RawContentKey, RawContentValue,
 };
@@ -30,7 +31,7 @@ use crate::{
         request::{OverlayRequest, RequestDirection},
     },
     put_content::propagate_put_content_cross_thread,
-    utils::portal_wire,
+    utils::portal_wire::{self, decode_single_content_payload},
     utp::timed_semaphore::OwnedTimedSemaphorePermit,
 };
 
@@ -206,7 +207,7 @@ impl<
                                 // fallback peers on an error.
                                 if let Err(err) = Self::fallback_find_content(
                                     content_key.clone(),
-                                    utp_processing,
+                                    utp_processing,protocol_version
                                 )
                                 .await {
                                     debug!(%err, ?content_key, "Fallback FINDCONTENT task failed, after uTP transfer failed");
@@ -233,7 +234,7 @@ impl<
                             tokio::spawn(async move {
                                 if let Err(err) = Self::fallback_find_content(
                                     content_key.clone(),
-                                    utp_processing,
+                                    utp_processing,protocol_version
                                 )
                                 .await {
                                     debug!(%err, ?content_key, "Fallback FINDCONTENT task failed, decoding and validating content payload failed");
@@ -268,7 +269,7 @@ impl<
                                 // Spawn a fallback FINDCONTENT task for each content key
                                 // that failed individual processing.
                                 if let Err(err) = Self::fallback_find_content(
-                                    key.clone(), utp_processing,
+                                    key.clone(), utp_processing,protocol_version
                                 )
                                 .await {
                                     debug!(%err, ?key, "Fallback FINDCONTENT task failed, after validating and storing content failed");
@@ -447,6 +448,7 @@ impl<
     async fn fallback_find_content(
         content_key: TContentKey,
         utp_processing: UtpProcessing<TValidator, TStore, TContentKey>,
+        protocol_version: ProtocolVersion,
     ) -> anyhow::Result<()> {
         let fallback_peer = match utp_processing
             .accept_queue
@@ -488,10 +490,20 @@ impl<
                             send: conn_id.wrapping_add(1),
                             peer_id: fallback_peer.node_id(),
                         };
-                        utp_processing
+                        let bytes = utp_processing
                             .utp_controller
                             .connect_inbound_stream(cid, UtpPeer(fallback_peer.clone()))
-                            .await?
+                            .await?;
+
+                        match protocol_version.is_v1_enabled() {
+                            true => match decode_single_content_payload(bytes) {
+                                Ok(bytes) => bytes,
+                                Err(err) => bail!(
+                                    "Unable to decode content payload from FINDCONTENT v1 response {err:?}",
+                                ),
+                            },
+                            false => bytes,
+                        }
                     }
                 }
             }

--- a/crates/portalnet/src/overlay/service/offer.rs
+++ b/crates/portalnet/src/overlay/service/offer.rs
@@ -207,7 +207,8 @@ impl<
                                 // fallback peers on an error.
                                 if let Err(err) = Self::fallback_find_content(
                                     content_key.clone(),
-                                    utp_processing,protocol_version
+                                    utp_processing,
+                                    protocol_version
                                 )
                                 .await {
                                     debug!(%err, ?content_key, "Fallback FINDCONTENT task failed, after uTP transfer failed");
@@ -234,7 +235,8 @@ impl<
                             tokio::spawn(async move {
                                 if let Err(err) = Self::fallback_find_content(
                                     content_key.clone(),
-                                    utp_processing,protocol_version
+                                    utp_processing,
+                                    protocol_version
                                 )
                                 .await {
                                     debug!(%err, ?content_key, "Fallback FINDCONTENT task failed, decoding and validating content payload failed");
@@ -269,7 +271,9 @@ impl<
                                 // Spawn a fallback FINDCONTENT task for each content key
                                 // that failed individual processing.
                                 if let Err(err) = Self::fallback_find_content(
-                                    key.clone(), utp_processing,protocol_version
+                                    key.clone(),
+                                    utp_processing,
+                                    protocol_version
                                 )
                                 .await {
                                     debug!(%err, ?key, "Fallback FINDCONTENT task failed, after validating and storing content failed");

--- a/crates/portalnet/src/utils/portal_wire.rs
+++ b/crates/portalnet/src/utils/portal_wire.rs
@@ -102,8 +102,8 @@ mod test {
         let varint_result = read_varint(&mut reader).unwrap();
         let bytes_read = original_len - reader.get_ref().len();
 
-        assert_eq!(varint_result, varint);
         assert_eq!(bytes_read, bytes_written);
+        assert_eq!(varint_result, varint);
     }
 
     #[test]

--- a/testing/ethportal-peertest/tests/self_peertest.rs
+++ b/testing/ethportal-peertest/tests/self_peertest.rs
@@ -88,24 +88,14 @@ mod protocol_v0 {
 
     const V0_NETWORK: Network = Network::Mainnet;
 
+    // offer tests
+
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn peertest_gossip_with_trace() {
         let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
         peertest::scenarios::put_content::test_gossip_with_trace(&peertest, &target, V0_NETWORK)
             .await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_history_gossip_dropped_with_find_content() {
-        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
-        peertest::scenarios::put_content::test_gossip_dropped_with_find_content(
-            &peertest, &target, V0_NETWORK,
-        )
-        .await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
     }
@@ -217,12 +207,65 @@ mod protocol_v0 {
         peertest.exit_all_nodes();
         handle.stop().unwrap();
     }
+
+    // find content tests
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_validate_block_body() {
+        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+        peertest::scenarios::validation::test_validate_pre_merge_block_body(&peertest, &target)
+            .await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_validate_receipts() {
+        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+        peertest::scenarios::validation::test_validate_pre_merge_receipts(&peertest, &target).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_history_gossip_dropped_with_find_content() {
+        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+        peertest::scenarios::put_content::test_gossip_dropped_with_find_content(
+            &peertest, &target, V0_NETWORK,
+        )
+        .await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_recursive_utp() {
+        let (peertest, _target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+        peertest::scenarios::utp::test_recursive_utp(&peertest).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_trace_recursive_utp() {
+        let (peertest, _target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+        peertest::scenarios::utp::test_trace_recursive_utp(&peertest).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
 }
 
 mod protocol_v1 {
     use super::*;
 
     const V1_NETWORK: Network = Network::Angelfood;
+
+    // offer tests
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
@@ -236,18 +279,6 @@ mod protocol_v1 {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn peertest_history_gossip_dropped_with_find_content() {
-        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
-        peertest::scenarios::put_content::test_gossip_dropped_with_find_content(
-            &peertest, &target, V1_NETWORK,
-        )
-        .await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
     async fn peertest_history_gossip_dropped_with_offer() {
         let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
         peertest::scenarios::put_content::test_gossip_dropped_with_offer(
@@ -359,6 +390,57 @@ mod protocol_v1 {
             &peertest, &target,
         )
         .await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    // find content tests
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_validate_block_body() {
+        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+        peertest::scenarios::validation::test_validate_pre_merge_block_body(&peertest, &target)
+            .await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_validate_receipts() {
+        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+        peertest::scenarios::validation::test_validate_pre_merge_receipts(&peertest, &target).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_history_gossip_dropped_with_find_content() {
+        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+        peertest::scenarios::put_content::test_gossip_dropped_with_find_content(
+            &peertest, &target, V1_NETWORK,
+        )
+        .await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_recursive_utp() {
+        let (peertest, _target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+        peertest::scenarios::utp::test_recursive_utp(&peertest).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_trace_recursive_utp() {
+        let (peertest, _target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+        peertest::scenarios::utp::test_trace_recursive_utp(&peertest).await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
     }
@@ -438,44 +520,6 @@ async fn peertest_validate_pre_merge_header_by_number() {
 async fn peertest_invalidate_header_by_hash() {
     let (peertest, target, handle) = setup_peertest(Network::Mainnet, &[Subnetwork::History]).await;
     peertest::scenarios::validation::test_invalidate_header_by_hash(&peertest, &target).await;
-    peertest.exit_all_nodes();
-    handle.stop().unwrap();
-}
-
-#[tokio::test(flavor = "multi_thread")]
-#[serial]
-async fn peertest_validate_block_body() {
-    let (peertest, target, handle) = setup_peertest(Network::Mainnet, &[Subnetwork::History]).await;
-    peertest::scenarios::validation::test_validate_pre_merge_block_body(&peertest, &target).await;
-    peertest.exit_all_nodes();
-    handle.stop().unwrap();
-}
-
-#[tokio::test(flavor = "multi_thread")]
-#[serial]
-async fn peertest_validate_receipts() {
-    let (peertest, target, handle) = setup_peertest(Network::Mainnet, &[Subnetwork::History]).await;
-    peertest::scenarios::validation::test_validate_pre_merge_receipts(&peertest, &target).await;
-    peertest.exit_all_nodes();
-    handle.stop().unwrap();
-}
-
-#[tokio::test(flavor = "multi_thread")]
-#[serial]
-async fn peertest_recursive_utp() {
-    let (peertest, _target, handle) =
-        setup_peertest(Network::Mainnet, &[Subnetwork::History]).await;
-    peertest::scenarios::utp::test_recursive_utp(&peertest).await;
-    peertest.exit_all_nodes();
-    handle.stop().unwrap();
-}
-
-#[tokio::test(flavor = "multi_thread")]
-#[serial]
-async fn peertest_trace_recursive_utp() {
-    let (peertest, _target, handle) =
-        setup_peertest(Network::Mainnet, &[Subnetwork::History]).await;
-    peertest::scenarios::utp::test_trace_recursive_utp(&peertest).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
 }


### PR DESCRIPTION
### What was wrong?
We don't support portal wire version 1 yet. This PR implements https://github.com/ethereum/portal-network-specs/pull/383 the new varint encoding on find_content uTP transfers
### How was it fixed?

Implementing it.

I also ended up setting some ethportal-peertests to test it as well, by making them run under angelfood which has v1 enabled already
