### PR TITLE
chore: bump ethportal-api version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "ethportal-api"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "alloy",
  "alloy-rlp",

--- a/crates/ethportal-api/Cargo.toml
+++ b/crates/ethportal-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethportal-api"
-version = "0.6.0"
+version = "0.7.0"
 description = "Definitions for various Ethereum Portal Network JSONRPC APIs"
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
### What was wrong?
ethportal-api needs a version bump for release
### How was it fixed?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
