### PR TITLE
fix: offer JsonRPC result was using wrong format for last 2 years

### DIFF
--- a/crates/ethportal-api/src/types/portal.rs
+++ b/crates/ethportal-api/src/types/portal.rs
@@ -68,11 +68,7 @@ pub const MAX_CONTENT_KEYS_PER_OFFER: usize = 64;
 
 /// Response for Offer endpoint
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AcceptInfo {
-    #[serde(with = "accept_code_hex")]
-    pub content_keys: AcceptCodeList,
-}
+pub struct AcceptInfo(#[serde(with = "accept_code_hex")] pub AcceptCodeList);
 
 /// Response for PutContent endpoint
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/subnetworks/beacon/src/jsonrpc.rs
+++ b/crates/subnetworks/beacon/src/jsonrpc.rs
@@ -368,9 +368,7 @@ async fn offer(
         .map(|(key, value)| (key.to_bytes(), value.encode()))
         .collect();
     match network.overlay.send_offer(enr, content_items).await {
-        Ok(accept_code_list) => Ok(json!(AcceptInfo {
-            content_keys: accept_code_list,
-        })),
+        Ok(accept_code_list) => Ok(json!(AcceptInfo(accept_code_list))),
         Err(msg) => Err(format!("Offer request timeout: {msg:?}")),
     }
 }

--- a/crates/subnetworks/history/src/jsonrpc.rs
+++ b/crates/subnetworks/history/src/jsonrpc.rs
@@ -314,9 +314,7 @@ async fn offer(
         .map(|(key, value)| (key.to_bytes(), value.encode()))
         .collect();
     match network.overlay.send_offer(enr, content_items).await {
-        Ok(accept_code_list) => Ok(json!(AcceptInfo {
-            content_keys: accept_code_list,
-        })),
+        Ok(accept_code_list) => Ok(json!(AcceptInfo(accept_code_list))),
         Err(msg) => Err(format!("Offer request timeout: {msg:?}")),
     }
 }

--- a/crates/subnetworks/state/src/jsonrpc.rs
+++ b/crates/subnetworks/state/src/jsonrpc.rs
@@ -314,9 +314,7 @@ async fn offer(
             .overlay
             .send_offer(enr, content_items)
             .await
-            .map(|accept_code_list| AcceptInfo {
-                content_keys: accept_code_list,
-            }),
+            .map(AcceptInfo),
     )
 }
 

--- a/testing/ethportal-peertest/src/scenarios/offer_accept.rs
+++ b/testing/ethportal-peertest/src/scenarios/offer_accept.rs
@@ -42,7 +42,7 @@ pub async fn test_offer(peertest: &Peertest, target: &Client) {
     // Check that ACCEPT response sent by bootnode accepted the offered content
     let mut accept_code_list = AcceptCodeList::new(1).unwrap();
     accept_code_list.set(0, AcceptCode::Accepted);
-    assert_eq!(result.content_keys, accept_code_list);
+    assert_eq!(result.0, accept_code_list);
 
     // Check if the stored content value in bootnode's DB matches the offered
     assert_eq!(


### PR DESCRIPTION
### What was wrong?
This problem was reported by both Shisui and fluffy today https://discordapp.com/channels/890617081744220180/1115672797046394890/1360071808966987806

Basically the spec
![image](https://github.com/user-attachments/assets/7558bc5a-ca59-4182-96f5-2f679372928b)

specifies offer to just return a hex string, but we are instead returning ``{ "content_keys": hex_string }``

This bug has been present for over 2 years at least. But it wasn't detected due to us not handling the Offers result in hive well testing till today, where I decided to handle the result.

### How was it fixed?

converting
```rust
/// Response for Offer endpoint
#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
#[serde(rename_all = "camelCase")]
pub struct AcceptInfo {
    #[serde(with = "accept_code_hex")]
    pub content_keys: AcceptCodeList,
}
```

to 

```rust
pub struct AcceptInfo(#[serde(with = "accept_code_hex")] pub AcceptCodeList);
```