### PR TITLE
perf: make e2hs writer 44x faster for generating E2HS files from Era1 files

### DIFF
--- a/bin/e2hs-writer/src/reader.rs
+++ b/bin/e2hs-writer/src/reader.rs
@@ -93,9 +93,9 @@ impl EpochReader {
     }
 
     fn get_pre_merge_block_data(&self, block_number: u64) -> anyhow::Result<AllBlockData> {
-        let raw_era1 = self.era_provider.get_era1_for_block(block_number)?;
+        let era1: Arc<Era1> = self.era_provider.get_era1_for_block(block_number)?;
         let block_index = block_number % EPOCH_SIZE;
-        let tuple = Era1::get_tuple_by_index(&raw_era1, block_index as usize)?;
+        let tuple = era1.block_tuples[block_index as usize].clone();
         let header = tuple.header.header;
         let Some(epoch_acc) = &self.epoch_accumulator else {
             bail!("Epoch accumulator not found for pre-merge block: {block_number}")

--- a/crates/e2store/src/e2hs.rs
+++ b/crates/e2store/src/e2hs.rs
@@ -71,11 +71,6 @@ impl E2HS {
         }))
     }
 
-    pub fn get_tuple_by_index(raw_e2hs: &[u8], index: usize) -> anyhow::Result<BlockTuple> {
-        let file = E2StoreMemory::deserialize(raw_e2hs)?;
-        BlockTuple::try_from(&file.entries[index * 3 + 1..index * 3 + 4])
-    }
-
     pub fn deserialize(buf: &[u8]) -> anyhow::Result<Self> {
         let file = E2StoreMemory::deserialize(buf)?;
         ensure!(
@@ -291,7 +286,8 @@ mod tests {
     #[case(8191)]
     fn test_e2hs_block_index(#[case] block_number: usize) {
         let raw_e2hs = fs::read("../../test_assets/era1/mainnet-00000-a6860fef.e2hs").unwrap();
-        let block_tuple = E2HS::get_tuple_by_index(&raw_e2hs, block_number).unwrap();
+        let e2hs = E2HS::deserialize(&raw_e2hs).expect("failed to deserialize e2hs");
+        let block_tuple = &e2hs.block_tuples[block_number];
         assert_eq!(
             block_tuple
                 .header_with_proof

--- a/crates/e2store/src/era1.rs
+++ b/crates/e2store/src/era1.rs
@@ -63,11 +63,6 @@ impl Era1 {
         })
     }
 
-    pub fn get_tuple_by_index(raw_era1: &[u8], index: usize) -> anyhow::Result<BlockTuple> {
-        let file = E2StoreMemory::deserialize(raw_era1)?;
-        BlockTuple::try_from(&file.entries[index * 4 + 1..index * 4 + 5])
-    }
-
     pub fn deserialize(buf: &[u8]) -> anyhow::Result<Self> {
         let file = E2StoreMemory::deserialize(buf)?;
         ensure!(


### PR DESCRIPTION
### What was wrong?

We where deserializing the Era1 file every time for every block retrieved from the Era1 file. So we were deserializing the Era1 file 8192 times. 

Before time: 8m27.011s

After my fix: 0m11.451s


^ these results came from generating E2HS file 1655
### How was it fixed?

I removed `get_tuple_by_index()` as the function is just not good and encourages bad patterns. Instead of using `get_tuple_by_index` I decoded the Era1 file once, then parsed the `block_tuple` out when needed

