### PR TITLE
fix: e2hs-writer can't generate merge transition e2hs file

### DIFF
--- a/bin/e2hs-writer/src/provider.rs
+++ b/bin/e2hs-writer/src/provider.rs
@@ -24,7 +24,7 @@ pub struct EraProvider {
 }
 
 pub enum EraSource {
-    // raw era1 file
+    // processed era1 file
     PreMerge(Arc<Era1>),
     // processed era file
     PostMerge(Arc<Era>),

--- a/bin/e2hs-writer/src/writer.rs
+++ b/bin/e2hs-writer/src/writer.rs
@@ -26,7 +26,8 @@ impl EpochWriter {
         let mut block_tuples: Vec<BlockTuple> = vec![];
         let mut block_stream = Box::pin(reader.iter_blocks());
 
-        while let Some(Ok(block_data)) = block_stream.next().await {
+        while let Some(block_data) = block_stream.next().await {
+            let block_data = block_data?;
             info!(
                 "Writing block {}",
                 block_data.header_with_proof.header.number


### PR DESCRIPTION
### What was wrong?

When I tried to generate E2HS 1896 which is the E2HS file which includes the merge boundary. So we use both ERA and ERA1 files in generating this E2HS file unlike all the other files. But when I attempted to build E2HS file 1896 it failed. This was due to E2HS 1896 requiring access to ERA1 1896 and ERA 574&575 to get all the blocks required to build E2HS 1896.

### How was it fixed?

I made it so the provider code could optionally download a 3rd Era file, only if e2hs-writer is building the E2hs file 1896
