### PR TITLE
perf: make e2hs writer 6.35x faster for processing Era files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,6 +2204,7 @@ dependencies = [
  "ethereum_ssz",
  "ethportal-api",
  "futures",
+ "humanize-duration",
  "portal-bridge",
  "reqwest",
  "rstest",

--- a/bin/e2hs-writer/Cargo.toml
+++ b/bin/e2hs-writer/Cargo.toml
@@ -20,6 +20,7 @@ e2store.workspace = true
 ethereum_ssz.workspace = true
 ethportal-api.workspace = true
 futures.workspace = true
+humanize-duration.workspace = true
 portal-bridge.workspace = true
 reqwest.workspace = true
 rstest.workspace = true

--- a/bin/e2hs-writer/src/main.rs
+++ b/bin/e2hs-writer/src/main.rs
@@ -7,7 +7,10 @@ pub mod reader;
 pub mod utils;
 pub mod writer;
 
+use std::time::Instant;
+
 use clap::Parser;
+use humanize_duration::{prelude::DurationExt, Truncate};
 use tracing::info;
 use trin_utils::log::init_tracing_logger;
 
@@ -19,9 +22,21 @@ async fn main() -> anyhow::Result<()> {
     info!("Running E2HS writer");
     let config = cli::WriterConfig::parse();
     info!("With configuration: {config:?}");
+
+    let start = Instant::now();
     let epoch_reader =
         EpochReader::new(config.epoch, config.epoch_acc_path, config.el_provider).await?;
+    info!(
+        "Time taken to download Era/Era1 and Receipts {}",
+        start.elapsed().human(Truncate::Second)
+    );
+
+    let start = Instant::now();
     let epoch_writer = EpochWriter::new(config.target_dir, config.epoch);
     epoch_writer.write_epoch(epoch_reader).await?;
+    info!(
+        "Time taken to finished writing blocks  {}",
+        start.elapsed().human(Truncate::Second)
+    );
     Ok(())
 }

--- a/bin/e2hs-writer/src/utils.rs
+++ b/bin/e2hs-writer/src/utils.rs
@@ -6,6 +6,7 @@ use alloy::{
     eips::eip4895::Withdrawal,
     primitives::{Bloom, B64, U256},
 };
+use anyhow::ensure;
 use ethportal_api::types::consensus::execution_payload::{
     ExecutionPayloadBellatrix, ExecutionPayloadCapella,
 };
@@ -16,7 +17,7 @@ pub fn pre_capella_execution_payload_to_header(
     transactions: &[TxEnvelope],
 ) -> anyhow::Result<Header> {
     let transactions_root = calculate_transaction_root(transactions);
-    Ok(Header {
+    let header = Header {
         parent_hash: payload.parent_hash,
         ommers_hash: EMPTY_UNCLE_ROOT_HASH,
         beneficiary: payload.fee_recipient,
@@ -38,7 +39,13 @@ pub fn pre_capella_execution_payload_to_header(
         excess_blob_gas: None,
         parent_beacon_block_root: None,
         requests_hash: None,
-    })
+    };
+
+    ensure!(
+        payload.block_hash == header.hash_slow(),
+        "Block hash mismatch"
+    );
+    Ok(header)
 }
 
 pub fn pre_deneb_execution_payload_to_header(
@@ -48,7 +55,7 @@ pub fn pre_deneb_execution_payload_to_header(
 ) -> anyhow::Result<Header> {
     let transactions_root = calculate_transaction_root(transactions);
     let withdrawals_root = calculate_withdrawals_root(withdrawals);
-    Ok(Header {
+    let header = Header {
         parent_hash: payload.parent_hash,
         ommers_hash: EMPTY_UNCLE_ROOT_HASH,
         beneficiary: payload.fee_recipient,
@@ -70,5 +77,11 @@ pub fn pre_deneb_execution_payload_to_header(
         excess_blob_gas: None,
         parent_beacon_block_root: None,
         requests_hash: None,
-    })
+    };
+
+    ensure!(
+        payload.block_hash == header.hash_slow(),
+        "Block hash mismatch"
+    );
+    Ok(header)
 }

--- a/bin/e2hs-writer/src/writer.rs
+++ b/bin/e2hs-writer/src/writer.rs
@@ -48,6 +48,7 @@ impl EpochWriter {
             };
             block_tuples.push(block_tuple);
         }
+
         assert_eq!(block_tuples.len(), BLOCK_TUPLE_COUNT);
         let version = VersionEntry {
             version: Entry::new(VERSION, vec![]),
@@ -87,7 +88,10 @@ impl EpochWriter {
             short_hash.trim_start_matches("0x")
         );
         std::fs::write(e2hs_path.clone(), raw_e2hs)?;
-        info!("Wrote epoch {} to {e2hs_path}", self.epoch);
+        info!(
+            "Wrote epoch {} to {e2hs_path}, Finished writing blocks in ",
+            self.epoch
+        );
         Ok(())
     }
 }

--- a/bin/e2hs-writer/src/writer.rs
+++ b/bin/e2hs-writer/src/writer.rs
@@ -88,10 +88,7 @@ impl EpochWriter {
             short_hash.trim_start_matches("0x")
         );
         std::fs::write(e2hs_path.clone(), raw_e2hs)?;
-        info!(
-            "Wrote epoch {} to {e2hs_path}, Finished writing blocks in ",
-            self.epoch
-        );
+        info!("Wrote epoch {} to {e2hs_path}", self.epoch);
         Ok(())
     }
 }

--- a/bin/portal-bridge/src/api/execution.rs
+++ b/bin/portal-bridge/src/api/execution.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use alloy::{
     consensus::{BlockBody as AlloyBlockBody, Header},
@@ -18,10 +18,9 @@ use ethportal_api::{
     utils::bytes::{hex_decode, hex_encode},
     HistoryContentKey, HistoryContentValue, Receipts,
 };
-use futures::future::join_all;
 use serde_json::{json, Value};
 use tokio::time::sleep;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 use trin_validation::{
     accumulator::PreMergeAccumulator, constants::MERGE_BLOCK_NUMBER,
     header_validator::HeaderValidator,
@@ -30,13 +29,13 @@ use url::Url;
 
 use crate::{
     cli::{url_to_client, ClientWithBaseUrl},
-    constants::{FALLBACK_RETRY_AFTER, GET_RECEIPTS_RETRY_AFTER},
+    constants::FALLBACK_RETRY_AFTER,
     types::full_header::FullHeader,
 };
 
 /// Limit the number of requests in a single batch to avoid exceeding the
-/// provider's batch size limit configuration of 100.
-const BATCH_LIMIT: usize = 100;
+/// provider's batch size limit configuration of 40.
+const BATCH_LIMIT: usize = 40;
 
 /// Implements endpoints from the Execution API to access data from the execution layer.
 /// Performs validation of the data returned from the provider.
@@ -212,52 +211,54 @@ impl ExecutionApi {
     }
 
     /// Return validated Receipts for the given block.
-    pub async fn get_receipts(
+    pub async fn get_receipts_and_validate(
         &self,
         block_number: u64,
-        tx_count: usize,
         receipts_root: B256,
     ) -> anyhow::Result<Receipts> {
-        // Build receipts
-        let receipts = match tx_count {
-            0 => Receipts(vec![]),
-            _ => self.get_trusted_receipts(block_number).await?,
-        };
+        // Get receipt from HashMap
+        let mut receipts = self.get_receipts(block_number..=block_number).await?;
+        let receipts = receipts
+            .remove(&block_number)
+            .ok_or_else(|| anyhow!("Missing receipts for block {block_number}"))?;
 
         // Validate Receipts
         let actual_receipts_root = receipts.root();
         if actual_receipts_root != receipts_root {
-            bail!(
-                "Receipts root doesn't match header receipts root: {actual_receipts_root:?} - {receipts_root:?}",
-            );
+            bail!("Receipts root doesn't match header receipts root: {actual_receipts_root:?} - {receipts_root:?}");
         }
+
         Ok(receipts)
     }
 
-    /// Return unvalidated receipts for the given transaction hashes.
-    async fn get_trusted_receipts(&self, height: u64) -> anyhow::Result<Receipts> {
-        let block_param = format!("0x{height:01X}");
-        // At this custom retry mechanism, the json-rpc is unreliable, we only call this function if
-        // we know the receipts should exist, but they might not be ready yet for any reason and the
-        // full-node will retry null, so we will just retry 3 times as we know they have it.
-        for _ in 0..3 {
-            let params = Params::Array(vec![json!(block_param)]);
-            let request = JsonRequest::new("eth_getBlockReceipts".to_string(), params, 1);
-            let response = self.try_request(request).await?;
-            let result = response.get("result").ok_or_else(|| {
-                anyhow!("Unable to fetch block receipts result for height: {height:?} {response:?}")
-            })?;
+    pub async fn get_receipts<I>(&self, block_range: I) -> anyhow::Result<HashMap<u64, Receipts>>
+    where
+        I: IntoIterator<Item = u64>,
+    {
+        let mut batch_request = vec![];
+        let mut block_numbers = vec![];
 
-            // Check if the result is null, if so, sleep and retry.
-            if result.is_null() {
-                sleep(GET_RECEIPTS_RETRY_AFTER).await;
-                continue;
-            }
-            return serde_json::from_value(response).map_err(|err| {
-                anyhow!("Unable to parse receipts from provider response: {err:?}")
-            });
+        for (id, block_number) in block_range.into_iter().enumerate() {
+            let block_param = format!("0x{block_number:01X}");
+            let params = Params::Array(vec![json!(block_param)]);
+            let request = JsonRequest::new("eth_getBlockReceipts".to_string(), params, id as u32);
+            batch_request.push(request);
+            block_numbers.push(block_number);
         }
-        bail!("Unable to fetch receipts for block: {height:?}");
+
+        let response = self.batch_requests(batch_request).await?;
+        let response: Vec<Value> = serde_json::from_str(&response).map_err(|e| anyhow!(e))?;
+
+        let mut receipts = HashMap::new();
+        for (i, res) in response.into_iter().enumerate() {
+            let block_number = block_numbers[i];
+            let receipt: Receipts = serde_json::from_value(res).map_err(|err| {
+                anyhow!("Unable to parse receipts for block {block_number} from provider response: {err:?}")
+            })?;
+            receipts.insert(block_number, receipt);
+        }
+
+        Ok(receipts)
     }
 
     pub async fn get_block_hash(&self, height: u64) -> anyhow::Result<B256> {
@@ -291,20 +292,18 @@ impl ExecutionApi {
     }
 
     async fn batch_requests(&self, obj: Vec<JsonRequest>) -> anyhow::Result<String> {
-        let batched_request_futures = obj
-            .chunks(BATCH_LIMIT)
-            .map(|chunk| self.try_batch_request(chunk.to_vec()))
-            .collect::<Vec<_>>();
-        match join_all(batched_request_futures)
-            .await
-            .into_iter()
-            .try_fold(Vec::new(), |mut acc, next| {
-                acc.extend_from_slice(&next?);
-                Ok::<Vec<Value>, Box<dyn std::error::Error>>(acc)
-            }) {
-            Ok(val) => Ok(serde_json::to_string(&val)?),
-            Err(err) => Err(anyhow!("Unable to flatten batch request: {err:?}")),
+        let mut all_responses = Vec::new();
+
+        for chunk in obj.chunks(BATCH_LIMIT) {
+            info!("Sending batch request with {} requests", chunk.len());
+            let responses = self
+                .try_batch_request(chunk.to_vec())
+                .await
+                .map_err(|err| anyhow!("Batch request failed: {err:?}"))?;
+            all_responses.extend(responses);
         }
+
+        Ok(serde_json::to_string(&all_responses)?)
     }
 
     async fn try_batch_request(&self, requests: Vec<JsonRequest>) -> anyhow::Result<Vec<Value>> {

--- a/bin/portal-bridge/src/api/execution.rs
+++ b/bin/portal-bridge/src/api/execution.rs
@@ -250,8 +250,7 @@ impl ExecutionApi {
         let response: Vec<Value> = serde_json::from_str(&response).map_err(|e| anyhow!(e))?;
 
         let mut receipts = HashMap::new();
-        for (i, res) in response.into_iter().enumerate() {
-            let block_number = block_numbers[i];
+        for (res, block_number) in response.into_iter().zip(block_numbers.into_iter()) {
             let receipt: Receipts = serde_json::from_value(res).map_err(|err| {
                 anyhow!("Unable to parse receipts for block {block_number} from provider response: {err:?}")
             })?;

--- a/bin/portal-bridge/src/api/execution.rs
+++ b/bin/portal-bridge/src/api/execution.rs
@@ -34,8 +34,8 @@ use crate::{
 };
 
 /// Limit the number of requests in a single batch to avoid exceeding the
-/// provider's batch size limit configuration of 40.
-const BATCH_LIMIT: usize = 40;
+/// provider's batch size limit configuration of 30.
+const BATCH_LIMIT: usize = 30;
 
 /// Implements endpoints from the Execution API to access data from the execution layer.
 /// Performs validation of the data returned from the provider.

--- a/bin/portal-bridge/src/bridge/history.rs
+++ b/bin/portal-bridge/src/bridge/history.rs
@@ -361,11 +361,7 @@ impl HistoryBridge {
     ) -> anyhow::Result<()> {
         let timer = metrics.start_process_timer("construct_and_gossip_receipt");
         let receipts = execution_api
-            .get_receipts(
-                full_header.header.number,
-                full_header.txs.len(),
-                full_header.header.receipts_root,
-            )
+            .get_receipts_and_validate(full_header.header.number, full_header.header.receipts_root)
             .await?;
         let content_key = HistoryContentKey::new_block_receipts(full_header.header.hash_slow());
         let content_value = HistoryContentValue::Receipts(receipts);


### PR DESCRIPTION
### What was wrong?

When I was testing generating post-merge E2HS files it was extremely slow taking 60+ minutes. My first thought was it was so slow because for every block we would call the Ethereum JSON-RPC to fetch the receipts. And after trying my fix in this PR I was right.

### How was it fixed?

- I implemented batch downloading for receipts while initializing the e2hs-reader instead of fetching the receipts on demand which was very slow
- downloading ERA files are super slow so I made it so `downloading the era files` and `downloading the receipts` are done in parallel and it saved around 2 minutes from my testing.

So my initial run on master took
60+ minutes and I was using the JSON-RPC provider `https://geth-lighthouse.mainnet.eu1.ethpandaops.io/ `

I then tested a bunch of different EL's and regions to see which one performed best, `https://nethermind-nimbus.mainnet.na1.ethpandaops.io/` performed pretty much 2x faster then RETH and 1.5-2x faster then Geth

So using `https://nethermind-nimbus.mainnet.na1.ethpandaops.io/` on master I got 34m43.340s

After I implemented my 2 performance improvements

I got 5m28.023s on `https://nethermind-nimbus.mainnet.na1.ethpandaops.io/`

So I need to generate post-merge E2HS files from epoch 1897 to 2716, so I went from needing to run my computer for 19.77-34  days worst case.

To only needing to run my computer for 3.11 days to generate all the post-merge E2HS files. I will also run e2hs writer in 8 different processes doing 8 different ranges so I should hopefully be able to generate them all in 0.38. But since I will need to use different JSON-RPC providers which could be slower, it might take like 0.7 days?

In the time I gave to generate epoch 1897 5m28.023s

It took `4m18s` to download the receipts and ERA files and it took 1m10s to generate the E2HS file. For context