### PR TITLE
feat: make E2HS bridge fetch from http endpoint, instead of using local directory

### DIFF
--- a/bin/portal-bridge/README.md
+++ b/bin/portal-bridge/README.md
@@ -4,7 +4,7 @@ Process to feed the portal network by gossiping data retrieved from a trusted pr
 
 ex.
 ```sh
-cargo run -p portal-bridge -- --executable-path ./target/debug/trin
+cargo run -p portal-bridge --release -- --executable-path ./target/debug/trin
 ```
 
 ## Providers

--- a/bin/portal-bridge/src/main.rs
+++ b/bin/portal-bridge/src/main.rs
@@ -107,7 +107,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         bridge_config.gossip_limit,
                         e2hs_range,
                         bridge_config.e2hs_randomize,
-                    )?;
+                    )
+                    .await?;
                     let bridge_handle = tokio::spawn(async move {
                         e2hs_bridge
                             .launch()

--- a/bin/trin-execution/src/era/binary_search.rs
+++ b/bin/trin-execution/src/era/binary_search.rs
@@ -57,7 +57,7 @@ impl EraBinarySearch {
 
                 let decoded_era = Era::deserialize(&era_to_check)?;
                 if decoded_era.contains(block_number) {
-                    return process_era_file(era_to_check.to_vec(), mid);
+                    return process_era_file(&era_to_check, mid);
                 }
                 return Err(anyhow::anyhow!("Block not found in any era file"));
             }
@@ -83,7 +83,7 @@ impl EraBinarySearch {
 
                 let decoded_era = Era::deserialize(&era_to_check)?;
                 if decoded_era.contains(block_number) {
-                    return process_era_file(era_to_check.to_vec(), mid);
+                    return process_era_file(&era_to_check, mid);
                 }
             }
 

--- a/bin/trin-execution/src/era/manager.rs
+++ b/bin/trin-execution/src/era/manager.rs
@@ -128,8 +128,8 @@ impl EraManager {
             };
             let raw_era = download_raw_era(next_era_path, http_client.clone()).await?;
             match next_era_type {
-                EraType::Era1 => process_era1_file(raw_era.to_vec(), next_epoch_index),
-                EraType::Era => process_era_file(raw_era.to_vec(), next_epoch_index),
+                EraType::Era1 => process_era1_file(&raw_era, next_epoch_index),
+                EraType::Era => process_era_file(&raw_era, next_epoch_index),
             }
         });
         self.next_era = Some(join_handle);
@@ -149,7 +149,7 @@ impl EraManager {
             };
             let raw_era1 = download_raw_era(era1_path, http_client.clone()).await?;
 
-            return process_era1_file(raw_era1.to_vec(), epoch_index);
+            return process_era1_file(&raw_era1, epoch_index);
         }
 
         EraBinarySearch::find_era_file(http_client.clone(), block_number).await

--- a/bin/trin-execution/src/era/utils.rs
+++ b/bin/trin-execution/src/era/utils.rs
@@ -17,9 +17,9 @@ use crate::era::{
     types::{EraType, ProcessedBlock, TransactionsWithSender},
 };
 
-pub fn process_era1_file(raw_era1: Vec<u8>, epoch_index: u64) -> anyhow::Result<ProcessedEra> {
+pub fn process_era1_file(raw_era1: &[u8], epoch_index: u64) -> anyhow::Result<ProcessedEra> {
     let mut blocks = Vec::with_capacity(BLOCK_TUPLE_COUNT);
-    for BlockTuple { header, body, .. } in Era1::iter_tuples(raw_era1) {
+    for BlockTuple { header, body, .. } in Era1::iter_tuples(raw_era1)? {
         let transactions_with_recovered_senders = body
             .body
             .transactions
@@ -50,7 +50,7 @@ pub fn process_era1_file(raw_era1: Vec<u8>, epoch_index: u64) -> anyhow::Result<
     })
 }
 
-pub fn process_era_file(raw_era: Vec<u8>, epoch_index: u64) -> anyhow::Result<ProcessedEra> {
+pub fn process_era_file(raw_era: &[u8], epoch_index: u64) -> anyhow::Result<ProcessedEra> {
     let blocks = Era::iter_blocks(raw_era)?
         .map(|compressed_block| {
             Ok(compressed_block

--- a/bin/trin-execution/src/execution.rs
+++ b/bin/trin-execution/src/execution.rs
@@ -179,7 +179,7 @@ mod tests {
             .await
             .unwrap();
         let raw_era1 = fs::read("../../test_assets/era1/mainnet-00000-5ec1ffb8.era1").unwrap();
-        let processed_era = process_era1_file(raw_era1, 0).unwrap();
+        let processed_era = process_era1_file(&raw_era1, 0).unwrap();
         for block in processed_era.blocks {
             trin_execution.process_next_block().await.unwrap();
             assert_eq!(trin_execution.get_root().unwrap(), block.header.state_root);

--- a/crates/e2store/src/e2hs.rs
+++ b/crates/e2store/src/e2hs.rs
@@ -59,8 +59,8 @@ impl E2HS {
     /// Function to iterate over block tuples in an e2hs file
     /// this is useful for processing large e2hs files without storing the entire
     /// deserialized e2hs object in memory.
-    pub fn iter_tuples(raw_e2hs: Vec<u8>) -> anyhow::Result<impl Iterator<Item = BlockTuple>> {
-        let file = E2StoreMemory::deserialize(&raw_e2hs)?;
+    pub fn iter_tuples(raw_e2hs: &[u8]) -> anyhow::Result<impl Iterator<Item = BlockTuple>> {
+        let file = E2StoreMemory::deserialize(raw_e2hs)?;
         let last_entry = file.entries.last().ok_or(anyhow!(
             "invalid e2hs file found during iter: missing block index entry"
         ))?;

--- a/crates/e2store/src/era.rs
+++ b/crates/e2store/src/era.rs
@@ -93,10 +93,10 @@ impl Era {
 
     /// Iterate over beacon blocks.
     pub fn iter_blocks(
-        raw_era: Vec<u8>,
+        raw_era: &[u8],
     ) -> anyhow::Result<impl Iterator<Item = anyhow::Result<CompressedSignedBeaconBlock>>> {
         let file_length = raw_era.len();
-        let file = E2StoreMemory::deserialize(&raw_era)?;
+        let file = E2StoreMemory::deserialize(raw_era)?;
         let entries_length = file.entries.len();
         let block_index = SlotIndexBlockEntry::try_from(&file.entries[entries_length - 2])?;
         let slot_indexes = Era::get_block_slot_indexes(file_length, &block_index);

--- a/crates/e2store/src/utils.rs
+++ b/crates/e2store/src/utils.rs
@@ -54,36 +54,13 @@ async fn download_e2store_links(
 
 pub async fn get_era_files(http_client: &Client) -> anyhow::Result<HashMap<u64, String>> {
     let era_files = download_e2store_links(http_client, ERA_DIR_URL).await?;
-    ensure!(!era_files.is_empty(), "No era files found at {ERA_DIR_URL}");
-    let missing_epochs: Vec<String> = (0..era_files.len())
-        .filter(|&epoch_num| !era_files.contains_key(&(epoch_num as u64)))
-        .map(|epoch_num| epoch_num.to_string())
-        .collect();
-
-    ensure!(
-        missing_epochs.is_empty(),
-        "Epoch indices are not starting from zero or not consecutive: missing epochs [{}]",
-        missing_epochs.join(", ")
-    );
+    assert_nonempty_and_consecutive_epochs(&era_files)?;
     Ok(era_files)
 }
 
 pub async fn get_e2hs_files(http_client: &Client) -> anyhow::Result<HashMap<u64, String>> {
     let e2hs_files = download_e2store_links(http_client, E2HS_DIR_URL).await?;
-    ensure!(
-        !e2hs_files.is_empty(),
-        "No e2hs files found at {ERA_DIR_URL}"
-    );
-    let missing_epochs: Vec<String> = (0..e2hs_files.len())
-        .filter(|&epoch_num| !e2hs_files.contains_key(&(epoch_num as u64)))
-        .map(|epoch_num| epoch_num.to_string())
-        .collect();
-
-    ensure!(
-        missing_epochs.is_empty(),
-        "Epoch indices are not starting from zero or not consecutive: missing epochs [{}]",
-        missing_epochs.join(", ")
-    );
+    assert_nonempty_and_consecutive_epochs(&e2hs_files)?;
     Ok(e2hs_files)
 }
 
@@ -97,8 +74,19 @@ pub async fn get_era1_files(http_client: &Client) -> anyhow::Result<HashMap<u64,
             era1_files.len()
         )
     );
-    let missing_epochs: Vec<String> = (0..ERA1_FILE_COUNT)
-        .filter(|&epoch_num| !era1_files.contains_key(&(epoch_num as u64)))
+    assert_nonempty_and_consecutive_epochs(&era1_files)?;
+    Ok(era1_files)
+}
+
+pub async fn get_e2ss_files(http_client: &Client) -> anyhow::Result<HashMap<u64, String>> {
+    let e2ss_files = download_e2store_links(http_client, E2SS_DIR_URL).await?;
+    Ok(e2ss_files)
+}
+
+fn assert_nonempty_and_consecutive_epochs(files: &HashMap<u64, String>) -> anyhow::Result<()> {
+    ensure!(!files.is_empty(), "No e2store files found at {ERA_DIR_URL}");
+    let missing_epochs: Vec<String> = (0..files.len())
+        .filter(|&epoch_num| !files.contains_key(&(epoch_num as u64)))
         .map(|epoch_num| epoch_num.to_string())
         .collect();
 
@@ -107,12 +95,7 @@ pub async fn get_era1_files(http_client: &Client) -> anyhow::Result<HashMap<u64,
         "Epoch indices are not starting from zero or not consecutive: missing epochs [{}]",
         missing_epochs.join(", ")
     );
-    Ok(era1_files)
-}
-
-pub async fn get_e2ss_files(http_client: &Client) -> anyhow::Result<HashMap<u64, String>> {
-    let e2ss_files = download_e2store_links(http_client, E2SS_DIR_URL).await?;
-    Ok(e2ss_files)
+    Ok(())
 }
 
 /// Fetches era1 files hosted on era1.ethportal.net and shuffles them

--- a/crates/e2store/src/utils.rs
+++ b/crates/e2store/src/utils.rs
@@ -72,7 +72,7 @@ pub async fn get_e2hs_files(http_client: &Client) -> anyhow::Result<HashMap<u64,
     let e2hs_files = download_e2store_links(http_client, E2HS_DIR_URL).await?;
     ensure!(
         !e2hs_files.is_empty(),
-        "No era files found at {ERA_DIR_URL}"
+        "No e2hs files found at {ERA_DIR_URL}"
     );
     let missing_epochs: Vec<String> = (0..e2hs_files.len())
         .filter(|&epoch_num| !e2hs_files.contains_key(&(epoch_num as u64)))
@@ -97,9 +97,15 @@ pub async fn get_era1_files(http_client: &Client) -> anyhow::Result<HashMap<u64,
             era1_files.len()
         )
     );
+    let missing_epochs: Vec<String> = (0..ERA1_FILE_COUNT)
+        .filter(|&epoch_num| !era1_files.contains_key(&(epoch_num as u64)))
+        .map(|epoch_num| epoch_num.to_string())
+        .collect();
+
     ensure!(
-        (0..ERA1_FILE_COUNT).all(|epoch| era1_files.contains_key(&(epoch as u64))),
-        "Epoch indices are not starting from zero or not consecutive",
+        missing_epochs.is_empty(),
+        "Epoch indices are not starting from zero or not consecutive: missing epochs [{}]",
+        missing_epochs.join(", ")
     );
     Ok(era1_files)
 }

--- a/testing/ethportal-peertest/src/scenarios/offer_accept.rs
+++ b/testing/ethportal-peertest/src/scenarios/offer_accept.rs
@@ -342,7 +342,7 @@ pub async fn test_offer_concurrent_utp_transfer_limit(peertest: &Peertest, targe
     // this is a special-case era1 file for testing that contains the first 500 blocks
     // from this epoch.
     let era1 = fs::read("./test_assets/era1/test-mainnet-01896-xxxxxx.era1").unwrap();
-    let era1 = Era1::iter_tuples(era1);
+    let era1 = Era1::iter_tuples(&era1).unwrap();
 
     // collect keys to offer based on limit
     let tuples = era1.take(limit).collect::<Vec<_>>();


### PR DESCRIPTION
### What was wrong?

We didn't have an HTTP endpoint hosting E2HS files so we temporarily used a local directory system

### How was it fixed?

By using `https://e2hs.ethportal.net/` in the same way we used to use `https://era1.ethportal.net/` for our ERA1 bridge. Currently `https://e2hs.ethportal.net/` is broken because all of the links point to the index page, but that should be fixed tomorrow. The PR itself is good to go
