### PR TITLE
refactor: remove `TracePutContent` json-rpc endpoint

### DIFF
--- a/crates/ethportal-api/src/beacon.rs
+++ b/crates/ethportal-api/src/beacon.rs
@@ -17,7 +17,6 @@ use crate::{
         portal::{
             AcceptInfo, DataRadius, FindContentInfo, FindNodesInfo, GetContentInfo,
             PaginateLocalContentInfo, PongInfo, PutContentInfo, TraceContentInfo,
-            TracePutContentInfo,
         },
         portal_wire::OfferTrace,
     },
@@ -128,15 +127,6 @@ pub trait BeaconNetworkApi {
         content_key: BeaconContentKey,
         content_value: RawContentValue,
     ) -> RpcResult<PutContentInfo>;
-
-    /// Send the provided content value to interested peers. Clients may choose to send to some or
-    /// all peers. Return tracing info detailing the gossip propagation.
-    #[method(name = "beaconTracePutContent")]
-    async fn trace_put_content(
-        &self,
-        content_key: BeaconContentKey,
-        content_value: RawContentValue,
-    ) -> RpcResult<TracePutContentInfo>;
 
     /// Send an OFFER request with given ContentItems, to the designated peer and wait for a
     /// response. Does not store the content locally.

--- a/crates/ethportal-api/src/history.rs
+++ b/crates/ethportal-api/src/history.rs
@@ -10,7 +10,6 @@ use crate::{
         portal::{
             AcceptInfo, DataRadius, FindContentInfo, FindNodesInfo, GetContentInfo,
             PaginateLocalContentInfo, PongInfo, PutContentInfo, TraceContentInfo,
-            TracePutContentInfo,
         },
         portal_wire::OfferTrace,
     },
@@ -99,15 +98,6 @@ pub trait HistoryNetworkApi {
         content_key: HistoryContentKey,
         content_value: RawContentValue,
     ) -> RpcResult<PutContentInfo>;
-
-    /// Send the provided content value to interested peers. Clients may choose to send to some or
-    /// all peers. Return tracing info detailing the gossip propagation.
-    #[method(name = "historyTracePutContent")]
-    async fn trace_put_content(
-        &self,
-        content_key: HistoryContentKey,
-        content_value: RawContentValue,
-    ) -> RpcResult<TracePutContentInfo>;
 
     /// Send an OFFER request with given ContentItems, to the designated peer and wait for a
     /// response. Does not store the content locally.

--- a/crates/ethportal-api/src/state.rs
+++ b/crates/ethportal-api/src/state.rs
@@ -10,7 +10,6 @@ use crate::{
         portal::{
             AcceptInfo, DataRadius, FindContentInfo, FindNodesInfo, GetContentInfo,
             PaginateLocalContentInfo, PongInfo, PutContentInfo, TraceContentInfo,
-            TracePutContentInfo,
         },
         portal_wire::OfferTrace,
     },
@@ -96,15 +95,6 @@ pub trait StateNetworkApi {
         content_key: StateContentKey,
         content_value: RawContentValue,
     ) -> RpcResult<PutContentInfo>;
-
-    /// Send the provided content value to interested peers. Clients may choose to send to some or
-    /// all peers. Return tracing info detailing the gossip propagation.
-    #[method(name = "stateTracePutContent")]
-    async fn trace_put_content(
-        &self,
-        content_key: StateContentKey,
-        content_value: RawContentValue,
-    ) -> RpcResult<TracePutContentInfo>;
 
     /// Send an OFFER request with given ContentItems, to the designated peer and wait for a
     /// response. Does not store the content locally.

--- a/crates/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/crates/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -53,8 +53,6 @@ pub enum StateEndpoint {
     TraceOffer(Enr, StateContentKey, StateContentValue),
     /// params: [enr, content_key, content_value]
     PutContent(StateContentKey, StateContentValue),
-    /// params: [content_key, content_value]
-    TracePutContent(StateContentKey, StateContentValue),
     /// params: [offset, limit]
     PaginateLocalContentKeys(u64, u64),
 }
@@ -80,8 +78,6 @@ pub enum HistoryEndpoint {
     LookupEnr(NodeId),
     /// params: [content_key, content_value]
     PutContent(HistoryContentKey, HistoryContentValue),
-    /// params: [content_key, content_value]
-    TracePutContent(HistoryContentKey, HistoryContentValue),
     /// params: [enr, Vec<(content_key, content_value)>]
     Offer(Enr, Vec<(HistoryContentKey, HistoryContentValue)>),
     /// params: [enr, content_key, content_value]
@@ -136,8 +132,6 @@ pub enum BeaconEndpoint {
     LookupEnr(NodeId),
     /// params: [content_key, content_value]
     PutContent(BeaconContentKey, BeaconContentValue),
-    /// params: [content_key, content_value]
-    TracePutContent(BeaconContentKey, BeaconContentValue),
     /// params: [enr, Vec<(content_key, content_value>)]
     Offer(Enr, Vec<(BeaconContentKey, BeaconContentValue)>),
     /// params: [enr, content_key, content_value]

--- a/crates/ethportal-api/src/types/portal.rs
+++ b/crates/ethportal-api/src/types/portal.rs
@@ -80,18 +80,6 @@ pub struct PutContentInfo {
     pub stored_locally: bool,
 }
 
-/// Response for TracePutContent endpoint
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TracePutContentInfo {
-    /// List of all ENRs that were offered the content
-    pub offered: Vec<String>,
-    /// List of all ENRs that accepted the offer
-    pub accepted: Vec<String>,
-    /// List of all ENRs to whom the content was successfully transferred
-    pub transferred: Vec<String>,
-}
-
 /// Response for the FindContent endpoint
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]

--- a/crates/portalnet/src/overlay/protocol.rs
+++ b/crates/portalnet/src/overlay/protocol.rs
@@ -58,10 +58,7 @@ use crate::{
         errors::OverlayRequestError,
         request::{OverlayRequest, RequestDirection},
     },
-    put_content::{
-        propagate_put_content_cross_thread, trace_propagate_put_content_cross_thread,
-        PutContentResult,
-    },
+    put_content::propagate_put_content_cross_thread,
     types::{
         kbucket::{Entry, SharedKBucketsTable},
         node::Node,
@@ -261,23 +258,6 @@ impl<
             ) as u32,
             stored_locally: should_we_store,
         }
-    }
-
-    /// Propagate put content accepted content via OFFER/ACCEPT, returns trace detailing outcome of
-    /// put content
-    pub async fn propagate_put_content_trace(
-        &self,
-        content_key: TContentKey,
-        data: RawContentValue,
-    ) -> PutContentResult {
-        trace_propagate_put_content_cross_thread::<_, TMetric>(
-            content_key,
-            data,
-            &self.kbuckets,
-            self.command_tx.clone(),
-            self.discovery.network_spec.clone(),
-        )
-        .await
     }
 
     /// Returns a vector of all the ENRs of nodes currently contained in the routing table.

--- a/crates/rpc/src/beacon_rpc.rs
+++ b/crates/rpc/src/beacon_rpc.rs
@@ -16,7 +16,7 @@ use ethportal_api::{
         portal::{
             AcceptInfo, DataRadius, FindContentInfo, FindNodesInfo, GetContentInfo,
             PaginateLocalContentInfo, PongInfo, PutContentInfo, TraceContentInfo,
-            TracePutContentInfo, MAX_CONTENT_KEYS_PER_OFFER,
+            MAX_CONTENT_KEYS_PER_OFFER,
         },
         portal_wire::OfferTrace,
     },
@@ -191,19 +191,6 @@ impl BeaconNetworkApiServer for BeaconNetworkApi {
         let content_value = BeaconContentValue::decode(&content_key, &content_value)
             .map_err(RpcServeError::from)?;
         let endpoint = BeaconEndpoint::PutContent(content_key, content_value);
-        Ok(proxy_to_subnet(&self.network, endpoint).await?)
-    }
-
-    /// Send the provided content to interested peers. Clients may choose to send to some or all
-    /// peers. Return tracing info.
-    async fn trace_put_content(
-        &self,
-        content_key: BeaconContentKey,
-        content_value: RawContentValue,
-    ) -> RpcResult<TracePutContentInfo> {
-        let content_value = BeaconContentValue::decode(&content_key, &content_value)
-            .map_err(RpcServeError::from)?;
-        let endpoint = BeaconEndpoint::TracePutContent(content_key, content_value);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 

--- a/crates/rpc/src/history_rpc.rs
+++ b/crates/rpc/src/history_rpc.rs
@@ -9,7 +9,7 @@ use ethportal_api::{
         portal::{
             AcceptInfo, DataRadius, FindContentInfo, FindNodesInfo, GetContentInfo,
             PaginateLocalContentInfo, PongInfo, PutContentInfo, TraceContentInfo,
-            TracePutContentInfo, MAX_CONTENT_KEYS_PER_OFFER,
+            MAX_CONTENT_KEYS_PER_OFFER,
         },
         portal_wire::OfferTrace,
     },
@@ -147,19 +147,6 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
         let content_value = HistoryContentValue::decode(&content_key, &content_value)
             .map_err(RpcServeError::from)?;
         let endpoint = HistoryEndpoint::PutContent(content_key, content_value);
-        Ok(proxy_to_subnet(&self.network, endpoint).await?)
-    }
-
-    /// Send the provided content to interested peers. Clients may choose to send to some or all
-    /// peers. Return tracing info.
-    async fn trace_put_content(
-        &self,
-        content_key: HistoryContentKey,
-        content_value: RawContentValue,
-    ) -> RpcResult<TracePutContentInfo> {
-        let content_value = HistoryContentValue::decode(&content_key, &content_value)
-            .map_err(RpcServeError::from)?;
-        let endpoint = HistoryEndpoint::TracePutContent(content_key, content_value);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 

--- a/crates/rpc/src/state_rpc.rs
+++ b/crates/rpc/src/state_rpc.rs
@@ -7,7 +7,7 @@ use ethportal_api::{
         portal::{
             AcceptInfo, DataRadius, FindContentInfo, FindNodesInfo, GetContentInfo,
             PaginateLocalContentInfo, PongInfo, PutContentInfo, TraceContentInfo,
-            TracePutContentInfo, MAX_CONTENT_KEYS_PER_OFFER,
+            MAX_CONTENT_KEYS_PER_OFFER,
         },
         portal_wire::OfferTrace,
     },
@@ -142,19 +142,6 @@ impl StateNetworkApiServer for StateNetworkApi {
         let content_value =
             StateContentValue::decode(&content_key, &content_value).map_err(RpcServeError::from)?;
         let endpoint = StateEndpoint::PutContent(content_key, content_value);
-        Ok(proxy_to_subnet(&self.network, endpoint).await?)
-    }
-
-    /// Send the provided content to interested peers. Clients may choose to send to some or all
-    /// peers. Return tracing info.
-    async fn trace_put_content(
-        &self,
-        content_key: StateContentKey,
-        content_value: RawContentValue,
-    ) -> RpcResult<TracePutContentInfo> {
-        let content_value =
-            StateContentValue::decode(&content_key, &content_value).map_err(RpcServeError::from)?;
-        let endpoint = StateEndpoint::TracePutContent(content_key, content_value);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 

--- a/crates/subnetworks/beacon/src/jsonrpc.rs
+++ b/crates/subnetworks/beacon/src/jsonrpc.rs
@@ -62,10 +62,7 @@ async fn complete_request(network: Arc<BeaconNetwork>, request: BeaconJsonRpcReq
         BeaconEndpoint::FindNodes(enr, distances) => find_nodes(network, enr, distances).await,
         BeaconEndpoint::GetEnr(node_id) => get_enr(network, node_id).await,
         BeaconEndpoint::PutContent(content_key, content_value) => {
-            put_content(network, content_key, content_value, false).await
-        }
-        BeaconEndpoint::TracePutContent(content_key, content_value) => {
-            put_content(network, content_key, content_value, true).await
+            put_content(network, content_key, content_value).await
         }
         BeaconEndpoint::LightClientStore => light_client_store(&network).await,
         BeaconEndpoint::LookupEnr(node_id) => lookup_enr(network, node_id).await,
@@ -341,20 +338,11 @@ async fn put_content(
     network: Arc<BeaconNetwork>,
     content_key: BeaconContentKey,
     content_value: BeaconContentValue,
-    is_trace: bool,
 ) -> Result<Value, String> {
     let data = content_value.encode();
-    match is_trace {
-        true => Ok(json!(
-            network
-                .overlay
-                .propagate_put_content_trace(content_key, data)
-                .await
-        )),
-        false => Ok(json!(network
-            .overlay
-            .propagate_put_content(content_key, data))),
-    }
+    Ok(json!(network
+        .overlay
+        .propagate_put_content(content_key, data)))
 }
 
 /// Constructs a JSON call for the Offer method.

--- a/crates/subnetworks/history/src/jsonrpc.rs
+++ b/crates/subnetworks/history/src/jsonrpc.rs
@@ -63,9 +63,6 @@ async fn complete_request(network: Arc<HistoryNetwork>, request: HistoryJsonRpcR
         HistoryEndpoint::PutContent(content_key, content_value) => {
             put_content(network, content_key, content_value).await
         }
-        HistoryEndpoint::TracePutContent(content_key, content_value) => {
-            trace_put_content(network, content_key, content_value).await
-        }
         HistoryEndpoint::LookupEnr(node_id) => lookup_enr(network, node_id).await,
         HistoryEndpoint::Offer(enr, content_items) => offer(network, enr, content_items).await,
         HistoryEndpoint::TraceOffer(enr, content_key, content_value) => {
@@ -286,21 +283,6 @@ async fn put_content(
     Ok(json!(network
         .overlay
         .propagate_put_content(content_key, data)))
-}
-
-/// Constructs a JSON call for the PutContent method, with tracing enabled.
-async fn trace_put_content(
-    network: Arc<HistoryNetwork>,
-    content_key: HistoryContentKey,
-    content_value: ethportal_api::HistoryContentValue,
-) -> Result<Value, String> {
-    let data = content_value.encode();
-    Ok(json!(
-        network
-            .overlay
-            .propagate_put_content_trace(content_key, data)
-            .await
-    ))
 }
 
 /// Constructs a JSON call for the Offer method.

--- a/crates/subnetworks/state/src/jsonrpc.rs
+++ b/crates/subnetworks/state/src/jsonrpc.rs
@@ -67,22 +67,7 @@ impl StateRequestHandler {
                 trace_offer(network, enr, content_key, content_value).await
             }
             StateEndpoint::PutContent(content_key, content_value) => {
-                put_content(
-                    network,
-                    content_key,
-                    content_value,
-                    /* is_trace= */ false,
-                )
-                .await
-            }
-            StateEndpoint::TracePutContent(content_key, content_value) => {
-                put_content(
-                    network,
-                    content_key,
-                    content_value,
-                    /* is_trace= */ true,
-                )
-                .await
+                put_content(network, content_key, content_value).await
             }
             StateEndpoint::PaginateLocalContentKeys(offset, limit) => {
                 paginate(network, offset, limit)
@@ -337,21 +322,11 @@ async fn put_content(
     network: Arc<StateNetwork>,
     content_key: StateContentKey,
     content_value: StateContentValue,
-    is_trace: bool,
 ) -> Result<Value, String> {
-    if is_trace {
-        Ok(json!(
-            network
-                .overlay
-                .propagate_put_content_trace(content_key, content_value.encode())
-                .await
-        ))
-    } else {
-        Ok(json!(network.overlay.propagate_put_content(
-            content_key,
-            content_value.encode(),
-        )))
-    }
+    Ok(json!(network.overlay.propagate_put_content(
+        content_key,
+        content_value.encode(),
+    )))
 }
 
 fn paginate(network: Arc<StateNetwork>, offset: u64, limit: u64) -> Result<Value, String> {

--- a/testing/ethportal-peertest/src/scenarios/put_content.rs
+++ b/testing/ethportal-peertest/src/scenarios/put_content.rs
@@ -9,12 +9,73 @@ use trin::cli::TrinConfig;
 
 use crate::{
     utils::{
-        fixture_block_body_15040708, fixture_header_by_hash_with_proof_15040641,
-        fixture_header_by_hash_with_proof_15040708, fixture_receipts_15040641,
-        wait_for_history_content,
+        fixture_block_body_15040708, fixture_header_by_hash,
+        fixture_header_by_hash_with_proof_15040641, fixture_header_by_hash_with_proof_15040708,
+        fixture_receipts_15040641, wait_for_history_content,
     },
     Peertest,
 };
+
+pub async fn test_put_content(peertest: &Peertest, target: &Client, network: Network) {
+    info!("Testing Put Content");
+
+    let _ = HistoryNetworkApiClient::ping(target, peertest.bootnode.enr.clone(), None, None)
+        .await
+        .unwrap();
+    let (content_key, content_value) = fixture_header_by_hash();
+    let result = target
+        .put_content(content_key.clone(), content_value.encode())
+        .await
+        .unwrap();
+
+    assert_eq!(result.peer_count, 1);
+
+    // Check if the stored content value in bootnode's DB matches the offered
+    let received_content_value =
+        wait_for_history_content(&peertest.bootnode.ipc_client, content_key.clone()).await;
+    assert_eq!(
+        content_value, received_content_value,
+        "The received content {received_content_value:?}, must match the expected {content_value:?}",
+    );
+
+    // Spin up a fresh client, not connected to existing peertest
+    let (fresh_ipc_path, trin_config) = fresh_node_config(network);
+    let _test_client_rpc_handle = trin::run_trin(trin_config).await.unwrap();
+    let fresh_target = reth_ipc::client::IpcClientBuilder::default()
+        .build(&fresh_ipc_path)
+        .await
+        .unwrap();
+    let fresh_enr = fresh_target.node_info().await.unwrap().enr;
+
+    // connect to new node
+    let _ = HistoryNetworkApiClient::ping(target, fresh_enr, None, None)
+        .await
+        .unwrap();
+
+    // send new trace gossip request
+    let result = target
+        .put_content(content_key.clone(), content_value.encode())
+        .await
+        .unwrap();
+
+    assert_eq!(result.peer_count, 2);
+
+    // Check if the stored content value in fresh node's DB matches the offered
+    let received_content_value = wait_for_history_content(&fresh_target, content_key.clone()).await;
+    assert_eq!(
+        content_value, received_content_value,
+        "The received content {received_content_value:?}, must match the expected {content_value:?}",
+    );
+
+    // test trace gossip without any expected accepts
+    let result = target
+        .put_content(content_key, content_value.encode())
+        .await
+        .unwrap();
+
+    assert_eq!(result.peer_count, 2);
+}
+
 pub async fn test_gossip_dropped_with_offer(
     peertest: &Peertest,
     target: &Client,

--- a/testing/ethportal-peertest/src/scenarios/put_content.rs
+++ b/testing/ethportal-peertest/src/scenarios/put_content.rs
@@ -9,78 +9,12 @@ use trin::cli::TrinConfig;
 
 use crate::{
     utils::{
-        fixture_block_body_15040708, fixture_header_by_hash,
-        fixture_header_by_hash_with_proof_15040641, fixture_header_by_hash_with_proof_15040708,
-        fixture_receipts_15040641, wait_for_history_content,
+        fixture_block_body_15040708, fixture_header_by_hash_with_proof_15040641,
+        fixture_header_by_hash_with_proof_15040708, fixture_receipts_15040641,
+        wait_for_history_content,
     },
     Peertest,
 };
-pub async fn test_gossip_with_trace(peertest: &Peertest, target: &Client, network: Network) {
-    info!("Testing Gossip with tracing");
-
-    let _ = HistoryNetworkApiClient::ping(target, peertest.bootnode.enr.clone(), None, None)
-        .await
-        .unwrap();
-    let (content_key, content_value) = fixture_header_by_hash();
-    let result = target
-        .trace_put_content(content_key.clone(), content_value.encode())
-        .await
-        .unwrap();
-
-    assert_eq!(result.offered.len(), 1);
-    assert_eq!(result.accepted.len(), 1);
-    assert_eq!(result.transferred.len(), 1);
-
-    // Check if the stored content value in bootnode's DB matches the offered
-    let received_content_value =
-        wait_for_history_content(&peertest.bootnode.ipc_client, content_key.clone()).await;
-    assert_eq!(
-        content_value, received_content_value,
-        "The received content {received_content_value:?}, must match the expected {content_value:?}",
-    );
-
-    // Spin up a fresh client, not connected to existing peertest
-    let (fresh_ipc_path, trin_config) = fresh_node_config(network);
-    let _test_client_rpc_handle = trin::run_trin(trin_config).await.unwrap();
-    let fresh_target = reth_ipc::client::IpcClientBuilder::default()
-        .build(&fresh_ipc_path)
-        .await
-        .unwrap();
-    let fresh_enr = fresh_target.node_info().await.unwrap().enr;
-
-    // connect to new node
-    let _ = HistoryNetworkApiClient::ping(target, fresh_enr, None, None)
-        .await
-        .unwrap();
-
-    // send new trace gossip request
-    let result = target
-        .trace_put_content(content_key.clone(), content_value.encode())
-        .await
-        .unwrap();
-
-    assert_eq!(result.offered.len(), 2);
-    assert_eq!(result.accepted.len(), 1);
-    assert_eq!(result.transferred.len(), 1);
-
-    // Check if the stored content value in fresh node's DB matches the offered
-    let received_content_value = wait_for_history_content(&fresh_target, content_key.clone()).await;
-    assert_eq!(
-        content_value, received_content_value,
-        "The received content {received_content_value:?}, must match the expected {content_value:?}",
-    );
-
-    // test trace gossip without any expected accepts
-    let result = target
-        .trace_put_content(content_key, content_value.encode())
-        .await
-        .unwrap();
-
-    assert_eq!(result.offered.len(), 2);
-    assert_eq!(result.accepted.len(), 0);
-    assert_eq!(result.transferred.len(), 0);
-}
-
 pub async fn test_gossip_dropped_with_offer(
     peertest: &Peertest,
     target: &Client,

--- a/testing/ethportal-peertest/tests/self_peertest.rs
+++ b/testing/ethportal-peertest/tests/self_peertest.rs
@@ -92,6 +92,15 @@ mod protocol_v0 {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
+    async fn peertest_put_content() {
+        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+        peertest::scenarios::put_content::test_put_content(&peertest, &target, V0_NETWORK).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
     async fn peertest_history_gossip_dropped_with_offer() {
         let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
         peertest::scenarios::put_content::test_gossip_dropped_with_offer(
@@ -256,6 +265,15 @@ mod protocol_v1 {
     const V1_NETWORK: Network = Network::Mainnet;
 
     // offer tests
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn peertest_put_content() {
+        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+        peertest::scenarios::put_content::test_put_content(&peertest, &target, V1_NETWORK).await;
+        peertest.exit_all_nodes();
+        handle.stop().unwrap();
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]

--- a/testing/ethportal-peertest/tests/self_peertest.rs
+++ b/testing/ethportal-peertest/tests/self_peertest.rs
@@ -92,16 +92,6 @@ mod protocol_v0 {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn peertest_gossip_with_trace() {
-        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
-        peertest::scenarios::put_content::test_gossip_with_trace(&peertest, &target, V0_NETWORK)
-            .await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
     async fn peertest_history_gossip_dropped_with_offer() {
         let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
         peertest::scenarios::put_content::test_gossip_dropped_with_offer(
@@ -266,16 +256,6 @@ mod protocol_v1 {
     const V1_NETWORK: Network = Network::Mainnet;
 
     // offer tests
-
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn peertest_gossip_with_trace() {
-        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
-        peertest::scenarios::put_content::test_gossip_with_trace(&peertest, &target, V1_NETWORK)
-            .await;
-        peertest.exit_all_nodes();
-        handle.stop().unwrap();
-    }
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]


### PR DESCRIPTION
This PR should be reviewed first https://github.com/ethereum/trin/pull/1760

### What was wrong?

`TracePutContent` or originally `TraceGossip` was an endpoint created so that we could build better bridges. In terms of knowing what happened and rate limiting the bridge. It was a time when we were still trying to reach 100% on Glados. `TracePutContent` was superseded by `TraceOffer` which ended up being the superior solution to our original effort.



### How was it fixed?

I removed it
