### PR TITLE
feat: implement Ephemeral Header Content Types

### DIFF
--- a/bin/portal-bridge/src/bridge/e2hs.rs
+++ b/bin/portal-bridge/src/bridge/e2hs.rs
@@ -346,10 +346,10 @@ async fn spawn_offer_tasks(
                     HistoryContentKey::BlockHeaderByNumber(_) => "header_by_number",
                     HistoryContentKey::BlockBody(_) => "block_body",
                     HistoryContentKey::BlockReceipts(_) => "receipts",
-                    HistoryContentKey::EphemeralHeadersByFindContent(_) => {
-                        "ephemeral_header_by_find_content"
+                    HistoryContentKey::EphemeralHeadersFindContent(_) => {
+                        "ephemeral_headers_find_content"
                     }
-                    HistoryContentKey::EphemeralHeaderByOffer(_) => "ephemeral_header_by_offer",
+                    HistoryContentKey::EphemeralHeaderOffer(_) => "ephemeral_header_offer",
                 },
                 match offer_trace {
                     OfferTrace::Success(_) => "success",

--- a/bin/portal-bridge/src/bridge/e2hs.rs
+++ b/bin/portal-bridge/src/bridge/e2hs.rs
@@ -346,6 +346,10 @@ async fn spawn_offer_tasks(
                     HistoryContentKey::BlockHeaderByNumber(_) => "header_by_number",
                     HistoryContentKey::BlockBody(_) => "block_body",
                     HistoryContentKey::BlockReceipts(_) => "receipts",
+                    HistoryContentKey::EphemeralHeadersByFindContent(_) => {
+                        "ephemeral_header_by_find_content"
+                    }
+                    HistoryContentKey::EphemeralHeaderByOffer(_) => "ephemeral_header_by_offer",
                 },
                 match offer_trace {
                     OfferTrace::Success(_) => "success",

--- a/crates/ethportal-api/src/types/content_key/history.rs
+++ b/crates/ethportal-api/src/types/content_key/history.rs
@@ -32,15 +32,16 @@ pub enum HistoryContentKey {
     BlockBody(BlockBodyKey),
     /// The transaction receipts for a block.
     BlockReceipts(BlockReceiptsKey),
-    /// Ephemeral headers by find content.
+    /// Ephemeral headers used for FindContent request.
     ///
     /// This is used to find the headers of a block and its ancestors.
-    /// This response can only be used by FindContent requests.
+    /// This content type can only be used by FindContent requests.
     EphemeralHeadersFindContent(EphemeralHeadersFindContentKey),
-    /// Ephemeral header offer.
+    /// Ephemeral header used for Offer request.
     ///
-    /// This is used to offer a block header to a peer. This response can only be used by Offer
-    /// requests. This type contains a single header.
+    /// This is used to offer an ephemeral block header to a peer. This content type can only be
+    /// used by Offer requests. The type contains a single header, but more headers should be
+    /// included in the single Offer request.
     EphemeralHeaderOffer(EphemeralHeaderOfferKey),
 }
 
@@ -204,7 +205,7 @@ impl fmt::Display for HistoryContentKey {
             }
             Self::EphemeralHeaderOffer(ephemeral_header) => {
                 format!(
-                    "EphemeralHeadersOffer {{ block_hash: {} }}",
+                    "EphemeralHeaderOffer {{ block_hash: {} }}",
                     hex_encode_compact(ephemeral_header.block_hash),
                 )
             }

--- a/crates/ethportal-api/src/types/content_key/history.rs
+++ b/crates/ethportal-api/src/types/content_key/history.rs
@@ -18,6 +18,8 @@ pub const HISTORY_BLOCK_HEADER_BY_HASH_KEY_PREFIX: u8 = 0x00;
 pub const HISTORY_BLOCK_BODY_KEY_PREFIX: u8 = 0x01;
 pub const HISTORY_BLOCK_RECEIPTS_KEY_PREFIX: u8 = 0x02;
 pub const HISTORY_BLOCK_HEADER_BY_NUMBER_KEY_PREFIX: u8 = 0x03;
+pub const HISTORY_EPHEMERAL_HEADERS_BY_FIND_CONTENT_KEY_PREFIX: u8 = 0x04;
+pub const HISTORY_EPHEMERAL_HEADER_BY_OFFER_KEY_PREFIX: u8 = 0x05;
 
 /// A content key in the history overlay network.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -30,6 +32,8 @@ pub enum HistoryContentKey {
     BlockBody(BlockBodyKey),
     /// The transaction receipts for a block.
     BlockReceipts(BlockReceiptsKey),
+    EphemeralHeadersByFindContent(EphemeralHeadersByFindContentKey),
+    EphemeralHeaderByOffer(EphemeralHeaderByOfferKey),
 }
 
 impl HistoryContentKey {
@@ -71,6 +75,22 @@ impl HistoryContentKey {
 
     pub fn new_block_receipts(block_hash: impl Into<[u8; 32]>) -> Self {
         Self::BlockReceipts(BlockReceiptsKey {
+            block_hash: block_hash.into(),
+        })
+    }
+
+    pub fn new_ephemeral_headers_by_find_content(
+        block_hash: impl Into<[u8; 32]>,
+        ancestor_count: u8,
+    ) -> Self {
+        Self::EphemeralHeadersByFindContent(EphemeralHeadersByFindContentKey {
+            block_hash: block_hash.into(),
+            ancestor_count,
+        })
+    }
+
+    pub fn new_ephemeral_header_by_offer(block_hash: impl Into<[u8; 32]>) -> Self {
+        Self::EphemeralHeaderByOffer(EphemeralHeaderByOfferKey {
             block_hash: block_hash.into(),
         })
     }
@@ -129,6 +149,21 @@ pub struct BlockReceiptsKey {
     pub block_hash: [u8; 32],
 }
 
+#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
+pub struct EphemeralHeadersByFindContentKey {
+    /// Hash of the block.
+    pub block_hash: [u8; 32],
+    /// The number of ancestors included in the response.
+    pub ancestor_count: u8,
+}
+
+/// A key for a block header by hash.
+#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, Default)]
+pub struct EphemeralHeaderByOfferKey {
+    /// Hash of the block.
+    pub block_hash: [u8; 32],
+}
+
 impl fmt::Display for HistoryContentKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
@@ -150,6 +185,19 @@ impl fmt::Display for HistoryContentKey {
                 format!(
                     "BlockHeaderByNumber {{ block_number: {} }}",
                     header.block_number
+                )
+            }
+            Self::EphemeralHeadersByFindContent(ephemeral_headers) => {
+                format!(
+                    "EphemeralHeadersByFindContent {{ block_hash: {}, ancestor_count: {} }}",
+                    hex_encode_compact(ephemeral_headers.block_hash),
+                    ephemeral_headers.ancestor_count
+                )
+            }
+            Self::EphemeralHeaderByOffer(ephemeral_header) => {
+                format!(
+                    "EphemeralHeadersByOffer {{ block_hash: {} }}",
+                    hex_encode_compact(ephemeral_header.block_hash),
                 )
             }
         };
@@ -183,6 +231,16 @@ impl OverlayContentKey for HistoryContentKey {
                 bytes.put_u8(HISTORY_BLOCK_HEADER_BY_NUMBER_KEY_PREFIX);
                 bytes.put_slice(&key.as_ssz_bytes());
             }
+            HistoryContentKey::EphemeralHeadersByFindContent(key) => {
+                bytes = BytesMut::with_capacity(1 + key.ssz_bytes_len());
+                bytes.put_u8(HISTORY_EPHEMERAL_HEADERS_BY_FIND_CONTENT_KEY_PREFIX);
+                bytes.put_slice(&key.as_ssz_bytes());
+            }
+            HistoryContentKey::EphemeralHeaderByOffer(key) => {
+                bytes = BytesMut::with_capacity(1 + key.ssz_bytes_len());
+                bytes.put_u8(HISTORY_EPHEMERAL_HEADER_BY_OFFER_KEY_PREFIX);
+                bytes.put_slice(&key.as_ssz_bytes());
+            }
         }
 
         RawContentKey::from(bytes.freeze())
@@ -211,6 +269,16 @@ impl OverlayContentKey for HistoryContentKey {
                     .map(Self::BlockHeaderByNumber)
                     .map_err(|e| ContentKeyError::from_decode_error(e, bytes))
             }
+            HISTORY_EPHEMERAL_HEADERS_BY_FIND_CONTENT_KEY_PREFIX => {
+                EphemeralHeadersByFindContentKey::from_ssz_bytes(key)
+                    .map(Self::EphemeralHeadersByFindContent)
+                    .map_err(|e| ContentKeyError::from_decode_error(e, bytes))
+            }
+            HISTORY_EPHEMERAL_HEADER_BY_OFFER_KEY_PREFIX => {
+                EphemeralHeaderByOfferKey::from_ssz_bytes(key)
+                    .map(Self::EphemeralHeaderByOffer)
+                    .map_err(|e| ContentKeyError::from_decode_error(e, bytes))
+            }
             _ => Err(ContentKeyError::from_decode_error(
                 DecodeError::UnionSelectorInvalid(selector),
                 bytes,
@@ -222,6 +290,8 @@ impl OverlayContentKey for HistoryContentKey {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
+    use alloy::{hex::FromHex, primitives::B256};
+
     use super::*;
     use crate::{types::content_key::overlay::OverlayContentKey, utils::bytes::hex_decode};
 
@@ -411,6 +481,82 @@ mod test {
         assert_eq!(
             serde_json::to_string(&content_key).unwrap(),
             content_key_json
+        );
+    }
+
+    #[test]
+    fn serde_ephemeral_headers_by_find_content() {
+        let content_key_json =
+            "\"0x04d24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f27618301\"";
+        let block_hash =
+            B256::from_hex("d24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f276183")
+                .unwrap();
+        let ancestor_count = 1;
+        let expected_content_key =
+            HistoryContentKey::new_ephemeral_headers_by_find_content(block_hash, ancestor_count);
+
+        let content_key: HistoryContentKey = serde_json::from_str(content_key_json).unwrap();
+
+        assert_eq!(content_key, expected_content_key);
+        assert_eq!(
+            serde_json::to_string(&content_key).unwrap(),
+            content_key_json
+        );
+    }
+
+    #[test]
+    fn ephemeral_headers_by_find_content_content_id_derivations() {
+        let block_hash =
+            B256::from_hex("d24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f276183")
+                .unwrap();
+        let ancestor_count = 1;
+        let content_key =
+            HistoryContentKey::new_ephemeral_headers_by_find_content(block_hash, ancestor_count);
+        assert_eq!(
+            **content_key.to_bytes(),
+            hex_decode("0x04d24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f27618301")
+                .unwrap()
+        );
+        assert_eq!(
+            content_key.content_id(),
+            B256::from_hex("0xbf9f37c72f6635bbe8dbb4d9377a56d8d579a434399f4c5ba4aad5a213ca04d8")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn serde_ephemeral_header_by_offer() {
+        let content_key_json =
+            "\"0x05d24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f276183\"";
+        let block_hash =
+            B256::from_hex("d24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f276183")
+                .unwrap();
+        let expected_content_key = HistoryContentKey::new_ephemeral_header_by_offer(block_hash);
+
+        let content_key: HistoryContentKey = serde_json::from_str(content_key_json).unwrap();
+
+        assert_eq!(content_key, expected_content_key);
+        assert_eq!(
+            serde_json::to_string(&content_key).unwrap(),
+            content_key_json
+        );
+    }
+
+    #[test]
+    fn ephemeral_header_by_offer_content_id_derivations() {
+        let block_hash =
+            B256::from_hex("d24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f276183")
+                .unwrap();
+        let content_key = HistoryContentKey::new_ephemeral_header_by_offer(block_hash);
+        assert_eq!(
+            **content_key.to_bytes(),
+            hex_decode("0x05d24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f276183")
+                .unwrap()
+        );
+        assert_eq!(
+            content_key.content_id(),
+            B256::from_hex("0x76744a5338183a04ea39bbb94906e539b9a839b4aa508f8493b2afbba2491567")
+                .unwrap()
         );
     }
 }

--- a/crates/ethportal-api/src/types/content_value/history.rs
+++ b/crates/ethportal-api/src/types/content_value/history.rs
@@ -4,7 +4,7 @@ use crate::{
     types::{
         content_value::ContentValue,
         execution::{
-            ephermeral_header::{EphemeralHeaderByOffer, EphemeralHeadersByFindContent},
+            ephermeral_header::{EphemeralHeaderOffer, EphemeralHeadersFindContent},
             header_with_proof::HeaderWithProof,
         },
         network::Subnetwork,
@@ -20,8 +20,8 @@ pub enum HistoryContentValue {
     BlockHeaderWithProof(HeaderWithProof),
     BlockBody(BlockBody),
     Receipts(Receipts),
-    EphemeralHeadersByFindContent(EphemeralHeadersByFindContent),
-    EphemeralHeaderByOffer(EphemeralHeaderByOffer),
+    EphemeralHeadersFindContent(EphemeralHeadersFindContent),
+    EphemeralHeaderOffer(EphemeralHeaderOffer),
 }
 
 impl ContentValue for HistoryContentValue {
@@ -32,8 +32,8 @@ impl ContentValue for HistoryContentValue {
             Self::BlockHeaderWithProof(value) => value.as_ssz_bytes().into(),
             Self::BlockBody(value) => value.as_ssz_bytes().into(),
             Self::Receipts(value) => value.as_ssz_bytes().into(),
-            Self::EphemeralHeadersByFindContent(value) => value.as_ssz_bytes().into(),
-            Self::EphemeralHeaderByOffer(value) => value.as_ssz_bytes().into(),
+            Self::EphemeralHeadersFindContent(value) => value.as_ssz_bytes().into(),
+            Self::EphemeralHeaderOffer(value) => value.as_ssz_bytes().into(),
         }
     }
 
@@ -54,14 +54,14 @@ impl ContentValue for HistoryContentValue {
                     return Ok(Self::Receipts(value));
                 }
             }
-            HistoryContentKey::EphemeralHeadersByFindContent(_) => {
-                if let Ok(value) = EphemeralHeadersByFindContent::from_ssz_bytes(buf) {
-                    return Ok(Self::EphemeralHeadersByFindContent(value));
+            HistoryContentKey::EphemeralHeadersFindContent(_) => {
+                if let Ok(value) = EphemeralHeadersFindContent::from_ssz_bytes(buf) {
+                    return Ok(Self::EphemeralHeadersFindContent(value));
                 }
             }
-            HistoryContentKey::EphemeralHeaderByOffer(_) => {
-                if let Ok(value) = EphemeralHeaderByOffer::from_ssz_bytes(buf) {
-                    return Ok(Self::EphemeralHeaderByOffer(value));
+            HistoryContentKey::EphemeralHeaderOffer(_) => {
+                if let Ok(value) = EphemeralHeaderOffer::from_ssz_bytes(buf) {
+                    return Ok(Self::EphemeralHeaderOffer(value));
                 }
             }
         }
@@ -104,20 +104,20 @@ mod test {
     }
 
     #[test]
-    fn ephemeral_headers_by_find_content_content_value() {
+    fn ephemeral_headers_find_content_content_value() {
         let content_key: HistoryContentKey = serde_json::from_str(
             "\"0x04d24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f27618301\"",
         )
         .unwrap();
         let raw_content_value  = Bytes::from_str(
-            "0x040000000800000063020000f90258a0b390d63aac03bbef75de888d16bd56b91c9291c2a7e38d36ac24731351522bd1a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479495222290dd7278aa3ddd389cc1e1d165cc4bafe5a068421c2c599dc31396a09772a073fb421c4bd25ef1462914ef13e5dfa2d31c23a0f0280ae7fd02f2b9684be8d740830710cd62e4869c891c3a0ead32ea757e70a3a0b39f9f7a13a342751bd2c575eca303e224393d4e11d715866b114b7e824da608b9010094a9480614840b245a1a2148e2100e2070472151b44c3020280930809a20c011609520bc10080074a61c782411e34713ee19c560ca02208f4770080013bc5d302d84743dd0008c5d089d5b1c95940de80809888ba7ed68512d426c048934c8cc0a08dd440b461265001ee50909a26d0213000a7411242c72a648c87e104c0097a0aaba477628508533c5924867341dd11305aa372350b019244034dc849419968b00fd2dda39ecff042639c43923f0d48495d2a40468524bce13a86444c82071ca9c431208870b33f5320f680f3991c2349e2433c80440b0832016820e1070a4405aadcc40050a5006c24504f0098c4391e0f04047c824d1d88ca8021d240510808401312d008401c9c38083a9371c84665ba27f8f6265617665726275696c642e6f7267a085175443c2889afcb52288e0fa8804b671e582f9fd416071a70642d90c7dc0db88000000000000000085012643ff14a0f0747de0368fb967ede9b81320a5b01a4d85b3d427e8bc8e96ff371478d80e768302000080a0ec0befcffe8b2792fc5e7b67dac85ee3bbb09bc56b0ea5d9a698ec3b402d296ff9025ba00d599f184bf4f978eb6f046eb0365b82ca9cb93e999dea93033556751707278ca01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479495222290dd7278aa3ddd389cc1e1d165cc4bafe5a07c77f711a2cb5c59fcc78d63f59dbf73a7fe69be3cad9d8220f9e64668a100eda0bed93e45262811ab648db2f41f3e43706d6ed0bfc9c09d30322e0d8c342657e8a0488fe820ca9e0ec9eb5006e55927151e29219c0709df152de872dfa7c89253f0b90100856931400a4b0f6f3aaaf091e2a05ad131c309001e2308908695014650224020b39105bf5a000230125333205ddf25268379af26ea51e9318666b56d43ef980b9834d708d3001b3bd82660ef8a76e928a0711385d46c4e7d00930e38f93c8100182221870217552690dcf09019316ccd2d31026911cdf436d61a4e3a7c2b40f46c0426d4a80c47022171f9c80625105ed801bf21ef0029297166606de1f18d3902860561e609e485474353cc2b0f2d4b9c2148a5c62513007f358127d080ca601dc28e16141a05786d209d845b8d04c600746e5fb40912b801044386527be54c2172ec46061c0740098c0b8cfc6d35060718d9aa490ce7d68905818070b1979d808401312cff8401c9c38083cc573d84665ba2738f6265617665726275696c642e6f7267a0d735fec5f0cefaf3aba227590a5b0f8ab52e1a6f6a3044d064ad132de188b8b988000000000000000085012a435d21a046d0c52945253f0084ee5f6d57e093b946cabcb415006fd3dfdbb3b797f8eb2f8304000083020000a0777b0eec9bf4a5496c56b87a64e41b89f8ff58e3feb9f611b0afeb34a263e920"
+            "0x0800000063020000f90258a0b390d63aac03bbef75de888d16bd56b91c9291c2a7e38d36ac24731351522bd1a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479495222290dd7278aa3ddd389cc1e1d165cc4bafe5a068421c2c599dc31396a09772a073fb421c4bd25ef1462914ef13e5dfa2d31c23a0f0280ae7fd02f2b9684be8d740830710cd62e4869c891c3a0ead32ea757e70a3a0b39f9f7a13a342751bd2c575eca303e224393d4e11d715866b114b7e824da608b9010094a9480614840b245a1a2148e2100e2070472151b44c3020280930809a20c011609520bc10080074a61c782411e34713ee19c560ca02208f4770080013bc5d302d84743dd0008c5d089d5b1c95940de80809888ba7ed68512d426c048934c8cc0a08dd440b461265001ee50909a26d0213000a7411242c72a648c87e104c0097a0aaba477628508533c5924867341dd11305aa372350b019244034dc849419968b00fd2dda39ecff042639c43923f0d48495d2a40468524bce13a86444c82071ca9c431208870b33f5320f680f3991c2349e2433c80440b0832016820e1070a4405aadcc40050a5006c24504f0098c4391e0f04047c824d1d88ca8021d240510808401312d008401c9c38083a9371c84665ba27f8f6265617665726275696c642e6f7267a085175443c2889afcb52288e0fa8804b671e582f9fd416071a70642d90c7dc0db88000000000000000085012643ff14a0f0747de0368fb967ede9b81320a5b01a4d85b3d427e8bc8e96ff371478d80e768302000080a0ec0befcffe8b2792fc5e7b67dac85ee3bbb09bc56b0ea5d9a698ec3b402d296ff9025ba00d599f184bf4f978eb6f046eb0365b82ca9cb93e999dea93033556751707278ca01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479495222290dd7278aa3ddd389cc1e1d165cc4bafe5a07c77f711a2cb5c59fcc78d63f59dbf73a7fe69be3cad9d8220f9e64668a100eda0bed93e45262811ab648db2f41f3e43706d6ed0bfc9c09d30322e0d8c342657e8a0488fe820ca9e0ec9eb5006e55927151e29219c0709df152de872dfa7c89253f0b90100856931400a4b0f6f3aaaf091e2a05ad131c309001e2308908695014650224020b39105bf5a000230125333205ddf25268379af26ea51e9318666b56d43ef980b9834d708d3001b3bd82660ef8a76e928a0711385d46c4e7d00930e38f93c8100182221870217552690dcf09019316ccd2d31026911cdf436d61a4e3a7c2b40f46c0426d4a80c47022171f9c80625105ed801bf21ef0029297166606de1f18d3902860561e609e485474353cc2b0f2d4b9c2148a5c62513007f358127d080ca601dc28e16141a05786d209d845b8d04c600746e5fb40912b801044386527be54c2172ec46061c0740098c0b8cfc6d35060718d9aa490ce7d68905818070b1979d808401312cff8401c9c38083cc573d84665ba2738f6265617665726275696c642e6f7267a0d735fec5f0cefaf3aba227590a5b0f8ab52e1a6f6a3044d064ad132de188b8b988000000000000000085012a435d21a046d0c52945253f0084ee5f6d57e093b946cabcb415006fd3dfdbb3b797f8eb2f8304000083020000a0777b0eec9bf4a5496c56b87a64e41b89f8ff58e3feb9f611b0afeb34a263e920"
         ).unwrap();
         let content_value = HistoryContentValue::decode(&content_key, &raw_content_value).unwrap();
         assert_eq!(content_value.encode(), raw_content_value);
     }
 
     #[test]
-    fn ephemeral_header_by_offer_content_value() {
+    fn ephemeral_header_offer_content_value() {
         let content_key: HistoryContentKey = serde_json::from_str(
             "\"0x05d24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f276183\"",
         )

--- a/crates/ethportal-api/src/types/content_value/history.rs
+++ b/crates/ethportal-api/src/types/content_value/history.rs
@@ -2,7 +2,11 @@ use ssz::{Decode, Encode};
 
 use crate::{
     types::{
-        content_value::ContentValue, execution::header_with_proof::HeaderWithProof,
+        content_value::ContentValue,
+        execution::{
+            ephermeral_header::{EphemeralHeaderByOffer, EphemeralHeadersByFindContent},
+            header_with_proof::HeaderWithProof,
+        },
         network::Subnetwork,
     },
     utils::bytes::hex_encode,
@@ -16,6 +20,8 @@ pub enum HistoryContentValue {
     BlockHeaderWithProof(HeaderWithProof),
     BlockBody(BlockBody),
     Receipts(Receipts),
+    EphemeralHeadersByFindContent(EphemeralHeadersByFindContent),
+    EphemeralHeaderByOffer(EphemeralHeaderByOffer),
 }
 
 impl ContentValue for HistoryContentValue {
@@ -26,6 +32,8 @@ impl ContentValue for HistoryContentValue {
             Self::BlockHeaderWithProof(value) => value.as_ssz_bytes().into(),
             Self::BlockBody(value) => value.as_ssz_bytes().into(),
             Self::Receipts(value) => value.as_ssz_bytes().into(),
+            Self::EphemeralHeadersByFindContent(value) => value.as_ssz_bytes().into(),
+            Self::EphemeralHeaderByOffer(value) => value.as_ssz_bytes().into(),
         }
     }
 
@@ -46,6 +54,16 @@ impl ContentValue for HistoryContentValue {
                     return Ok(Self::Receipts(value));
                 }
             }
+            HistoryContentKey::EphemeralHeadersByFindContent(_) => {
+                if let Ok(value) = EphemeralHeadersByFindContent::from_ssz_bytes(buf) {
+                    return Ok(Self::EphemeralHeadersByFindContent(value));
+                }
+            }
+            HistoryContentKey::EphemeralHeaderByOffer(_) => {
+                if let Ok(value) = EphemeralHeaderByOffer::from_ssz_bytes(buf) {
+                    return Ok(Self::EphemeralHeaderByOffer(value));
+                }
+            }
         }
 
         Err(ContentValueError::UnknownContent {
@@ -57,6 +75,10 @@ impl ContentValue for HistoryContentValue {
 
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
+
+    use alloy::primitives::Bytes;
+
     use super::*;
     use crate::HistoryContentValue;
 
@@ -79,5 +101,31 @@ mod test {
             error.to_string(),
             "could not determine content type of 0x010203040506070809 from History subnetwork"
         );
+    }
+
+    #[test]
+    fn ephemeral_headers_by_find_content_content_value() {
+        let content_key: HistoryContentKey = serde_json::from_str(
+            "\"0x04d24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f27618301\"",
+        )
+        .unwrap();
+        let raw_content_value  = Bytes::from_str(
+            "0x040000000800000063020000f90258a0b390d63aac03bbef75de888d16bd56b91c9291c2a7e38d36ac24731351522bd1a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479495222290dd7278aa3ddd389cc1e1d165cc4bafe5a068421c2c599dc31396a09772a073fb421c4bd25ef1462914ef13e5dfa2d31c23a0f0280ae7fd02f2b9684be8d740830710cd62e4869c891c3a0ead32ea757e70a3a0b39f9f7a13a342751bd2c575eca303e224393d4e11d715866b114b7e824da608b9010094a9480614840b245a1a2148e2100e2070472151b44c3020280930809a20c011609520bc10080074a61c782411e34713ee19c560ca02208f4770080013bc5d302d84743dd0008c5d089d5b1c95940de80809888ba7ed68512d426c048934c8cc0a08dd440b461265001ee50909a26d0213000a7411242c72a648c87e104c0097a0aaba477628508533c5924867341dd11305aa372350b019244034dc849419968b00fd2dda39ecff042639c43923f0d48495d2a40468524bce13a86444c82071ca9c431208870b33f5320f680f3991c2349e2433c80440b0832016820e1070a4405aadcc40050a5006c24504f0098c4391e0f04047c824d1d88ca8021d240510808401312d008401c9c38083a9371c84665ba27f8f6265617665726275696c642e6f7267a085175443c2889afcb52288e0fa8804b671e582f9fd416071a70642d90c7dc0db88000000000000000085012643ff14a0f0747de0368fb967ede9b81320a5b01a4d85b3d427e8bc8e96ff371478d80e768302000080a0ec0befcffe8b2792fc5e7b67dac85ee3bbb09bc56b0ea5d9a698ec3b402d296ff9025ba00d599f184bf4f978eb6f046eb0365b82ca9cb93e999dea93033556751707278ca01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479495222290dd7278aa3ddd389cc1e1d165cc4bafe5a07c77f711a2cb5c59fcc78d63f59dbf73a7fe69be3cad9d8220f9e64668a100eda0bed93e45262811ab648db2f41f3e43706d6ed0bfc9c09d30322e0d8c342657e8a0488fe820ca9e0ec9eb5006e55927151e29219c0709df152de872dfa7c89253f0b90100856931400a4b0f6f3aaaf091e2a05ad131c309001e2308908695014650224020b39105bf5a000230125333205ddf25268379af26ea51e9318666b56d43ef980b9834d708d3001b3bd82660ef8a76e928a0711385d46c4e7d00930e38f93c8100182221870217552690dcf09019316ccd2d31026911cdf436d61a4e3a7c2b40f46c0426d4a80c47022171f9c80625105ed801bf21ef0029297166606de1f18d3902860561e609e485474353cc2b0f2d4b9c2148a5c62513007f358127d080ca601dc28e16141a05786d209d845b8d04c600746e5fb40912b801044386527be54c2172ec46061c0740098c0b8cfc6d35060718d9aa490ce7d68905818070b1979d808401312cff8401c9c38083cc573d84665ba2738f6265617665726275696c642e6f7267a0d735fec5f0cefaf3aba227590a5b0f8ab52e1a6f6a3044d064ad132de188b8b988000000000000000085012a435d21a046d0c52945253f0084ee5f6d57e093b946cabcb415006fd3dfdbb3b797f8eb2f8304000083020000a0777b0eec9bf4a5496c56b87a64e41b89f8ff58e3feb9f611b0afeb34a263e920"
+        ).unwrap();
+        let content_value = HistoryContentValue::decode(&content_key, &raw_content_value).unwrap();
+        assert_eq!(content_value.encode(), raw_content_value);
+    }
+
+    #[test]
+    fn ephemeral_header_by_offer_content_value() {
+        let content_key: HistoryContentKey = serde_json::from_str(
+            "\"0x05d24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f276183\"",
+        )
+        .unwrap();
+        let raw_content_value  = Bytes::from_str(
+            "0x04000000f90258a0b390d63aac03bbef75de888d16bd56b91c9291c2a7e38d36ac24731351522bd1a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479495222290dd7278aa3ddd389cc1e1d165cc4bafe5a068421c2c599dc31396a09772a073fb421c4bd25ef1462914ef13e5dfa2d31c23a0f0280ae7fd02f2b9684be8d740830710cd62e4869c891c3a0ead32ea757e70a3a0b39f9f7a13a342751bd2c575eca303e224393d4e11d715866b114b7e824da608b9010094a9480614840b245a1a2148e2100e2070472151b44c3020280930809a20c011609520bc10080074a61c782411e34713ee19c560ca02208f4770080013bc5d302d84743dd0008c5d089d5b1c95940de80809888ba7ed68512d426c048934c8cc0a08dd440b461265001ee50909a26d0213000a7411242c72a648c87e104c0097a0aaba477628508533c5924867341dd11305aa372350b019244034dc849419968b00fd2dda39ecff042639c43923f0d48495d2a40468524bce13a86444c82071ca9c431208870b33f5320f680f3991c2349e2433c80440b0832016820e1070a4405aadcc40050a5006c24504f0098c4391e0f04047c824d1d88ca8021d240510808401312d008401c9c38083a9371c84665ba27f8f6265617665726275696c642e6f7267a085175443c2889afcb52288e0fa8804b671e582f9fd416071a70642d90c7dc0db88000000000000000085012643ff14a0f0747de0368fb967ede9b81320a5b01a4d85b3d427e8bc8e96ff371478d80e768302000080a0ec0befcffe8b2792fc5e7b67dac85ee3bbb09bc56b0ea5d9a698ec3b402d296f"
+        ).unwrap();
+        let content_value = HistoryContentValue::decode(&content_key, &raw_content_value).unwrap();
+        assert_eq!(content_value.encode(), raw_content_value);
     }
 }

--- a/crates/ethportal-api/src/types/execution/ephermeral_header.rs
+++ b/crates/ethportal-api/src/types/execution/ephermeral_header.rs
@@ -1,0 +1,65 @@
+use alloy::{consensus::Header, rlp};
+use ssz::{Decode, Encode, SszDecoderBuilder, SszEncoder};
+use ssz_derive::{Decode, Encode};
+use ssz_types::{typenum::U256, VariableList};
+
+use crate::types::{bytes::ByteList2048, execution::header_with_proof::ssz_header};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EphemeralHeadersByFindContent {
+    pub headers: VariableList<Header, U256>,
+}
+
+impl Encode for EphemeralHeadersByFindContent {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        let offset = <VariableList<ByteList2048, U256> as Encode>::ssz_fixed_len();
+        let mut encoder = SszEncoder::container(buf, offset);
+        let headers = self
+            .headers
+            .iter()
+            .map(|header| ByteList2048::from(rlp::encode(header)))
+            .collect::<Vec<_>>();
+        let headers =
+            VariableList::<ByteList2048, U256>::new(headers).expect("Input has same length");
+        encoder.append(&headers);
+        encoder.finalize();
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        self.as_ssz_bytes().len()
+    }
+}
+
+impl Decode for EphemeralHeadersByFindContent {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        let mut builder = SszDecoderBuilder::new(bytes);
+        builder.register_type::<VariableList<ByteList2048, U256>>()?;
+        let mut decoder = builder.build()?;
+        let headers: VariableList<ByteList2048, U256> = decoder.decode_next()?;
+        let headers = headers
+            .into_iter()
+            .map(|header| ssz_header::decode::from_ssz_bytes(&header))
+            .collect::<Result<Vec<_>, _>>()?;
+        let headers = VariableList::<Header, U256>::new(headers).map_err(|err| {
+            ssz::DecodeError::BytesInvalid(format!(
+                "Failed to create VariableList for Ephemeral Headers: {err:?}"
+            ))
+        })?;
+
+        Ok(Self { headers })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct EphemeralHeaderByOffer {
+    #[ssz(with = "ssz_header")]
+    pub header: Header,
+}

--- a/crates/ethportal-api/src/types/execution/header_with_proof.rs
+++ b/crates/ethportal-api/src/types/execution/header_with_proof.rs
@@ -13,7 +13,10 @@ use crate::types::{
         beacon_state::{BeaconStateCapella, HistoricalBatch},
         proof::build_merkle_proof_for_index,
     },
-    execution::block_body::{MERGE_TIMESTAMP, SHANGHAI_TIMESTAMP},
+    execution::{
+        block_body::{MERGE_TIMESTAMP, SHANGHAI_TIMESTAMP},
+        ssz_header,
+    },
 };
 
 /// The accumulator proof for EL BlockHeader for the pre-merge blocks.
@@ -144,59 +147,6 @@ pub struct BlockProofHistoricalSummaries {
     pub execution_block_proof: ExecutionBlockProofCapella,
     /// Slot of BeaconBlock, used to calculate the historical_summaries index
     pub slot: u64,
-}
-
-pub mod ssz_header {
-
-    use crate::types::bytes::ByteList2048;
-
-    pub mod encode {
-        use alloy::consensus::Header;
-        use ssz::Encode;
-
-        use super::*;
-
-        pub fn is_ssz_fixed_len() -> bool {
-            ByteList2048::is_ssz_fixed_len()
-        }
-
-        pub fn ssz_append(header: &Header, buf: &mut Vec<u8>) {
-            let header = alloy::rlp::encode(header);
-            ByteList2048::from(header).ssz_append(buf);
-        }
-
-        pub fn ssz_fixed_len() -> usize {
-            ByteList2048::ssz_fixed_len()
-        }
-
-        pub fn ssz_bytes_len(header: &Header) -> usize {
-            // The ssz encoded length is the same as rlp encoded length.
-            alloy_rlp::Encodable::length(header)
-        }
-    }
-
-    pub mod decode {
-        use alloy::consensus::Header;
-        use alloy_rlp::Decodable;
-        use ssz::Decode;
-
-        use super::*;
-
-        pub fn is_ssz_fixed_len() -> bool {
-            ByteList2048::is_ssz_fixed_len()
-        }
-
-        pub fn ssz_fixed_len() -> usize {
-            ByteList2048::ssz_fixed_len()
-        }
-
-        pub fn from_ssz_bytes(bytes: &[u8]) -> Result<Header, ssz::DecodeError> {
-            let rlp_encoded_header = ByteList2048::from_ssz_bytes(bytes)?;
-            Header::decode(&mut &*rlp_encoded_header).map_err(|_| {
-                ssz::DecodeError::BytesInvalid("Unable to decode bytes into header.".to_string())
-            })
-        }
-    }
 }
 
 pub fn build_historical_roots_proof(

--- a/crates/ethportal-api/src/types/execution/mod.rs
+++ b/crates/ethportal-api/src/types/execution/mod.rs
@@ -1,4 +1,5 @@
 pub mod accumulator;
 pub mod block_body;
+pub mod ephermeral_header;
 pub mod header_with_proof;
 pub mod receipts;

--- a/crates/ethportal-api/src/types/execution/mod.rs
+++ b/crates/ethportal-api/src/types/execution/mod.rs
@@ -3,3 +3,4 @@ pub mod block_body;
 pub mod ephermeral_header;
 pub mod header_with_proof;
 pub mod receipts;
+pub mod ssz_header;

--- a/crates/ethportal-api/src/types/execution/ssz_header.rs
+++ b/crates/ethportal-api/src/types/execution/ssz_header.rs
@@ -1,0 +1,49 @@
+use crate::types::bytes::ByteList2048;
+
+pub mod encode {
+    use alloy::consensus::Header;
+    use ssz::Encode;
+
+    use super::*;
+
+    pub fn is_ssz_fixed_len() -> bool {
+        ByteList2048::is_ssz_fixed_len()
+    }
+
+    pub fn ssz_append(header: &Header, buf: &mut Vec<u8>) {
+        let header = alloy::rlp::encode(header);
+        ByteList2048::from(header).ssz_append(buf);
+    }
+
+    pub fn ssz_fixed_len() -> usize {
+        ByteList2048::ssz_fixed_len()
+    }
+
+    pub fn ssz_bytes_len(header: &Header) -> usize {
+        // The ssz encoded length is the same as rlp encoded length.
+        alloy_rlp::Encodable::length(header)
+    }
+}
+
+pub mod decode {
+    use alloy::consensus::Header;
+    use alloy_rlp::Decodable;
+    use ssz::Decode;
+
+    use super::*;
+
+    pub fn is_ssz_fixed_len() -> bool {
+        ByteList2048::is_ssz_fixed_len()
+    }
+
+    pub fn ssz_fixed_len() -> usize {
+        ByteList2048::ssz_fixed_len()
+    }
+
+    pub fn from_ssz_bytes(bytes: &[u8]) -> Result<Header, ssz::DecodeError> {
+        let rlp_encoded_header = ByteList2048::from_ssz_bytes(bytes)?;
+        Header::decode(&mut &*rlp_encoded_header).map_err(|_| {
+            ssz::DecodeError::BytesInvalid("Unable to decode bytes into header.".to_string())
+        })
+    }
+}

--- a/crates/subnetworks/history/src/validation.rs
+++ b/crates/subnetworks/history/src/validation.rs
@@ -114,6 +114,12 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
                 }
                 Ok(ValidationResult::new(true))
             }
+            HistoryContentKey::EphemeralHeaderByOffer(_) => Err(anyhow!(
+                "Validation is not implemented for EphemeralHeaderByOffer yet"
+            )),
+            HistoryContentKey::EphemeralHeadersByFindContent(_) => Err(anyhow!(
+                "Validation is not implemented for EphemeralHeadersByFindContent yet"
+            )),
         }
     }
 }

--- a/crates/subnetworks/history/src/validation.rs
+++ b/crates/subnetworks/history/src/validation.rs
@@ -114,11 +114,11 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
                 }
                 Ok(ValidationResult::new(true))
             }
-            HistoryContentKey::EphemeralHeaderByOffer(_) => Err(anyhow!(
-                "Validation is not implemented for EphemeralHeaderByOffer yet"
+            HistoryContentKey::EphemeralHeaderOffer(_) => Err(anyhow!(
+                "Validation is not implemented for EphemeralHeaderOffer yet"
             )),
-            HistoryContentKey::EphemeralHeadersByFindContent(_) => Err(anyhow!(
-                "Validation is not implemented for EphemeralHeadersByFindContent yet"
+            HistoryContentKey::EphemeralHeadersFindContent(_) => Err(anyhow!(
+                "Validation is not implemented for EphemeralHeadersFindContent yet"
             )),
         }
     }


### PR DESCRIPTION
### What was wrong?
We don't implement the Ephemeral Header Content Types https://github.com/ethereum/portal-network-specs/pull/387
### How was it fixed?
Implementing them and adding tests https://github.com/ethereum/portal-network-specs/pull/390