### PR TITLE
feat: reduce e2hs-writer memory usage by 5.48x for era to e2hs files

### DIFF
--- a/bin/e2hs-writer/src/cli.rs
+++ b/bin/e2hs-writer/src/cli.rs
@@ -10,7 +10,7 @@ pub const DEFAULT_EPOCH_ACC_PATH: &str = "./portal-accumulators";
 #[command(name = "E2HS Writer", about = "Generate E2HS files")]
 pub struct WriterConfig {
     #[arg(long, help = "Target directory where E2HS files will be written")]
-    pub target_dir: String,
+    pub target_dir: PathBuf,
 
     #[arg(long, help = "Epoch used to generate E2HS file")]
     pub epoch: u64,

--- a/bin/e2hs-writer/src/main.rs
+++ b/bin/e2hs-writer/src/main.rs
@@ -38,5 +38,6 @@ async fn main() -> anyhow::Result<()> {
         "Time taken to finished writing blocks  {}",
         start.elapsed().human(Truncate::Second)
     );
+
     Ok(())
 }

--- a/bin/e2hs-writer/src/provider.rs
+++ b/bin/e2hs-writer/src/provider.rs
@@ -2,10 +2,11 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, bail, ensure};
 use e2store::{
-    era::Era,
+    era::{CompressedSignedBeaconBlock, Era},
     era1::Era1,
     utils::{get_era1_files, get_era_files},
 };
+use ethportal_api::consensus::beacon_state::HistoricalBatch;
 use reqwest::{
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},
     Client,
@@ -14,20 +15,11 @@ use tracing::info;
 use trin_execution::era::binary_search::EraBinarySearch;
 use trin_validation::constants::{EPOCH_SIZE, MERGE_BLOCK_NUMBER};
 
-// This struct provides various era files based on the epoch and makes
-// them accessible via a specific block number from that epoch.
-// - pre-merge: all epochs will correspond 1:1 with era1 files
-// - merge-boundary: will have an era1 & 2 era files
-// - post-merge: all epochs will likely have 2 era files
-pub struct EraProvider {
-    sources: Vec<EraSource>,
-}
-
 pub enum EraSource {
     // processed era1 file
     PreMerge(Arc<Era1>),
     // processed era file
-    PostMerge(Arc<Era>),
+    PostMerge(Arc<MinimalEra>),
 }
 
 impl EraSource {
@@ -46,6 +38,33 @@ impl EraSource {
     }
 }
 
+/// Decompressed Era files are really big, so we only want to keep in memory what we need.
+pub struct MinimalEra {
+    pub blocks: Vec<CompressedSignedBeaconBlock>,
+    pub historical_batch: HistoricalBatch,
+}
+
+impl From<Era> for MinimalEra {
+    fn from(era: Era) -> Self {
+        Self {
+            blocks: era.blocks,
+            historical_batch: HistoricalBatch {
+                block_roots: era.era_state.state.block_roots().clone(),
+                state_roots: era.era_state.state.state_roots().clone(),
+            },
+        }
+    }
+}
+
+// This struct provides various era files based on the epoch and makes
+// them accessible via a specific block number from that epoch.
+// - pre-merge: all epochs will correspond 1:1 with era1 files
+// - merge-boundary: will have an era1 & 2 era files
+// - post-merge: all epochs will likely have 2 era files
+pub struct EraProvider {
+    pub sources: Vec<EraSource>,
+}
+
 impl EraProvider {
     pub async fn new(epoch: u64) -> anyhow::Result<Self> {
         info!("Fetching e2store files for epoch: {epoch}");
@@ -61,6 +80,8 @@ impl EraProvider {
         let mut next_block = starting_block;
         let mut sources = vec![];
 
+        let mut previous_era_epoch_index = None;
+        let era_links = get_era_files(&http_client).await?;
         while next_block < ending_block {
             let source = if next_block < MERGE_BLOCK_NUMBER {
                 let era1_paths = get_era1_files(&http_client).await?;
@@ -71,13 +92,43 @@ impl EraProvider {
                 let raw_era1 = fetch_bytes(http_client.clone(), era1_path).await?;
                 EraSource::PreMerge(Arc::new(Era1::deserialize(&raw_era1)?))
             } else {
-                let era = fetch_era_file_for_block(http_client.clone(), next_block).await?;
+                let era = Arc::new(match previous_era_epoch_index {
+                    Some(previous_epoch_index) => {
+                        let era_path = era_links
+                            .get(&(previous_epoch_index + 1))
+                            .ok_or(anyhow!("Era file not found for block number: {next_block}",))?;
+                        info!(
+                            "Downloading era file for block number: {next_block}, path: {era_path}"
+                        );
+                        let raw_era = fetch_bytes(http_client.clone(), era_path).await?;
+                        info!(
+                            "Downloaded era file for block number: {next_block}, path: {era_path}"
+                        );
+                        let era = Era::deserialize(&raw_era)?;
+                        previous_era_epoch_index = Some(era.epoch_index());
+                        MinimalEra::from(era)
+                    }
+                    None => {
+                        let era = EraBinarySearch::fetch_era_file(
+                            http_client.clone(),
+                            &era_links,
+                            next_block,
+                        )
+                        .await?;
+                        previous_era_epoch_index = Some(era.epoch_index());
+                        MinimalEra::from(era)
+                    }
+                });
                 EraSource::PostMerge(era)
             };
             next_block = source.last_block() + 1;
             sources.push(source);
         }
 
+        ensure!(
+            sources.len() <= 3,
+            "Provider should never download more then 3 e2store files"
+        );
         Ok(Self { sources })
     }
 
@@ -94,38 +145,33 @@ impl EraProvider {
         })
     }
 
-    pub fn get_era_for_block(&self, block_number: u64) -> anyhow::Result<Arc<Era>> {
+    pub fn get_block(
+        &self,
+        block_number: u64,
+    ) -> anyhow::Result<(CompressedSignedBeaconBlock, &MinimalEra)> {
         ensure!(
             block_number >= MERGE_BLOCK_NUMBER,
             "Invalid logic, tried to lookup era file for pre-merge block"
         );
         for sources in self.sources.iter() {
             if let EraSource::PostMerge(era) = sources {
-                if era.contains(block_number) {
-                    return Ok(era.clone());
+                let first_block_number = era.blocks[0].block.execution_block_number();
+                let last_block_number = era.blocks[era.blocks.len() - 1]
+                    .block
+                    .execution_block_number();
+                if (first_block_number..=last_block_number).contains(&block_number) {
+                    if let Some(block) = era
+                        .blocks
+                        .iter()
+                        .find(|block| block.block.execution_block_number() == block_number)
+                    {
+                        return Ok((block.clone(), era));
+                    }
                 }
             }
         }
         bail!("Couldn't find error file not found for block number: {block_number}");
     }
-}
-
-async fn fetch_era_file_for_block(
-    http_client: Client,
-    block_number: u64,
-) -> anyhow::Result<Arc<Era>> {
-    ensure!(
-        block_number >= MERGE_BLOCK_NUMBER,
-        "Invalid logic, tried to fetch era file for pre-merge block"
-    );
-    info!("Starting binary search for era file for block number: {block_number}");
-    let era = EraBinarySearch::find_era_file(http_client.clone(), block_number).await?;
-    let era_links = get_era_files(&http_client).await?;
-    let era_path = era_links.get(&era.epoch_index).ok_or(anyhow!(
-        "Era file not found for block number: {block_number}",
-    ))?;
-    let raw_era = fetch_bytes(http_client.clone(), era_path).await?;
-    Ok(Arc::new(Era::deserialize(&raw_era)?))
 }
 
 async fn fetch_bytes(http_client: Client, path: &str) -> anyhow::Result<Vec<u8>> {

--- a/bin/e2hs-writer/src/writer.rs
+++ b/bin/e2hs-writer/src/writer.rs
@@ -1,31 +1,47 @@
+use std::path::PathBuf;
+
+use anyhow::bail;
 use e2store::{
-    e2hs::{BlockTuple, E2HSBlockIndexEntry, HeaderWithProofEntry, BLOCK_TUPLE_COUNT, E2HS},
-    e2store::types::{Entry, VersionEntry},
-    entry_types::VERSION,
+    e2hs::{
+        BlockTuple, BlockTupleOrIndexEntry, E2HSBlockIndexEntry, E2HSWriter, HeaderWithProofEntry,
+        BLOCK_TUPLE_COUNT,
+    },
+    e2store::types::Entry,
     era1::{BlockIndex, BodyEntry, ReceiptsEntry},
 };
 use ethportal_api::utils::bytes::hex_encode;
 use futures::StreamExt;
 use tracing::info;
+use trin_validation::constants::EPOCH_SIZE;
 
 use crate::reader::EpochReader;
 
 // The `EpochWriter` struct is responsible for writing an epoch to disk in E2HS format.
 pub struct EpochWriter {
-    target_dir: String,
-    epoch: u64,
+    target_dir: PathBuf,
+    epoch_index: u64,
 }
 
 impl EpochWriter {
-    pub fn new(target_dir: String, epoch: u64) -> Self {
-        Self { target_dir, epoch }
+    pub fn new(target_dir: PathBuf, epoch_index: u64) -> Self {
+        Self {
+            target_dir,
+            epoch_index,
+        }
     }
 
     pub async fn write_epoch(&self, reader: EpochReader) -> anyhow::Result<()> {
-        info!("Writing epoch {} to {}", self.epoch, self.target_dir);
-        let mut block_tuples: Vec<BlockTuple> = vec![];
+        info!(
+            "Writing epoch {} to {:?}",
+            self.epoch_index, self.target_dir
+        );
+        let mut e2hs_writer = E2HSWriter::create(&self.target_dir, self.epoch_index)?;
         let mut block_stream = Box::pin(reader.iter_blocks());
 
+        let mut block_index_offset = e2hs_writer.version.version.length() as u64;
+        let mut block_index_indices = vec![];
+        let mut block_tuple_count = 0;
+        let mut last_block_hash = None;
         while let Some(block_data) = block_stream.next().await {
             let block_data = block_data?;
             info!(
@@ -46,49 +62,47 @@ impl EpochWriter {
                 body,
                 receipts,
             };
-            block_tuples.push(block_tuple);
-        }
 
-        assert_eq!(block_tuples.len(), BLOCK_TUPLE_COUNT);
-        let version = VersionEntry {
-            version: Entry::new(VERSION, vec![]),
-        };
-        let mut offset = version.version.length() as u64;
-        let mut indices = vec![];
-        for block_tuple in &block_tuples {
-            indices.push(offset);
-            let entry = <[Entry; 3]>::try_from(block_tuple)?;
+            block_index_indices.push(block_index_offset);
+            let entry = <[Entry; 3]>::try_from(&block_tuple)?;
             let length = entry.iter().map(|entry| entry.length() as u64).sum::<u64>();
-            offset += length;
-        }
-        let starting_header = &block_tuples[0].header_with_proof.header_with_proof.header;
-        let ending_header_hash = &block_tuples[BLOCK_TUPLE_COUNT - 1]
-            .header_with_proof
-            .header_with_proof
-            .header
-            .hash_slow();
-        let block_index = BlockIndex {
-            starting_number: starting_header.number,
-            indices,
-            count: BLOCK_TUPLE_COUNT as u64,
-        };
-        let block_index = E2HSBlockIndexEntry { block_index };
-        let e2hs = E2HS {
-            version,
-            block_tuples,
-            block_index,
-        };
-        let raw_e2hs = e2hs.write()?;
+            block_index_offset += length;
+            block_tuple_count += 1;
 
-        let short_hash = hex_encode(&ending_header_hash[..4]);
-        let e2hs_path = format!(
-            "{}/mainnet-{:05}-{}.e2hs",
-            self.target_dir,
-            self.epoch,
-            short_hash.trim_start_matches("0x")
-        );
-        std::fs::write(e2hs_path.clone(), raw_e2hs)?;
-        info!("Wrote epoch {} to {e2hs_path}", self.epoch);
+            if block_tuple_count == BLOCK_TUPLE_COUNT {
+                last_block_hash = Some(
+                    block_tuple
+                        .header_with_proof
+                        .header_with_proof
+                        .header
+                        .hash_slow(),
+                );
+            }
+
+            e2hs_writer.append_entry(&BlockTupleOrIndexEntry::BlockTuple(block_tuple))?;
+
+            // Flush the writer to ensure memory usage is kept low.
+            if block_tuple_count % 100 == 0 {
+                e2hs_writer.flush()?;
+            }
+        }
+        assert_eq!(block_tuple_count, BLOCK_TUPLE_COUNT);
+
+        e2hs_writer.append_entry(&BlockTupleOrIndexEntry::BlockIndex(
+            E2HSBlockIndexEntry::new(BlockIndex {
+                starting_number: self.epoch_index * EPOCH_SIZE,
+                indices: block_index_indices,
+                count: BLOCK_TUPLE_COUNT as u64,
+            }),
+        ))?;
+
+        let Some(last_block_hash) = last_block_hash else {
+            bail!("No last block hash found");
+        };
+        let short_hash = hex_encode(&last_block_hash[..4]);
+        let e2hs_path = e2hs_writer.finish(self.epoch_index, short_hash)?;
+
+        info!("Wrote epoch {} to {e2hs_path:?}", self.epoch_index);
         Ok(())
     }
 }

--- a/bin/portal-bridge/src/bridge/e2hs.rs
+++ b/bin/portal-bridge/src/bridge/e2hs.rs
@@ -9,7 +9,7 @@ use alloy::primitives::B256;
 use anyhow::ensure;
 use clap::Parser;
 use e2store::{
-    e2hs::{BlockTuple, E2HS},
+    e2hs::{BlockTuple, E2HSMemory},
     utils::get_e2hs_files,
 };
 use ethportal_api::{
@@ -126,7 +126,7 @@ impl E2HSBridge {
             .unwrap_or_else(|err| {
                 panic!("unable to read e2hs file at path: {e2hs_path:?} : {err}")
             });
-        let block_stream = E2HS::iter_tuples(&raw_e2hs).expect("to be able to iter tuples");
+        let block_stream = E2HSMemory::iter_tuples(&raw_e2hs).expect("to be able to iter tuples");
         for block_tuple in block_stream {
             let block_number = block_tuple
                 .header_with_proof

--- a/bin/trin-execution/src/execution.rs
+++ b/bin/trin-execution/src/execution.rs
@@ -179,7 +179,7 @@ mod tests {
             .await
             .unwrap();
         let raw_era1 = fs::read("../../test_assets/era1/mainnet-00000-5ec1ffb8.era1").unwrap();
-        let processed_era = process_era1_file(&raw_era1, 0).unwrap();
+        let processed_era = process_era1_file(&raw_era1).unwrap();
         for block in processed_era.blocks {
             trin_execution.process_next_block().await.unwrap();
             assert_eq!(trin_execution.get_root().unwrap(), block.header.state_root);

--- a/crates/e2store/src/e2hs.rs
+++ b/crates/e2store/src/e2hs.rs
@@ -95,14 +95,9 @@ impl E2HSWriter {
     pub fn append_block_tuple(&mut self, block_tuple: &BlockTuple) -> anyhow::Result<()> {
         self.block_index_indices.push(self.block_index_offset);
         let entries = <[Entry; 3]>::try_from(block_tuple)?;
-        let length = entries
-            .iter()
-            .map(|entry| entry.length() as u64)
-            .sum::<u64>();
-        self.block_index_offset += length;
-
         for entry in entries {
             self.writer.append_entry(&entry)?;
+            self.block_index_offset += entry.length() as u64;
         }
 
         if self.block_index_indices.len() == BLOCK_TUPLE_COUNT {

--- a/crates/e2store/src/era1.rs
+++ b/crates/e2store/src/era1.rs
@@ -92,8 +92,7 @@ impl Era1 {
         })
     }
 
-    #[allow(dead_code)]
-    fn write(&self) -> anyhow::Result<Vec<u8>> {
+    pub fn write(&self) -> anyhow::Result<Vec<u8>> {
         let mut entries: Vec<Entry> = vec![];
         let version_entry = Entry::from(&self.version);
         entries.push(version_entry);


### PR DESCRIPTION
### What was wrong?

My computer is freezing because my computer is running out of memory. I have seen instances where `e2hs-writer` would use over 35GB's of ram.

### How was it fixed?

- Reducing the memory usage caused by downloading receipts. I think there used to be a memory leak as well, which I fixed.
- Reducing the memory usage caused by downloading Era files, we were doing a lot of redownloading&re-deserialization as well, which was slowing things down. I think there was a memory leak here as well as for some reason memory wasn't being cleared when large structures went out of scope.
- I changed the batch_limit to 10 as I was getting rate limited on generating quite a few e2hs files. I tried 20/30 and it didn't work, we can work on a more specification solution in the future, but this is good enough for the time being.
- Don't generate the whole E2HS file in memory before writing to disk. Stream the data to the file. From testing there was no time performance degradation, just a big memory save.
- Decompressed Era files are really big, only store what we need to, to a reasonable degree
- Don't binary search the era_list multiple times as it is slow


#### testing on master generating epoch 2062
```rust
Number from HTOP: 33.4GB RAM usage
dhat: Total:     278,560,633,350 bytes in 656,615,524 blocks
dhat: At t-gmax: 17,793,603,521 bytes in 101,603,533 blocks
dhat: At t-end:  556,688 bytes in 924 blocks
```

#### testing using this PR generating epoch 2062
```rust 
Number from HTOP: 6.095GB RAM usage
dhat: Total:     194,542,923,155 bytes in 512,040,056 blocks
dhat: At t-gmax: 4,594,085,926 bytes in 5,771,296 blocks
dhat: At t-end:  555,632 bytes in 922 blocks
```

I don't understand why the memory wasn't being cleared, but overall I fixed of downloading the same data multiple times, and deseralizing the same data multiple times in this PR.

5.48x in reduce memory usage is massive, this will unblock me from continuing to generate `post-merge to pre-deneb` E2HS files. I have a script which runs N different instances of `e2hs-writer` in parallel using N different json-rpc endpoints