### PR TITLE
chore: bump ethportal-api & e2store version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "e2store"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "ethportal-api"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "alloy",
  "alloy-rlp",

--- a/crates/e2store/Cargo.toml
+++ b/crates/e2store/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 alloy = { workspace = true, features = ["rlp", "consensus"] }

--- a/crates/ethportal-api/Cargo.toml
+++ b/crates/ethportal-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethportal-api"
-version = "0.7.0"
+version = "0.8.0"
 description = "Definitions for various Ethereum Portal Network JSONRPC APIs"
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
### What was wrong?
we want to release ethportal-api and e2store which both have breaking api changes
### How was it fixed?

bump the minor versions
