### PR TITLE
fix: update E2HS URL to fixed one by devops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "e2store"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alloy",
  "alloy-rlp",

--- a/crates/e2store/Cargo.toml
+++ b/crates/e2store/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 alloy = { workspace = true, features = ["rlp", "consensus"] }

--- a/crates/e2store/src/utils.rs
+++ b/crates/e2store/src/utils.rs
@@ -8,7 +8,7 @@ use url::Url;
 
 const ERA_DIR_URL: &str = "https://mainnet.era.nimbus.team/";
 const ERA1_DIR_URL: &str = "https://era1.ethportal.net/";
-const E2HS_DIR_URL: &str = "https://e2hs.ethportal.net/";
+const E2HS_DIR_URL: &str = "https://e2hs.ethportal.net/index.html";
 const E2SS_DIR_URL: &str = "https://e2ss.ethportal.net/index.html";
 pub const ERA1_FILE_COUNT: usize = 1897;
 


### PR DESCRIPTION
### What was wrong?
`https://e2hs.ethportal.net/` doesn't work it was broken and I could download any files
### How was it fixed?

Devops removed the redirect role and now we need to use this url `https://e2hs.ethportal.net/index.html`, I tried to download a file and it download a file now