### PR TITLE
chore(book): fix final PoW block number

### DIFF
--- a/book/src/developers/core_concepts/cryptographic_accumulator.md
+++ b/book/src/developers/core_concepts/cryptographic_accumulator.md
@@ -110,7 +110,7 @@ epoch,index
 15523839,0x804008940c025a4e8a00ea42a659b484ba32c14dff133e9d3b7bf3685c1e54de // penultimate epoch (full)
 15532031,0x3f81607c8cb3f0448a11cab8df0e504b605581f4891a9a35bd9c0dd37a71834f // final epoch (incomplete)
 ```
-Final PoW block: `15537394`
+Final PoW block: `15537393`
 
 The hash tree root of the Master Accumulator is:
 ```sh


### PR DESCRIPTION
### What was wrong?
The "last PoW block" in the book was off by one
Block 15,537,394 is actually the [first PoS block](https://ethereum.org/en/history/#paris)

### How was it fixed?
Changing it to the right block number.
Verify that the other amounts in that section of the book are correct.

### To-Do

