### PR TITLE
chore(ci): bump deprecated actions/checkout version

### DIFF
--- a/.github/workflows/monthly_block_root_update.yml
+++ b/.github/workflows/monthly_block_root_update.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq


### PR DESCRIPTION
### What was wrong?
A PR was made on portal-network-specs saying that `Artifact Actions v3 will be deprecated by January 30, 2025` https://github.com/ethereum/portal-network-specs/pull/392 all of our CI's are using v4 of checkout except this one

I did this for other CI's in the past context can be found here https://github.com/ethereum/trin/pull/1628

### How was it fixed?

bump it

