### PR TITLE
refactor: e2hs bridge logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4717,6 +4717,7 @@ version = "0.2.1"
 dependencies = [
  "alloy",
  "anyhow",
+ "bytes",
  "chrono",
  "clap",
  "delay_map 0.4.1",

--- a/bin/portal-bridge/Cargo.toml
+++ b/bin/portal-bridge/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 [dependencies]
 alloy.workspace = true
 anyhow.workspace = true
+bytes.workspace = true
 chrono.workspace = true
 clap.workspace = true
 delay_map.workspace = true

--- a/bin/portal-bridge/src/bridge/beacon.rs
+++ b/bin/portal-bridge/src/bridge/beacon.rs
@@ -547,7 +547,6 @@ impl BeaconBridge {
         let offer_report = Arc::new(StdMutex::new(OfferReport::new(
             content_key.clone(),
             enrs.len(),
-            None,
         )));
         let encoded_content_value = content_value.encode();
         for enr in enrs.clone() {

--- a/bin/portal-bridge/src/bridge/constants.rs
+++ b/bin/portal-bridge/src/bridge/constants.rs
@@ -1,4 +1,4 @@
 use std::time::Duration;
 
-pub const HEADER_SATURATION_DELAY: u64 = 10; // seconds
+pub const HEADER_SATURATION_DELAY: Duration = Duration::from_secs(15);
 pub const SERVE_BLOCK_TIMEOUT: Duration = Duration::from_secs(120);

--- a/bin/portal-bridge/src/bridge/e2hs.rs
+++ b/bin/portal-bridge/src/bridge/e2hs.rs
@@ -7,7 +7,9 @@ use std::{
 
 use alloy::primitives::B256;
 use anyhow::ensure;
+use bytes::Bytes;
 use clap::Parser;
+use discv5::Enr;
 use e2store::{
     e2hs::{BlockTuple, E2HSMemory},
     utils::get_e2hs_files,
@@ -17,17 +19,19 @@ use ethportal_api::{
     types::{
         execution::header_with_proof::HeaderWithProof, network::Subnetwork, portal_wire::OfferTrace,
     },
-    ContentValue, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
-    OverlayContentKey,
+    BlockBody, ContentValue, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
+    OverlayContentKey, RawContentValue, Receipts,
 };
+use futures::future::join_all;
 use rand::seq::SliceRandom;
 use reqwest::{
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},
     Client,
 };
 use tokio::{
-    sync::{oneshot, OwnedSemaphorePermit, Semaphore},
-    time::timeout,
+    sync::{OwnedSemaphorePermit, Semaphore},
+    task::JoinHandle,
+    time::{sleep, timeout},
 };
 use tracing::{debug, error, info, warn};
 use trin_metrics::bridge::BridgeMetricsReporter;
@@ -35,20 +39,22 @@ use trin_validation::header_validator::HeaderValidator;
 
 use super::offer_report::{GlobalOfferReport, OfferReport};
 use crate::{
-    bridge::constants::SERVE_BLOCK_TIMEOUT, census::Census, types::range::block_range_to_epochs,
+    bridge::constants::{HEADER_SATURATION_DELAY, SERVE_BLOCK_TIMEOUT},
+    census::Census,
+    types::range::block_range_to_epochs,
 };
 
-#[derive(Debug)]
 pub struct E2HSBridge {
-    portal_client: HttpClient,
-    metrics: BridgeMetricsReporter,
-    /// Semaphore used to limit the amount of active offer transfers
-    /// to make sure we don't overwhelm the trin client
-    offer_semaphore: Arc<Semaphore>,
-    /// Used to request all interested enrs in the network.
-    census: Census,
-    /// Global offer report for tallying total performance of history bridge
-    global_offer_report: Arc<Mutex<GlobalOfferReport>>,
+    /// Gossips the content.
+    ///
+    /// Creates tasks responsible to gossiping the content, but gossip rate is limited with
+    /// [Gossiper::offer_semaphore].
+    gossiper: Gossiper,
+    /// Semaphore used to limit the number of active blocks transfers.
+    ///
+    /// It has the same number of permits as [Gossiper::offer_semaphore], as there is no need
+    /// to gossip more blocks in parallel.
+    block_semaphore: Arc<Semaphore>,
     header_validator: HeaderValidator,
     block_range: BlockRange,
     random_fill: bool,
@@ -65,6 +71,7 @@ impl E2HSBridge {
         census: Census,
     ) -> anyhow::Result<Self> {
         let offer_semaphore = Arc::new(Semaphore::new(offer_limit));
+        let block_semaphore = Arc::new(Semaphore::new(offer_limit));
         let mode = format!("{}-{}:{}", block_range.start, block_range.end, random_fill);
         let metrics = BridgeMetricsReporter::new("e2hs".to_string(), &mode);
         let header_validator = HeaderValidator::new();
@@ -76,12 +83,16 @@ impl E2HSBridge {
             .build()?;
         let e2hs_files = get_e2hs_files(&http_client).await?;
         let global_offer_report = Arc::new(Mutex::new(GlobalOfferReport::default()));
-        Ok(Self {
+        let gossiper = Gossiper {
+            census,
             portal_client,
             metrics,
-            offer_semaphore,
-            census,
             global_offer_report,
+            offer_semaphore,
+        };
+        Ok(Self {
+            gossiper,
+            block_semaphore,
             header_validator,
             block_range,
             random_fill,
@@ -101,7 +112,8 @@ impl E2HSBridge {
             let block_range = epochs.get(&index).expect("to be able to get block range");
             self.gossip_epoch(index, *block_range).await;
         }
-        self.global_offer_report
+        self.gossiper
+            .global_offer_report
             .lock()
             .expect("to acquire lock")
             .report();
@@ -109,24 +121,16 @@ impl E2HSBridge {
 
     async fn gossip_epoch(&self, epoch_index: u64, block_range: Option<(u64, u64)>) {
         match block_range {
-            Some(_) => info!("Gossiping block range: {block_range:?} from epoch {epoch_index}"),
+            Some(block_range) => {
+                info!("Gossiping block range: {block_range:?} from epoch {epoch_index}")
+            }
             None => info!("Gossiping entire epoch {epoch_index}"),
         }
-        let Some(e2hs_path) = self.e2hs_files.get(&epoch_index) else {
-            panic!("Failed to find e2hs file for epoch {epoch_index}");
-        };
-        let raw_e2hs = self
-            .http_client
-            .get(e2hs_path.clone())
-            .send()
-            .await
-            .expect("to be able to send request")
-            .bytes()
-            .await
-            .unwrap_or_else(|err| {
-                panic!("unable to read e2hs file at path: {e2hs_path:?} : {err}")
-            });
+
+        let raw_e2hs = self.download_e2hs(epoch_index).await;
         let block_stream = E2HSMemory::iter_tuples(&raw_e2hs).expect("to be able to iter tuples");
+
+        let mut tasks = vec![];
         for block_tuple in block_stream {
             let block_number = block_tuple
                 .header_with_proof
@@ -143,103 +147,29 @@ impl E2HSBridge {
                 error!("Failed to validate block tuple: {err:?}");
                 continue;
             }
-            self.serve_block_tuple(block_number, block_tuple).await;
+
+            let gossiper = self.gossiper.clone();
+            let block_permit = self.block_semaphore.clone().acquire_owned().await;
+            tasks.push(tokio::spawn(async move {
+                gossiper.gossip_block(block_number, block_tuple).await;
+                drop(block_permit);
+            }));
         }
+        join_all(tasks).await;
     }
 
-    async fn serve_block_tuple(&self, block_number: u64, block_tuple: BlockTuple) {
-        info!("Serving block tuple for block #{block_number}");
-        let block_hash = block_tuple
-            .header_with_proof
-            .header_with_proof
-            .header
-            .hash_slow();
-
-        let (is_finished_tx, is_finished_rx) = oneshot::channel();
-        self.gossip_header_by_hash(
-            block_tuple.header_with_proof.header_with_proof.clone(),
-            block_hash,
-            is_finished_tx,
-        )
-        .await;
-        self.gossip_header_by_number(
-            block_tuple.header_with_proof.header_with_proof,
-            block_number,
-        )
-        .await;
-
-        let census = self.census.clone();
-        let portal_client = self.portal_client.clone();
-        let metrics = self.metrics.clone();
-        let global_offer_report = self.global_offer_report.clone();
-        let offer_semaphore = self.offer_semaphore.clone();
-        tokio::spawn(async move {
-            if let Err(err) = is_finished_rx.await {
-                error!("Failed to receive header_by_hash finished response: {err:?}");
-                return;
-            }
-
-            spawn_offer_tasks(
-                HistoryContentKey::new_block_body(block_hash),
-                HistoryContentValue::BlockBody(block_tuple.body.body),
-                census.clone(),
-                portal_client.clone(),
-                metrics.clone(),
-                global_offer_report.clone(),
-                offer_semaphore.clone(),
-                None,
-            )
-            .await;
-
-            spawn_offer_tasks(
-                HistoryContentKey::new_block_receipts(block_hash),
-                HistoryContentValue::Receipts(block_tuple.receipts.receipts),
-                census.clone(),
-                portal_client.clone(),
-                metrics.clone(),
-                global_offer_report.clone(),
-                offer_semaphore.clone(),
-                None,
-            )
-            .await;
-        });
-    }
-
-    async fn gossip_header_by_hash(
-        &self,
-        header_with_proof: HeaderWithProof,
-        block_hash: B256,
-        is_finished_tx: oneshot::Sender<()>,
-    ) {
-        let content_key = HistoryContentKey::new_block_header_by_hash(block_hash);
-        let content_value = HistoryContentValue::BlockHeaderWithProof(header_with_proof);
-        spawn_offer_tasks(
-            content_key,
-            content_value,
-            self.census.clone(),
-            self.portal_client.clone(),
-            self.metrics.clone(),
-            self.global_offer_report.clone(),
-            self.offer_semaphore.clone(),
-            Some(is_finished_tx),
-        )
-        .await;
-    }
-
-    async fn gossip_header_by_number(&self, header_with_proof: HeaderWithProof, block_number: u64) {
-        let content_key = HistoryContentKey::new_block_header_by_number(block_number);
-        let content_value = HistoryContentValue::BlockHeaderWithProof(header_with_proof);
-        spawn_offer_tasks(
-            content_key,
-            content_value,
-            self.census.clone(),
-            self.portal_client.clone(),
-            self.metrics.clone(),
-            self.global_offer_report.clone(),
-            self.offer_semaphore.clone(),
-            None,
-        )
-        .await;
+    async fn download_e2hs(&self, epoch_index: u64) -> Bytes {
+        let Some(e2hs_path) = self.e2hs_files.get(&epoch_index) else {
+            panic!("Failed to find e2hs file for epoch {epoch_index}");
+        };
+        self.http_client
+            .get(e2hs_path.clone())
+            .send()
+            .await
+            .expect("to be able to send request")
+            .bytes()
+            .await
+            .unwrap_or_else(|err| panic!("unable to read e2hs file at path: {e2hs_path:?} : {err}"))
     }
 
     fn validate_block_tuple(&self, block_tuple: &BlockTuple) -> anyhow::Result<()> {
@@ -257,120 +187,270 @@ impl E2HSBridge {
     }
 }
 
-// spawn individual offer tasks of the content key for each interested enr found in Census
-#[allow(clippy::too_many_arguments)]
-async fn spawn_offer_tasks(
-    content_key: HistoryContentKey,
-    content_value: HistoryContentValue,
+/// Structure that sends offer requests to peers.
+///
+/// This structure is cheap to clone, which makes it easy to use with tokio tasks.
+#[derive(Clone)]
+struct Gossiper {
+    /// Used to request all interested enrs in the network.
     census: Census,
+    /// Used to send RPC request to trin
     portal_client: HttpClient,
+    /// Records and reports bridge metrics
     metrics: BridgeMetricsReporter,
+    /// Global offer report for tallying total performance of history bridge
     global_offer_report: Arc<Mutex<GlobalOfferReport>>,
+    /// Semaphore used to limit the number of active offer transfers, in order to make sure we
+    /// don't overwhelm the trin client
     offer_semaphore: Arc<Semaphore>,
-    is_finished_tx: Option<oneshot::Sender<()>>,
-) {
-    let Ok(enrs) = census.select_peers(Subnetwork::History, &content_key.content_id()) else {
-        error!("Failed to request enrs for content key, skipping offer: {content_key:?}");
-        return;
-    };
-    let offer_report = Arc::new(Mutex::new(OfferReport::new(
-        content_key.clone(),
-        enrs.len(),
-        is_finished_tx,
-    )));
-    let encoded_content_value = content_value.encode();
-    for enr in enrs.clone() {
-        let content_key = content_key.clone();
-        let encoded_content_value = encoded_content_value.clone();
-        let permit = acquire_offer_permit(offer_semaphore.clone()).await;
-        let census = census.clone();
-        let portal_client = portal_client.clone();
-        let offer_report = offer_report.clone();
-        let metrics = metrics.clone();
-        let global_offer_report = global_offer_report.clone();
-        tokio::spawn(async move {
-            let timer = metrics.start_process_timer("spawn_offer_history");
-
-            let start_time = Instant::now();
-            let content_value_size = encoded_content_value.len();
-
-            let result = timeout(
-                SERVE_BLOCK_TIMEOUT,
-                HistoryNetworkApiClient::trace_offer(
-                    &portal_client,
-                    enr.clone(),
-                    content_key.clone(),
-                    encoded_content_value,
-                ),
-            )
-            .await;
-
-            let offer_trace = match &result {
-                Ok(Ok(result)) => {
-                    if matches!(result, &OfferTrace::Failed) {
-                        warn!("Internal error offering to: {enr}");
-                    }
-                    result
-                }
-                Ok(Err(err)) => {
-                    warn!("Error offering to: {enr}, error: {err:?}");
-                    &OfferTrace::Failed
-                }
-                Err(_) => {
-                    error!("trace_offer timed out on history {content_key}: indicating a bug is present");
-                    &OfferTrace::Failed
-                }
-            };
-
-            census.record_offer_result(
-                Subnetwork::History,
-                enr.node_id(),
-                content_value_size,
-                start_time.elapsed(),
-                offer_trace,
-            );
-
-            // Update report and metrics
-            global_offer_report
-                .lock()
-                .expect("to acquire lock")
-                .update(offer_trace);
-            offer_report
-                .lock()
-                .expect("to acquire lock")
-                .update(&enr, offer_trace);
-
-            metrics.report_offer(
-                match content_key {
-                    HistoryContentKey::BlockHeaderByHash(_) => "header_by_hash",
-                    HistoryContentKey::BlockHeaderByNumber(_) => "header_by_number",
-                    HistoryContentKey::BlockBody(_) => "block_body",
-                    HistoryContentKey::BlockReceipts(_) => "receipts",
-                    HistoryContentKey::EphemeralHeadersFindContent(_) => {
-                        "ephemeral_headers_find_content"
-                    }
-                    HistoryContentKey::EphemeralHeaderOffer(_) => "ephemeral_header_offer",
-                },
-                match offer_trace {
-                    OfferTrace::Success(_) => "success",
-                    OfferTrace::Declined => "declined",
-                    OfferTrace::Failed => "failed",
-                },
-            );
-
-            // Release permit
-            drop(permit);
-            metrics.stop_process_timer(timer);
-        });
-    }
 }
 
-async fn acquire_offer_permit(offer_semaphore: Arc<Semaphore>) -> OwnedSemaphorePermit {
-    offer_semaphore
-        .clone()
-        .acquire_owned()
-        .await
-        .expect("to be able to acquire semaphore")
+impl Gossiper {
+    /// Gossips the all block relate content.
+    ///
+    /// Gossips BlockHeaderByHash at the start. Afterwards, starts gossiping BlockHeaderByNumber.
+    /// It waits for [HEADER_SATURATION_DELAY] after BlockHeaderByHash is gossiped to start
+    /// gossiping BlockBody and BlockReceipts.
+    ///
+    /// Finishes once all content is gossiped.
+    async fn gossip_block(&self, block_number: u64, block_tuple: BlockTuple) {
+        info!("Serving block tuple for block #{block_number}");
+        let BlockTuple {
+            header_with_proof,
+            body,
+            receipts,
+        } = block_tuple;
+        let block_hash = header_with_proof.header_with_proof.header.hash_slow();
+
+        // Gossip BlockHeaderByHash and wait until it finishes
+        if let Err(err) = self
+            .start_gossip_header_by_hash_task(
+                block_hash,
+                header_with_proof.header_with_proof.clone(),
+            )
+            .await
+        {
+            error!(%block_hash, %err, "Error while trying to gossip BlockHeaderByHash");
+        }
+
+        let mut gossip_tasks = vec![];
+
+        // Start gossiping BlockHeaderByNumber
+        gossip_tasks.push(
+            self.start_gossip_header_by_number_task(
+                block_number,
+                header_with_proof.header_with_proof,
+            ),
+        );
+
+        // Wait until BlockHeaderByHash saturates network,
+        // since it must be available for body / receipt validation
+        sleep(HEADER_SATURATION_DELAY).await;
+
+        // Start gossiping BlockBody and BlockReceipts
+        gossip_tasks.push(self.start_gossip_body_task(block_hash, body.body));
+        gossip_tasks.push(self.start_gossip_receipts_task(block_hash, receipts.receipts));
+
+        // Wait until BlockHeaderByNumber, BlockBody and BlockReceipts are gossiped
+        join_all(gossip_tasks).await;
+    }
+
+    fn start_gossip_header_by_hash_task(
+        &self,
+        block_hash: B256,
+        header_with_proof: HeaderWithProof,
+    ) -> JoinHandle<Vec<OfferTrace>> {
+        let content_key = HistoryContentKey::new_block_header_by_hash(block_hash);
+        let content_value = HistoryContentValue::BlockHeaderWithProof(header_with_proof);
+        self.start_gossip_task(content_key, content_value)
+    }
+
+    fn start_gossip_header_by_number_task(
+        &self,
+        block_number: u64,
+        header_with_proof: HeaderWithProof,
+    ) -> JoinHandle<Vec<OfferTrace>> {
+        let content_key = HistoryContentKey::new_block_header_by_number(block_number);
+        let content_value = HistoryContentValue::BlockHeaderWithProof(header_with_proof);
+        self.start_gossip_task(content_key, content_value)
+    }
+
+    fn start_gossip_body_task(
+        &self,
+        block_hash: B256,
+        body: BlockBody,
+    ) -> JoinHandle<Vec<OfferTrace>> {
+        let content_key = HistoryContentKey::new_block_body(block_hash);
+        let content_value = HistoryContentValue::BlockBody(body);
+        self.start_gossip_task(content_key, content_value)
+    }
+
+    fn start_gossip_receipts_task(
+        &self,
+        block_hash: B256,
+        receipts: Receipts,
+    ) -> JoinHandle<Vec<OfferTrace>> {
+        let content_key = HistoryContentKey::new_block_receipts(block_hash);
+        let content_value = HistoryContentValue::Receipts(receipts);
+        self.start_gossip_task(content_key, content_value)
+    }
+
+    /// Starts async task that gossips content, retuning [JoinHandle] for it.
+    fn start_gossip_task(
+        &self,
+        content_key: HistoryContentKey,
+        content_value: HistoryContentValue,
+    ) -> JoinHandle<Vec<OfferTrace>> {
+        let executor = self.clone();
+        tokio::spawn(async move { executor.gossip_content(content_key, content_value).await })
+    }
+
+    /// Spawn individual offer tasks for each interested enr found in Census.
+    ///
+    /// Returns once all tasks complete.
+    async fn gossip_content(
+        &self,
+        content_key: HistoryContentKey,
+        content_value: HistoryContentValue,
+    ) -> Vec<OfferTrace> {
+        let Ok(enrs) = self
+            .census
+            .select_peers(Subnetwork::History, &content_key.content_id())
+        else {
+            error!("Failed to request enrs for content key, skipping offer: {content_key:?}");
+            return vec![];
+        };
+        let offer_report = Arc::new(Mutex::new(OfferReport::new(
+            content_key.clone(),
+            enrs.len(),
+        )));
+        let encoded_content_value = content_value.encode();
+        let mut tasks = vec![];
+        for enr in enrs.clone() {
+            let offer_permit = self.acquire_offer_permit().await;
+            let offer_report = offer_report.clone();
+            let content_key = content_key.clone();
+            let raw_content_value = encoded_content_value.clone();
+
+            let gossiper = self.clone();
+            tasks.push(tokio::spawn(async move {
+                gossiper
+                    .send_offer(
+                        offer_permit,
+                        offer_report,
+                        enr,
+                        content_key,
+                        raw_content_value,
+                    )
+                    .await
+            }));
+        }
+        join_all(tasks)
+            .await
+            .into_iter()
+            .map(|task_result| match task_result {
+                Ok(offer_trace) => offer_trace,
+                Err(err) => {
+                    error!("Sending offer task failed: {err}");
+                    OfferTrace::Failed
+                }
+            })
+            .collect()
+    }
+
+    async fn send_offer(
+        &self,
+        offer_permit: OwnedSemaphorePermit,
+        offer_report: Arc<Mutex<OfferReport<HistoryContentKey>>>,
+        enr: Enr,
+        content_key: HistoryContentKey,
+        raw_content_value: RawContentValue,
+    ) -> OfferTrace {
+        let timer = self.metrics.start_process_timer("history_send_offer");
+
+        let start_time = Instant::now();
+        let content_value_size = raw_content_value.len();
+
+        let result = timeout(
+            SERVE_BLOCK_TIMEOUT,
+            HistoryNetworkApiClient::trace_offer(
+                &self.portal_client,
+                enr.clone(),
+                content_key.clone(),
+                raw_content_value,
+            ),
+        )
+        .await;
+
+        let offer_trace = match result {
+            Ok(Ok(result)) => {
+                if matches!(result, OfferTrace::Failed) {
+                    warn!("Internal error offering to: {enr}");
+                }
+                result
+            }
+            Ok(Err(err)) => {
+                warn!("Error offering to: {enr}, error: {err:?}");
+                OfferTrace::Failed
+            }
+            Err(_) => {
+                error!(
+                    "trace_offer timed out on history {content_key}: indicating a bug is present"
+                );
+                OfferTrace::Failed
+            }
+        };
+
+        self.census.record_offer_result(
+            Subnetwork::History,
+            enr.node_id(),
+            content_value_size,
+            start_time.elapsed(),
+            &offer_trace,
+        );
+
+        // Update report and metrics
+        self.global_offer_report
+            .lock()
+            .expect("to acquire lock")
+            .update(&offer_trace);
+        offer_report
+            .lock()
+            .expect("to acquire lock")
+            .update(&enr, &offer_trace);
+
+        self.metrics.report_offer(
+            match content_key {
+                HistoryContentKey::BlockHeaderByHash(_) => "header_by_hash",
+                HistoryContentKey::BlockHeaderByNumber(_) => "header_by_number",
+                HistoryContentKey::BlockBody(_) => "block_body",
+                HistoryContentKey::BlockReceipts(_) => "receipts",
+                HistoryContentKey::EphemeralHeadersFindContent(_) => {
+                    "ephemeral_headers_find_content"
+                }
+                HistoryContentKey::EphemeralHeaderOffer(_) => "ephemeral_header_offer",
+            },
+            match offer_trace {
+                OfferTrace::Success(_) => "success",
+                OfferTrace::Declined => "declined",
+                OfferTrace::Failed => "failed",
+            },
+        );
+
+        self.metrics.stop_process_timer(timer);
+        // Release permit
+        drop(offer_permit);
+
+        offer_trace
+    }
+
+    async fn acquire_offer_permit(&self) -> OwnedSemaphorePermit {
+        self.offer_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("to be able to acquire semaphore")
+    }
 }
 
 /// BlockRange used specifically for the E2HS bridge

--- a/bin/portal-bridge/src/bridge/offer_report.rs
+++ b/bin/portal-bridge/src/bridge/offer_report.rs
@@ -1,6 +1,5 @@
 use discv5::Enr;
 use ethportal_api::{types::portal_wire::OfferTrace, OverlayContentKey};
-use tokio::sync::oneshot;
 use tracing::{debug, enabled, info, Level};
 
 /// Global report for outcomes of offering state content keys from long-running state bridge
@@ -46,25 +45,19 @@ pub struct OfferReport<ContentKey> {
     success: Vec<Enr>,
     failed: Vec<Enr>,
     declined: Vec<Enr>,
-    is_finished_tx: Option<oneshot::Sender<()>>,
 }
 
 impl<ContentKey> OfferReport<ContentKey>
 where
     ContentKey: OverlayContentKey + std::fmt::Debug,
 {
-    pub fn new(
-        content_key: ContentKey,
-        total: usize,
-        is_finished_tx: Option<oneshot::Sender<()>>,
-    ) -> Self {
+    pub fn new(content_key: ContentKey, total: usize) -> Self {
         Self {
             content_key,
             total,
             success: Vec::new(),
             failed: Vec::new(),
             declined: Vec::new(),
-            is_finished_tx,
         }
     }
 
@@ -101,11 +94,6 @@ where
                 self.declined.len(),
                 self.failed.len(),
             );
-        }
-        if let Some(is_finished_tx) = self.is_finished_tx.take() {
-            if let Err(err) = is_finished_tx.send(()) {
-                debug!("Failed to send single for bodies and receipts to start being gossiped: {err:?}");
-            }
         }
     }
 }

--- a/bin/portal-bridge/src/bridge/state.rs
+++ b/bin/portal-bridge/src/bridge/state.rs
@@ -516,7 +516,6 @@ impl StateBridge {
         let offer_report = Arc::new(Mutex::new(OfferReport::new(
             content_key.clone(),
             enrs.len(),
-            None,
         )));
         let encoded_content_value = content_value.encode();
         for enr in enrs.clone() {


### PR DESCRIPTION
### What was wrong?

The e2hs bridge wasn't designed very well:

- We would just spawn many tokio tasks and have no way of tracking them, resulting in:
    - they can fail (e.g. if they panic) and we have no way of knowing 
    - we can't wait for them to finish, resulting in the last content that is gossiped not having enough time before tasks is aborted (entire process finishes)
- We use `GlobalOfferReport::is_finished_tx` to detect when headers were gossiped. This has two drawbacks:
    - If any of the offer tasks fails, the `is_finished_tx` will never be called
    - We don't allow any time for headers to propagate through network using recursive gossip

### How was it fixed?

Create `Gossiper` struct, responsible for gossiping the content. It's cheap to clone (which means we can clone it and use it in tasks). We now have access to each task (in the form of `JoinHandle`), and at each gossip granularity (epoch, block_tuple, content key/value,  individual offer)

Removed `is_finished_tx` and starting using HEADER_SATURATION_DELAY again, to wait for header to saturate the network.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
