### PR TITLE
feat: change EnrOfferLimit from 2 to 8

### DIFF
--- a/bin/portal-bridge/src/census/mod.rs
+++ b/bin/portal-bridge/src/census/mod.rs
@@ -31,11 +31,6 @@ pub enum CensusError {
     AlreadyInitialized,
 }
 
-/// The maximum number of enrs to return in a response,
-/// limiting the number of OFFER requests spawned by the bridge
-/// for each piece of content
-pub const ENR_OFFER_LIMIT: usize = 2;
-
 /// The census is responsible for maintaining a list of known peers in the network,
 /// checking their liveness, updating their data radius, iterating through their
 /// rfn to find new peers, and providing interested enrs for a given content id.

--- a/bin/portal-bridge/src/cli.rs
+++ b/bin/portal-bridge/src/cli.rs
@@ -32,9 +32,9 @@ use crate::{
 pub const DEFAULT_SUBNETWORK: &str = "history";
 pub const DEFAULT_EXECUTABLE_PATH: &str = "./target/debug/trin";
 
-/// The maximum number of enrs to return in a response,
-/// limiting the number of OFFER requests spawned by the bridge
-/// for each piece of content
+/// The maximum number of peers to send each piece of content.
+///
+/// This is used as a parameter in census, which selects the peers.
 pub const ENR_OFFER_LIMIT: usize = 8;
 
 #[derive(Parser, Debug, Clone)]

--- a/bin/portal-bridge/src/cli.rs
+++ b/bin/portal-bridge/src/cli.rs
@@ -23,7 +23,6 @@ use url::Url;
 
 use crate::{
     bridge::e2hs::BlockRange,
-    census::ENR_OFFER_LIMIT,
     constants::{DEFAULT_OFFER_LIMIT, DEFAULT_TOTAL_REQUEST_TIMEOUT},
     types::mode::BridgeMode,
     DEFAULT_BASE_CL_ENDPOINT, DEFAULT_BASE_EL_ENDPOINT, FALLBACK_BASE_CL_ENDPOINT,
@@ -32,6 +31,11 @@ use crate::{
 
 pub const DEFAULT_SUBNETWORK: &str = "history";
 pub const DEFAULT_EXECUTABLE_PATH: &str = "./target/debug/trin";
+
+/// The maximum number of enrs to return in a response,
+/// limiting the number of OFFER requests spawned by the bridge
+/// for each piece of content
+pub const ENR_OFFER_LIMIT: usize = 8;
 
 #[derive(Parser, Debug, Clone)]
 #[command(name = "Trin Bridge", about = "Feed the network")]

--- a/testing/ethportal-peertest/src/scenarios/bridge.rs
+++ b/testing/ethportal-peertest/src/scenarios/bridge.rs
@@ -8,8 +8,8 @@ use ethportal_api::{
 use portal_bridge::{
     api::consensus::ConsensusApi,
     bridge::beacon::BeaconBridge,
-    census::{Census, ENR_OFFER_LIMIT},
-    cli::{BridgeConfig, BridgeId, DEFAULT_EXECUTABLE_PATH, DEFAULT_SUBNETWORK},
+    census::Census,
+    cli::{BridgeConfig, BridgeId, DEFAULT_EXECUTABLE_PATH, DEFAULT_SUBNETWORK, ENR_OFFER_LIMIT},
     constants::{DEFAULT_OFFER_LIMIT, DEFAULT_TOTAL_REQUEST_TIMEOUT},
     types::mode::BridgeMode,
     DEFAULT_BASE_CL_ENDPOINT, DEFAULT_BASE_EL_ENDPOINT, FALLBACK_BASE_CL_ENDPOINT,


### PR DESCRIPTION
### What was wrong?

Today in the call I said I would add the granular offer code I wrote for the StateBridge to the E2HS bridge, but after thinking about that I think that would be completely overkill, expessially when the History Network has 100-1000x less content for us to offer.

- Census code was originally added with a offer limit of 8 https://github.com/ethereum/trin/pull/1422
- Offer limit lowered to 4 https://github.com/ethereum/trin/pull/1490
- Offer limit lowered to 2 https://github.com/ethereum/trin/pull/1597

Because long term the state bridge won't be apart of `portal-bridge` and I am already running the 4 E2HS bridges I am running with `--enr-offer-limit=8` with good results. I think just increasing the default is good enough for the E2HS bridge

### How was it fixed?

changed the default limit from 2 to 8. It isn't worth the additional complexity, as the E2HS bridge doesn't face the same challenges which warrant it
