### PR TITLE
feat: remove `disable_history_storage`

### DIFF
--- a/bin/trin/src/cli.rs
+++ b/bin/trin/src/cli.rs
@@ -216,13 +216,6 @@ pub struct TrinConfig {
         value_parser = max_radius_parser,
     )]
     pub max_radius: Distance,
-
-    #[arg(
-        long = "disable-history-storage",
-        help = "Disable storing all history data locally. This is a temporary flag used for upgrading the network, and should be removed once the upgrade is complete.",
-        default_value = "false"
-    )]
-    pub disable_history_storage: bool,
 }
 
 impl Default for TrinConfig {
@@ -256,7 +249,6 @@ impl Default for TrinConfig {
             network: MAINNET.clone(),
             max_radius: max_radius_parser(DEFAULT_MAX_RADIUS)
                 .expect("Parsing static DEFAULT_MAX_RADIUS to work"),
-            disable_history_storage: false,
         }
     }
 }

--- a/bin/trin/src/lib.rs
+++ b/bin/trin/src/lib.rs
@@ -139,7 +139,6 @@ pub async fn run_trin(
             portalnet_config.clone(),
             storage_config_factory.create(&Subnetwork::History, trin_config.max_radius)?,
             header_oracle.clone(),
-            trin_config.disable_history_storage,
         )
         .await?
     } else {

--- a/crates/subnetworks/history/src/lib.rs
+++ b/crates/subnetworks/history/src/lib.rs
@@ -41,7 +41,6 @@ pub async fn initialize_history_network(
     portalnet_config: PortalnetConfig,
     storage_config: PortalStorageConfig,
     header_oracle: Arc<RwLock<HeaderOracle>>,
-    disable_history_storage: bool,
 ) -> anyhow::Result<(
     HistoryHandler,
     HistoryNetworkTask,
@@ -59,7 +58,6 @@ pub async fn initialize_history_network(
         storage_config,
         portalnet_config.clone(),
         header_oracle,
-        disable_history_storage,
     )
     .await?;
     let event_stream = history_network.overlay.event_stream().await?;

--- a/crates/subnetworks/history/src/network.rs
+++ b/crates/subnetworks/history/src/network.rs
@@ -46,7 +46,6 @@ impl HistoryNetwork {
         storage_config: PortalStorageConfig,
         portal_config: PortalnetConfig,
         header_oracle: Arc<RwLock<HeaderOracle>>,
-        disable_history_storage: bool,
     ) -> anyhow::Result<Self> {
         let config = OverlayConfig {
             bootnode_enrs: portal_config.bootnodes,
@@ -55,10 +54,7 @@ impl HistoryNetwork {
             utp_transfer_limit: portal_config.utp_transfer_limit,
             ..Default::default()
         };
-        let storage = Arc::new(Mutex::new(HistoryStorage::new(
-            storage_config,
-            disable_history_storage,
-        )?));
+        let storage = Arc::new(Mutex::new(HistoryStorage::new(storage_config)?));
         let validator = Arc::new(ChainHistoryValidator { header_oracle });
         let ping_extensions = Arc::new(HistoryPingExtensions {});
         let overlay = OverlayProtocol::new(

--- a/crates/subnetworks/history/src/storage.rs
+++ b/crates/subnetworks/history/src/storage.rs
@@ -12,7 +12,6 @@ use trin_storage::{
 #[derive(Debug)]
 pub struct HistoryStorage {
     store: IdIndexedV1Store<HistoryContentKey>,
-    disable_history_storage: bool,
 }
 
 impl ContentStore for HistoryStorage {
@@ -36,10 +35,6 @@ impl ContentStore for HistoryStorage {
         key: &HistoryContentKey,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
         let content_id = ContentId::from(key.content_id());
-        // temporarily disable storing all history network
-        if self.disable_history_storage {
-            return Ok(ShouldWeStoreContent::NotWithinRadius);
-        }
         if self.store.distance_to_content_id(&content_id) > self.store.radius() {
             Ok(ShouldWeStoreContent::NotWithinRadius)
         } else if self.store.has_content(&content_id)? {
@@ -55,16 +50,12 @@ impl ContentStore for HistoryStorage {
 }
 
 impl HistoryStorage {
-    pub fn new(
-        config: PortalStorageConfig,
-        disable_history_storage: bool,
-    ) -> Result<Self, ContentStoreError> {
+    pub fn new(config: PortalStorageConfig) -> Result<Self, ContentStoreError> {
         let sql_connection_pool = config.sql_connection_pool.clone();
         let config =
             IdIndexedV1StoreConfig::new(ContentType::HistoryEternal, Subnetwork::History, config);
         Ok(Self {
             store: create_store(ContentType::HistoryEternal, config, sql_connection_pool)?,
-            disable_history_storage,
         })
     }
 
@@ -107,7 +98,7 @@ pub mod test {
         fn test_store_random_bytes() -> TestResult {
             let (temp_dir, storage_config) =
                 create_test_portal_storage_config_with_capacity(CAPACITY_MB).unwrap();
-            let mut storage = HistoryStorage::new(storage_config, false).unwrap();
+            let mut storage = HistoryStorage::new(storage_config).unwrap();
             let content_key = HistoryContentKey::random().unwrap();
             let mut value = [0u8; 32];
             rand::thread_rng().fill_bytes(&mut value);
@@ -128,7 +119,7 @@ pub mod test {
     async fn test_get_data() -> Result<(), ContentStoreError> {
         let (temp_dir, storage_config) =
             create_test_portal_storage_config_with_capacity(CAPACITY_MB).unwrap();
-        let mut storage = HistoryStorage::new(storage_config, false)?;
+        let mut storage = HistoryStorage::new(storage_config)?;
         let content_key = HistoryContentKey::BlockHeaderByHash(BlockHeaderByHashKey::default());
         let value: Vec<u8> = "OGFWs179fWnqmjvHQFGHszXloc3Wzdb4".into();
         storage.put(content_key.clone(), &value)?;

--- a/crates/validation/src/header_validator.rs
+++ b/crates/validation/src/header_validator.rs
@@ -74,7 +74,9 @@ impl HeaderValidator {
                     ));
                 }
                 // TODO: Validation for post-Capella headers is not implemented
-                Ok(())
+                Err(anyhow!(
+                    "Post-Capella header validation is not implemented yet."
+                ))
             }
         }
     }


### PR DESCRIPTION
### What was wrong?

Our nodes had a flag which was temporarily added called `--disable-history-storage`. This was a temporary step which was supposed to be removed after we upgraded our proof format
![image](https://github.com/user-attachments/assets/c5c760f3-4c88-44cd-9ace-1ae6926e1e9b)

### How was it fixed?

remove it
