### PR TITLE
feat: enable post-capella HistoricalSummary Header validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7783,6 +7783,7 @@ dependencies = [
  "serde_yaml",
  "ssz_types",
  "tokio",
+ "tracing",
  "tree_hash",
  "tree_hash_derive",
  "trin-utils",

--- a/bin/e2hs-writer/src/reader.rs
+++ b/bin/e2hs-writer/src/reader.rs
@@ -76,7 +76,7 @@ impl EpochReader {
             Some(Arc::new(
                 lookup_epoch_acc(
                     epoch_index,
-                    &HeaderValidator::new().pre_merge_acc,
+                    &HeaderValidator::new_without_historical_summaries().pre_merge_acc,
                     &epoch_acc_path,
                 )
                 .await?,

--- a/bin/portal-bridge/src/bridge/e2hs.rs
+++ b/bin/portal-bridge/src/bridge/e2hs.rs
@@ -15,7 +15,9 @@ use e2store::{
 };
 use ethportal_api::{
     types::{
-        execution::header_with_proof::HeaderWithProof, network::Subnetwork, portal_wire::OfferTrace,
+        execution::header_with_proof::{BlockHeaderProof, HeaderWithProof},
+        network::Subnetwork,
+        portal_wire::OfferTrace,
     },
     BlockBody, ContentValue, HistoryContentKey, HistoryContentValue, OverlayContentKey,
     RawContentValue, Receipts,
@@ -95,7 +97,7 @@ impl E2HSBridge {
         Ok(Self {
             gossiper,
             block_semaphore,
-            header_validator: HeaderValidator::new(),
+            header_validator: HeaderValidator::new_without_historical_summaries(),
             block_range,
             random_fill,
             e2hs_files,
@@ -171,7 +173,7 @@ impl E2HSBridge {
                     continue;
                 }
             }
-            if let Err(err) = self.validate_block_tuple(&block_tuple) {
+            if let Err(err) = self.validate_block_tuple(&block_tuple).await {
                 error!("Failed to validate block tuple: {err:?}");
                 continue;
             }
@@ -206,10 +208,19 @@ impl E2HSBridge {
             .unwrap_or_else(|err| panic!("unable to read e2hs file at path: {e2hs_path:?} : {err}"))
     }
 
-    fn validate_block_tuple(&self, block_tuple: &BlockTuple) -> anyhow::Result<()> {
+    async fn validate_block_tuple(&self, block_tuple: &BlockTuple) -> anyhow::Result<()> {
         let header_with_proof = &block_tuple.header_with_proof.header_with_proof;
-        self.header_validator
-            .validate_header_with_proof(header_with_proof)?;
+        // The E2HS bridge doesn't have access to a provider so it can't validate historical summary
+        // Header with Proofs
+        if !matches!(
+            header_with_proof.proof,
+            BlockHeaderProof::HistoricalSummariesCapella(_)
+                | BlockHeaderProof::HistoricalSummariesDeneb(_)
+        ) {
+            self.header_validator
+                .validate_header_with_proof(header_with_proof)
+                .await?;
+        }
         let body = &block_tuple.body.body;
         body.validate_against_header(&header_with_proof.header)?;
         let receipts = &block_tuple.receipts.receipts;

--- a/bin/portal-bridge/src/bridge/e2hs.rs
+++ b/bin/portal-bridge/src/bridge/e2hs.rs
@@ -14,6 +14,7 @@ use e2store::{
     utils::get_e2hs_files,
 };
 use ethportal_api::{
+    consensus::historical_summaries::HistoricalSummaries,
     types::{
         execution::header_with_proof::{BlockHeaderProof, HeaderWithProof},
         network::Subnetwork,
@@ -97,7 +98,9 @@ impl E2HSBridge {
         Ok(Self {
             gossiper,
             block_semaphore,
-            header_validator: HeaderValidator::new_without_historical_summaries(),
+            header_validator: HeaderValidator::new_with_historical_summaries(
+                HistoricalSummaries::default(),
+            ),
             block_range,
             random_fill,
             e2hs_files,

--- a/bin/portal-bridge/src/types/range.rs
+++ b/bin/portal-bridge/src/types/range.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use trin_validation::constants::EPOCH_SIZE;
+use trin_validation::constants::SLOTS_PER_HISTORICAL_ROOT;
 
 /// Converts a block range into a mapping of epoch indexes to block ranges.
 ///
@@ -16,14 +16,14 @@ pub fn block_range_to_epochs(start_block: u64, end_block: u64) -> HashMap<u64, O
     let mut epoch_map = HashMap::new();
 
     // Calculate start and end epochs
-    let start_epoch = start_block / EPOCH_SIZE;
-    let end_epoch = end_block / EPOCH_SIZE;
+    let start_epoch = start_block / SLOTS_PER_HISTORICAL_ROOT;
+    let end_epoch = end_block / SLOTS_PER_HISTORICAL_ROOT;
 
     // Process each epoch in the range
     for epoch in start_epoch..=end_epoch {
         // Calculate the first and last block of the current epoch
-        let epoch_first_block = epoch * EPOCH_SIZE;
-        let epoch_last_block = epoch_first_block + EPOCH_SIZE - 1;
+        let epoch_first_block = epoch * SLOTS_PER_HISTORICAL_ROOT;
+        let epoch_last_block = epoch_first_block + SLOTS_PER_HISTORICAL_ROOT - 1;
 
         // Determine if the epoch is fully or partially covered
         if epoch_first_block >= start_block && epoch_last_block <= end_block {

--- a/bin/trin/src/run.rs
+++ b/bin/trin/src/run.rs
@@ -2,7 +2,6 @@ use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
 use ethportal_api::{
     types::{distance::Distance, network::Subnetwork},
-    utils::bytes::hex_encode,
     version::get_trin_version,
 };
 use portalnet::{
@@ -14,7 +13,6 @@ use portalnet::{
 use rpc::{config::RpcConfig, launch_jsonrpc_server, RpcServerHandle};
 use tokio::sync::{mpsc, RwLock};
 use tracing::info;
-use tree_hash::TreeHash;
 use trin_beacon::initialize_beacon_network;
 use trin_history::initialize_history_network;
 use trin_state::initialize_state_network;
@@ -121,12 +119,7 @@ async fn run_trin_internal(
     }
 
     // Initialize validation oracle
-    let header_oracle = HeaderOracle::default();
-    info!(
-        hash_tree_root = %hex_encode(header_oracle.header_validator.pre_merge_acc.tree_hash_root().0),
-        "Loaded pre-merge accumulator."
-    );
-    let header_oracle = Arc::new(RwLock::new(header_oracle));
+    let header_oracle = Arc::new(RwLock::new(HeaderOracle::default()));
 
     // Initialize and spawn uTP socket
     let (utp_talk_reqs_tx, utp_talk_reqs_rx) = mpsc::unbounded_channel();

--- a/crates/subnetworks/history/src/validation.rs
+++ b/crates/subnetworks/history/src/validation.rs
@@ -11,10 +11,8 @@ use ethportal_api::{
 };
 use ssz::Decode;
 use tokio::sync::RwLock;
-use tracing::info;
-use tree_hash::TreeHash;
 use trin_validation::{
-    header_validator::{HeaderValidator, HistoricalSummariesProvider, HistoricalSummariesSource},
+    header_validator::HeaderValidator,
     oracle::HeaderOracle,
     validator::{ValidationResult, Validator},
 };
@@ -26,13 +24,7 @@ pub struct ChainHistoryValidator {
 
 impl ChainHistoryValidator {
     pub fn new(header_oracle: Arc<RwLock<HeaderOracle>>) -> Self {
-        let header_validator = HeaderValidator::new(HistoricalSummariesProvider::new(
-            HistoricalSummariesSource::HeaderOracle(header_oracle.clone()),
-        ));
-        info!(
-            hash_tree_root = %header_validator.pre_merge_acc.tree_hash_root(),
-            "Loaded pre-merge accumulator."
-        );
+        let header_validator = HeaderValidator::new_with_header_oracle(header_oracle.clone());
         Self {
             header_oracle,
             header_validator,

--- a/crates/validation/Cargo.toml
+++ b/crates/validation/Cargo.toml
@@ -26,6 +26,7 @@ serde.workspace = true
 serde_json.workspace = true
 ssz_types.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 tree_hash.workspace = true
 tree_hash_derive.workspace = true
 

--- a/crates/validation/src/accumulator.rs
+++ b/crates/validation/src/accumulator.rs
@@ -14,7 +14,9 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum, VariableList};
 use tree_hash_derive::TreeHash;
 
-use crate::{constants::EPOCH_SIZE, merkle::proof::MerkleTree, TrinValidationAssets};
+use crate::{
+    constants::SLOTS_PER_HISTORICAL_ROOT, merkle::proof::MerkleTree, TrinValidationAssets,
+};
 
 /// SSZ List[Hash256, max_length = MAX_HISTORICAL_EPOCHS]
 /// List of historical epoch accumulator merkle roots preceding current epoch.
@@ -49,7 +51,7 @@ impl PreMergeAccumulator {
     }
 
     pub(crate) fn get_epoch_index_of_header(&self, header: &Header) -> u64 {
-        header.number / EPOCH_SIZE
+        header.number / SLOTS_PER_HISTORICAL_ROOT
     }
 
     pub fn construct_proof(
@@ -57,7 +59,7 @@ impl PreMergeAccumulator {
         epoch_acc: &EpochAccumulator,
     ) -> anyhow::Result<BlockProofHistoricalHashesAccumulator> {
         // Validate header hash matches historical hash from epoch accumulator
-        let hr_index = (header.number % EPOCH_SIZE) as usize;
+        let hr_index = (header.number % SLOTS_PER_HISTORICAL_ROOT) as usize;
         let header_record = epoch_acc[hr_index];
         if header_record.block_hash != header.hash_slow() {
             return Err(anyhow!(

--- a/crates/validation/src/constants.rs
+++ b/crates/validation/src/constants.rs
@@ -1,13 +1,15 @@
+use alloy::primitives::{b256, B256};
+
 // Execution Layer hard forks https://ethereum.org/en/history/
 pub const CAPELLA_FORK_EPOCH: u64 = 194_048;
 pub const SLOTS_PER_EPOCH: u64 = 32;
 
 /// The default hash of the pre-merge accumulator at the time of the merge block.
-pub const DEFAULT_PRE_MERGE_ACC_HASH: &str =
-    "0x8eac399e24480dce3cfe06f4bdecba51c6e5d0c46200e3e8611a0b44a3a69ff9";
+pub const DEFAULT_PRE_MERGE_ACC_HASH: B256 =
+    b256!("0x8eac399e24480dce3cfe06f4bdecba51c6e5d0c46200e3e8611a0b44a3a69ff9");
 
 /// Max number of blocks / epoch = 2 ** 13
-pub const EPOCH_SIZE: u64 = 8192;
+pub const SLOTS_PER_HISTORICAL_ROOT: u64 = 8192;
 
 // Max number of epochs = 2 ** 17
 // const MAX_HISTORICAL_EPOCHS: usize = 131072;

--- a/crates/validation/src/historical_summaries_provider.rs
+++ b/crates/validation/src/historical_summaries_provider.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use anyhow::bail;
+use ethportal_api::consensus::historical_summaries::{HistoricalSummaries, HistoricalSummary};
+use tokio::sync::RwLock;
+
+use crate::{
+    constants::{CAPELLA_FORK_EPOCH, SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT},
+    oracle::HeaderOracle,
+};
+
+#[derive(Debug, Clone)]
+pub enum HistoricalSummariesSource {
+    /// The historical summaries are provided by the header oracle.
+    HeaderOracle(Arc<RwLock<HeaderOracle>>),
+    /// The historical summaries are provided by passed historical summaries.
+    HistoricalSummaries(HistoricalSummaries),
+}
+
+#[derive(Debug, Clone)]
+pub struct HistoricalSummariesProvider {
+    cache: Arc<RwLock<HistoricalSummaries>>,
+    source: HistoricalSummariesSource,
+}
+
+impl HistoricalSummariesProvider {
+    pub fn new(source: HistoricalSummariesSource) -> Self {
+        Self {
+            cache: Arc::new(RwLock::new(HistoricalSummaries::default())),
+            source,
+        }
+    }
+
+    pub async fn get_historical_summary(&self, slot: u64) -> anyhow::Result<HistoricalSummary> {
+        let epoch = slot / SLOTS_PER_EPOCH;
+        let historical_summary_index =
+            ((slot - CAPELLA_FORK_EPOCH * SLOTS_PER_EPOCH) / SLOTS_PER_HISTORICAL_ROOT) as usize;
+
+        // Check to see if we have the historical summaries in cache
+        if let Some(historical_summary) = self.cache.read().await.get(historical_summary_index) {
+            return Ok(historical_summary.clone());
+        }
+
+        let historical_summaries = match &self.source {
+            HistoricalSummariesSource::HeaderOracle(header_oracle) => {
+                &header_oracle
+                    .read()
+                    .await
+                    .get_historical_summary(epoch)
+                    .await?
+            }
+            HistoricalSummariesSource::HistoricalSummaries(historical_summaries) => {
+                historical_summaries
+            }
+        };
+
+        match historical_summaries.get(historical_summary_index) {
+            Some(historical_summary) => {
+                // Update the cache with the historical summary
+                *self.cache.write().await = historical_summaries.clone();
+                Ok(historical_summary.clone())
+            }
+            None => {
+                bail!("Historical summary index out of bounds: {historical_summary_index}")
+            }
+        }
+    }
+}

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -5,6 +5,7 @@ pub mod accumulator;
 pub mod constants;
 pub mod header_validator;
 pub mod historical_roots_acc;
+pub mod historical_summaries_provider;
 pub mod merkle;
 pub mod oracle;
 pub mod validator;


### PR DESCRIPTION
### What was wrong?
HistoricalSummary HeaderWithProof validation wasn't enabled
### How was it fixed?

Enabled it, the E2HS bridge has no way to verify post-capella HeaderWithProofs as it doesn't have access to a provider and we don't want to give it access to one. So the assumption is the the E2HS bridge is downloading the files from a trusted source.

For this to work, it requires the BeaconNetwork or validation will fail