### PR TITLE
feat: make beacon required network if history is enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2561,6 +2561,7 @@ dependencies = [
  "ethportal-api",
  "futures",
  "hex",
+ "itertools 0.13.0",
  "jsonrpsee",
  "portal-bridge",
  "portalnet",

--- a/bin/portal-bridge/src/handle.rs
+++ b/bin/portal-bridge/src/handle.rs
@@ -48,9 +48,10 @@ pub fn build_trin(bridge_config: &BridgeConfig) -> anyhow::Result<Child> {
 pub fn subnetworks_flag(bridge_config: &BridgeConfig) -> String {
     let subnetworks = match bridge_config.portal_subnetwork {
         Subnetwork::Beacon => vec![Subnetwork::Beacon],
-        Subnetwork::History => vec![Subnetwork::History],
-        // State requires both history and state
-        Subnetwork::State => vec![Subnetwork::History, Subnetwork::State],
+        // History requires beacon and history
+        Subnetwork::History => vec![Subnetwork::Beacon, Subnetwork::History],
+        // State requires beacon, history and state
+        Subnetwork::State => vec![Subnetwork::Beacon, Subnetwork::History, Subnetwork::State],
         subnetwork => panic!("Unsupported subnetwork: {subnetwork:?}"),
     }
     .into_iter()

--- a/book/src/users/startup.md
+++ b/book/src/users/startup.md
@@ -36,7 +36,7 @@ For now, only the history network is on by default, because the others are still
 To try out state access, you can turn it on like this:
 
 ```text
-trin --mb 5000 --portal-subnetworks history,state
+trin --mb 5000 --portal-subnetworks beacon,history,state
 ```
 
 Note that to access state, you must also run with history enabled, in order to validate peer responses.

--- a/book/src/users/use/ethereum_data.md
+++ b/book/src/users/use/ethereum_data.md
@@ -37,7 +37,7 @@ BLOCK_NUM=20987654; curl -X POST -H "Content-Type: application/json" -d '{"jsonr
 
 To read data out of a contract, use the `eth_call` method.
 
-The data needed to make this call is well populated in the Portal Network for the first 1 million blocks, and is being expanded over time. To activate contract storage access, connect to the Portal state network by running trin with the flag `--portal-subnetworks state,history`.
+The data needed to make this call is well populated in the Portal Network for the first 1 million blocks, and is being expanded over time. To activate contract storage access, connect to the Portal state network by running trin with the flag `--portal-subnetworks state,history,beacon`.
 
 Calling a contract fuction usually involves enough formatting that it's helpful to use a tool to build the request, like Web3.py.
 

--- a/crates/ethportal-api/src/types/network.rs
+++ b/crates/ethportal-api/src/types/network.rs
@@ -74,8 +74,8 @@ impl std::str::FromStr for Subnetwork {
     }
 }
 
-// Convert camel_case cli args to/from the Subnetwork enum.
 impl Subnetwork {
+    /// Convert Subnetwork enum to camel_case cli arg.
     pub fn to_cli_arg(&self) -> String {
         match self {
             Subnetwork::Beacon => "beacon".to_string(),
@@ -99,5 +99,19 @@ impl Subnetwork {
             Subnetwork::TransactionGossip => false,
             Subnetwork::Utp => false,
         }
+    }
+
+    /// Returns Subnetworks that it depends on.
+    pub fn dependencies(&self) -> Vec<Subnetwork> {
+        match self {
+            Subnetwork::History => vec![Subnetwork::Beacon],
+            Subnetwork::State => vec![Subnetwork::History, Subnetwork::Beacon],
+            _ => vec![],
+        }
+    }
+
+    /// Returns itself and subnetworks that it depends on.
+    pub fn with_dependencies(&self) -> impl IntoIterator<Item = Subnetwork> {
+        Iterator::chain([*self].into_iter(), self.dependencies())
     }
 }

--- a/testing/ethportal-peertest/Cargo.toml
+++ b/testing/ethportal-peertest/Cargo.toml
@@ -20,6 +20,7 @@ ethereum_ssz.workspace = true
 ethportal-api.workspace = true
 futures.workspace = true
 hex.workspace = true
+itertools.workspace = true
 jsonrpsee = { workspace = true, features = ["async-client", "client", "macros", "server"] }
 portalnet.workspace = true
 portal-bridge.workspace = true

--- a/testing/ethportal-peertest/src/lib.rs
+++ b/testing/ethportal-peertest/src/lib.rs
@@ -15,6 +15,7 @@ use ethportal_api::{
     Discv5ApiClient,
 };
 use futures::future;
+use itertools::Itertools;
 use jsonrpsee::async_client::Client;
 use portalnet::constants::DEFAULT_DISCOVERY_PORT;
 use rpc::RpcServerHandle;
@@ -86,8 +87,9 @@ fn generate_trin_config(
     let private_key = hex_encode(private_key);
     let subnetworks = subnetworks
         .iter()
-        .map(|sn| sn.to_cli_arg())
-        .collect::<Vec<String>>()
+        .flat_map(Subnetwork::with_dependencies)
+        .unique()
+        .map(|subnetwork| subnetwork.to_cli_arg())
         .join(",");
     let network = network.to_string();
 

--- a/testing/ethportal-peertest/src/scenarios/put_content.rs
+++ b/testing/ethportal-peertest/src/scenarios/put_content.rs
@@ -370,7 +370,7 @@ fn fresh_node_config(network: Network) -> (String, TrinConfig) {
         "--network",
         &network.to_string(),
         "--portal-subnetworks",
-        "history",
+        "beacon,history",
         "--external-address",
         external_addr.as_str(),
         "--mb",


### PR DESCRIPTION
### What was wrong?

In order to validate post-capella and Ephemeral content, we need beacon network enabled.

### How was it fixed?

Adding check to ensure that beacon network is enabled when history is enabled.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
