### PR TITLE
chore: bump workspace and ethportal-api version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,7 +2194,7 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "e2hs-writer"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "ethportal-api"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -2551,7 +2551,7 @@ dependencies = [
 
 [[package]]
 name = "ethportal-peertest"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4714,7 +4714,7 @@ dependencies = [
 
 [[package]]
 name = "portal-bridge"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4760,7 +4760,7 @@ dependencies = [
 
 [[package]]
 name = "portalnet"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5501,7 +5501,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rpc"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "discv5",
@@ -7183,7 +7183,7 @@ dependencies = [
 
 [[package]]
 name = "trin"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7210,7 +7210,7 @@ dependencies = [
 
 [[package]]
 name = "trin-beacon"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7239,7 +7239,7 @@ dependencies = [
 
 [[package]]
 name = "trin-evm"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "ethportal-api",
@@ -7250,7 +7250,7 @@ dependencies = [
 
 [[package]]
 name = "trin-execution"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -7287,7 +7287,7 @@ dependencies = [
 
 [[package]]
 name = "trin-history"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7322,7 +7322,7 @@ dependencies = [
 
 [[package]]
 name = "trin-metrics"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "ethportal-api",
@@ -7332,7 +7332,7 @@ dependencies = [
 
 [[package]]
 name = "trin-state"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7362,7 +7362,7 @@ dependencies = [
 
 [[package]]
 name = "trin-storage"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7383,7 +7383,7 @@ dependencies = [
 
 [[package]]
 name = "trin-utils"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "ansi_term",
@@ -7397,7 +7397,7 @@ dependencies = [
 
 [[package]]
 name = "trin-validation"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7623,7 +7623,7 @@ dependencies = [
 
 [[package]]
 name = "utp-testing"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ethereum/trin"
 rust-version = "1.85.0"
-version = "0.2.1"
+version = "0.2.6"
 
 [workspace.dependencies]
 alloy = { version = "0.12", default-features = false, features = ["std", "serde"] }

--- a/crates/ethportal-api/Cargo.toml
+++ b/crates/ethportal-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethportal-api"
-version = "0.8.0"
+version = "0.8.1"
 description = "Definitions for various Ethereum Portal Network JSONRPC APIs"
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
Bumping the crate version for the new release