### PR TITLE
refactor: simplify header proof generation

### DIFF
--- a/bin/e2hs-writer/src/reader.rs
+++ b/bin/e2hs-writer/src/reader.rs
@@ -11,16 +11,14 @@ use ethportal_api::types::execution::{
     accumulator::EpochAccumulator,
     block_body::BlockBody,
     header_with_proof::{
-        BlockHeaderProof, BlockProofHistoricalHashesAccumulator, BlockProofHistoricalRoots,
-        BlockProofHistoricalSummaries, HeaderWithProof,
+        build_historical_roots_proof, build_historical_summaries_proof, BlockHeaderProof,
+        BlockProofHistoricalHashesAccumulator, HeaderWithProof,
     },
     receipts::Receipts,
 };
 use futures::Stream;
 use portal_bridge::api::execution::ExecutionApi;
-use ssz_types::{typenum, FixedVector, VariableList};
 use tokio::try_join;
-use tree_hash::TreeHash;
 use trin_execution::era::beacon::decode_transactions;
 use trin_validation::{
     accumulator::PreMergeAccumulator,
@@ -140,35 +138,16 @@ impl EpochReader {
             .block
             .message_merge()
             .map_err(|e| anyhow!("Unable to decode merge block: {e:?}"))?;
-        let payload = block.body.execution_payload.clone();
-        let transactions = decode_transactions(&payload.transactions)?;
-        let header = pre_capella_execution_payload_to_header(payload.clone(), &transactions)?;
-
-        let slot = block.slot;
-
-        // create beacon block proof
-        let historical_batch_proof = era
-            .historical_batch
-            .build_block_root_proof(slot % EPOCH_SIZE);
-        let beacon_block_proof: FixedVector<B256, typenum::U14> = historical_batch_proof.into();
-
-        // create execution block proof
-        let mut execution_block_hash_proof = block.body.build_execution_block_hash_proof();
-        let body_root_proof = block.build_body_root_proof();
-        execution_block_hash_proof.extend(body_root_proof);
-        let execution_block_proof: FixedVector<B256, typenum::U11> =
-            execution_block_hash_proof.into();
-
-        let proof = BlockProofHistoricalRoots {
-            beacon_block_proof,
-            beacon_block_root: block.tree_hash_root(),
-            slot,
-            execution_block_proof,
-        };
+        let execution_payload = block.body.execution_payload.clone();
+        let transactions = decode_transactions(&execution_payload.transactions)?;
 
         let header_with_proof = HeaderWithProof {
-            header,
-            proof: BlockHeaderProof::HistoricalRoots(proof),
+            header: pre_capella_execution_payload_to_header(execution_payload, &transactions)?,
+            proof: BlockHeaderProof::HistoricalRoots(build_historical_roots_proof(
+                block.slot,
+                &era.historical_batch,
+                block,
+            )),
         };
         let body = BlockBody(AlloyBlockBody {
             transactions,
@@ -197,33 +176,18 @@ impl EpochReader {
         let transactions = decode_transactions(&payload.transactions)?;
         let withdrawals: Vec<Withdrawal> =
             payload.withdrawals.iter().map(Withdrawal::from).collect();
-        let header =
-            pre_deneb_execution_payload_to_header(payload.clone(), &transactions, &withdrawals)?;
-
-        let slot = block.slot;
-
-        // create beacon block proof
-        let historical_batch_proof = era
-            .historical_batch
-            .build_block_root_proof(slot % EPOCH_SIZE);
-        let beacon_block_proof: FixedVector<B256, typenum::U13> = historical_batch_proof.into();
-
-        // create execution block proof
-        let mut execution_block_hash_proof = block.body.build_execution_block_hash_proof();
-        let body_root_proof = block.build_body_root_proof();
-        execution_block_hash_proof.extend(body_root_proof);
-        let execution_block_proof: VariableList<B256, typenum::U12> =
-            execution_block_hash_proof.into();
-        let proof = BlockProofHistoricalSummaries {
-            beacon_block_proof,
-            beacon_block_root: block.tree_hash_root(),
-            slot,
-            execution_block_proof,
-        };
 
         let header_with_proof = HeaderWithProof {
-            header,
-            proof: BlockHeaderProof::HistoricalSummaries(proof),
+            header: pre_deneb_execution_payload_to_header(
+                payload.clone(),
+                &transactions,
+                &withdrawals,
+            )?,
+            proof: BlockHeaderProof::HistoricalSummaries(build_historical_summaries_proof(
+                block.slot,
+                &era.historical_batch.block_roots,
+                block,
+            )),
         };
         let body = BlockBody(AlloyBlockBody {
             transactions,
@@ -271,123 +235,5 @@ impl EpochReader {
             .ok_or_else(|| anyhow!("Receipts not found for block number {block_number}"))?;
         ensure!(receipts.root() == receipts_root, "Receipts root mismatch");
         Ok(receipts)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use ethportal_api::types::{
-        consensus::{
-            beacon_block::{BeaconBlockBellatrix, BeaconBlockCapella},
-            beacon_state::BeaconState,
-            fork::ForkName,
-        },
-        execution::header_with_proof::{
-            build_historical_roots_proof, build_historical_summaries_proof,
-            BlockProofHistoricalRoots, BlockProofHistoricalSummaries,
-        },
-    };
-    use serde_yaml::Value;
-    use ssz::Decode;
-
-    #[rstest::rstest]
-    // epoch #575
-    #[case(15539558, 4702208, "block_proofs_bellatrix/beacon_block_proof-15539558-cdf9ed89b0c43cda17398dc4da9cfc505e5ccd19f7c39e3b43474180f1051e01.yaml")]
-    // epoch #576
-    #[case(15547621, 4710400, "block_proofs_bellatrix/beacon_block_proof-15547621-96a9313cd506e32893d46c82358569ad242bb32786bd5487833e0f77767aec2a.yaml")]
-    // epoch #577
-    #[case(15555729, 4718592, "block_proofs_bellatrix/beacon_block_proof-15555729-c6fd396d54f61c6d0f1dd3653f81267b0378e9a0d638a229b24586d8fd0bc499.yaml")]
-    #[tokio::test]
-    async fn test_pre_capella_proof_generation(
-        #[case] block_number: u64,
-        #[case] slot: u64,
-        #[case] file_path: &str,
-    ) {
-        use ethportal_api::consensus::beacon_state::HistoricalBatch;
-
-        let test_vector = std::fs::read_to_string(format!(
-            "../../portal-spec-tests/tests/mainnet/history/headers_with_proof/{file_path}"
-        ))
-        .unwrap();
-        let test_vector: Value = serde_yaml::from_str(&test_vector).unwrap();
-        let actual_proof = BlockProofHistoricalRoots {
-            beacon_block_proof: serde_yaml::from_value(test_vector["beacon_block_proof"].clone())
-                .unwrap(),
-            beacon_block_root: serde_yaml::from_value(test_vector["beacon_block_root"].clone())
-                .unwrap(),
-            execution_block_proof: serde_yaml::from_value(
-                test_vector["execution_block_proof"].clone(),
-            )
-            .unwrap(),
-            slot: serde_yaml::from_value(test_vector["slot"].clone()).unwrap(),
-        };
-
-        let test_assets_dir =
-            format!("../../portal-spec-tests/tests/mainnet/history/headers_with_proof/beacon_data/{block_number}");
-        let historical_batch_path = format!("{test_assets_dir}/historical_batch.ssz");
-        let historical_batch_raw = std::fs::read(historical_batch_path).unwrap();
-        let historical_batch = HistoricalBatch::from_ssz_bytes(&historical_batch_raw).unwrap();
-        let block_path = format!("{test_assets_dir}/block.ssz");
-        let block_raw = std::fs::read(block_path).unwrap();
-        let block = BeaconBlockBellatrix::from_ssz_bytes(&block_raw).unwrap();
-        let proof = build_historical_roots_proof(slot, &historical_batch, block);
-
-        assert_eq!(actual_proof, proof);
-    }
-
-    #[rstest::rstest]
-    #[case(
-        17034870,
-        6209538,
-        // epoch #759,
-        "block_proofs_capella/beacon_block_proof-17034870.yaml"
-    )]
-    #[case(
-        17042287,
-        6217730,
-        // epoch #760,
-        "block_proofs_capella/beacon_block_proof-17042287.yaml"
-    )]
-    #[case(
-        17062257,
-        6238210,
-        // epoch #762
-        "block_proofs_capella/beacon_block_proof-17062257.yaml"
-    )]
-    #[tokio::test]
-    async fn test_pre_deneb_proof_generation(
-        #[case] block_number: u64,
-        #[case] slot: u64,
-        #[case] file_path: &str,
-    ) {
-        let test_vector = std::fs::read_to_string(format!(
-            "../../portal-spec-tests/tests/mainnet/history/headers_with_proof/{file_path}"
-        ))
-        .unwrap();
-        let test_vector: Value = serde_yaml::from_str(&test_vector).unwrap();
-        let actual_proof = BlockProofHistoricalSummaries {
-            beacon_block_proof: serde_yaml::from_value(test_vector["beacon_block_proof"].clone())
-                .unwrap(),
-            beacon_block_root: serde_yaml::from_value(test_vector["beacon_block_root"].clone())
-                .unwrap(),
-            execution_block_proof: serde_yaml::from_value(
-                test_vector["execution_block_proof"].clone(),
-            )
-            .unwrap(),
-            slot: serde_yaml::from_value(test_vector["slot"].clone()).unwrap(),
-        };
-
-        let test_assets_dir =
-            format!("../../portal-spec-tests/tests/mainnet/history/headers_with_proof/beacon_data/{block_number}");
-        let state_path = format!("{test_assets_dir}/beacon_state.ssz");
-        let state_raw = std::fs::read(state_path).unwrap();
-        let beacon_state = BeaconState::from_ssz_bytes(&state_raw, ForkName::Capella).unwrap();
-        let beacon_state = beacon_state.as_capella().unwrap();
-        let block_path = format!("{test_assets_dir}/block.ssz");
-        let block_raw = std::fs::read(block_path).unwrap();
-        let block = BeaconBlockCapella::from_ssz_bytes(&block_raw).unwrap();
-        let proof = build_historical_summaries_proof(slot, beacon_state, block);
-
-        assert_eq!(actual_proof, proof);
     }
 }

--- a/bin/e2hs-writer/src/utils.rs
+++ b/bin/e2hs-writer/src/utils.rs
@@ -21,7 +21,7 @@ use trin_execution::era::beacon::EMPTY_UNCLE_ROOT_HASH;
 use trin_validation::accumulator::PreMergeAccumulator;
 
 pub fn pre_capella_execution_payload_to_header(
-    payload: ExecutionPayloadBellatrix,
+    payload: &ExecutionPayloadBellatrix,
     transactions: &[TxEnvelope],
 ) -> anyhow::Result<Header> {
     let transactions_root = calculate_transaction_root(transactions);
@@ -57,7 +57,7 @@ pub fn pre_capella_execution_payload_to_header(
 }
 
 pub fn pre_deneb_execution_payload_to_header(
-    payload: ExecutionPayloadCapella,
+    payload: &ExecutionPayloadCapella,
     transactions: &[TxEnvelope],
     withdrawals: &[Withdrawal],
 ) -> anyhow::Result<Header> {

--- a/bin/trin-execution/src/era/binary_search.rs
+++ b/bin/trin-execution/src/era/binary_search.rs
@@ -2,8 +2,9 @@ use std::collections::HashMap;
 
 use e2store::{
     e2store::types::{Entry, Header as E2StoreHeader},
-    era::{get_beacon_fork, CompressedSignedBeaconBlock, Era, SLOTS_PER_HISTORICAL_ROOT},
+    era::{get_beacon_fork, CompressedSignedBeaconBlock, Era},
 };
+use ethportal_api::consensus::constants::SLOTS_PER_HISTORICAL_ROOT;
 use reqwest::Client;
 use revm_primitives::SpecId;
 use trin_evm::spec_id::get_spec_block_number;

--- a/crates/e2store/src/era.rs
+++ b/crates/e2store/src/era.rs
@@ -5,7 +5,8 @@ use std::{
 
 use anyhow::{anyhow, ensure};
 use ethportal_api::consensus::{
-    beacon_block::SignedBeaconBlock, beacon_state::BeaconState, fork::ForkName,
+    beacon_block::SignedBeaconBlock, beacon_state::BeaconState,
+    constants::SLOTS_PER_HISTORICAL_ROOT, fork::ForkName,
 };
 use ssz::Encode;
 
@@ -16,8 +17,6 @@ use crate::{
     },
     entry_types,
 };
-
-pub const SLOTS_PER_HISTORICAL_ROOT: usize = 8192;
 
 /// group := Version | block* | era-state | other-entries* | slot-index(block)? | slot-index(state)
 /// block := CompressedSignedBeaconBlock

--- a/crates/ethportal-api/src/types/consensus/beacon_block.rs
+++ b/crates/ethportal-api/src/types/consensus/beacon_block.rs
@@ -69,31 +69,49 @@ impl BeaconBlock {
     }
 }
 
-impl BeaconBlockCapella {
+impl BeaconBlockBellatrix {
     pub fn build_body_root_proof(&self) -> Vec<B256> {
-        let leaves = vec![
-            self.slot.tree_hash_root().0,
-            self.proposer_index.tree_hash_root().0,
-            self.parent_root.tree_hash_root().0,
-            self.state_root.tree_hash_root().0,
-            self.body.tree_hash_root().0,
+        let leaves = [
+            self.slot.tree_hash_root(),
+            self.proposer_index.tree_hash_root(),
+            self.parent_root.tree_hash_root(),
+            self.state_root.tree_hash_root(),
+            self.body.tree_hash_root(),
         ];
         // We want to prove the body root, which is the 5th leaf
         build_merkle_proof_for_index(leaves, 4)
     }
+
+    pub fn build_execution_block_hash_proof(&self) -> Vec<B256> {
+        [
+            self.body.execution_payload.build_block_hash_proof(),
+            self.body.build_execution_payload_proof(),
+            self.build_body_root_proof(),
+        ]
+        .concat()
+    }
 }
 
-impl BeaconBlockBellatrix {
+impl BeaconBlockCapella {
     pub fn build_body_root_proof(&self) -> Vec<B256> {
-        let leaves = vec![
-            self.slot.tree_hash_root().0,
-            self.proposer_index.tree_hash_root().0,
-            self.parent_root.tree_hash_root().0,
-            self.state_root.tree_hash_root().0,
-            self.body.tree_hash_root().0,
+        let leaves = [
+            self.slot.tree_hash_root(),
+            self.proposer_index.tree_hash_root(),
+            self.parent_root.tree_hash_root(),
+            self.state_root.tree_hash_root(),
+            self.body.tree_hash_root(),
         ];
         // We want to prove the body root, which is the 5th leaf
         build_merkle_proof_for_index(leaves, 4)
+    }
+
+    pub fn build_execution_block_hash_proof(&self) -> Vec<B256> {
+        [
+            self.body.execution_payload.build_block_hash_proof(),
+            self.body.build_execution_payload_proof(),
+            self.build_body_root_proof(),
+        ]
+        .concat()
     }
 }
 

--- a/crates/ethportal-api/src/types/consensus/beacon_state.rs
+++ b/crates/ethportal-api/src/types/consensus/beacon_state.rs
@@ -35,6 +35,7 @@ type EpochsPerHistoricalVector = U65536;
 type EpochsPerSlashingsVector = U8192;
 type JustificationBitsLength = U4;
 
+pub type RootsPerHistoricalRoot = FixedVector<B256, SlotsPerHistoricalRoot>;
 pub type HistoricalRoots = VariableList<B256, HistoricalRootsLimit>;
 
 /// The state of the `BeaconChain` at some slot.
@@ -73,8 +74,8 @@ pub struct BeaconState {
 
     // History
     pub latest_block_header: BeaconBlockHeader,
-    pub block_roots: FixedVector<B256, SlotsPerHistoricalRoot>,
-    pub state_roots: FixedVector<B256, SlotsPerHistoricalRoot>,
+    pub block_roots: RootsPerHistoricalRoot,
+    pub state_roots: RootsPerHistoricalRoot,
     // Frozen in Capella, replaced by historical_summaries
     pub historical_roots: HistoricalRoots,
 
@@ -162,49 +163,37 @@ impl BeaconState {
     }
 }
 
-impl BeaconStateCapella {
-    pub fn build_block_root_proof(&self, block_root_index: usize) -> Vec<B256> {
-        // Build block hash proof for self.block_roots
-        let leaves: Vec<[u8; 32]> = self
-            .block_roots
-            .iter()
-            .map(|root| root.tree_hash_root().0)
-            .collect();
-        build_merkle_proof_for_index(leaves, block_root_index)
-    }
-}
-
 impl BeaconStateDeneb {
     pub fn build_historical_summaries_proof(&self) -> Vec<B256> {
-        let leaves = vec![
-            self.genesis_time.tree_hash_root().0,
-            self.genesis_validators_root.tree_hash_root().0,
-            self.slot.tree_hash_root().0,
-            self.fork.tree_hash_root().0,
-            self.latest_block_header.tree_hash_root().0,
-            self.block_roots.tree_hash_root().0,
-            self.state_roots.tree_hash_root().0,
-            self.historical_roots.tree_hash_root().0,
-            self.eth1_data.tree_hash_root().0,
-            self.eth1_data_votes.tree_hash_root().0,
-            self.eth1_deposit_index.tree_hash_root().0,
-            self.validators.tree_hash_root().0,
-            self.balances.tree_hash_root().0,
-            self.randao_mixes.tree_hash_root().0,
-            self.slashings.tree_hash_root().0,
-            self.previous_epoch_participation.tree_hash_root().0,
-            self.current_epoch_participation.tree_hash_root().0,
-            self.justification_bits.tree_hash_root().0,
-            self.previous_justified_checkpoint.tree_hash_root().0,
-            self.current_justified_checkpoint.tree_hash_root().0,
-            self.finalized_checkpoint.tree_hash_root().0,
-            self.inactivity_scores.tree_hash_root().0,
-            self.current_sync_committee.tree_hash_root().0,
-            self.next_sync_committee.tree_hash_root().0,
-            self.latest_execution_payload_header.tree_hash_root().0,
-            self.next_withdrawal_index.tree_hash_root().0,
-            self.next_withdrawal_validator_index.tree_hash_root().0,
-            self.historical_summaries.tree_hash_root().0,
+        let leaves = [
+            self.genesis_time.tree_hash_root(),
+            self.genesis_validators_root.tree_hash_root(),
+            self.slot.tree_hash_root(),
+            self.fork.tree_hash_root(),
+            self.latest_block_header.tree_hash_root(),
+            self.block_roots.tree_hash_root(),
+            self.state_roots.tree_hash_root(),
+            self.historical_roots.tree_hash_root(),
+            self.eth1_data.tree_hash_root(),
+            self.eth1_data_votes.tree_hash_root(),
+            self.eth1_deposit_index.tree_hash_root(),
+            self.validators.tree_hash_root(),
+            self.balances.tree_hash_root(),
+            self.randao_mixes.tree_hash_root(),
+            self.slashings.tree_hash_root(),
+            self.previous_epoch_participation.tree_hash_root(),
+            self.current_epoch_participation.tree_hash_root(),
+            self.justification_bits.tree_hash_root(),
+            self.previous_justified_checkpoint.tree_hash_root(),
+            self.current_justified_checkpoint.tree_hash_root(),
+            self.finalized_checkpoint.tree_hash_root(),
+            self.inactivity_scores.tree_hash_root(),
+            self.current_sync_committee.tree_hash_root(),
+            self.next_sync_committee.tree_hash_root(),
+            self.latest_execution_payload_header.tree_hash_root(),
+            self.next_withdrawal_index.tree_hash_root(),
+            self.next_withdrawal_validator_index.tree_hash_root(),
+            self.historical_summaries.tree_hash_root(),
         ];
 
         build_merkle_proof_for_index(leaves, 27)
@@ -307,19 +296,15 @@ pub struct Validator {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct HistoricalBatch {
-    pub block_roots: FixedVector<B256, SlotsPerHistoricalRoot>,
-    pub state_roots: FixedVector<B256, SlotsPerHistoricalRoot>,
+    pub block_roots: RootsPerHistoricalRoot,
+    pub state_roots: RootsPerHistoricalRoot,
 }
 
 impl HistoricalBatch {
     pub fn build_block_root_proof(&self, block_root_index: u64) -> Vec<B256> {
         // Build block hash proof for self.block_roots
-        let leaves: Vec<[u8; 32]> = self
-            .block_roots
-            .iter()
-            .map(|root| root.tree_hash_root().0)
-            .collect();
-        let mut proof_hashes = build_merkle_proof_for_index(leaves, block_root_index as usize);
+        let mut proof_hashes =
+            build_merkle_proof_for_index(self.block_roots.clone(), block_root_index as usize);
 
         // To generate proof for block root anchored to the historical batch tree_hash_root, we need
         // to add the self.state_root tree_hash_root to the proof_hashes

--- a/crates/ethportal-api/src/types/consensus/beacon_state.rs
+++ b/crates/ethportal-api/src/types/consensus/beacon_state.rs
@@ -301,10 +301,10 @@ pub struct HistoricalBatch {
 }
 
 impl HistoricalBatch {
-    pub fn build_block_root_proof(&self, block_root_index: u64) -> Vec<B256> {
+    pub fn build_block_root_proof(&self, block_root_index: usize) -> Vec<B256> {
         // Build block hash proof for self.block_roots
         let mut proof_hashes =
-            build_merkle_proof_for_index(self.block_roots.clone(), block_root_index as usize);
+            build_merkle_proof_for_index(self.block_roots.clone(), block_root_index);
 
         // To generate proof for block root anchored to the historical batch tree_hash_root, we need
         // to add the self.state_root tree_hash_root to the proof_hashes

--- a/crates/ethportal-api/src/types/consensus/body.rs
+++ b/crates/ethportal-api/src/types/consensus/body.rs
@@ -87,9 +87,9 @@ impl BeaconBlockBody {
     }
 }
 
-impl BeaconBlockBodyCapella {
+impl BeaconBlockBodyBellatrix {
     pub fn build_execution_payload_proof(&self) -> Vec<B256> {
-        let leaves = vec![
+        let leaves = [
             self.randao_reveal.tree_hash_root().0,
             self.eth1_data.tree_hash_root().0,
             self.graffiti.tree_hash_root().0,
@@ -100,42 +100,29 @@ impl BeaconBlockBodyCapella {
             self.voluntary_exits.tree_hash_root().0,
             self.sync_aggregate.tree_hash_root().0,
             self.execution_payload.tree_hash_root().0,
-            self.bls_to_execution_changes.tree_hash_root().0,
         ];
         // We want to prove the 10th leaf
         build_merkle_proof_for_index(leaves, 9)
-    }
-
-    pub fn build_execution_block_hash_proof(&self) -> Vec<B256> {
-        let mut block_hash_proof = self.execution_payload.build_block_hash_proof();
-        let execution_payload_proof = self.build_execution_payload_proof();
-        block_hash_proof.extend(execution_payload_proof);
-        block_hash_proof
     }
 }
 
-impl BeaconBlockBodyBellatrix {
+impl BeaconBlockBodyCapella {
     pub fn build_execution_payload_proof(&self) -> Vec<B256> {
-        let leaves = vec![
-            self.randao_reveal.tree_hash_root().0,
-            self.eth1_data.tree_hash_root().0,
-            self.graffiti.tree_hash_root().0,
-            self.proposer_slashings.tree_hash_root().0,
-            self.attester_slashings.tree_hash_root().0,
-            self.attestations.tree_hash_root().0,
-            self.deposits.tree_hash_root().0,
-            self.voluntary_exits.tree_hash_root().0,
-            self.sync_aggregate.tree_hash_root().0,
-            self.execution_payload.tree_hash_root().0,
+        let leaves = [
+            self.randao_reveal.tree_hash_root(),
+            self.eth1_data.tree_hash_root(),
+            self.graffiti.tree_hash_root(),
+            self.proposer_slashings.tree_hash_root(),
+            self.attester_slashings.tree_hash_root(),
+            self.attestations.tree_hash_root(),
+            self.deposits.tree_hash_root(),
+            self.voluntary_exits.tree_hash_root(),
+            self.sync_aggregate.tree_hash_root(),
+            self.execution_payload.tree_hash_root(),
+            self.bls_to_execution_changes.tree_hash_root(),
         ];
         // We want to prove the 10th leaf
         build_merkle_proof_for_index(leaves, 9)
-    }
-
-    pub fn build_execution_block_hash_proof(&self) -> Vec<B256> {
-        let mut block_hash_proof = self.execution_payload.build_block_hash_proof();
-        block_hash_proof.extend(self.build_execution_payload_proof());
-        block_hash_proof
     }
 }
 

--- a/crates/ethportal-api/src/types/consensus/constants.rs
+++ b/crates/ethportal-api/src/types/consensus/constants.rs
@@ -1,0 +1,3 @@
+//! Consensus specs values, taken from: https://github.com/ethereum/consensus-specs/blob/d8cfdf2626c1219a40048f8fa3dd103ae8c0b040/presets/mainnet/phase0.yaml
+
+pub const SLOTS_PER_HISTORICAL_ROOT: usize = 8192;

--- a/crates/ethportal-api/src/types/consensus/execution_payload.rs
+++ b/crates/ethportal-api/src/types/consensus/execution_payload.rs
@@ -92,46 +92,46 @@ impl ExecutionPayload {
     }
 }
 
-impl ExecutionPayloadCapella {
+impl ExecutionPayloadBellatrix {
     pub fn build_block_hash_proof(&self) -> Vec<B256> {
-        let leaves = vec![
-            self.parent_hash.tree_hash_root().0,
-            self.fee_recipient.tree_hash_root().0,
-            self.state_root.tree_hash_root().0,
-            self.receipts_root.tree_hash_root().0,
-            self.logs_bloom.tree_hash_root().0,
-            self.prev_randao.tree_hash_root().0,
-            self.block_number.tree_hash_root().0,
-            self.gas_limit.tree_hash_root().0,
-            self.gas_used.tree_hash_root().0,
-            self.timestamp.tree_hash_root().0,
-            self.extra_data.tree_hash_root().0,
-            self.base_fee_per_gas.tree_hash_root().0,
-            self.block_hash.tree_hash_root().0,
-            self.transactions.tree_hash_root().0,
-            self.withdrawals.tree_hash_root().0,
+        let leaves = [
+            self.parent_hash.tree_hash_root(),
+            self.fee_recipient.tree_hash_root(),
+            self.state_root.tree_hash_root(),
+            self.receipts_root.tree_hash_root(),
+            self.logs_bloom.tree_hash_root(),
+            self.prev_randao.tree_hash_root(),
+            self.block_number.tree_hash_root(),
+            self.gas_limit.tree_hash_root(),
+            self.gas_used.tree_hash_root(),
+            self.timestamp.tree_hash_root(),
+            self.extra_data.tree_hash_root(),
+            self.base_fee_per_gas.tree_hash_root(),
+            self.block_hash.tree_hash_root(),
+            self.transactions.tree_hash_root(),
         ];
         build_merkle_proof_for_index(leaves, 12)
     }
 }
 
-impl ExecutionPayloadBellatrix {
+impl ExecutionPayloadCapella {
     pub fn build_block_hash_proof(&self) -> Vec<B256> {
-        let leaves = vec![
-            self.parent_hash.tree_hash_root().0,
-            self.fee_recipient.tree_hash_root().0,
-            self.state_root.tree_hash_root().0,
-            self.receipts_root.tree_hash_root().0,
-            self.logs_bloom.tree_hash_root().0,
-            self.prev_randao.tree_hash_root().0,
-            self.block_number.tree_hash_root().0,
-            self.gas_limit.tree_hash_root().0,
-            self.gas_used.tree_hash_root().0,
-            self.timestamp.tree_hash_root().0,
-            self.extra_data.tree_hash_root().0,
-            self.base_fee_per_gas.tree_hash_root().0,
-            self.block_hash.tree_hash_root().0,
-            self.transactions.tree_hash_root().0,
+        let leaves = [
+            self.parent_hash.tree_hash_root(),
+            self.fee_recipient.tree_hash_root(),
+            self.state_root.tree_hash_root(),
+            self.receipts_root.tree_hash_root(),
+            self.logs_bloom.tree_hash_root(),
+            self.prev_randao.tree_hash_root(),
+            self.block_number.tree_hash_root(),
+            self.gas_limit.tree_hash_root(),
+            self.gas_used.tree_hash_root(),
+            self.timestamp.tree_hash_root(),
+            self.extra_data.tree_hash_root(),
+            self.base_fee_per_gas.tree_hash_root(),
+            self.block_hash.tree_hash_root(),
+            self.transactions.tree_hash_root(),
+            self.withdrawals.tree_hash_root(),
         ];
         build_merkle_proof_for_index(leaves, 12)
     }

--- a/crates/ethportal-api/src/types/consensus/mod.rs
+++ b/crates/ethportal-api/src/types/consensus/mod.rs
@@ -1,6 +1,7 @@
 pub mod beacon_block;
 pub mod beacon_state;
 pub mod body;
+pub mod constants;
 pub mod execution_payload;
 pub mod fork;
 pub mod header;

--- a/crates/ethportal-api/src/types/consensus/proof.rs
+++ b/crates/ethportal-api/src/types/consensus/proof.rs
@@ -1,13 +1,20 @@
 use alloy::primitives::B256;
 use rs_merkle::{algorithms::Sha256, MerkleTree};
 
-pub fn build_merkle_proof_for_index(mut leaves: Vec<[u8; 32]>, index_to_prove: usize) -> Vec<B256> {
+pub fn build_merkle_proof_for_index<T: Into<[u8; 32]>>(
+    leaves: impl IntoIterator<Item = T, IntoIter: ExactSizeIterator>,
+    index_to_prove: usize,
+) -> Vec<B256> {
+    let leaves = leaves.into_iter();
     // Returns the smallest power of two greater than or equal to self
     let full_tree_len = leaves.len().next_power_of_two();
-    // We want to add empty leaves to make the tree a power of 2
-    while leaves.len() < full_tree_len {
-        leaves.push([0; 32]);
-    }
+
+    // Convert to [u8;32], and append [0;32] until we have full_tree_len
+    let leaves = leaves
+        .map(Into::into)
+        .chain(std::iter::repeat([0; 32]))
+        .take(full_tree_len)
+        .collect::<Vec<_>>();
 
     let merkle_tree = MerkleTree::<Sha256>::from_leaves(&leaves);
     let indices_to_prove = vec![index_to_prove];

--- a/crates/ethportal-api/src/types/execution/header_with_proof.rs
+++ b/crates/ethportal-api/src/types/execution/header_with_proof.rs
@@ -7,7 +7,7 @@ use ssz_types::{typenum, FixedVector, VariableList};
 use tree_hash::TreeHash;
 
 use crate::{
-    consensus::beacon_state::RootsPerHistoricalRoot,
+    consensus::{beacon_state::RootsPerHistoricalRoot, constants::SLOTS_PER_HISTORICAL_ROOT},
     types::{
         bytes::ByteList1024,
         consensus::{
@@ -158,9 +158,10 @@ pub fn build_historical_roots_proof(
     historical_batch: &HistoricalBatch,
     beacon_block: &BeaconBlockBellatrix,
 ) -> BlockProofHistoricalRoots {
-    let beacon_block_proof =
-        BeaconBlockProofHistoricalRoots::new(historical_batch.build_block_root_proof(slot % 8192))
-            .expect("error creating BeaconBlockProofHistoricalRoots");
+    let beacon_block_proof = BeaconBlockProofHistoricalRoots::new(
+        historical_batch.build_block_root_proof(slot as usize % SLOTS_PER_HISTORICAL_ROOT),
+    )
+    .expect("error creating BeaconBlockProofHistoricalRoots");
 
     // execution block proof
     let execution_block_proof =
@@ -183,8 +184,10 @@ pub fn build_historical_summaries_proof(
     block_roots: &RootsPerHistoricalRoot,
     beacon_block: &BeaconBlockCapella,
 ) -> BlockProofHistoricalSummaries {
-    let beacon_block_proof =
-        build_merkle_proof_for_index(block_roots.clone(), slot as usize % 8192);
+    let beacon_block_proof = build_merkle_proof_for_index(
+        block_roots.clone(),
+        slot as usize % SLOTS_PER_HISTORICAL_ROOT,
+    );
     let beacon_block_proof = BeaconBlockProofHistoricalSummaries::new(beacon_block_proof)
         .expect("error creating BeaconBlockProofHistoricalSummaries");
 

--- a/crates/ethportal-api/src/types/execution/header_with_proof.rs
+++ b/crates/ethportal-api/src/types/execution/header_with_proof.rs
@@ -6,16 +6,19 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum, FixedVector, VariableList};
 use tree_hash::TreeHash;
 
-use crate::types::{
-    bytes::ByteList1024,
-    consensus::{
-        beacon_block::{BeaconBlockBellatrix, BeaconBlockCapella},
-        beacon_state::{BeaconStateCapella, HistoricalBatch},
-        proof::build_merkle_proof_for_index,
-    },
-    execution::{
-        block_body::{MERGE_TIMESTAMP, SHANGHAI_TIMESTAMP},
-        ssz_header,
+use crate::{
+    consensus::beacon_state::RootsPerHistoricalRoot,
+    types::{
+        bytes::ByteList1024,
+        consensus::{
+            beacon_block::{BeaconBlockBellatrix, BeaconBlockCapella},
+            beacon_state::HistoricalBatch,
+            proof::build_merkle_proof_for_index,
+        },
+        execution::{
+            block_body::{MERGE_TIMESTAMP, SHANGHAI_TIMESTAMP},
+            ssz_header,
+        },
     },
 };
 
@@ -149,93 +152,50 @@ pub struct BlockProofHistoricalSummaries {
     pub slot: u64,
 }
 
+/// Builds `BlockProofHistoricalRoots` for a given slot.
 pub fn build_historical_roots_proof(
     slot: u64,
     historical_batch: &HistoricalBatch,
-    beacon_block: BeaconBlockBellatrix,
+    beacon_block: &BeaconBlockBellatrix,
 ) -> BlockProofHistoricalRoots {
-    let beacon_block_proof = historical_batch.build_block_root_proof(slot % 8192);
+    let beacon_block_proof =
+        BeaconBlockProofHistoricalRoots::new(historical_batch.build_block_root_proof(slot % 8192))
+            .expect("error creating BeaconBlockProofHistoricalRoots");
 
     // execution block proof
-    let mut execution_block_hash_proof = beacon_block.body.build_execution_block_hash_proof();
-    let body_root_proof = beacon_block.build_body_root_proof();
-    execution_block_hash_proof.extend(body_root_proof);
+    let execution_block_proof =
+        ExecutionBlockProof::new(beacon_block.build_execution_block_hash_proof())
+            .expect("error creating ExecutionBlockProof");
 
     BlockProofHistoricalRoots {
-        beacon_block_proof: beacon_block_proof.into(),
+        beacon_block_proof,
         beacon_block_root: beacon_block.tree_hash_root(),
-        execution_block_proof: execution_block_hash_proof.into(),
+        execution_block_proof,
         slot,
     }
 }
 
+/// Builds `BlockProofHistoricalSummaries` for a given slot.
+///
+/// The `block_roots` represents the `block_roots` fields from `BeaconState`.
 pub fn build_historical_summaries_proof(
     slot: u64,
-    capella_state: &BeaconStateCapella,
-    beacon_block: BeaconBlockCapella,
+    block_roots: &RootsPerHistoricalRoot,
+    beacon_block: &BeaconBlockCapella,
 ) -> BlockProofHistoricalSummaries {
-    // beacon block proof
-    let block_root_proof = capella_state.build_block_root_proof(slot as usize % 8192);
-    let beacon_block_proof: FixedVector<B256, typenum::U13> = block_root_proof.into();
+    let beacon_block_proof =
+        build_merkle_proof_for_index(block_roots.clone(), slot as usize % 8192);
+    let beacon_block_proof = BeaconBlockProofHistoricalSummaries::new(beacon_block_proof)
+        .expect("error creating BeaconBlockProofHistoricalSummaries");
 
-    // execution block proof
-    let mut execution_block_hash_proof = beacon_block.body.build_execution_block_hash_proof();
-    let body_root_proof = beacon_block.build_body_root_proof();
-    execution_block_hash_proof.extend(body_root_proof);
+    let execution_block_proof =
+        ExecutionBlockProofCapella::new(beacon_block.build_execution_block_hash_proof())
+            .expect("error creating ExecutionBlockProofCapella");
 
     BlockProofHistoricalSummaries {
         beacon_block_proof,
         beacon_block_root: beacon_block.tree_hash_root(),
-        execution_block_proof: execution_block_hash_proof.into(),
-        slot,
-    }
-}
-
-pub fn build_block_proof_historical_roots(
-    slot: u64,
-    historical_batch: HistoricalBatch,
-    beacon_block: BeaconBlockBellatrix,
-) -> BlockProofHistoricalRoots {
-    // beacon block proof
-    let historical_batch_proof = historical_batch.build_block_root_proof(slot % 8192);
-
-    // execution block proof
-    let mut execution_block_hash_proof = beacon_block.body.build_execution_block_hash_proof();
-    let body_root_proof = beacon_block.build_body_root_proof();
-    execution_block_hash_proof.extend(body_root_proof);
-
-    BlockProofHistoricalRoots {
-        beacon_block_proof: historical_batch_proof.into(),
-        beacon_block_root: beacon_block.tree_hash_root(),
-        execution_block_proof: execution_block_hash_proof.into(),
-        slot,
-    }
-}
-
-pub fn build_block_proof_historical_summaries(
-    slot: u64,
-    // block roots fields from BeaconState
-    block_roots: FixedVector<B256, typenum::U8192>,
-    beacon_block: BeaconBlockCapella,
-) -> BlockProofHistoricalSummaries {
-    // beacon block proof
-    let leaves = block_roots
-        .iter()
-        .map(|root| root.tree_hash_root().0)
-        .collect();
-    let slot_index = slot as usize % 8192;
-    let block_root_proof = build_merkle_proof_for_index(leaves, slot_index);
-    let beacon_block_proof: FixedVector<B256, typenum::U13> = block_root_proof.into();
-
-    // execution block proof
-    let mut execution_block_hash_proof = beacon_block.body.build_execution_block_hash_proof();
-    let body_root_proof = beacon_block.build_body_root_proof();
-    execution_block_hash_proof.extend(body_root_proof);
-
-    BlockProofHistoricalSummaries {
-        beacon_block_proof,
-        beacon_block_root: beacon_block.tree_hash_root(),
-        execution_block_proof: execution_block_hash_proof.into(),
+        execution_block_proof,
         slot,
     }
 }
@@ -243,23 +203,26 @@ pub fn build_block_proof_historical_summaries(
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    use std::path::{Path, PathBuf};
+
+    use alloy::{hex::FromHex, primitives::Bytes};
     use serde_json::Value;
-    use serde_yaml::Value as YamlValue;
     use ssz::Decode;
 
     use super::*;
     use crate::{
+        consensus::beacon_state::BeaconStateCapella,
         test_utils::{read_bytes_from_tests_submodule, read_file_from_tests_submodule},
-        types::consensus::{beacon_state::BeaconState, fork::ForkName},
         utils::bytes::{hex_decode, hex_encode},
     };
 
+    const TEST_DIR: &str = "tests/mainnet/history/headers_with_proof";
+
     #[test_log::test]
     fn decode_encode_headers_with_proof() {
-        let file = read_file_from_tests_submodule(
-            "tests/mainnet/history/headers_with_proof/1000001-1000010.json",
-        )
-        .unwrap();
+        let file =
+            read_file_from_tests_submodule(PathBuf::from(TEST_DIR).join("1000001-1000010.json"))
+                .unwrap();
         let json: Value = serde_json::from_str(&file).unwrap();
         let hwps = json.as_object().unwrap();
         for (block_number, obj) in hwps {
@@ -273,121 +236,160 @@ mod tests {
     }
 
     #[rstest::rstest]
-    #[case("1000010")]
-    #[case("14764013")]
-    #[case("15537392")]
-    #[case("15537393")]
-    #[case("15539558")]
-    #[case("15547621")]
-    #[case("15555729")]
-    #[case("17034870")]
-    #[case("17042287")]
-    #[case("17062257")]
-    fn decode_encode_more_headers_with_proofs(#[case] filename: &str) {
-        let file = read_file_from_tests_submodule(format!(
-            "tests/mainnet/history/headers_with_proof/{filename}.yaml"
-        ))
-        .unwrap();
-        let yaml: serde_yaml::Value = serde_yaml::from_str(&file).unwrap();
-        let actual_hwp = yaml.get("content_value").unwrap().as_str().unwrap();
-        let hwp = HeaderWithProof::from_ssz_bytes(&hex_decode(actual_hwp).unwrap()).unwrap();
-        assert_eq!(hwp.header.number, filename.parse::<u64>().unwrap());
-        let encoded = hex_encode(ssz::Encode::as_ssz_bytes(&hwp));
+    #[case(1000010)]
+    #[case(14764013)]
+    #[case(15537392)]
+    #[case(15537393)]
+    #[case(15539558)]
+    #[case(15547621)]
+    #[case(15555729)]
+    #[case(17034870)]
+    #[case(17042287)]
+    #[case(17062257)]
+    fn decode_encode_more_headers_with_proofs(#[case] block_number: u64) {
+        let yaml: serde_yaml::Value =
+            read_yaml_test_file(PathBuf::from(TEST_DIR).join(format!("{block_number}.yaml")));
+        let actual_hwp = yaml["content_value"].as_str().unwrap();
+        let header_with_proof =
+            HeaderWithProof::from_ssz_bytes(&hex_decode(actual_hwp).unwrap()).unwrap();
+        assert_eq!(header_with_proof.header.number, block_number);
+        let encoded = hex_encode(ssz::Encode::as_ssz_bytes(&header_with_proof));
         assert_eq!(encoded, actual_hwp);
     }
 
-    #[rstest::rstest]
-    #[case(
-        15539558,
-        4702208,
-        "15539558-cdf9ed89b0c43cda17398dc4da9cfc505e5ccd19f7c39e3b43474180f1051e01"
-    )] // epoch 575
-    #[case(
-        15547621,
-        4710400,
-        "15547621-96a9313cd506e32893d46c82358569ad242bb32786bd5487833e0f77767aec2a"
-    )] // epoch 576
-    #[case(
-        15555729,
-        4718592,
-        "15555729-c6fd396d54f61c6d0f1dd3653f81267b0378e9a0d638a229b24586d8fd0bc499"
-    )] // epoch 577
-    #[tokio::test]
-    async fn historical_roots_proof_generation(
-        #[case] block_number: u64,
-        #[case] slot: u64,
-        #[case] file_path: &str,
-    ) {
-        let test_vector = read_file_from_tests_submodule(format!(
-            "tests/mainnet/history/headers_with_proof/block_proofs_bellatrix/beacon_block_proof-{file_path}.yaml"
-        ))
-        .unwrap();
-        let test_vector: YamlValue = serde_yaml::from_str(&test_vector).unwrap();
-        let expected_proof = BlockProofHistoricalRoots {
-            beacon_block_proof: serde_yaml::from_value(test_vector["beacon_block_proof"].clone())
-                .unwrap(),
-            beacon_block_root: serde_yaml::from_value(test_vector["beacon_block_root"].clone())
-                .unwrap(),
-            execution_block_proof: serde_yaml::from_value(
-                test_vector["execution_block_proof"].clone(),
-            )
-            .unwrap(),
-            slot: serde_yaml::from_value(test_vector["slot"].clone()).unwrap(),
-        };
+    /// Tests that proof withing decoded HeaderWithProof matches expected value
+    mod proof_decoding {
+        use super::*;
 
-        let test_assets_dir =
-            format!("tests/mainnet/history/headers_with_proof/beacon_data/{block_number}");
-        let historical_batch_raw =
-            read_bytes_from_tests_submodule(format!("{test_assets_dir}/historical_batch.ssz",))
-                .unwrap();
-        let historical_batch = HistoricalBatch::from_ssz_bytes(&historical_batch_raw).unwrap();
-        let block_raw =
-            read_bytes_from_tests_submodule(format!("{test_assets_dir}/block.ssz",)).unwrap();
-        let block = BeaconBlockBellatrix::from_ssz_bytes(&block_raw).unwrap();
-        let actual_proof = build_block_proof_historical_roots(slot, historical_batch, block);
+        #[rstest::rstest]
+        #[case(
+            15539558,
+            "15539558-cdf9ed89b0c43cda17398dc4da9cfc505e5ccd19f7c39e3b43474180f1051e01"
+        )] // epoch 575
+        #[case(
+            15547621,
+            "15547621-96a9313cd506e32893d46c82358569ad242bb32786bd5487833e0f77767aec2a"
+        )] // epoch 576
+        #[case(
+            15555729,
+            "15555729-c6fd396d54f61c6d0f1dd3653f81267b0378e9a0d638a229b24586d8fd0bc499"
+        )] // epoch 577
+        #[test]
+        fn bellatrix(#[case] block_number: u64, #[case] file_path: &str) -> anyhow::Result<()> {
+            let header_with_proof_yaml: serde_yaml::Value =
+                read_yaml_test_file(PathBuf::from(TEST_DIR).join(format!("{block_number}.yaml")));
+            let header_with_proof = HeaderWithProof::from_ssz_bytes(&Bytes::from_hex(
+                header_with_proof_yaml["content_value"].as_str().unwrap(),
+            )?)
+            .unwrap();
 
-        assert_eq!(expected_proof, actual_proof);
+            let expected_block_header_proof = BlockHeaderProof::HistoricalRoots(
+                read_yaml_test_file(PathBuf::from(TEST_DIR).join(format!(
+                    "block_proofs_bellatrix/beacon_block_proof-{file_path}.yaml"
+                ))),
+            );
+
+            assert_eq!(header_with_proof.proof, expected_block_header_proof);
+            Ok(())
+        }
+
+        #[rstest::rstest]
+        #[case(17034870)] // epoch 759
+        #[case(17042287)] // epoch 760
+        #[case(17062257)] // epoch 762
+        #[test]
+        fn capella(#[case] block_number: u64) -> anyhow::Result<()> {
+            let block_header_proof = BlockHeaderProof::HistoricalSummaries(read_yaml_test_file(
+                PathBuf::from(TEST_DIR).join(format!(
+                    "block_proofs_capella/beacon_block_proof-{block_number}.yaml"
+                )),
+            ));
+
+            let header_with_proof_yaml: serde_yaml::Value =
+                read_yaml_test_file(PathBuf::from(TEST_DIR).join(format!("{block_number}.yaml")));
+            let header_with_proof = HeaderWithProof::from_ssz_bytes(&Bytes::from_hex(
+                header_with_proof_yaml["content_value"].as_str().unwrap(),
+            )?)
+            .unwrap();
+
+            assert_eq!(header_with_proof.proof, block_header_proof);
+            Ok(())
+        }
     }
 
-    #[rstest::rstest]
-    #[case(17034870, 6209538)] // epoch 759
-    #[case(17042287, 6217730)] // epoch 760
-    #[case(17062257, 6238210)] // epoch 762
-    #[tokio::test]
-    async fn pre_deneb_historical_summaries_generation(
-        #[case] block_number: u64,
-        #[case] slot: u64,
-    ) {
-        let test_vector = read_file_from_tests_submodule(format!(
-            "tests/mainnet/history/headers_with_proof/block_proofs_capella/beacon_block_proof-{block_number}.yaml",
-        ))
-        .unwrap();
-        let test_vector: YamlValue = serde_yaml::from_str(&test_vector).unwrap();
-        let expected_proof = BlockProofHistoricalSummaries {
-            beacon_block_proof: serde_yaml::from_value(test_vector["beacon_block_proof"].clone())
-                .unwrap(),
-            beacon_block_root: serde_yaml::from_value(test_vector["beacon_block_root"].clone())
-                .unwrap(),
-            execution_block_proof: serde_yaml::from_value(
-                test_vector["execution_block_proof"].clone(),
-            )
-            .unwrap(),
-            slot: serde_yaml::from_value(test_vector["slot"].clone()).unwrap(),
-        };
+    mod proof_generation {
+        use super::*;
 
-        let test_assets_dir =
-            format!("tests/mainnet/history/headers_with_proof/beacon_data/{block_number}");
-        let beacon_state_raw =
-            read_bytes_from_tests_submodule(format!("{test_assets_dir}/beacon_state.ssz",))
-                .unwrap();
-        let beacon_state =
-            BeaconState::from_ssz_bytes(&beacon_state_raw, ForkName::Capella).unwrap();
-        let block_roots = beacon_state.as_capella().unwrap().block_roots.clone();
-        let block_raw =
-            read_bytes_from_tests_submodule(format!("{test_assets_dir}/block.ssz",)).unwrap();
-        let block = BeaconBlockCapella::from_ssz_bytes(&block_raw).unwrap();
-        let actual_proof = build_block_proof_historical_summaries(slot, block_roots, block);
+        #[rstest::rstest]
+        #[case(
+            15539558,
+            4702208,
+            "15539558-cdf9ed89b0c43cda17398dc4da9cfc505e5ccd19f7c39e3b43474180f1051e01"
+        )] // epoch 575
+        #[case(
+            15547621,
+            4710400,
+            "15547621-96a9313cd506e32893d46c82358569ad242bb32786bd5487833e0f77767aec2a"
+        )] // epoch 576
+        #[case(
+            15555729,
+            4718592,
+            "15555729-c6fd396d54f61c6d0f1dd3653f81267b0378e9a0d638a229b24586d8fd0bc499"
+        )] // epoch 577
+        #[test]
+        fn bellatrix(#[case] block_number: u64, #[case] slot: u64, #[case] file_path: &str) {
+            let expected_proof: BlockProofHistoricalRoots =
+                read_yaml_test_file(PathBuf::from(TEST_DIR).join(format!(
+                    "block_proofs_bellatrix/beacon_block_proof-{file_path}.yaml"
+                )));
 
-        assert_eq!(expected_proof, actual_proof);
+            let beacon_data_dir = PathBuf::from(TEST_DIR)
+                .join("beacon_data")
+                .join(format!("{block_number}"));
+            let historical_batch_raw =
+                read_bytes_from_tests_submodule(beacon_data_dir.join("historical_batch.ssz"))
+                    .unwrap();
+            let historical_batch = HistoricalBatch::from_ssz_bytes(&historical_batch_raw).unwrap();
+            let block_raw =
+                read_bytes_from_tests_submodule(beacon_data_dir.join("block.ssz")).unwrap();
+            let block = BeaconBlockBellatrix::from_ssz_bytes(&block_raw).unwrap();
+            let actual_proof = build_historical_roots_proof(slot, &historical_batch, &block);
+
+            assert_eq!(expected_proof, actual_proof);
+        }
+
+        #[rstest::rstest]
+        #[case(17034870, 6209538)] // epoch 759
+        #[case(17042287, 6217730)] // epoch 760
+        #[case(17062257, 6238210)] // epoch 762
+        #[test]
+        fn capella(#[case] block_number: u64, #[case] slot: u64) {
+            let expected_proof: BlockProofHistoricalSummaries =
+                read_yaml_test_file(PathBuf::from(TEST_DIR).join(format!(
+                    "block_proofs_capella/beacon_block_proof-{block_number}.yaml"
+                )));
+
+            let beacon_data_dir = PathBuf::from(TEST_DIR)
+                .join("beacon_data")
+                .join(format!("{block_number}"));
+            let beacon_state_raw =
+                read_bytes_from_tests_submodule(beacon_data_dir.join("beacon_state.ssz")).unwrap();
+            let beacon_state = BeaconStateCapella::from_ssz_bytes(&beacon_state_raw).unwrap();
+            let block_raw =
+                read_bytes_from_tests_submodule(beacon_data_dir.join("block.ssz")).unwrap();
+            let block = BeaconBlockCapella::from_ssz_bytes(&block_raw).unwrap();
+            let actual_proof =
+                build_historical_summaries_proof(slot, &beacon_state.block_roots, &block);
+
+            assert_eq!(expected_proof, actual_proof);
+        }
+    }
+
+    fn read_yaml_test_file<T>(path: impl AsRef<Path>) -> T
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        let file_as_str = read_file_from_tests_submodule(path).unwrap();
+        serde_yaml::from_str(&file_as_str).unwrap()
     }
 }

--- a/testing/ef-tests/tests/build_proofs.rs
+++ b/testing/ef-tests/tests/build_proofs.rs
@@ -92,7 +92,7 @@ fn block_body_execution_payload_proof() {
     assert_eq!(proof.len(), 4);
     assert_eq!(proof, expected_execution_payload_proof.to_vec());
 
-    let mut expected_block_hash_proof = [
+    let expected_block_hash_proof = [
         "0x7ffe241ea60187fdb0187bfa22de35d1f9bed7ab061d9401fd47e34a54fbede1",
         "0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b",
         "0xf00e3441849a7e4228e6f48d5a5b231e153b39cb2ef283febdd9f7df1f777551",
@@ -100,10 +100,9 @@ fn block_body_execution_payload_proof() {
     ]
     .map(|x| B256::from_str(x).unwrap())
     .to_vec();
-    let proof = content.build_execution_block_hash_proof();
-    expected_block_hash_proof.extend(expected_execution_payload_proof);
+    let proof = content.execution_payload.build_block_hash_proof();
 
-    assert_eq!(proof.len(), 8);
+    assert_eq!(proof.len(), 4);
     assert_eq!(proof, expected_block_hash_proof);
 }
 


### PR DESCRIPTION
This is first PR that simplifies existing logic before I start adding changes from: #1779

### What was wrong?

The code for generating historical_roots and historical_summaries proof  is duplicated in a few places.
Some of the utility functions could also be more specific

### How was it fixed?

- simplify proof generation logic in `headers_with_proof` and improve tests a bit
- moved the logic for generating `execution_block_proof` into `BeaconBlock`
    - removed similar, no longer needed, logic from `BlockBody`
- removed block generation logic from bin/e2hs-writer/src/reader.rs (it was identical with the one in headers_with_proof)
    - also removed the tests, because they were also identical
- added tests for verifying that decoded `HeaderWithProof::proof` matches expected value
- make `build_merkle_proof_for_index` generic

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
