### PR TITLE
feat: change ExecutionBlockProof from list to vector

### DIFF
--- a/bin/e2hs-writer/src/main.rs
+++ b/bin/e2hs-writer/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
 
     let start = Instant::now();
     let epoch_writer = EpochWriter::new(config.target_dir, config.epoch);
-    epoch_writer.write_epoch(epoch_reader).await?;
+    epoch_writer.write_epoch(epoch_reader)?;
     info!(
         "Time taken to finished writing blocks  {}",
         start.elapsed().human(Truncate::Second)

--- a/bin/e2hs-writer/src/writer.rs
+++ b/bin/e2hs-writer/src/writer.rs
@@ -4,7 +4,6 @@ use e2store::{
     e2hs::{BlockTuple, E2HSWriter, HeaderWithProofEntry},
     era1::{BodyEntry, ReceiptsEntry},
 };
-use futures::StreamExt;
 use tracing::info;
 
 use crate::reader::EpochReader;
@@ -23,15 +22,14 @@ impl EpochWriter {
         }
     }
 
-    pub async fn write_epoch(&self, reader: EpochReader) -> anyhow::Result<()> {
+    pub fn write_epoch(&self, reader: EpochReader) -> anyhow::Result<()> {
         info!(
             "Writing epoch {} to {:?}",
             self.epoch_index, self.target_dir
         );
         let mut e2hs_writer = E2HSWriter::create(&self.target_dir, self.epoch_index)?;
-        let mut block_stream = Box::pin(reader.iter_blocks());
 
-        while let Some(block_data) = block_stream.next().await {
+        for block_data in reader.iter_blocks() {
             let block_data = block_data?;
             info!(
                 "Writing block {}",

--- a/crates/ethportal-api/src/types/execution/block_body.rs
+++ b/crates/ethportal-api/src/types/execution/block_body.rs
@@ -16,10 +16,6 @@ use anyhow::{anyhow, bail};
 use serde::Deserialize;
 use ssz::{Encode, SszDecoderBuilder, SszEncoder};
 
-pub const SHANGHAI_TIMESTAMP: u64 = 1681338455;
-// block 15537393 timestamp
-pub const MERGE_TIMESTAMP: u64 = 1663224162;
-
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, RlpEncodableWrapper, RlpDecodableWrapper)]
 pub struct BlockBody(pub AlloyBlockBody<TxEnvelope>);
 

--- a/crates/validation/src/header_validator.rs
+++ b/crates/validation/src/header_validator.rs
@@ -43,15 +43,14 @@ impl HeaderValidator {
         &self,
         header_with_proof: &HeaderWithProof,
     ) -> anyhow::Result<()> {
-        match &header_with_proof.proof {
+        let HeaderWithProof { header, proof } = header_with_proof;
+        match &proof {
             BlockHeaderProof::HistoricalHashes(proof) => {
-                self.verify_pre_merge_header(&header_with_proof.header, proof)
+                self.verify_pre_merge_header(header, proof)
             }
-            BlockHeaderProof::HistoricalRoots(proof) => self.verify_merge_to_capella_header(
-                header_with_proof.header.number,
-                header_with_proof.header.hash_slow(),
-                proof,
-            ),
+            BlockHeaderProof::HistoricalRoots(proof) => {
+                self.verify_merge_to_capella_header(header.number, header.hash_slow(), proof)
+            }
             BlockHeaderProof::HistoricalSummariesCapella(_) => Err(anyhow!(
                 "HistoricalSummariesCapella header validation is not implemented yet."
             )),

--- a/testing/ethportal-peertest/src/scenarios/state.rs
+++ b/testing/ethportal-peertest/src/scenarios/state.rs
@@ -1,7 +1,8 @@
 use ethportal_api::{
     jsonrpsee::async_client::Client,
     types::execution::header_with_proof::{
-        BlockHeaderProof, BlockProofHistoricalRoots, BlockProofHistoricalSummaries, HeaderWithProof,
+        BlockHeaderProof, BlockProofHistoricalRoots, BlockProofHistoricalSummariesCapella,
+        HeaderWithProof,
     },
     ContentValue, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
     StateNetworkApiClient,
@@ -63,7 +64,7 @@ async fn test_state_offer(fixture: &StateFixture, target: &Client, peer: &Peerte
             })
         }
         SHANGHAI_BLOCK_NUMBER.. => {
-            BlockHeaderProof::HistoricalSummaries(BlockProofHistoricalSummaries {
+            BlockHeaderProof::HistoricalSummariesCapella(BlockProofHistoricalSummariesCapella {
                 beacon_block_proof: Default::default(),
                 beacon_block_root: Default::default(),
                 execution_block_proof: Default::default(),


### PR DESCRIPTION
This is a followup of #1782 , which ~should be reviewed and merged first~ is now merged.
Next PR will add Deneb types

### What was wrong?

The `ExecutionBlockProof` format change from List to Vector in https://github.com/ethereum/portal-network-specs/pull/396

### How was it fixed?

- Updated our format and naming to be consistent with spec
- Updated `portal-spec-tests` submodule
- Updated header validation logic (but didn't enable it yet)

I also noticed that several functions in `e2hs-writer` crate are async without a reason so I simplified logic there a bit as well.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
