### PR TITLE
feat: add Deneb header proof type and generation

### DIFF
--- a/bin/e2hs-writer/src/reader.rs
+++ b/bin/e2hs-writer/src/reader.rs
@@ -212,7 +212,12 @@ impl EpochReader {
             payload.withdrawals.iter().map(Withdrawal::from).collect();
 
         let header_with_proof = HeaderWithProof {
-            header: post_deneb_execution_payload_to_header(payload, &transactions, &withdrawals)?,
+            header: post_deneb_execution_payload_to_header(
+                payload,
+                block.parent_root,
+                &transactions,
+                &withdrawals,
+            )?,
             proof: BlockHeaderProof::HistoricalSummariesDeneb(
                 build_deneb_historical_summaries_proof(
                     block.slot,

--- a/bin/e2hs-writer/src/reader.rs
+++ b/bin/e2hs-writer/src/reader.rs
@@ -10,8 +10,9 @@ use ethportal_api::types::execution::{
     accumulator::EpochAccumulator,
     block_body::BlockBody,
     header_with_proof::{
-        build_capella_historical_summaries_proof, build_historical_roots_proof, BlockHeaderProof,
-        BlockProofHistoricalHashesAccumulator, HeaderWithProof,
+        build_capella_historical_summaries_proof, build_deneb_historical_summaries_proof,
+        build_historical_roots_proof, BlockHeaderProof, BlockProofHistoricalHashesAccumulator,
+        HeaderWithProof,
     },
     receipts::Receipts,
 };
@@ -28,8 +29,8 @@ use url::Url;
 use crate::{
     provider::EraProvider,
     utils::{
-        lookup_epoch_acc, pre_capella_execution_payload_to_header,
-        pre_deneb_execution_payload_to_header,
+        bellatrix_execution_payload_to_header, capella_execution_payload_to_header,
+        lookup_epoch_acc, post_deneb_execution_payload_to_header,
     },
 };
 
@@ -140,7 +141,7 @@ impl EpochReader {
         let transactions = decode_transactions(&execution_payload.transactions)?;
 
         let header_with_proof = HeaderWithProof {
-            header: pre_capella_execution_payload_to_header(execution_payload, &transactions)?,
+            header: bellatrix_execution_payload_to_header(execution_payload, &transactions)?,
             proof: BlockHeaderProof::HistoricalRoots(build_historical_roots_proof(
                 block.slot,
                 &era.historical_batch,
@@ -176,7 +177,7 @@ impl EpochReader {
             payload.withdrawals.iter().map(Withdrawal::from).collect();
 
         let header_with_proof = HeaderWithProof {
-            header: pre_deneb_execution_payload_to_header(payload, &transactions, &withdrawals)?,
+            header: capella_execution_payload_to_header(payload, &transactions, &withdrawals)?,
             proof: BlockHeaderProof::HistoricalSummariesCapella(
                 build_capella_historical_summaries_proof(
                     block.slot,
@@ -199,17 +200,51 @@ impl EpochReader {
         })
     }
 
+    fn get_deneb_block_data(&mut self, block_number: u64) -> anyhow::Result<AllBlockData> {
+        let (block, era) = self.era_provider.get_post_merge(block_number)?;
+        let block = block
+            .block
+            .message_deneb()
+            .map_err(|e| anyhow!("Unable to decode deneb block: {e:?}"))?;
+        let payload = &block.body.execution_payload;
+        let transactions = decode_transactions(&payload.transactions)?;
+        let withdrawals: Vec<Withdrawal> =
+            payload.withdrawals.iter().map(Withdrawal::from).collect();
+
+        let header_with_proof = HeaderWithProof {
+            header: post_deneb_execution_payload_to_header(payload, &transactions, &withdrawals)?,
+            proof: BlockHeaderProof::HistoricalSummariesDeneb(
+                build_deneb_historical_summaries_proof(
+                    block.slot,
+                    &era.historical_batch.block_roots,
+                    block,
+                ),
+            ),
+        };
+        let body = BlockBody(AlloyBlockBody {
+            transactions,
+            ommers: vec![],
+            withdrawals: Some(Withdrawals::new(withdrawals)),
+        });
+        let receipts = self.get_receipts(block_number, header_with_proof.header.receipts_root)?;
+        Ok(AllBlockData {
+            block_number,
+            header_with_proof,
+            body,
+            receipts,
+        })
+    }
+
     pub fn iter_blocks(mut self) -> impl Iterator<Item = anyhow::Result<AllBlockData>> {
-        (self.starting_block..self.ending_block).map(move |current_block| {
-            if current_block < MERGE_BLOCK_NUMBER {
-                self.get_pre_merge_block_data(current_block)
-            } else if current_block < SHANGHAI_BLOCK_NUMBER {
+        (self.starting_block..self.ending_block).map(move |current_block| match current_block {
+            0..MERGE_BLOCK_NUMBER => self.get_pre_merge_block_data(current_block),
+            MERGE_BLOCK_NUMBER..SHANGHAI_BLOCK_NUMBER => {
                 self.get_merge_to_capella_block_data(current_block)
-            } else if current_block < CANCUN_BLOCK_NUMBER {
-                self.get_capella_to_deneb_block_data(current_block)
-            } else {
-                Err(anyhow!("Unsupported block number: {current_block}"))
             }
+            SHANGHAI_BLOCK_NUMBER..CANCUN_BLOCK_NUMBER => {
+                self.get_capella_to_deneb_block_data(current_block)
+            }
+            CANCUN_BLOCK_NUMBER.. => self.get_deneb_block_data(current_block),
         })
     }
 

--- a/bin/e2hs-writer/src/utils.rs
+++ b/bin/e2hs-writer/src/utils.rs
@@ -10,6 +10,7 @@ use alloy::{
 };
 use anyhow::{anyhow, ensure};
 use ethportal_api::{
+    consensus::execution_payload::ExecutionPayloadDeneb,
     types::{
         consensus::execution_payload::{ExecutionPayloadBellatrix, ExecutionPayloadCapella},
         execution::accumulator::EpochAccumulator,
@@ -20,7 +21,7 @@ use ssz::Decode;
 use trin_execution::era::beacon::EMPTY_UNCLE_ROOT_HASH;
 use trin_validation::accumulator::PreMergeAccumulator;
 
-pub fn pre_capella_execution_payload_to_header(
+pub fn bellatrix_execution_payload_to_header(
     payload: &ExecutionPayloadBellatrix,
     transactions: &[TxEnvelope],
 ) -> anyhow::Result<Header> {
@@ -56,7 +57,7 @@ pub fn pre_capella_execution_payload_to_header(
     Ok(header)
 }
 
-pub fn pre_deneb_execution_payload_to_header(
+pub fn capella_execution_payload_to_header(
     payload: &ExecutionPayloadCapella,
     transactions: &[TxEnvelope],
     withdrawals: &[Withdrawal],
@@ -83,6 +84,44 @@ pub fn pre_deneb_execution_payload_to_header(
         withdrawals_root: Some(withdrawals_root),
         blob_gas_used: None,
         excess_blob_gas: None,
+        parent_beacon_block_root: None,
+        requests_hash: None,
+    };
+
+    ensure!(
+        payload.block_hash == header.hash_slow(),
+        "Block hash mismatch"
+    );
+    Ok(header)
+}
+
+pub fn post_deneb_execution_payload_to_header(
+    payload: &ExecutionPayloadDeneb,
+    transactions: &[TxEnvelope],
+    withdrawals: &[Withdrawal],
+) -> anyhow::Result<Header> {
+    let transactions_root = calculate_transaction_root(transactions);
+    let withdrawals_root = calculate_withdrawals_root(withdrawals);
+    let header = Header {
+        parent_hash: payload.parent_hash,
+        ommers_hash: EMPTY_UNCLE_ROOT_HASH,
+        beneficiary: payload.fee_recipient,
+        state_root: payload.state_root,
+        transactions_root,
+        receipts_root: payload.receipts_root,
+        logs_bloom: Bloom::from_slice(payload.logs_bloom.to_vec().as_slice()),
+        difficulty: U256::ZERO,
+        number: payload.block_number,
+        gas_limit: payload.gas_limit,
+        gas_used: payload.gas_used,
+        timestamp: payload.timestamp,
+        extra_data: payload.extra_data.to_vec().into(),
+        mix_hash: payload.prev_randao,
+        nonce: B64::ZERO,
+        base_fee_per_gas: Some(payload.base_fee_per_gas.to()),
+        withdrawals_root: Some(withdrawals_root),
+        blob_gas_used: Some(payload.blob_gas_used),
+        excess_blob_gas: Some(payload.excess_blob_gas),
         parent_beacon_block_root: None,
         requests_hash: None,
     };

--- a/bin/e2hs-writer/src/utils.rs
+++ b/bin/e2hs-writer/src/utils.rs
@@ -6,7 +6,7 @@ use alloy::{
         Header, TxEnvelope,
     },
     eips::eip4895::Withdrawal,
-    primitives::{Bloom, B64, U256},
+    primitives::{Bloom, B256, B64, U256},
 };
 use anyhow::{anyhow, ensure};
 use ethportal_api::{
@@ -97,6 +97,7 @@ pub fn capella_execution_payload_to_header(
 
 pub fn post_deneb_execution_payload_to_header(
     payload: &ExecutionPayloadDeneb,
+    parent_beacon_block_root: B256,
     transactions: &[TxEnvelope],
     withdrawals: &[Withdrawal],
 ) -> anyhow::Result<Header> {
@@ -122,7 +123,7 @@ pub fn post_deneb_execution_payload_to_header(
         withdrawals_root: Some(withdrawals_root),
         blob_gas_used: Some(payload.blob_gas_used),
         excess_blob_gas: Some(payload.excess_blob_gas),
-        parent_beacon_block_root: None,
+        parent_beacon_block_root: Some(parent_beacon_block_root),
         requests_hash: None,
     };
 

--- a/crates/ethportal-api/src/types/consensus/beacon_block.rs
+++ b/crates/ethportal-api/src/types/consensus/beacon_block.rs
@@ -115,6 +115,29 @@ impl BeaconBlockCapella {
     }
 }
 
+impl BeaconBlockDeneb {
+    pub fn build_body_root_proof(&self) -> Vec<B256> {
+        let leaves = [
+            self.slot.tree_hash_root(),
+            self.proposer_index.tree_hash_root(),
+            self.parent_root.tree_hash_root(),
+            self.state_root.tree_hash_root(),
+            self.body.tree_hash_root(),
+        ];
+        // We want to prove the body root, which is the 5th leaf
+        build_merkle_proof_for_index(leaves, 4)
+    }
+
+    pub fn build_execution_block_hash_proof(&self) -> Vec<B256> {
+        [
+            self.body.execution_payload.build_block_hash_proof(),
+            self.body.build_execution_payload_proof(),
+            self.build_body_root_proof(),
+        ]
+        .concat()
+    }
+}
+
 /// A `BeaconBlock` and a signature from its proposer.
 #[superstruct(
     variants(Bellatrix, Capella, Deneb),

--- a/crates/ethportal-api/src/types/consensus/beacon_state.rs
+++ b/crates/ethportal-api/src/types/consensus/beacon_state.rs
@@ -1,14 +1,16 @@
 use std::sync::Arc;
 
 use alloy::primitives::B256;
-use discv5::enr::k256::elliptic_curve::consts::{U1099511627776, U2048, U4, U65536, U8192};
 use jsonrpsee::core::Serialize;
 use serde::Deserialize;
 use serde_this_or_that::as_u64;
 use serde_utils;
 use ssz::{Decode, DecodeError, Encode};
 use ssz_derive::{Decode, Encode};
-use ssz_types::{typenum::U16777216, BitVector, FixedVector, VariableList};
+use ssz_types::{
+    typenum::{U1099511627776, U16777216, U2048, U4, U65536, U8192},
+    BitVector, FixedVector, VariableList,
+};
 use superstruct::superstruct;
 use tree_hash::{Hash256, TreeHash};
 use tree_hash_derive::TreeHash;

--- a/crates/ethportal-api/src/types/consensus/body.rs
+++ b/crates/ethportal-api/src/types/consensus/body.rs
@@ -1,12 +1,11 @@
 use alloy::primitives::{Address, B256};
-use discv5::enr::k256::elliptic_curve::consts::U16;
 use serde::{Deserialize, Serialize};
 use serde_this_or_that::as_u64;
 use ssz::Decode;
 use ssz_derive::{Decode, Encode};
 use ssz_types::{
     typenum,
-    typenum::{U128, U2, U33, U4096},
+    typenum::{U128, U16, U2, U33, U4096},
     BitList, BitVector, FixedVector, VariableList,
 };
 use superstruct::superstruct;
@@ -120,6 +119,27 @@ impl BeaconBlockBodyCapella {
             self.sync_aggregate.tree_hash_root(),
             self.execution_payload.tree_hash_root(),
             self.bls_to_execution_changes.tree_hash_root(),
+        ];
+        // We want to prove the 10th leaf
+        build_merkle_proof_for_index(leaves, 9)
+    }
+}
+
+impl BeaconBlockBodyDeneb {
+    pub fn build_execution_payload_proof(&self) -> Vec<B256> {
+        let leaves = [
+            self.randao_reveal.tree_hash_root(),
+            self.eth1_data.tree_hash_root(),
+            self.graffiti.tree_hash_root(),
+            self.proposer_slashings.tree_hash_root(),
+            self.attester_slashings.tree_hash_root(),
+            self.attestations.tree_hash_root(),
+            self.deposits.tree_hash_root(),
+            self.voluntary_exits.tree_hash_root(),
+            self.sync_aggregate.tree_hash_root(),
+            self.execution_payload.tree_hash_root(),
+            self.bls_to_execution_changes.tree_hash_root(),
+            self.blob_kzg_commitments.tree_hash_root(),
         ];
         // We want to prove the 10th leaf
         build_merkle_proof_for_index(leaves, 9)

--- a/crates/ethportal-api/src/types/consensus/execution_payload.rs
+++ b/crates/ethportal-api/src/types/consensus/execution_payload.rs
@@ -137,6 +137,31 @@ impl ExecutionPayloadCapella {
     }
 }
 
+impl ExecutionPayloadDeneb {
+    pub fn build_block_hash_proof(&self) -> Vec<B256> {
+        let leaves = [
+            self.parent_hash.tree_hash_root(),
+            self.fee_recipient.tree_hash_root(),
+            self.state_root.tree_hash_root(),
+            self.receipts_root.tree_hash_root(),
+            self.logs_bloom.tree_hash_root(),
+            self.prev_randao.tree_hash_root(),
+            self.block_number.tree_hash_root(),
+            self.gas_limit.tree_hash_root(),
+            self.gas_used.tree_hash_root(),
+            self.timestamp.tree_hash_root(),
+            self.extra_data.tree_hash_root(),
+            self.base_fee_per_gas.tree_hash_root(),
+            self.block_hash.tree_hash_root(),
+            self.transactions.tree_hash_root(),
+            self.withdrawals.tree_hash_root(),
+            self.blob_gas_used.tree_hash_root(),
+            self.excess_blob_gas.tree_hash_root(),
+        ];
+        build_merkle_proof_for_index(leaves, 12)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct Withdrawal {
     #[serde(deserialize_with = "as_u64")]

--- a/crates/ethportal-api/src/types/execution/header_with_proof.rs
+++ b/crates/ethportal-api/src/types/execution/header_with_proof.rs
@@ -7,7 +7,10 @@ use ssz_types::{typenum, FixedVector};
 use tree_hash::TreeHash;
 
 use crate::{
-    consensus::{beacon_state::RootsPerHistoricalRoot, constants::SLOTS_PER_HISTORICAL_ROOT},
+    consensus::{
+        beacon_block::BeaconBlockDeneb, beacon_state::RootsPerHistoricalRoot,
+        constants::SLOTS_PER_HISTORICAL_ROOT,
+    },
     types::{
         bytes::ByteList1024,
         consensus::{
@@ -43,6 +46,9 @@ pub type BlockProofHistoricalHashesAccumulator = FixedVector<B256, typenum::U15>
 /// Proof that EL block_hash is in BeaconBlock -> BeaconBlockBody -> ExecutionPayload
 /// for Bellatrix until Deneb (exclusive)
 pub type ExecutionBlockProofBellatrix = FixedVector<B256, typenum::U11>;
+/// Proof that EL block_hash is in BeaconBlock -> BeaconBlockBody -> ExecutionPayload
+/// for Deneb and onwards
+pub type ExecutionBlockProofDeneb = FixedVector<B256, typenum::U12>;
 
 /// Proof that BeaconBlock root is part of historical_roots and thus canonical
 /// from TheMerge until Capella (exclusive)
@@ -63,12 +69,14 @@ pub struct HeaderWithProof {
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub enum BlockHeaderProof {
-    // Pre-Merge
+    /// The block header proof for pre-Merge blocks
     HistoricalHashes(BlockProofHistoricalHashesAccumulator),
-    // Merge -> Capella
+    /// The block header proof for Merge -> Capella blocks
     HistoricalRoots(BlockProofHistoricalRoots),
-    // Post-Capella
+    /// The block header proof for Capella -> Deneb blocks
     HistoricalSummariesCapella(BlockProofHistoricalSummariesCapella),
+    /// The block header proof for post-Deneb blocks
+    HistoricalSummariesDeneb(BlockProofHistoricalSummariesDeneb),
 }
 
 impl ssz::Decode for HeaderWithProof {
@@ -96,11 +104,9 @@ impl ssz::Decode for HeaderWithProof {
             SHAPELLA_TIMESTAMP..DENCUN_TIMESTAMP => BlockHeaderProof::HistoricalSummariesCapella(
                 BlockProofHistoricalSummariesCapella::from_ssz_bytes(&proof)?,
             ),
-            DENCUN_TIMESTAMP.. => {
-                return Err(ssz::DecodeError::BytesInvalid(
-                    "post-Dencun HeaderWithProof is not yet implemented".to_string(),
-                ));
-            }
+            DENCUN_TIMESTAMP.. => BlockHeaderProof::HistoricalSummariesDeneb(
+                BlockProofHistoricalSummariesDeneb::from_ssz_bytes(&proof)?,
+            ),
         };
         Ok(Self { header, proof })
     }
@@ -113,15 +119,10 @@ impl ssz::Encode for BlockHeaderProof {
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
         match self {
-            BlockHeaderProof::HistoricalHashes(proof) => {
-                proof.ssz_append(buf);
-            }
-            BlockHeaderProof::HistoricalRoots(proof) => {
-                proof.ssz_append(buf);
-            }
-            BlockHeaderProof::HistoricalSummariesCapella(proof) => {
-                proof.ssz_append(buf);
-            }
+            BlockHeaderProof::HistoricalHashes(proof) => proof.ssz_append(buf),
+            BlockHeaderProof::HistoricalRoots(proof) => proof.ssz_append(buf),
+            BlockHeaderProof::HistoricalSummariesCapella(proof) => proof.ssz_append(buf),
+            BlockHeaderProof::HistoricalSummariesDeneb(proof) => proof.ssz_append(buf),
         }
     }
 
@@ -130,6 +131,7 @@ impl ssz::Encode for BlockHeaderProof {
             BlockHeaderProof::HistoricalHashes(proof) => proof.ssz_bytes_len(),
             BlockHeaderProof::HistoricalRoots(proof) => proof.ssz_bytes_len(),
             BlockHeaderProof::HistoricalSummariesCapella(proof) => proof.ssz_bytes_len(),
+            BlockHeaderProof::HistoricalSummariesDeneb(proof) => proof.ssz_bytes_len(),
         }
     }
 }
@@ -166,6 +168,24 @@ pub struct BlockProofHistoricalSummariesCapella {
     pub beacon_block_root: B256,
     /// Proof that EL BlockHash is part of the BeaconBlock
     pub execution_block_proof: ExecutionBlockProofBellatrix,
+    /// Slot of BeaconBlock, used to calculate the historical_summaries index
+    pub slot: u64,
+}
+
+/// The struct holds a chain of proofs. This chain of proofs allows for verifying that an EL
+/// `BlockHeader` is part of the canonical chain. The only requirement is having access to the
+/// beacon chain `historical_summaries`.
+///
+/// Proof for EL BlockHeader for Deneb and onwards
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, Serialize, Deserialize)]
+pub struct BlockProofHistoricalSummariesDeneb {
+    /// Proof that the BeaconBlock is part of the historical_summaries
+    /// and thus part of the canonical chain.
+    pub beacon_block_proof: BeaconBlockProofHistoricalSummaries,
+    /// hash_tree_root of BeaconBlock used to verify the proofs
+    pub beacon_block_root: B256,
+    /// Proof that EL BlockHash is part of the BeaconBlock
+    pub execution_block_proof: ExecutionBlockProofDeneb,
     /// Slot of BeaconBlock, used to calculate the historical_summaries index
     pub slot: u64,
 }
@@ -221,6 +241,33 @@ pub fn build_capella_historical_summaries_proof(
     }
 }
 
+/// Builds `BlockProofHistoricalSummariesDeneb` for a given slot.
+///
+/// The `block_roots` represents the `block_roots` fields from `BeaconState`.
+pub fn build_deneb_historical_summaries_proof(
+    slot: u64,
+    block_roots: &RootsPerHistoricalRoot,
+    beacon_block: &BeaconBlockDeneb,
+) -> BlockProofHistoricalSummariesDeneb {
+    let beacon_block_proof = build_merkle_proof_for_index(
+        block_roots.clone(),
+        slot as usize % SLOTS_PER_HISTORICAL_ROOT,
+    );
+    let beacon_block_proof = BeaconBlockProofHistoricalSummaries::new(beacon_block_proof)
+        .expect("error creating BeaconBlockProofHistoricalSummaries");
+
+    let execution_block_proof =
+        ExecutionBlockProofDeneb::new(beacon_block.build_execution_block_hash_proof())
+            .expect("error creating ExecutionBlockProofDeneb");
+
+    BlockProofHistoricalSummariesDeneb {
+        beacon_block_proof,
+        beacon_block_root: beacon_block.tree_hash_root(),
+        execution_block_proof,
+        slot,
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -240,10 +287,9 @@ mod tests {
 
     #[test_log::test]
     fn decode_encode_headers_with_proof() {
-        let file =
-            read_file_from_tests_submodule(PathBuf::from(TEST_DIR).join("1000001-1000010.json"))
-                .unwrap();
-        let json: Value = serde_json::from_str(&file).unwrap();
+        let path = PathBuf::from(TEST_DIR).join("1000001-1000010.json");
+        let json: Value =
+            serde_json::from_str(&read_file_from_tests_submodule(path).unwrap()).unwrap();
         let hwps = json.as_object().unwrap();
         for (block_number, obj) in hwps {
             let block_number: u64 = block_number.parse().unwrap();
@@ -256,19 +302,19 @@ mod tests {
     }
 
     #[rstest::rstest]
-    #[case(1000010)]
-    #[case(14764013)]
-    #[case(15537392)]
-    #[case(15537393)]
-    #[case(15539558)]
-    #[case(15547621)]
-    #[case(15555729)]
-    #[case(17034870)]
-    #[case(17042287)]
-    #[case(17062257)]
+    #[case::block_1_000_010(1_000_010)]
+    #[case::block_14_764_013(14_764_013)]
+    #[case::block_15_537_392(15_537_392)]
+    #[case::block_15_537_393(15_537_393)]
+    #[case::block_15_539_558(15_539_558)]
+    #[case::block_15_547_621(15_547_621)]
+    #[case::block_15_555_729(15_555_729)]
+    #[case::block_17_034_870(17_034_870)]
+    #[case::block_17_042_287(17_042_287)]
+    #[case::block_17_062_257(17_062_257)]
+    #[case::block_22_162_263(22_162_263)]
     fn decode_encode_more_headers_with_proofs(#[case] block_number: u64) {
-        let yaml: serde_yaml::Value =
-            read_yaml_test_file(PathBuf::from(TEST_DIR).join(format!("{block_number}.yaml")));
+        let yaml: serde_yaml::Value = read_yaml_test_file(format!("{block_number}.yaml"));
         let actual_hwp = yaml["content_value"].as_str().unwrap();
         let header_with_proof =
             HeaderWithProof::from_ssz_bytes(&hex_decode(actual_hwp).unwrap()).unwrap();
@@ -282,51 +328,69 @@ mod tests {
         use super::*;
 
         #[rstest::rstest]
-        #[case(
-            15539558,
+        #[case::block_number_15_539_558(
+            15_539_558,
             "15539558-cdf9ed89b0c43cda17398dc4da9cfc505e5ccd19f7c39e3b43474180f1051e01"
         )] // epoch 575
-        #[case(
-            15547621,
+        #[case::block_number_15_547_621(
+            15_547_621,
             "15547621-96a9313cd506e32893d46c82358569ad242bb32786bd5487833e0f77767aec2a"
         )] // epoch 576
-        #[case(
-            15555729,
+        #[case::block_number_15_555_729(
+            15_555_729,
             "15555729-c6fd396d54f61c6d0f1dd3653f81267b0378e9a0d638a229b24586d8fd0bc499"
         )] // epoch 577
         #[test]
         fn bellatrix(#[case] block_number: u64, #[case] file_path: &str) -> anyhow::Result<()> {
             let header_with_proof_yaml: serde_yaml::Value =
-                read_yaml_test_file(PathBuf::from(TEST_DIR).join(format!("{block_number}.yaml")));
+                read_yaml_test_file(format!("{block_number}.yaml"));
             let header_with_proof = HeaderWithProof::from_ssz_bytes(&Bytes::from_hex(
                 header_with_proof_yaml["content_value"].as_str().unwrap(),
             )?)
             .unwrap();
 
-            let expected_block_header_proof = BlockHeaderProof::HistoricalRoots(
-                read_yaml_test_file(PathBuf::from(TEST_DIR).join(format!(
+            let expected_block_header_proof =
+                BlockHeaderProof::HistoricalRoots(read_yaml_test_file(format!(
                     "block_proofs_bellatrix/beacon_block_proof-{file_path}.yaml"
-                ))),
-            );
+                )));
 
             assert_eq!(header_with_proof.proof, expected_block_header_proof);
             Ok(())
         }
 
         #[rstest::rstest]
-        #[case(17034870)] // epoch 759
-        #[case(17042287)] // epoch 760
-        #[case(17062257)] // epoch 762
+        #[case::block_number_17_034_870(17_034_870)] // epoch 759
+        #[case::block_number_17_042_287(17_042_287)] // epoch 760
+        #[case::block_number_17_062_257(17_062_257)] // epoch 762
         #[test]
         fn capella(#[case] block_number: u64) -> anyhow::Result<()> {
-            let block_header_proof = BlockHeaderProof::HistoricalSummariesCapella(
-                read_yaml_test_file(PathBuf::from(TEST_DIR).join(format!(
+            let block_header_proof =
+                BlockHeaderProof::HistoricalSummariesCapella(read_yaml_test_file(format!(
                     "block_proofs_capella/beacon_block_proof-{block_number}.yaml"
-                ))),
-            );
+                )));
 
             let header_with_proof_yaml: serde_yaml::Value =
-                read_yaml_test_file(PathBuf::from(TEST_DIR).join(format!("{block_number}.yaml")));
+                read_yaml_test_file(format!("{block_number}.yaml"));
+            let header_with_proof = HeaderWithProof::from_ssz_bytes(&Bytes::from_hex(
+                header_with_proof_yaml["content_value"].as_str().unwrap(),
+            )?)
+            .unwrap();
+
+            assert_eq!(header_with_proof.proof, block_header_proof);
+            Ok(())
+        }
+
+        #[rstest::rstest]
+        #[case::block_number_22_162_263(22_162_263)]
+        #[test]
+        fn deneb(#[case] block_number: u64) -> anyhow::Result<()> {
+            let block_header_proof =
+                BlockHeaderProof::HistoricalSummariesDeneb(read_yaml_test_file(format!(
+                    "block_proofs_deneb/beacon_block_proof-{block_number}.yaml"
+                )));
+
+            let header_with_proof_yaml: serde_yaml::Value =
+                read_yaml_test_file(format!("{block_number}.yaml"));
             let header_with_proof = HeaderWithProof::from_ssz_bytes(&Bytes::from_hex(
                 header_with_proof_yaml["content_value"].as_str().unwrap(),
             )?)
@@ -341,74 +405,86 @@ mod tests {
         use super::*;
 
         #[rstest::rstest]
-        #[case(
-            15539558,
-            4702208,
+        #[case::block_number_15_539_558(
+            15_539_558,
+            4_702_208,
             "15539558-cdf9ed89b0c43cda17398dc4da9cfc505e5ccd19f7c39e3b43474180f1051e01"
         )] // epoch 575
-        #[case(
-            15547621,
-            4710400,
+        #[case::block_number_15_547_621(
+            15_547_621,
+            4_710_400,
             "15547621-96a9313cd506e32893d46c82358569ad242bb32786bd5487833e0f77767aec2a"
         )] // epoch 576
-        #[case(
-            15555729,
-            4718592,
+        #[case::block_number_15_555_729(
+            15_555_729,
+            4_718_592,
             "15555729-c6fd396d54f61c6d0f1dd3653f81267b0378e9a0d638a229b24586d8fd0bc499"
         )] // epoch 577
         #[test]
         fn bellatrix(#[case] block_number: u64, #[case] slot: u64, #[case] file_path: &str) {
-            let expected_proof: BlockProofHistoricalRoots =
-                read_yaml_test_file(PathBuf::from(TEST_DIR).join(format!(
-                    "block_proofs_bellatrix/beacon_block_proof-{file_path}.yaml"
-                )));
+            let expected_proof: BlockProofHistoricalRoots = read_yaml_test_file(format!(
+                "block_proofs_bellatrix/beacon_block_proof-{file_path}.yaml"
+            ));
 
-            let beacon_data_dir = PathBuf::from(TEST_DIR)
-                .join("beacon_data")
-                .join(format!("{block_number}"));
-            let historical_batch_raw =
-                read_bytes_from_tests_submodule(beacon_data_dir.join("historical_batch.ssz"))
-                    .unwrap();
-            let historical_batch = HistoricalBatch::from_ssz_bytes(&historical_batch_raw).unwrap();
-            let block_raw =
-                read_bytes_from_tests_submodule(beacon_data_dir.join("block.ssz")).unwrap();
-            let block = BeaconBlockBellatrix::from_ssz_bytes(&block_raw).unwrap();
+            let historical_batch =
+                read_ssz_test_file(format!("beacon_data/{block_number}/historical_batch.ssz"));
+            let block = read_ssz_test_file(format!("beacon_data/{block_number}/block.ssz"));
             let actual_proof = build_historical_roots_proof(slot, &historical_batch, &block);
 
             assert_eq!(expected_proof, actual_proof);
         }
 
         #[rstest::rstest]
-        #[case(17034870, 6209538)] // epoch 759
-        #[case(17042287, 6217730)] // epoch 760
-        #[case(17062257, 6238210)] // epoch 762
+        #[case::block_number_17_034_870(17_034_870, 6_209_538)] // epoch 759
+        #[case::block_number_17_042_287(17_042_287, 6_217_730)] // epoch 760
+        #[case::block_number_17_062_257(17_062_257, 6_238_210)] // epoch 762
         #[test]
         fn capella(#[case] block_number: u64, #[case] slot: u64) {
-            let expected_proof: BlockProofHistoricalSummariesCapella =
-                read_yaml_test_file(PathBuf::from(TEST_DIR).join(format!(
-                    "block_proofs_capella/beacon_block_proof-{block_number}.yaml"
-                )));
+            let expected_proof: BlockProofHistoricalSummariesCapella = read_yaml_test_file(
+                format!("block_proofs_capella/beacon_block_proof-{block_number}.yaml"),
+            );
 
-            let beacon_data_dir = PathBuf::from(TEST_DIR)
-                .join("beacon_data")
-                .join(format!("{block_number}"));
-            let block_roots_raw =
-                read_bytes_from_tests_submodule(beacon_data_dir.join("block_roots.ssz")).unwrap();
-            let block_roots = RootsPerHistoricalRoot::from_ssz_bytes(&block_roots_raw).unwrap();
-            let block_raw =
-                read_bytes_from_tests_submodule(beacon_data_dir.join("block.ssz")).unwrap();
-            let block = BeaconBlockCapella::from_ssz_bytes(&block_raw).unwrap();
+            let block_roots =
+                read_ssz_test_file(format!("beacon_data/{block_number}/block_roots.ssz"));
+            let block = read_ssz_test_file(format!("beacon_data/{block_number}/block.ssz"));
             let actual_proof = build_capella_historical_summaries_proof(slot, &block_roots, &block);
+
+            assert_eq!(expected_proof, actual_proof);
+        }
+
+        #[rstest::rstest]
+        #[case::block_number_22162263(22162263, 11378687)]
+        #[test]
+        fn deneb(#[case] block_number: u64, #[case] slot: u64) {
+            let expected_proof: BlockProofHistoricalSummariesDeneb = read_yaml_test_file(format!(
+                "block_proofs_deneb/beacon_block_proof-{block_number}.yaml"
+            ));
+
+            let block_roots =
+                read_ssz_test_file(format!("beacon_data/{block_number}/block_roots.ssz"));
+            let block = read_ssz_test_file(format!("beacon_data/{block_number}/block.ssz"));
+            let actual_proof = build_deneb_historical_summaries_proof(slot, &block_roots, &block);
 
             assert_eq!(expected_proof, actual_proof);
         }
     }
 
+    /// Reads and deserializes the yaml test file.
+    ///
+    /// The `path` argument is relative to [TEST_DIR].
     fn read_yaml_test_file<T>(path: impl AsRef<Path>) -> T
     where
         T: for<'de> Deserialize<'de>,
     {
-        let file_as_str = read_file_from_tests_submodule(path).unwrap();
-        serde_yaml::from_str(&file_as_str).unwrap()
+        let path = PathBuf::from(TEST_DIR).join(path);
+        serde_yaml::from_str(&read_file_from_tests_submodule(path).unwrap()).unwrap()
+    }
+
+    /// Reads and decodes the ssz test file.
+    ///
+    /// The `path` argument is relative to [TEST_DIR].
+    fn read_ssz_test_file<T: Decode>(path: impl AsRef<Path>) -> T {
+        let path = PathBuf::from(TEST_DIR).join(path);
+        T::from_ssz_bytes(&read_bytes_from_tests_submodule(path).unwrap()).unwrap()
     }
 }

--- a/crates/validation/src/header_validator.rs
+++ b/crates/validation/src/header_validator.rs
@@ -54,6 +54,9 @@ impl HeaderValidator {
             BlockHeaderProof::HistoricalSummariesCapella(_) => Err(anyhow!(
                 "HistoricalSummariesCapella header validation is not implemented yet."
             )),
+            BlockHeaderProof::HistoricalSummariesDeneb(_) => Err(anyhow!(
+                "HistoricalSummariesDeneb header validation is not implemented yet."
+            )),
         }
     }
 


### PR DESCRIPTION
### What was wrong?

We don't have Deneb header proof, generation and validation.

### How was it fixed?

I created Deneb header proof type and generation code.

I also added support for it in e2hs binary.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
