### PR TITLE
fix: stop bridging content to nodes outside their radius

### DIFF
--- a/bin/portal-bridge/src/census/scoring.rs
+++ b/bin/portal-bridge/src/census/scoring.rs
@@ -134,7 +134,11 @@ impl<W: Weight> PeerSelector<W> {
         content_id: &[u8; 32],
         peers: impl IntoIterator<Item = &'a Peer>,
     ) -> Vec<PeerInfo> {
-        let weighted_peers = self.weight.weight_all(content_id, peers).collect_vec();
+        let weighted_peers = self
+            .weight
+            .weight_all(content_id, peers)
+            .filter(|(_peer, weight)| *weight > 0)
+            .collect_vec();
 
         weighted_peers
             .choose_multiple_weighted(&mut thread_rng(), self.limit, |(_peer, weight)| *weight)


### PR DESCRIPTION
### What was wrong?

After I implemented AcceptCodes I found we had a bug in our Bridge. We should never offer content to Nodes if we know it outside of their radius, as this is just wasted resources, which for a bridge resources are limited. https://github.com/ethereum/trin/pull/1773

I was just testing the bridge and I noticed it again.

```rust
2025-04-29T05:35:17.146519Z  INFO portal_bridge::bridge::offer_report: Successfully offered to 0/8 peers. Content key: 0x00b60bfc414b961eb745736cd6ee0f8284b0c0c0549bb4ba9c7e68b6bda346f29b. Decline reasons: AlreadyStored:[Trin] | Declined:[Ultralight,Ultralight] | NotWithinRadius:[Unknown(None),Trin,Trin,Unknown(None),Unknown(None)]. Failed: 0.
```

### How was it fixed?

By adding a filter to only include nodes with a weight over 0. `choose_multiple_weighted()` will include peers with 0 weight, if there are less then `amount` of nodes with a weight of over 0. We don't want to gossip to though peers though as we already know they won't accept the content. We can instead offer other content to other nodes which will accept the content.
