### PR TITLE
chore: bump alloy/revm/ssz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,21 +108,21 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4ae82946772d69f868b9ef81fc66acb1b149ef9b4601849bec4bcf5da6552e"
+checksum = "3287a60462d933cbc753a1a87439016d4eb717401f3052ff72742c6dd0dbce3f"
 dependencies = [
- "alloy-consensus 0.12.6",
+ "alloy-consensus",
  "alloy-contract",
  "alloy-core",
- "alloy-eips 0.12.6",
+ "alloy-eips 0.15.6",
  "alloy-genesis",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde 0.12.6",
+ "alloy-serde 0.15.6",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ipc",
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.69"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e2652684758b0d9b389d248b209ed9fd9989ef489a550265fe4bb8454fe7eb"
+checksum = "7734aecfc58a597dde036e4c5cace2ae43e2f8bf3d406b022a1ef34da178dd49"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -142,31 +142,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.11.1"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e32ef5c74bbeb1733c37f4ac7f866f8c8af208b7b4265e21af609dcac5bd5e"
+checksum = "94ee204a7795e56b8e78013f5824d6ea6e4da457a4aaf6c72e4800c4d4987fce"
 dependencies = [
- "alloy-eips 0.11.1",
+ "alloy-eips 0.15.6",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.11.1",
- "alloy-trie",
- "auto_impl",
- "c-kzg",
- "derive_more 1.0.0",
- "serde",
-]
-
-[[package]]
-name = "alloy-consensus"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fbf458101ed6c389e9bb70a34ebc56039868ad10472540614816cdedc8f5265"
-dependencies = [
- "alloy-eips 0.12.6",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.12.6",
+ "alloy-serde 0.15.6",
  "alloy-trie",
  "auto_impl",
  "c-kzg",
@@ -182,47 +165,33 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.11.1"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa13b7b1e1e3fedc42f0728103bfa3b4d566d3d42b606db449504d88dbdbdcf"
+checksum = "a16df75c656be4465ab411b88c5ec6bae4931ce806834efbf375ca85b8db6f9a"
 dependencies = [
- "alloy-consensus 0.11.1",
- "alloy-eips 0.11.1",
+ "alloy-consensus",
+ "alloy-eips 0.15.6",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.11.1",
- "serde",
-]
-
-[[package]]
-name = "alloy-consensus-any"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc982af629e511292310fe85b433427fd38cb3105147632b574abc997db44c91"
-dependencies = [
- "alloy-consensus 0.12.6",
- "alloy-eips 0.12.6",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.12.6",
+ "alloy-serde 0.15.6",
  "serde",
 ]
 
 [[package]]
 name = "alloy-contract"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0a0c1ddee20ecc14308aae21c2438c994df7b39010c26d70f86e1d8fdb8db0"
+checksum = "258feff52f1e3be58b4d235ef85f5c0224905e371fb023dfbf758d5a7e027672"
 dependencies = [
- "alloy-consensus 0.12.6",
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-network",
- "alloy-network-primitives 0.12.6",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-provider",
  "alloy-pubsub",
- "alloy-rpc-types-eth 0.12.6",
+ "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-transport",
  "futures",
@@ -232,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8bcce99ad10fe02640cfaec1c6bc809b837c783c1d52906aa5af66e2a196f6"
+checksum = "9d020a85ae8cf79b9c897a86d617357817bbc9a7d159dd7e6fedf1bc90f64d35"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -245,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb8e762aefd39a397ff485bc86df673465c4ad3ec8819cc60833a8a3ba5cdc87"
+checksum = "884a5d4560f7e5e34ec3c5e54a60223c56352677dd049b495fbb59384cf72a90"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -262,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2124"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675264c957689f0fd75f5993a73123c2cc3b5c235a38f5b9037fe6c826bfb2c0"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -275,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
+checksum = "dbe3e16484669964c26ac48390245d84c410b1a5f968976076c17184725ef235"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -286,21 +255,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.1.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea59dc42102bc9a1905dc57901edc6dd48b9f38115df86c7d252acba70d71d04"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "k256",
- "serde",
-]
-
-[[package]]
-name = "alloy-eip7702"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b15b13d38b366d01e818fe8e710d4d702ef7499eacd44926a06171dd9585d0c"
+checksum = "804cefe429015b4244966c006d25bda5545fa9db5990e9c9079faf255052f50a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -311,63 +268,62 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.11.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5591581ca2ab0b3e7226a4047f9a1bfcf431da1d0cce3752fda609fea3c27e37"
+checksum = "609515c1955b33af3d78d26357540f68c5551a90ef58fd53def04f2aa074ec43"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
- "alloy-eip7702 0.5.1",
+ "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.11.1",
- "auto_impl",
- "c-kzg",
- "derive_more 1.0.0",
- "once_cell",
- "serde",
- "sha2",
-]
-
-[[package]]
-name = "alloy-eips"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e86967eb559920e4b9102e4cb825fe30f2e9467988353ce4809f0d3f2c90cd4"
-dependencies = [
- "alloy-eip2124",
- "alloy-eip2930",
- "alloy-eip7702 0.5.1",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.12.6",
+ "alloy-serde 0.14.0",
  "auto_impl",
  "c-kzg",
  "derive_more 2.0.1",
  "either",
- "once_cell",
  "serde",
- "sha2",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8ce6197b2cc38968c80c676372f383ed46051fb8600a421b5259f3f2d13a15"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.15.6",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 2.0.1",
+ "either",
+ "serde",
+ "sha2 0.10.8",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40de6f5b53ecf5fd7756072942f41335426d9a3704cd961f77d854739933bcf"
+checksum = "bc13f76f34587a9d5efd1d141dd6a596983be715922ccc488209e58dc643ec65"
 dependencies = [
- "alloy-eips 0.12.6",
+ "alloy-eips 0.15.6",
  "alloy-primitives",
- "alloy-serde 0.12.6",
+ "alloy-serde 0.15.6",
  "alloy-trie",
  "serde",
 ]
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6beff64ad0aa6ad1019a3db26fef565aefeb011736150ab73ed3366c3cfd1b"
+checksum = "5189fa9a8797e92396bc4b4454c5f2073a4945f7c2b366af9af60f9536558f7a"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -377,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27434beae2514d4a2aa90f53832cbdf6f23e4b5e2656d95eaf15f9276e2418b6"
+checksum = "3593ce03c82601517eee458f67bb5dc642b9baff7016063f03a4ccbcfb52a387"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -391,19 +347,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a33a38c7486b1945f8d093ff027add2f3a8f83c7300dbad6165cc49150085e"
+checksum = "36be8015a205bf2e6784b0367c0f29e87f901f5f9b80b0a9bb4e1411c65242fd"
 dependencies = [
- "alloy-consensus 0.12.6",
- "alloy-consensus-any 0.12.6",
- "alloy-eips 0.12.6",
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips 0.15.6",
  "alloy-json-rpc",
- "alloy-network-primitives 0.12.6",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
- "alloy-rpc-types-eth 0.12.6",
- "alloy-serde 0.12.6",
+ "alloy-rpc-types-eth",
+ "alloy-serde 0.15.6",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -417,35 +373,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.11.1"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a00ce618ae2f78369918be0c20f620336381502c83b6ed62c2f7b2db27698b0"
+checksum = "3449fdd0908f50fb68eef8c43201d73d4ff51882b36e2adaadab277a7539ce4f"
 dependencies = [
- "alloy-consensus 0.11.1",
- "alloy-eips 0.11.1",
+ "alloy-consensus",
+ "alloy-eips 0.15.6",
  "alloy-primitives",
- "alloy-serde 0.11.1",
- "serde",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db973a7a23cbe96f2958e5687c51ce2d304b5c6d0dc5ccb3de8667ad8476f50b"
-dependencies = [
- "alloy-consensus 0.12.6",
- "alloy-eips 0.12.6",
- "alloy-primitives",
- "alloy-serde 0.12.6",
+ "alloy-serde 0.15.6",
  "serde",
 ]
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c77490fe91a0ce933a1f219029521f20fc28c2c0ca95d53fa4da9c00b8d9d4e"
+checksum = "70b98b99c1dcfbe74d7f0b31433ff215e7d1555e367d90e62db904f3c9d4ff53"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -453,7 +396,7 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
- "getrandom 0.2.16",
+ "getrandom 0.3.2",
  "hashbrown 0.15.2",
  "indexmap 2.9.0",
  "itoa",
@@ -461,7 +404,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.8.5",
+ "rand 0.9.1",
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
@@ -471,21 +414,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b03bde77ad73feae14aa593bcabb932c8098c0f0750ead973331cfc0003a4e1"
+checksum = "16db7e6c225828a4540b1cce6047f06777c057df58386db9641827a2d1afb4f5"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 0.12.6",
- "alloy-eips 0.12.6",
+ "alloy-consensus",
+ "alloy-eips 0.15.6",
  "alloy-json-rpc",
  "alloy-network",
- "alloy-network-primitives 0.12.6",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types-engine 0.12.6",
- "alloy-rpc-types-eth 0.12.6",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
@@ -495,6 +439,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "dashmap",
+ "either",
  "futures",
  "futures-utils-wasm",
  "lru 0.13.0",
@@ -512,21 +457,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721aca709a9231815ad5903a2d284042cc77e7d9d382696451b30c9ee0950001"
+checksum = "2fbf7f3b22f7d34eb9aedf637bcdc5d4f47f5e028d3f7520f6ecc7fc75a7a027"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-transport",
  "bimap",
  "futures",
+ "parking_lot 0.12.3",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
  "tower 0.5.2",
  "tracing",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -553,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445a3298c14fae7afb5b9f2f735dead989f3dd83020c2ab8e48ed95d7b6d1acb"
+checksum = "821fca097f02720cd2a53e785776e265f36288f8210aa9177c9de05e2c2724c3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -581,55 +528,39 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157deaec6ba2ad7854f16146e4cd60280e76593eed79fdcb06e0fa8b6c60f77"
+checksum = "30890a9856721a376e989283a17b2698acc3e1a612415abbca980aa4d29d7367"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-engine 0.12.6",
- "alloy-rpc-types-eth 0.12.6",
- "alloy-serde 0.12.6",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-serde 0.15.6",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604dea1f00fd646debe8033abe8e767c732868bf8a5ae9df6321909ccbc99c56"
+checksum = "93017fb350fe2c0cccda41f9be45352012696a5fbd08c5fef4be0df838999bfa"
 dependencies = [
- "alloy-consensus-any 0.12.6",
- "alloy-rpc-types-eth 0.12.6",
- "alloy-serde 0.12.6",
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde 0.15.6",
 ]
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.11.1"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83dde9fcf1ccb9b815cc0c89bba26bbbbaae5150a53ae624ed0fc63cb3676c1"
+checksum = "4f09bac3a6651e3e9e292e946a1fc393128aa1a572254e2ff641e9911f024f61"
 dependencies = [
- "alloy-consensus 0.11.1",
- "alloy-eips 0.11.1",
+ "alloy-consensus",
+ "alloy-eips 0.15.6",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.11.1",
- "derive_more 1.0.0",
- "serde",
- "strum 0.26.3",
-]
-
-[[package]]
-name = "alloy-rpc-types-engine"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874ac9d1249ece0453e262d9ba72da9dbb3b7a2866220ded5940c2e47f1aa04d"
-dependencies = [
- "alloy-consensus 0.12.6",
- "alloy-eips 0.12.6",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.12.6",
+ "alloy-serde 0.15.6",
  "derive_more 2.0.1",
  "rand 0.8.5",
  "serde",
@@ -638,37 +569,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.11.1"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4dbee4d82f8a22dde18c28257bed759afeae7ba73da4a1479a039fd1445d04"
+checksum = "d9f96bc409dee49f68d70bf1303c3b34d7153e185dda75caa8b72919a28cd6ac"
 dependencies = [
- "alloy-consensus 0.11.1",
- "alloy-consensus-any 0.11.1",
- "alloy-eips 0.11.1",
- "alloy-network-primitives 0.11.1",
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips 0.15.6",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.11.1",
- "alloy-sol-types",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-rpc-types-eth"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e13d71eac04513a71af4b3df580f52f2b4dcbff9d971cc9a52519acf55514cb"
-dependencies = [
- "alloy-consensus 0.12.6",
- "alloy-consensus-any 0.12.6",
- "alloy-eips 0.12.6",
- "alloy-network-primitives 0.12.6",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.12.6",
+ "alloy-serde 0.15.6",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
@@ -678,13 +589,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.11.1"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd951155515fa452a2ca4b5434d4b3ab742bcd3d1d1b9a91704bcef5b8d2604"
+checksum = "1c24a733a999bbfa706d03f54332ad03697e745ed27c25bdeebac39586f184d8"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth 0.11.1",
- "alloy-serde 0.11.1",
+ "alloy-rpc-types-eth",
+ "alloy-serde 0.15.6",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -692,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.11.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8732058f5ca28c1d53d241e8504620b997ef670315d7c8afab856b3e3b80d945"
+checksum = "d4dba6ff08916bc0a9cbba121ce21f67c0b554c39cf174bc7b9df6c651bd3c3b"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -703,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1cd73fc054de6353c7f22ff9b846b0f0f145cd0112da07d4119e41e9959207"
+checksum = "3fa2fc7f82a9884ff1632d2a2137d35fef4db9270c85668634a603be5948fcdc"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -714,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96fbde54bee943cd94ebacc8a62c50b38c7dfd2552dcd79ff61aea778b1bfcc"
+checksum = "44eaf520bbb527ba90a3dd963aadf0c339595932169fb10f7330fe779336436e"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -729,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10ae8e9a91d328ae954c22542415303919aabe976fe7a92eb06db1b68fd59f2"
+checksum = "60fcfa26956bcb22f66ab13407115197f26ef23abca5b48d39a1946897382d74"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -743,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ad5da86c127751bc607c174d6c9fe9b85ef0889a9ca0c641735d77d4f98f26"
+checksum = "72a9b402f0013f1ff8c24066eeafc2207a8e52810a2b18b77776ce7fead5af41"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -761,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3d30f0d3f9ba3b7686f3ff1de9ee312647aac705604417a2f40c604f409a9e"
+checksum = "d02d61741337bb6b3f4899c2e3173fe17ffa2810e143d3b28acd953197c8dd79"
 dependencies = [
  "const-hex",
  "dunce",
@@ -777,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
+checksum = "d2b5f5f9f561c29f78ea521ebe2e5ac1633f1b1442dae582f68ecd57c6350042"
 dependencies = [
  "serde",
  "winnow",
@@ -787,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43d5e60466a440230c07761aa67671d4719d46f43be8ea6e7ed334d8db4a9ab"
+checksum = "c02635bce18205ff8149fb752c753b0a91ea3f3c8ee04c58846448be4811a640"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -800,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec325c2af8562ef355c02aeb527c755a07e9d8cf6a1e65dda8d0bf23e29b2c"
+checksum = "609f69c9153df716e7e6ef002cba69f94b7635eb2c603fff69b664aa6acea93a"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -822,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a082c9473c6642cce8b02405a979496126a03b096997888e86229afad05db06c"
+checksum = "c2e60987afbc49b8719578355726059579a1a197741a2adae52f860d5d7464cc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -837,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a78cfda2cac16fa83f6b5dd8b4643caec6161433b25b67e484ce05d2194513"
+checksum = "0a0cad5f19f718b83d4a52ebc12f3b691b245111e50403d2adfd46674bc73da8"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -857,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae865917bdabaae21f418010fe7e8837c6daa6611fde25f8d78a1778d6ecb523"
+checksum = "f48cc4f88d59463992251b89381760be901c4789a4721c657b832994331aff05"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -875,14 +786,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.7.9"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a94854e420f07e962f7807485856cde359ab99ab6413883e15235ad996e8b"
+checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arrayvec",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "nybbles",
  "serde",
  "smallvec",
@@ -970,6 +881,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-r1cs-std",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash 0.8.11",
+ "ark-ff 0.5.0",
+ "ark-poly",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +973,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1010,16 @@ checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1053,6 +1048,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash 0.8.11",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "ark-r1cs-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-relations",
+ "ark-std 0.5.0",
+ "educe",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+dependencies = [
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+ "tracing",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1126,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1168,22 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
 ]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -1337,6 +1429,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,10 +1585,11 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "1.0.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0307f72feab3300336fb803a57134159f6e20139af1357f36c54cb90d8e8928"
+checksum = "4e7e3c397401eb76228c89561cf22f85f41c95aa799ee9d860de3ea1cbc728fc"
 dependencies = [
+ "arbitrary",
  "blst",
  "cc",
  "glob",
@@ -2024,6 +2133,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2364b9aa47e460ce9bca6ac1777d14c98eef7e274eb077beed49f3adc94183ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,7 +2192,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
- "unicode-xid",
 ]
 
 [[package]]
@@ -2187,12 +2317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
-
-[[package]]
 name = "e2hs-writer"
 version = "0.2.6"
 dependencies = [
@@ -2277,9 +2401,21 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2367,6 +2503,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "enumn"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,14 +2595,14 @@ dependencies = [
 
 [[package]]
 name = "eth_trie"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ffb0d2fa42ad87f02c0683c04b31cb41bf3853f2327d037738345bc5b56671"
+checksum = "518b70507e2fd9eda64e46553cda599d1aa01ebbddb22b3af298b96850b64e4a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "hashbrown 0.14.5",
- "keccak-hash",
+ "hashbrown 0.15.2",
+ "keccak-hash 0.11.0",
  "log",
  "parking_lot 0.12.3",
 ]
@@ -2459,14 +2615,14 @@ checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
 dependencies = [
  "cpufeatures",
  "ring",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
 name = "ethereum_serde_utils"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70cbccfccf81d67bff0ab36e591fa536c8a935b078a7b0e58c1d00d418332fc9"
+checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -2477,20 +2633,24 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e999563461faea0ab9bc0024e5e66adcee35881f3d5062f52f31a4070fe1522"
+checksum = "9ca8ba45b63c389c6e115b095ca16381534fdcc03cf58176a3f8554db2dbe19b"
 dependencies = [
  "alloy-primitives",
+ "ethereum_serde_utils",
  "itertools 0.13.0",
+ "serde",
+ "serde_derive",
  "smallvec",
+ "typenum",
 ]
 
 [[package]]
 name = "ethereum_ssz_derive"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3deae99c8e74829a00ba7a92d49055732b3c1f093f2ccfa3cbc621679b6fa91"
+checksum = "0dd55d08012b4e0dfcc92b8d6081234df65f2986ad34cc76eeed69c5e2ce7506"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -2504,7 +2664,7 @@ version = "0.8.1"
 dependencies = [
  "alloy",
  "alloy-rlp",
- "alloy-rpc-types-eth 0.12.6",
+ "alloy-rpc-types-eth",
  "anyhow",
  "base64 0.13.1",
  "bimap",
@@ -2520,19 +2680,19 @@ dependencies = [
  "hex",
  "itertools 0.13.0",
  "jsonrpsee",
- "keccak-hash",
+ "keccak-hash 0.10.0",
  "lazy_static",
  "once_cell",
  "quickcheck",
  "rand 0.8.5",
  "rs_merkle",
  "rstest",
- "secp256k1",
+ "secp256k1 0.29.1",
  "serde",
  "serde-this-or-that",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.8",
  "sha3 0.9.1",
  "snap",
  "ssz_types",
@@ -3004,7 +3164,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.11",
- "allocator-api2",
 ]
 
 [[package]]
@@ -3066,6 +3225,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -3807,7 +3975,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2",
+ "sha2 0.10.8",
  "signature",
 ]
 
@@ -3836,7 +4004,17 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b286e6b663fb926e1eeb68528e69cb70ed46c6d65871a21b2215ae8154c6d3c"
 dependencies = [
- "primitive-types",
+ "primitive-types 0.12.2",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "keccak-hash"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1b8590eb6148af2ea2d75f38e7d29f5ca970d5a4df456b3ef19b8b415d0264"
+dependencies = [
+ "primitive-types 0.13.1",
  "tiny-keccak",
 ]
 
@@ -3845,9 +4023,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "lazycell"
@@ -3907,6 +4082,52 @@ dependencies = [
  "libz-sys",
  "lz4-sys",
  "zstd-sys",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
+dependencies = [
+ "arrayref",
+ "base64 0.22.1",
+ "digest 0.9.0",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.9.9",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -4441,6 +4662,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4589,6 +4822,7 @@ checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
  "phf_shared 0.11.3",
+ "serde",
 ]
 
 [[package]]
@@ -4739,8 +4973,8 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
- "revm 14.0.3",
- "revm-primitives 10.0.0",
+ "revm",
+ "revm-primitives",
  "rstest",
  "scraper",
  "serde",
@@ -4830,6 +5064,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4838,6 +5081,16 @@ dependencies = [
  "fixed-hash",
  "impl-codec",
  "uint 0.9.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
+dependencies = [
+ "fixed-hash",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -5032,6 +5285,7 @@ checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+ "serde",
 ]
 
 [[package]]
@@ -5070,6 +5324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
+ "serde",
 ]
 
 [[package]]
@@ -5300,47 +5555,140 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "14.0.3"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641702b12847f9ed418d552f4fcabe536d867a2c980e96b6e7e25d7b992f929f"
+checksum = "f5378e95ffe5c8377002dafeb6f7d370a55517cef7d6d6c16fc552253af3b123"
 dependencies = [
- "auto_impl",
- "cfg-if",
- "dyn-clone",
- "revm-interpreter 10.0.3",
- "revm-precompile 11.0.3",
- "serde",
- "serde_json",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
 ]
 
 [[package]]
-name = "revm"
-version = "19.7.0"
+name = "revm-bytecode"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c175ecec83bba464aa8406502fe5bf670491c2ace81a153264891d43bc7fa332"
+checksum = "e63e138d520c5c5bc25ecc82506e9e4e6e85a811809fc5251c594378dccabfc6"
+dependencies = [
+ "bitvec",
+ "phf 0.11.3",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9765628dfea4f3686aa8f2a72471c52801e6b38b601939ac16965f49bac66580"
+dependencies = [
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d74335aa1f14222cc4d3be1f62a029cc7dc03819cc8d080ff17b7e1d76375f"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5c80c5a2fd605f2119ee32a63fb3be941fb6a81ced8cdb3397abca28317224"
+dependencies = [
+ "alloy-eips 0.14.0",
+ "revm-bytecode",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e4dfbc734b1ea67b5e8f8b3c7dc4283e2210d978cdaf6c7a45e97be5ea53b3"
 dependencies = [
  "auto_impl",
- "cfg-if",
- "dyn-clone",
- "revm-interpreter 15.2.0",
- "revm-precompile 16.2.0",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-handler"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8676379521c7bf179c31b685c5126ce7800eab5844122aef3231b97026d41a10"
+dependencies = [
+ "auto_impl",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfed4ecf999a3f6ae776ae2d160478c5dca986a8c2d02168e04066b1e34c789e"
+dependencies = [
+ "auto_impl",
+ "revm-context",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-interpreter",
+ "revm-primitives",
+ "revm-state",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "revm-inspectors"
-version = "0.15.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d87cdf1c0d878b48423f8a86232950657abaf72a2d0d14af609467542313b1a"
+checksum = "2a46e0edeec681bd33f8dc64d03e1bff1e331e7984459ffa6a2fa08675717469"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth 0.11.1",
+ "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-sol-types",
  "anstyle",
  "colorchoice",
- "revm 19.7.0",
+ "revm",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -5348,97 +5696,60 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "10.0.3"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5e14002afae20b5bf1566f22316122f42f57517000e559c55b25bf7a49cba2"
+checksum = "feb20260342003cfb791536e678ef5bbea1bfd1f8178b170e8885ff821985473"
 dependencies = [
- "revm-primitives 10.0.0",
- "serde",
-]
-
-[[package]]
-name = "revm-interpreter"
-version = "15.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcab7ef2064057acfc84731205f4bc77f4ec1b35630800b26ff6a185731c5ab"
-dependencies = [
- "revm-primitives 15.2.0",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-primitives",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "11.0.3"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3198c06247e8d4ad0d1312591edf049b0de4ddffa9fecb625c318fd67db8639b"
+checksum = "418e95eba68c9806c74f3e36cd5d2259170b61e90ac608b17ff8c435038ddace"
 dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
  "aurora-engine-modexp",
  "c-kzg",
  "cfg-if",
  "k256",
+ "libsecp256k1",
  "once_cell",
- "revm-primitives 10.0.0",
+ "p256",
+ "revm-primitives",
  "ripemd",
- "secp256k1",
- "sha2",
- "substrate-bn",
-]
-
-[[package]]
-name = "revm-precompile"
-version = "16.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99743c3a2cac341084cc15ac74286c4bf34a0941ebf60aa420cfdb9f81f72f9f"
-dependencies = [
- "aurora-engine-modexp",
- "c-kzg",
- "cfg-if",
- "k256",
- "once_cell",
- "revm-primitives 15.2.0",
- "ripemd",
- "secp256k1",
- "sha2",
- "substrate-bn",
+ "secp256k1 0.30.0",
+ "sha2 0.10.8",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "10.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f1525851a03aff9a9d6a1d018b414d76252d6802ab54695b27093ecd7e7a101"
+checksum = "1fc2283ff87358ec7501956c5dd8724a6c2be959c619c4861395ae5e0054575f"
 dependencies = [
- "alloy-eip2930",
- "alloy-eip7702 0.1.1",
  "alloy-primitives",
- "auto_impl",
- "bitflags 2.9.0",
- "bitvec",
- "c-kzg",
- "cfg-if",
- "dyn-clone",
  "enumn",
- "hex",
  "serde",
 ]
 
 [[package]]
-name = "revm-primitives"
-version = "15.2.0"
+name = "revm-state"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f987564210317706def498421dfba2ae1af64a8edce82c6102758b48133fcb"
+checksum = "09dd121f6e66d75ab111fb51b4712f129511569bc3e41e6067ae760861418bd8"
 dependencies = [
- "alloy-eip2930",
- "alloy-eip7702 0.5.1",
- "alloy-primitives",
- "auto_impl",
  "bitflags 2.9.0",
- "bitvec",
- "c-kzg",
- "cfg-if",
- "dyn-clone",
- "enumn",
- "hex",
+ "revm-bytecode",
+ "revm-primitives",
  "serde",
 ]
 
@@ -5512,7 +5823,7 @@ dependencies = [
  "http 1.3.1",
  "portalnet",
  "reth-ipc",
- "revm 14.0.3",
+ "revm",
  "serde",
  "serde_json",
  "strum 0.26.3",
@@ -5532,7 +5843,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb09b49230ba22e8c676e7b75dfe2887dea8121f18b530ae0ba519ce442d2b21"
 dependencies = [
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -5580,7 +5891,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
  "rand 0.9.1",
@@ -5641,7 +5952,7 @@ version = "8.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d55b95147fe01265d06b3955db798bdaed52e60e2211c41137701b3aba8e21"
 dependencies = [
- "sha2",
+ "sha2 0.10.8",
  "walkdir",
 ]
 
@@ -5899,6 +6210,17 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
+ "rand 0.8.5",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
  "rand 0.8.5",
  "secp256k1-sys",
 ]
@@ -6166,6 +6488,19 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
@@ -6328,12 +6663,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6345,11 +6674,10 @@ dependencies = [
 
 [[package]]
 name = "ssz_types"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e0719d2b86ac738a55ae71a8429f52aa2741da988f1fd0975b4cc610fd1e08"
+checksum = "75b55bedc9a18ed2860a46d6beb4f4082416ee1d60be0cc364cebdcdddc7afd4"
 dependencies = [
- "derivative",
  "ethereum_serde_utils",
  "ethereum_ssz",
  "itertools 0.13.0",
@@ -6481,19 +6809,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-bn"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
-dependencies = [
- "byteorder",
- "crunchy",
- "lazy_static",
- "rand 0.8.5",
- "rustc-hex",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6537,9 +6852,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4560533fbd6914b94a8fb5cc803ed6801c3455668db3b810702c57612bac9412"
+checksum = "34c9c96de1f835488c1501092847b522be88c9ac6fb0d4c0fbea92992324c8f4"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -7169,20 +7484,22 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373495c23db675a5192de8b610395e1bec324d596f9e6111192ce903dc11403a"
+checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
+ "ethereum_ssz",
  "smallvec",
+ "typenum",
 ]
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0857056ca4eb5de8c417309be42bcff6017b47e86fbaddde609b4633f66061e"
+checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -7252,8 +7569,8 @@ version = "0.2.6"
 dependencies = [
  "alloy",
  "ethportal-api",
- "revm 14.0.3",
- "revm-primitives 10.0.0",
+ "revm",
+ "revm-primitives",
  "tokio",
 ]
 
@@ -7263,14 +7580,14 @@ version = "0.2.6"
 dependencies = [
  "alloy",
  "alloy-rlp",
- "alloy-rpc-types-engine 0.11.1",
+ "alloy-rpc-types-engine",
  "anyhow",
  "clap",
  "e2store",
  "eth_trie",
  "ethportal-api",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "humanize-duration",
  "jsonrpsee",
  "lazy_static",
@@ -7279,9 +7596,9 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "reqwest",
- "revm 14.0.3",
+ "revm",
  "revm-inspectors",
- "revm-primitives 10.0.0",
+ "revm-primitives",
  "rocksdb",
  "serde",
  "serde_json",
@@ -7350,7 +7667,7 @@ dependencies = [
  "env_logger 0.9.3",
  "eth_trie",
  "ethportal-api",
- "keccak-hash",
+ "keccak-hash 0.10.0",
  "parking_lot 0.11.2",
  "portalnet",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rust-version = "1.85.0"
 version = "0.2.6"
 
 [workspace.dependencies]
-alloy = { version = "0.12", default-features = false, features = ["std", "serde"] }
+alloy = { version = "0.15", default-features = false, features = ["std", "serde", "getrandom"] }
 alloy-rlp = { version = "0.3.8", default-features = false, features = ["derive"] }
 anyhow = "1.0.68"
 async-trait = "0.1.68"
@@ -48,11 +48,11 @@ delay_map = "0.4.0"
 directories = "3.0"
 discv5 = { version = "0.9.1", features = ["serde"] }
 env_logger = "0.9.0"
-eth_trie = "0.5.0"
+eth_trie = "0.6"
 ethereum_hashing = "0.7.0"
-ethereum_serde_utils = "0.7.0"
-ethereum_ssz = "0.7.1"
-ethereum_ssz_derive = "0.7.1"
+ethereum_serde_utils = "0.8"
+ethereum_ssz = "0.9"
+ethereum_ssz_derive = "0.9"
 futures = "0.3.23"
 futures-util = "0.3.23"
 hex = "0.4.3"
@@ -69,8 +69,8 @@ r2d2_sqlite = "0.24.0"
 rand = "0.8.5"
 reqwest = { version = "0.12.7", features = ["native-tls-vendored", "json"] }
 reth-ipc = { tag = "v1.0.8", git = "https://github.com/paradigmxyz/reth.git"}
-revm = { version = "14.0.3", default-features = false, features = ["std", "secp256k1", "serde-json", "c-kzg"] }
-revm-primitives = { version = "10.0.0", default-features = false, features = ["std", "serde"] }
+revm = { version = "22.0", default-features = false, features = ["std", "secp256k1", "serde-json", "c-kzg"] }
+revm-primitives = { version = "18.0.0", default-features = false, features = ["std", "serde"] }
 rstest = "0.18.2"
 rust-embed = "8.5.0"
 rusqlite = { version = "0.31.0", features = ["bundled"] }
@@ -82,7 +82,7 @@ serde-this-or-that = "0.4.2"
 serial_test = "0.5.1"
 sha3 = "0.9.1"
 snap = "1.1.1"
-ssz_types = "0.8.0"
+ssz_types = "0.11.0"
 strum = { version = "0.26.1", features = ["derive"] }
 tempfile = "3.3.0"
 test-log = { version = "0.2.11", features = ["trace"] }
@@ -92,8 +92,8 @@ tokio-test = "0.4.2"
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 tracing-test = "0.1"
-tree_hash = "0.8.0"
-tree_hash_derive = "0.8.0"
+tree_hash = "0.10"
+tree_hash_derive = "0.10"
 uds_windows = "1.0.1"
 ureq = { version = "2.5.0", features = ["json"] }
 url = "2.3.1"

--- a/bin/portal-bridge/src/bridge/state.rs
+++ b/bin/portal-bridge/src/bridge/state.rs
@@ -20,8 +20,8 @@ use reqwest::{
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},
     Client,
 };
-use revm::{Database, DatabaseRef};
-use revm_primitives::{keccak256, Bytecode, SpecId, B256};
+use revm::{state::Bytecode, Database, DatabaseRef};
+use revm_primitives::{hardfork::SpecId, keccak256, B256};
 use tokio::{
     sync::{OwnedSemaphorePermit, Semaphore},
     time::timeout,

--- a/bin/trin-execution/Cargo.toml
+++ b/bin/trin-execution/Cargo.toml
@@ -14,14 +14,14 @@ version.workspace = true
 [dependencies]
 alloy = { workspace = true, features = ["eips", "rpc-types-engine", "serde"] }
 alloy-rlp.workspace = true
-alloy-rpc-types-engine = { version = "0.11.1", default-features = false, features = ["serde"] }
+alloy-rpc-types-engine = { version = "0.15", default-features = false, features = ["serde"] }
 anyhow.workspace = true
 clap.workspace = true
 ethportal-api.workspace = true
 e2store.workspace = true
 eth_trie.workspace = true
 futures-util.workspace = true
-hashbrown = "0.14.0"
+hashbrown = "0.15"
 humanize-duration.workspace = true
 jsonrpsee = { workspace = true, features = ["async-client", "client", "macros", "server"]}
 lazy_static.workspace = true
@@ -31,7 +31,7 @@ rand.workspace = true
 rayon = "1.10.0"
 reqwest =  { workspace = true, features = ["stream"] }
 revm.workspace = true
-revm-inspectors = "0.15.0"
+revm-inspectors = "0.20.0"
 revm-primitives.workspace = true
 rocksdb = "0.22.0"
 serde = { workspace = true, features = ["rc"] }

--- a/bin/trin-execution/src/content.rs
+++ b/bin/trin-execution/src/content.rs
@@ -10,7 +10,7 @@ use ethportal_api::{
     },
     StateContentKey, StateContentValue,
 };
-use revm_primitives::Bytecode;
+use revm::state::Bytecode;
 
 use super::types::trie_proof::TrieProof;
 

--- a/bin/trin-execution/src/era/binary_search.rs
+++ b/bin/trin-execution/src/era/binary_search.rs
@@ -6,7 +6,7 @@ use e2store::{
 };
 use ethportal_api::consensus::constants::SLOTS_PER_HISTORICAL_ROOT;
 use reqwest::Client;
-use revm_primitives::SpecId;
+use revm_primitives::hardfork::SpecId;
 use trin_evm::spec_id::get_spec_block_number;
 
 use super::{constants::FIRST_ERA_EPOCH_WITH_EXECUTION_PAYLOAD, utils::download_raw_era};

--- a/bin/trin-execution/src/era/types.rs
+++ b/bin/trin-execution/src/era/types.rs
@@ -2,7 +2,8 @@ use alloy::{
     consensus::{Header, TxEip4844Variant, TxEnvelope},
     eips::eip4895::Withdrawal,
 };
-use revm_primitives::{Address, SpecId, TxEnv};
+use revm::context::TxEnv;
+use revm_primitives::{hardfork::SpecId, Address};
 use trin_evm::{spec_id::get_spec_block_number, tx_env_modifier::TxEnvModifier};
 
 #[derive(Debug, Clone)]

--- a/bin/trin-execution/src/evm/pre_block_contracts.rs
+++ b/bin/trin-execution/src/evm/pre_block_contracts.rs
@@ -1,14 +1,19 @@
 use alloy::{consensus::Header, eips::eip4788};
 use anyhow::anyhow;
-use revm::{db::State, DatabaseCommit, Evm};
-use revm_primitives::{SpecId, TxEnv, TxKind, U256};
+use revm::{
+    context::{ContextTr, TxEnv},
+    database::State,
+    handler::MainnetContext,
+    DatabaseCommit, ExecuteEvm, MainnetEvm,
+};
+use revm_primitives::{hardfork::SpecId, TxKind};
 use trin_evm::spec_id::get_spec_id;
 
 use crate::storage::evm_db::EvmDB;
 
 /// Apply the beacon roots contract from eip-4788
 fn apply_beacon_root_contract(
-    evm: &mut Evm<(), State<EvmDB>>,
+    evm: &mut MainnetEvm<MainnetContext<State<EvmDB>>, ()>,
     header: &Header,
 ) -> anyhow::Result<()> {
     if !get_spec_id(header.number).is_enabled_in(SpecId::CANCUN) {
@@ -20,19 +25,21 @@ fn apply_beacon_root_contract(
     };
 
     // Save the previous environment
-    let previous_env = Box::new(evm.context.evm.env().clone());
+    let previous_block = evm.block.clone();
+    let previous_cfg = evm.cfg.clone();
+    let previous_transaction = evm.tx.clone();
 
     // Update transaction environment to call the beacon roots contract
-    evm.context.evm.env.tx = TxEnv {
+    evm.tx = TxEnv {
         caller: eip4788::SYSTEM_ADDRESS,
-        transact_to: TxKind::Call(eip4788::BEACON_ROOTS_ADDRESS),
+        kind: TxKind::Call(eip4788::BEACON_ROOTS_ADDRESS),
         data: parent_beacon_block_root.0.into(),
         ..Default::default()
     };
-    evm.context.evm.env.block.gas_limit = U256::from(evm.context.evm.env.tx.gas_limit);
-    evm.context.evm.env.block.basefee = U256::ZERO;
+    evm.block.gas_limit = evm.tx.gas_limit;
+    evm.block.basefee = 0;
 
-    let mut state = match evm.transact() {
+    let mut state = match evm.replay() {
         Ok(result) => result.state,
         Err(err) => return Err(anyhow!("Failed to call beacon roots contract: {err:?}")),
     };
@@ -41,17 +48,19 @@ fn apply_beacon_root_contract(
     // keep
     state.retain(|address, _| address == &eip4788::BEACON_ROOTS_ADDRESS);
 
-    evm.context.evm.db.commit(state);
+    evm.db().commit(state);
 
     // Restore the previous environment
-    evm.context.evm.env = previous_env;
+    evm.block = previous_block;
+    evm.cfg = previous_cfg;
+    evm.tx = previous_transaction;
 
     Ok(())
 }
 
 /// Apply pre-block contracts
 pub fn apply_pre_block_contracts(
-    evm: &mut Evm<(), State<EvmDB>>,
+    evm: &mut MainnetEvm<MainnetContext<State<EvmDB>>, ()>,
     header: &Header,
 ) -> anyhow::Result<()> {
     apply_beacon_root_contract(evm, header)?;

--- a/bin/trin-execution/src/execution.rs
+++ b/bin/trin-execution/src/execution.rs
@@ -9,7 +9,7 @@ use alloy::{
 };
 use anyhow::ensure;
 use eth_trie::{RootWithTrieDiff, Trie};
-use revm::inspectors::TracerEip3155;
+use revm::inspector::inspectors::TracerEip3155;
 use tokio::sync::{oneshot::Receiver, Mutex};
 use tracing::{info, warn};
 
@@ -130,7 +130,7 @@ impl TrinExecution {
     async fn commit(
         &mut self,
         header: &Header,
-        block_executor: BlockExecutor<'_>,
+        block_executor: BlockExecutor,
     ) -> anyhow::Result<RootWithTrieDiff> {
         let root_with_trie_diff = block_executor.commit_bundle()?;
         ensure!(

--- a/bin/trin-execution/src/storage/error.rs
+++ b/bin/trin-execution/src/storage/error.rs
@@ -1,3 +1,4 @@
+use revm::context::DBErrorMarker;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -20,3 +21,5 @@ pub enum EVMError {
     #[error("balance error")]
     BalanceError,
 }
+
+impl DBErrorMarker for EVMError {}

--- a/bin/trin-execution/src/storage/evm_db.rs
+++ b/bin/trin-execution/src/storage/evm_db.rs
@@ -11,10 +11,11 @@ use hashbrown::{HashMap as BrownHashMap, HashSet};
 use parking_lot::Mutex;
 use prometheus_exporter::prometheus::HistogramTimer;
 use revm::{
-    db::{states::PlainStorageChangeset, BundleState, OriginalValuesKnown},
+    database::{states::PlainStorageChangeset, BundleState, OriginalValuesKnown},
+    state::{AccountInfo, Bytecode},
     Database, DatabaseRef,
 };
-use revm_primitives::{AccountInfo, Bytecode, KECCAK_EMPTY};
+use revm_primitives::KECCAK_EMPTY;
 use rocksdb::DB as RocksDB;
 use tracing::info;
 
@@ -289,7 +290,7 @@ impl EvmDB {
         // Currently we don't use reverts, so we can ignore them, but they are here for when we do.
         let timer = start_commit_timer("generate_plain_state_and_reverts");
         let (plain_state, _reverts) =
-            bundle_state.into_plain_state_and_reverts(OriginalValuesKnown::Yes);
+            bundle_state.to_plain_state_and_reverts(OriginalValuesKnown::Yes);
         stop_timer(timer);
 
         info!(

--- a/crates/e2store/src/utils.rs
+++ b/crates/e2store/src/utils.rs
@@ -7,7 +7,7 @@ use scraper::{Html, Selector};
 use url::Url;
 
 const ERA_DIR_URL: &str = "https://mainnet.era.nimbus.team/";
-const ERA1_DIR_URL: &str = "https://era1.ethportal.net/";
+const ERA1_DIR_URL: &str = "https://era1.ethportal.net/index.html";
 const E2HS_DIR_URL: &str = "https://e2hs.ethportal.net/index.html";
 const E2SS_DIR_URL: &str = "https://e2ss.ethportal.net/index.html";
 pub const ERA1_FILE_COUNT: usize = 1897;
@@ -54,13 +54,13 @@ async fn download_e2store_links(
 
 pub async fn get_era_files(http_client: &Client) -> anyhow::Result<HashMap<u64, String>> {
     let era_files = download_e2store_links(http_client, ERA_DIR_URL).await?;
-    assert_nonempty_and_consecutive_epochs(&era_files)?;
+    assert_nonempty_and_consecutive_epochs(&era_files, ERA_DIR_URL)?;
     Ok(era_files)
 }
 
 pub async fn get_e2hs_files(http_client: &Client) -> anyhow::Result<HashMap<u64, String>> {
     let e2hs_files = download_e2store_links(http_client, E2HS_DIR_URL).await?;
-    assert_nonempty_and_consecutive_epochs(&e2hs_files)?;
+    assert_nonempty_and_consecutive_epochs(&e2hs_files, E2HS_DIR_URL)?;
     Ok(e2hs_files)
 }
 
@@ -74,7 +74,7 @@ pub async fn get_era1_files(http_client: &Client) -> anyhow::Result<HashMap<u64,
             era1_files.len()
         )
     );
-    assert_nonempty_and_consecutive_epochs(&era1_files)?;
+    assert_nonempty_and_consecutive_epochs(&era1_files, ERA1_DIR_URL)?;
     Ok(era1_files)
 }
 
@@ -83,8 +83,11 @@ pub async fn get_e2ss_files(http_client: &Client) -> anyhow::Result<HashMap<u64,
     Ok(e2ss_files)
 }
 
-fn assert_nonempty_and_consecutive_epochs(files: &HashMap<u64, String>) -> anyhow::Result<()> {
-    ensure!(!files.is_empty(), "No e2store files found at {ERA_DIR_URL}");
+fn assert_nonempty_and_consecutive_epochs(
+    files: &HashMap<u64, String>,
+    e2store_url: &str,
+) -> anyhow::Result<()> {
+    ensure!(!files.is_empty(), "No e2store files found at {e2store_url}");
     let missing_epochs: Vec<String> = (0..files.len())
         .filter(|&epoch_num| !files.contains_key(&(epoch_num as u64)))
         .map(|epoch_num| epoch_num.to_string())
@@ -92,7 +95,7 @@ fn assert_nonempty_and_consecutive_epochs(files: &HashMap<u64, String>) -> anyho
 
     ensure!(
         missing_epochs.is_empty(),
-        "Epoch indices are not starting from zero or not consecutive: missing epochs [{}]",
+        "Epoch indices are not starting from zero or not consecutive from {e2store_url}: missing epochs [{}]",
         missing_epochs.join(", ")
     );
     Ok(())

--- a/crates/ethportal-api/Cargo.toml
+++ b/crates/ethportal-api/Cargo.toml
@@ -14,12 +14,12 @@ rust-version.workspace = true
 [dependencies]
 alloy = { workspace = true, features = ["consensus", "eips", "k256", "rlp", "rpc-types-eth", "serde"] }
 alloy-rlp.workspace = true
-alloy-rpc-types-eth = { version = "0.12", default-features = false, features = ["serde"] }
+alloy-rpc-types-eth = { version = "0.15", default-features = false, features = ["serde"] }
 anyhow.workspace = true
 base64 = "0.13.0"
 bimap = "0.6.3"
 bytes.workspace = true
-c-kzg = "1.0.0"
+c-kzg = "2.1.0"
 discv5.workspace = true
 eth_trie.workspace = true
 ethereum_hashing.workspace = true

--- a/crates/ethportal-api/src/types/accept_code.rs
+++ b/crates/ethportal-api/src/types/accept_code.rs
@@ -123,6 +123,9 @@ pub enum AcceptCodeListError {
 
     #[error("SSZ types error: {0}")]
     SSZTypesError(String),
+
+    #[error("SSZ Bitfield error: {0}")]
+    SSZBitfieldError(String),
 }
 
 impl From<ssz::DecodeError> for AcceptCodeListError {
@@ -134,6 +137,12 @@ impl From<ssz::DecodeError> for AcceptCodeListError {
 impl From<ssz_types::Error> for AcceptCodeListError {
     fn from(err: ssz_types::Error) -> Self {
         AcceptCodeListError::SSZTypesError(format!("{err:?}"))
+    }
+}
+
+impl From<ssz::BitfieldError> for AcceptCodeListError {
+    fn from(err: ssz::BitfieldError) -> Self {
+        AcceptCodeListError::SSZBitfieldError(format!("{err:?}"))
     }
 }
 

--- a/crates/evm/src/spec_id.rs
+++ b/crates/evm/src/spec_id.rs
@@ -1,4 +1,4 @@
-use revm_primitives::SpecId;
+use revm_primitives::hardfork::SpecId;
 
 // Execution Layer hard forks https://github.com/ethereum/execution-specs/tree/master/network-upgrades/mainnet-upgrades
 pub const SPEC_FORK_BLOCK_NUMBER: [(SpecId, u64); 18] = [
@@ -28,7 +28,7 @@ pub fn get_spec_id(block_number: u64) -> SpecId {
             return *spec_id;
         }
     }
-    SpecId::LATEST
+    SpecId::PRAGUE
 }
 
 pub fn get_spec_block_number(spec_id: SpecId) -> u64 {
@@ -108,7 +108,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_get_spec_block_number_unsupported() {
-        get_spec_block_number(SpecId::LATEST);
+        get_spec_block_number(SpecId::PRAGUE);
     }
 
     #[test]

--- a/crates/evm/src/tx_env_modifier.rs
+++ b/crates/evm/src/tx_env_modifier.rs
@@ -129,7 +129,7 @@ impl TxEnvModifier for TransactionRequest {
         }
         tx_env.gas_priority_fee = self.max_priority_fee_per_gas;
         if let Some(max_fee_per_blob_gas) = self.max_fee_per_blob_gas {
-            tx_env.gas_price = max_fee_per_blob_gas;
+            tx_env.max_fee_per_blob_gas = max_fee_per_blob_gas;
         }
         if let Some(gas) = self.gas {
             tx_env.gas_limit = gas;

--- a/crates/evm/src/tx_env_modifier.rs
+++ b/crates/evm/src/tx_env_modifier.rs
@@ -1,9 +1,10 @@
 use alloy::{
     consensus::{TxEip1559, TxEip2930, TxEip4844, TxLegacy},
-    primitives::U256,
+    eips::eip2930::{AccessList, AccessListItem},
     rpc::types::TransactionRequest,
 };
-use revm_primitives::{AccessListItem, SpecId, TransactTo, TxEnv, TxKind};
+use revm::context::{TransactTo, TxEnv};
+use revm_primitives::{hardfork::SpecId, TxKind};
 
 use super::spec_id::get_spec_id;
 
@@ -14,9 +15,9 @@ pub trait TxEnvModifier {
 impl TxEnvModifier for TxLegacy {
     fn modify(&self, block_number: u64, tx_env: &mut TxEnv) {
         tx_env.gas_limit = self.gas_limit;
-        tx_env.gas_price = U256::from(self.gas_price);
+        tx_env.gas_price = self.gas_price;
         tx_env.gas_priority_fee = None;
-        tx_env.transact_to = match self.to {
+        tx_env.kind = match self.to {
             TxKind::Call(to) => TransactTo::Call(to),
             TxKind::Create => TransactTo::Create,
         };
@@ -27,85 +28,88 @@ impl TxEnvModifier for TxLegacy {
         } else {
             None
         };
-        tx_env.nonce = Some(self.nonce);
-        tx_env.access_list.clear();
+        tx_env.nonce = self.nonce;
+        tx_env.access_list = AccessList::default();
         tx_env.blob_hashes.clear();
-        tx_env.max_fee_per_blob_gas.take();
+        tx_env.max_fee_per_blob_gas = 0;
     }
 }
 
 impl TxEnvModifier for TxEip1559 {
     fn modify(&self, _block_number: u64, tx_env: &mut TxEnv) {
         tx_env.gas_limit = self.gas_limit;
-        tx_env.gas_price = U256::from(self.max_fee_per_gas);
-        tx_env.gas_priority_fee = Some(U256::from(self.max_priority_fee_per_gas));
-        tx_env.transact_to = match self.to {
+        tx_env.gas_price = self.max_fee_per_gas;
+        tx_env.gas_priority_fee = Some(self.max_priority_fee_per_gas);
+        tx_env.kind = match self.to {
             TxKind::Call(to) => TransactTo::Call(to),
             TxKind::Create => TransactTo::Create,
         };
         tx_env.value = self.value;
         tx_env.data = self.input.clone();
         tx_env.chain_id = Some(self.chain_id);
-        tx_env.nonce = Some(self.nonce);
-        tx_env.access_list = self
-            .access_list
-            .iter()
-            .map(|l| AccessListItem {
-                address: l.address,
-                storage_keys: l.storage_keys.clone(),
-            })
-            .collect();
+        tx_env.nonce = self.nonce;
+        tx_env.access_list = AccessList::from(
+            self.access_list
+                .iter()
+                .map(|l| AccessListItem {
+                    address: l.address,
+                    storage_keys: l.storage_keys.clone(),
+                })
+                .collect::<Vec<_>>(),
+        );
         tx_env.blob_hashes.clear();
-        tx_env.max_fee_per_blob_gas.take();
+        tx_env.max_fee_per_blob_gas = 0;
     }
 }
 
 impl TxEnvModifier for TxEip2930 {
     fn modify(&self, _block_number: u64, tx_env: &mut TxEnv) {
         tx_env.gas_limit = self.gas_limit;
-        tx_env.gas_price = U256::from(self.gas_price);
+        tx_env.gas_price = self.gas_price;
         tx_env.gas_priority_fee = None;
-        tx_env.transact_to = match self.to {
+        tx_env.kind = match self.to {
             TxKind::Call(to) => TransactTo::Call(to),
             TxKind::Create => TransactTo::Create,
         };
         tx_env.value = self.value;
         tx_env.data = self.input.clone();
         tx_env.chain_id = Some(self.chain_id);
-        tx_env.nonce = Some(self.nonce);
-        tx_env.access_list = self
-            .access_list
-            .iter()
-            .map(|l| AccessListItem {
-                address: l.address,
-                storage_keys: l.storage_keys.clone(),
-            })
-            .collect();
+        tx_env.nonce = self.nonce;
+        tx_env.access_list = AccessList::from(
+            self.access_list
+                .iter()
+                .map(|l| AccessListItem {
+                    address: l.address,
+                    storage_keys: l.storage_keys.clone(),
+                })
+                .collect::<Vec<_>>(),
+        );
         tx_env.blob_hashes.clear();
-        tx_env.max_fee_per_blob_gas.take();
+        tx_env.max_fee_per_blob_gas = 0;
     }
 }
 
 impl TxEnvModifier for TxEip4844 {
     fn modify(&self, _block_number: u64, tx_env: &mut TxEnv) {
         tx_env.gas_limit = self.gas_limit;
-        tx_env.gas_price = U256::from(self.max_fee_per_gas);
-        tx_env.gas_priority_fee = Some(U256::from(self.max_priority_fee_per_gas));
-        tx_env.transact_to = TransactTo::Call(self.to);
+        tx_env.gas_price = self.max_fee_per_gas;
+        tx_env.gas_priority_fee = Some(self.max_priority_fee_per_gas);
+        tx_env.kind = TransactTo::Call(self.to);
         tx_env.value = self.value;
         tx_env.data = self.input.clone();
         tx_env.chain_id = Some(self.chain_id);
-        tx_env.nonce = Some(self.nonce);
-        tx_env.access_list = self
-            .access_list
-            .iter()
-            .map(|l| AccessListItem {
-                address: l.address,
-                storage_keys: l.storage_keys.clone(),
-            })
-            .collect();
+        tx_env.nonce = self.nonce;
+        tx_env.access_list = AccessList::from(
+            self.access_list
+                .iter()
+                .map(|l| AccessListItem {
+                    address: l.address,
+                    storage_keys: l.storage_keys.clone(),
+                })
+                .collect::<Vec<_>>(),
+        );
         tx_env.blob_hashes.clone_from(&self.blob_versioned_hashes);
-        tx_env.max_fee_per_blob_gas = Some(U256::from(self.max_fee_per_blob_gas));
+        tx_env.max_fee_per_blob_gas = self.max_fee_per_blob_gas;
     }
 }
 
@@ -115,16 +119,18 @@ impl TxEnvModifier for TransactionRequest {
             tx_env.caller = from;
         }
         if let Some(to) = self.to {
-            tx_env.transact_to = to;
+            tx_env.kind = to;
         }
         if let Some(gas_price) = self.gas_price {
-            tx_env.gas_price = U256::from(gas_price);
+            tx_env.gas_price = gas_price;
         }
         if let Some(max_fee_per_gas) = self.max_fee_per_gas {
-            tx_env.gas_price = U256::from(max_fee_per_gas);
+            tx_env.gas_price = max_fee_per_gas;
         }
-        tx_env.gas_priority_fee = self.max_priority_fee_per_gas.map(U256::from);
-        tx_env.max_fee_per_blob_gas = self.max_fee_per_blob_gas.map(U256::from);
+        tx_env.gas_priority_fee = self.max_priority_fee_per_gas;
+        if let Some(max_fee_per_blob_gas) = self.max_fee_per_blob_gas {
+            tx_env.gas_price = max_fee_per_blob_gas;
+        }
         if let Some(gas) = self.gas {
             tx_env.gas_limit = gas;
         }
@@ -134,7 +140,9 @@ impl TxEnvModifier for TransactionRequest {
         if let Some(data) = self.input.input() {
             tx_env.data.clone_from(data);
         }
-        tx_env.nonce = self.nonce;
+        if let Some(nounce) = self.nonce {
+            tx_env.nonce = nounce;
+        }
         tx_env.chain_id = self.chain_id;
         if let Some(access_list) = &self.access_list {
             tx_env.access_list.clone_from(access_list);
@@ -148,7 +156,7 @@ impl TxEnvModifier for TransactionRequest {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::bytes::Bytes;
-    use revm_primitives::{TxEnv, TxKind};
+    use revm_primitives::{TxKind, U256};
 
     use super::*;
 
@@ -165,10 +173,10 @@ mod tests {
         };
         let mut tx_env = TxEnv::default();
         tx.modify(0, &mut tx_env);
-        assert_eq!(tx_env.nonce, Some(1));
-        assert_eq!(tx_env.gas_price, U256::from(1));
+        assert_eq!(tx_env.nonce, 1);
+        assert_eq!(tx_env.gas_price, 1);
         assert_eq!(tx_env.gas_limit, 1);
-        assert_eq!(tx_env.transact_to, TransactTo::Call(Default::default()));
+        assert_eq!(tx_env.kind, TransactTo::Call(Default::default()));
         assert_eq!(tx_env.value, U256::from(1));
         assert_eq!(tx_env.data.0, vec![1, 2, 3]);
     }
@@ -188,15 +196,15 @@ mod tests {
         };
         let mut tx_env = TxEnv::default();
         tx.modify(0, &mut tx_env);
-        assert_eq!(tx_env.nonce, Some(1));
-        assert_eq!(tx_env.gas_price, U256::from(1));
-        assert_eq!(tx_env.gas_priority_fee, Some(U256::from(1)));
+        assert_eq!(tx_env.nonce, 1);
+        assert_eq!(tx_env.gas_price, 1);
+        assert_eq!(tx_env.gas_priority_fee, Some(1));
         assert_eq!(tx_env.gas_limit, 1);
-        assert_eq!(tx_env.transact_to, TransactTo::Call(Default::default()));
+        assert_eq!(tx_env.kind, TransactTo::Call(Default::default()));
         assert_eq!(tx_env.value, U256::from(1));
         assert_eq!(tx_env.data.0, vec![1, 2, 3]);
         assert_eq!(tx_env.chain_id, Some(1));
-        assert_eq!(tx_env.access_list, vec![]);
+        assert_eq!(tx_env.access_list, AccessList::default());
     }
 
     #[test]
@@ -213,14 +221,14 @@ mod tests {
         };
         let mut tx_env = TxEnv::default();
         tx.modify(0, &mut tx_env);
-        assert_eq!(tx_env.nonce, Some(1));
-        assert_eq!(tx_env.gas_price, U256::from(1));
+        assert_eq!(tx_env.nonce, 1);
+        assert_eq!(tx_env.gas_price, 1);
         assert_eq!(tx_env.gas_limit, 1);
-        assert_eq!(tx_env.transact_to, TransactTo::Call(Default::default()));
+        assert_eq!(tx_env.kind, TransactTo::Call(Default::default()));
         assert_eq!(tx_env.value, U256::from(1));
         assert_eq!(tx_env.data.0, vec![1, 2, 3]);
         assert_eq!(tx_env.chain_id, Some(1));
-        assert_eq!(tx_env.access_list, vec![]);
+        assert_eq!(tx_env.access_list, AccessList::default());
     }
 
     #[test]
@@ -240,16 +248,16 @@ mod tests {
         };
         let mut tx_env = TxEnv::default();
         tx.modify(0, &mut tx_env);
-        assert_eq!(tx_env.nonce, Some(1));
-        assert_eq!(tx_env.gas_price, U256::from(1));
-        assert_eq!(tx_env.gas_priority_fee, Some(U256::from(1)));
+        assert_eq!(tx_env.nonce, 1);
+        assert_eq!(tx_env.gas_price, 1);
+        assert_eq!(tx_env.gas_priority_fee, Some(1));
         assert_eq!(tx_env.gas_limit, 1);
-        assert_eq!(tx_env.transact_to, TransactTo::Call(Default::default()));
+        assert_eq!(tx_env.kind, TransactTo::Call(Default::default()));
         assert_eq!(tx_env.value, U256::from(1));
         assert_eq!(tx_env.data.0, vec![1, 2, 3]);
         assert_eq!(tx_env.chain_id, Some(1));
-        assert_eq!(tx_env.access_list, vec![]);
+        assert_eq!(tx_env.access_list, AccessList::default());
         assert_eq!(tx_env.blob_hashes.len(), 0);
-        assert_eq!(tx_env.max_fee_per_blob_gas, Some(U256::from(1)));
+        assert_eq!(tx_env.max_fee_per_blob_gas, 1);
     }
 }

--- a/crates/rpc/src/eth_rpc.rs
+++ b/crates/rpc/src/eth_rpc.rs
@@ -18,7 +18,7 @@ use ethportal_api::{
     },
     ContentValue, EthApiServer, HistoryContentKey, HistoryContentValue,
 };
-use revm::primitives::ExecutionResult;
+use revm::context::result::ExecutionResult;
 use tokio::sync::mpsc;
 use trin_evm::{
     async_db::{execute_transaction, AsyncDatabase},

--- a/crates/rpc/src/evm_state.rs
+++ b/crates/rpc/src/evm_state.rs
@@ -20,7 +20,11 @@ use ethportal_api::{
     },
     ContentValue, ContentValueError, OverlayContentKey, StateContentKey, StateContentValue,
 };
-use revm::primitives::{AccountInfo, Bytecode, KECCAK_EMPTY};
+use revm::{
+    context::DBErrorMarker,
+    primitives::KECCAK_EMPTY,
+    state::{AccountInfo, Bytecode},
+};
 use tokio::sync::mpsc;
 use tracing::debug;
 use trin_evm::async_db::AsyncDatabase;
@@ -44,6 +48,8 @@ pub enum EvmStateError {
     #[error("Internal Error: {0}")]
     InternalError(String),
 }
+
+impl DBErrorMarker for EvmStateError {}
 
 impl From<EvmStateError> for RpcServeError {
     fn from(value: EvmStateError) -> Self {

--- a/testing/ethportal-peertest/tests/rpc_server.rs
+++ b/testing/ethportal-peertest/tests/rpc_server.rs
@@ -59,7 +59,7 @@ async fn setup_web3_server() -> (RpcServerHandle, DynProvider, Client) {
 
     let web3_server = trin::run_trin(trin_config).await.unwrap();
     let ipc = IpcConnect::new(DEFAULT_WEB3_IPC_PATH.to_string());
-    let web3_client = DynProvider::new(ProviderBuilder::new().on_ipc(ipc).await.unwrap());
+    let web3_client = DynProvider::new(ProviderBuilder::new().connect_ipc(ipc).await.unwrap());
 
     // Tests that use native client belong in tests/self_peertest.rs, but it is convenient to use
     // the native client to populate content in the server's database.


### PR DESCRIPTION
### What was wrong?
- We want to avoid importing multiple versions of alloy crates
- I want to use alloy-hardforks a crate which was made 3 months ago, which implements all the Ethereum Fork stuff
- We use a quite old version of alloy and revm, and ssz, all of which is required to be upgraded as they depend on each other

### How was it fixed?

Bumping the versions of
- alloy
- revm
- ssz
- ckzg

I also had to update some code to match the upstream changes
