### PR TITLE
feat: update portal-spec-tests and refactor reading from test files

### DIFF
--- a/crates/ethportal-api/src/test_utils/types.rs
+++ b/crates/ethportal-api/src/test_utils/types.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    types::execution::header_with_proof::HeaderWithProof, ContentValue, ContentValueError,
+    HistoryContentKey, HistoryContentValue, OverlayContentKey, RawContentValue,
+};
+
+/// A common type used in test files.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContentItem<K: OverlayContentKey> {
+    pub content_key: K,
+    #[serde(rename = "content_value")]
+    pub raw_content_value: RawContentValue,
+}
+
+impl<K: OverlayContentKey> ContentItem<K> {
+    pub fn content_value<V: ContentValue<TContentKey = K>>(&self) -> Result<V, ContentValueError> {
+        V::decode(&self.content_key, &self.raw_content_value)
+    }
+}
+
+impl ContentItem<HistoryContentKey> {
+    /// Decodes content value as HeaderWithProof.
+    ///
+    /// Panics if content value is not HeaderWithProof.
+    pub fn content_value_as_header_with_proof(&self) -> HeaderWithProof {
+        let HistoryContentValue::BlockHeaderWithProof(header_with_proof) =
+            self.content_value().unwrap()
+        else {
+            panic!(
+                "Expected BlockHeaderWithProof content value. Actual {}",
+                self.raw_content_value
+            );
+        };
+        header_with_proof
+    }
+}

--- a/crates/ethportal-api/src/types/content_key/state.rs
+++ b/crates/ethportal-api/src/types/content_key/state.rs
@@ -177,7 +177,7 @@ mod test {
     use serde_yaml::Value;
 
     use super::*;
-    use crate::{test_utils::read_file_from_tests_submodule, utils::bytes::hex_decode};
+    use crate::{test_utils::read_yaml_portal_spec_tests_file, utils::bytes::hex_decode};
 
     const TEST_DATA_DIRECTORY: &str = "tests/mainnet/state/serialization";
 
@@ -293,9 +293,7 @@ mod test {
     }
 
     fn read_yaml_file(filename: &str) -> anyhow::Result<Value> {
-        let path = PathBuf::from(TEST_DATA_DIRECTORY).join(filename);
-        let file = read_file_from_tests_submodule(path)?;
-        Ok(serde_yaml::from_str(&file)?)
+        read_yaml_portal_spec_tests_file(PathBuf::from(TEST_DATA_DIRECTORY).join(filename))
     }
 
     fn yaml_as_address(value: &Value) -> Address {

--- a/crates/ethportal-api/src/types/content_value/beacon.rs
+++ b/crates/ethportal-api/src/types/content_value/beacon.rs
@@ -548,32 +548,22 @@ impl ContentValue for BeaconContentValue {
 
 #[cfg(test)]
 mod test {
-    use std::str::FromStr;
-
-    use alloy::primitives::Bytes;
     use serde::Deserialize;
-    use serde_yaml::Value;
 
     use super::*;
-    use crate::test_utils::read_file_from_tests_submodule;
+    use crate::test_utils::{read_yaml_portal_spec_tests_file, types::ContentItem};
 
     #[rstest::rstest]
     #[case("capella", 6718368)]
     #[case("deneb", 10248000)]
     fn light_client_bootstrap_encode_decode(#[case] fork_name: &str, #[case] expected_slot: u64) {
-        let file = read_file_from_tests_submodule(format!(
+        let test_data: ContentItem<BeaconContentKey> = read_yaml_portal_spec_tests_file(format!(
             "tests/mainnet/beacon_chain/light_client/{fork_name}/bootstrap.yaml",
         ))
         .unwrap();
+        let content_value: BeaconContentValue = test_data.content_value().unwrap();
 
-        let value: Value = serde_yaml::from_str(&file).unwrap();
-        let content_key: BeaconContentKey =
-            serde_yaml::from_value(value["content_key"].clone()).unwrap();
-        let raw_content_value = Bytes::from_str(value["content_value"].as_str().unwrap()).unwrap();
-        let content_value = BeaconContentValue::decode(&content_key, raw_content_value.as_ref())
-            .expect("unable to decode content value");
-
-        assert_str_roundtrip(content_key, content_value.clone());
+        assert_str_roundtrip(test_data.content_key, content_value.clone());
 
         match content_value {
             BeaconContentValue::LightClientBootstrap(value) => {
@@ -590,19 +580,13 @@ mod test {
         #[case] fork_name: &str,
         #[case] expected_slot: u64,
     ) {
-        let file = read_file_from_tests_submodule(format!(
+        let test_data: ContentItem<BeaconContentKey> = read_yaml_portal_spec_tests_file(format!(
             "tests/mainnet/beacon_chain/light_client/{fork_name}/updates.yaml",
         ))
         .unwrap();
+        let content_value: BeaconContentValue = test_data.content_value().unwrap();
 
-        let value: Value = serde_yaml::from_str(&file).unwrap();
-        let content_key: BeaconContentKey =
-            serde_yaml::from_value(value["content_key"].clone()).unwrap();
-        let raw_content_value = Bytes::from_str(value["content_value"].as_str().unwrap()).unwrap();
-        let content_value = BeaconContentValue::decode(&content_key, raw_content_value.as_ref())
-            .expect("unable to decode content value");
-
-        assert_str_roundtrip(content_key, content_value.clone());
+        assert_str_roundtrip(test_data.content_key, content_value.clone());
 
         let update = match content_value {
             BeaconContentValue::LightClientUpdatesByRange(value) => value[0].update.clone(),
@@ -623,19 +607,13 @@ mod test {
         #[case] fork_name: &str,
         #[case] expected_slot: u64,
     ) {
-        let file = read_file_from_tests_submodule(format!(
+        let test_data: ContentItem<BeaconContentKey> = read_yaml_portal_spec_tests_file(format!(
             "tests/mainnet/beacon_chain/light_client/{fork_name}/optimistic_update.yaml",
         ))
         .unwrap();
+        let content_value: BeaconContentValue = test_data.content_value().unwrap();
 
-        let value: Value = serde_yaml::from_str(&file).unwrap();
-        let content_key: BeaconContentKey =
-            serde_yaml::from_value(value["content_key"].clone()).unwrap();
-        let raw_content_value = Bytes::from_str(value["content_value"].as_str().unwrap()).unwrap();
-        let content_value = BeaconContentValue::decode(&content_key, raw_content_value.as_ref())
-            .expect("unable to decode content value");
-
-        assert_str_roundtrip(content_key, content_value.clone());
+        assert_str_roundtrip(test_data.content_key, content_value.clone());
 
         let update = match content_value {
             BeaconContentValue::LightClientOptimisticUpdate(value) => value.update,
@@ -656,19 +634,13 @@ mod test {
         #[case] fork_name: &str,
         #[case] expected_slot: u64,
     ) {
-        let file = read_file_from_tests_submodule(format!(
-            "tests/mainnet/beacon_chain/light_client/{fork_name}/finality_update.yaml"
+        let test_data: ContentItem<BeaconContentKey> = read_yaml_portal_spec_tests_file(format!(
+            "tests/mainnet/beacon_chain/light_client/{fork_name}/finality_update.yaml",
         ))
         .unwrap();
+        let content_value: BeaconContentValue = test_data.content_value().unwrap();
 
-        let value: Value = serde_yaml::from_str(&file).unwrap();
-        let content_key: BeaconContentKey =
-            serde_yaml::from_value(value["content_key"].clone()).unwrap();
-        let raw_content_value = Bytes::from_str(value["content_value"].as_str().unwrap()).unwrap();
-        let content_value = BeaconContentValue::decode(&content_key, raw_content_value.as_ref())
-            .expect("unable to decode content value");
-
-        assert_str_roundtrip(content_key, content_value.clone());
+        assert_str_roundtrip(test_data.content_key, content_value.clone());
 
         let update = match content_value {
             BeaconContentValue::LightClientFinalityUpdate(value) => value.update,
@@ -684,10 +656,9 @@ mod test {
 
     #[test]
     fn deneb_historical_summaries_with_proof_encode_decode() {
-        let file = read_file_from_tests_submodule(
+        let value: serde_yaml::Value = read_yaml_portal_spec_tests_file(
             "tests/mainnet/beacon_chain/historical_summaries_with_proof/deneb/historical_summaries_with_proof.yaml",
         ).unwrap();
-        let value: serde_yaml::Value = serde_yaml::from_str(&file).unwrap();
         let content_key = BeaconContentKey::deserialize(&value["content_key"]).unwrap();
         let content_bytes = RawContentValue::deserialize(&value["content_value"]).unwrap();
         let beacon_content = BeaconContentValue::decode(&content_key, &content_bytes).unwrap();

--- a/crates/ethportal-api/src/types/content_value/state.rs
+++ b/crates/ethportal-api/src/types/content_value/state.rs
@@ -126,7 +126,7 @@ mod test {
     use serde_yaml::Value;
 
     use super::*;
-    use crate::test_utils::read_file_from_tests_submodule;
+    use crate::test_utils::read_yaml_portal_spec_tests_file;
 
     const TEST_DATA_DIRECTORY: &str = "tests/mainnet/state/serialization";
 
@@ -273,9 +273,7 @@ mod test {
     }
 
     fn read_yaml_file(filename: &str) -> Result<Value> {
-        let path = PathBuf::from(TEST_DATA_DIRECTORY).join(filename);
-        let file = read_file_from_tests_submodule(path)?;
-        Ok(serde_yaml::from_str(&file)?)
+        read_yaml_portal_spec_tests_file(PathBuf::from(TEST_DATA_DIRECTORY).join(filename))
     }
 
     fn yaml_to_bytes(value: &Value) -> Vec<u8> {

--- a/crates/ethportal-api/src/types/execution/header_with_proof.rs
+++ b/crates/ethportal-api/src/types/execution/header_with_proof.rs
@@ -257,220 +257,181 @@ pub fn build_deneb_historical_summaries_proof(
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use std::path::{Path, PathBuf};
+    use std::{
+        collections::HashMap,
+        path::{Path, PathBuf},
+    };
 
-    use alloy::{hex::FromHex, primitives::Bytes};
-    use serde_json::Value;
-    use ssz::Decode;
+    use alloy::primitives::Bytes;
+    use ssz::Encode;
 
     use super::*;
     use crate::{
-        test_utils::{read_bytes_from_tests_submodule, read_file_from_tests_submodule},
-        utils::bytes::{hex_decode, hex_encode},
+        test_utils::{
+            read_json_portal_spec_tests_file, read_ssz_portal_spec_tests_file,
+            read_yaml_portal_spec_tests_file, types::ContentItem,
+        },
+        HistoryContentKey,
     };
 
     const TEST_DIR: &str = "tests/mainnet/history/headers_with_proof";
+    fn test_path(path: impl AsRef<Path>) -> PathBuf {
+        PathBuf::from(TEST_DIR).join(path)
+    }
 
-    #[test_log::test]
+    #[test]
     fn decode_encode_headers_with_proof() {
-        let path = PathBuf::from(TEST_DIR).join("1000001-1000010.json");
-        let json: Value =
-            serde_json::from_str(&read_file_from_tests_submodule(path).unwrap()).unwrap();
-        let hwps = json.as_object().unwrap();
-        for (block_number, obj) in hwps {
-            let block_number: u64 = block_number.parse().unwrap();
-            let actual_hwp = obj.get("content_value").unwrap().as_str().unwrap();
-            let hwp = HeaderWithProof::from_ssz_bytes(&hex_decode(actual_hwp).unwrap()).unwrap();
-            assert_eq!(block_number, hwp.header.number);
-            let encoded = hex_encode(ssz::Encode::as_ssz_bytes(&hwp));
-            assert_eq!(encoded, actual_hwp);
+        let all_test_data: HashMap<u64, ContentItem<HistoryContentKey>> =
+            read_json_portal_spec_tests_file(test_path("1000001-1000010.json")).unwrap();
+        for (block_number, test_data) in all_test_data {
+            let header_with_proof = test_data.content_value_as_header_with_proof();
+            assert_eq!(block_number, header_with_proof.header.number);
+
+            let encoded = Bytes::from(header_with_proof.as_ssz_bytes());
+            assert_eq!(encoded, test_data.raw_content_value);
         }
     }
 
     #[rstest::rstest]
-    #[case::block_1_000_010(1_000_010)]
-    #[case::block_14_764_013(14_764_013)]
-    #[case::block_15_537_392(15_537_392)]
-    #[case::block_15_537_393(15_537_393)]
-    #[case::block_15_539_558(15_539_558)]
-    #[case::block_15_547_621(15_547_621)]
-    #[case::block_15_555_729(15_555_729)]
-    #[case::block_17_034_870(17_034_870)]
-    #[case::block_17_042_287(17_042_287)]
-    #[case::block_17_062_257(17_062_257)]
-    #[case::block_22_162_263(22_162_263)]
-    fn decode_encode_more_headers_with_proofs(#[case] block_number: u64) {
-        let yaml: serde_yaml::Value = read_yaml_test_file(format!("{block_number}.yaml"));
-        let actual_hwp = yaml["content_value"].as_str().unwrap();
-        let header_with_proof =
-            HeaderWithProof::from_ssz_bytes(&hex_decode(actual_hwp).unwrap()).unwrap();
+    fn decode_encode_more_headers_with_proofs(
+        #[values(
+            1_000_010, 14_764_013, 15_537_392, 15_537_393, 15_537_394, 15_539_558, 15_547_621,
+            15_555_729, 17_034_869, 17_034_870, 17_042_287, 17_062_257, 19_426_586, 19_426_587,
+            22_162_263
+        )]
+        block_number: u64,
+    ) {
+        let test_data: ContentItem<HistoryContentKey> =
+            read_yaml_portal_spec_tests_file(test_path(format!("{block_number}.yaml"))).unwrap();
+        let header_with_proof = test_data.content_value_as_header_with_proof();
         assert_eq!(header_with_proof.header.number, block_number);
-        let encoded = hex_encode(ssz::Encode::as_ssz_bytes(&header_with_proof));
-        assert_eq!(encoded, actual_hwp);
+
+        let encoded = Bytes::from(header_with_proof.as_ssz_bytes());
+        assert_eq!(encoded, test_data.raw_content_value);
     }
 
-    /// Tests that proof withing decoded HeaderWithProof matches expected value
+    /// Tests that decoded HeaderWithProof matches expected value
     mod proof_decoding {
         use super::*;
 
         #[rstest::rstest]
-        #[case::block_number_15_539_558(
-            15_539_558,
-            "15539558-cdf9ed89b0c43cda17398dc4da9cfc505e5ccd19f7c39e3b43474180f1051e01"
-        )] // epoch 575
-        #[case::block_number_15_547_621(
-            15_547_621,
-            "15547621-96a9313cd506e32893d46c82358569ad242bb32786bd5487833e0f77767aec2a"
-        )] // epoch 576
-        #[case::block_number_15_555_729(
-            15_555_729,
-            "15555729-c6fd396d54f61c6d0f1dd3653f81267b0378e9a0d638a229b24586d8fd0bc499"
-        )] // epoch 577
-        #[test]
-        fn bellatrix(#[case] block_number: u64, #[case] file_path: &str) -> anyhow::Result<()> {
-            let header_with_proof_yaml: serde_yaml::Value =
-                read_yaml_test_file(format!("{block_number}.yaml"));
-            let header_with_proof = HeaderWithProof::from_ssz_bytes(&Bytes::from_hex(
-                header_with_proof_yaml["content_value"].as_str().unwrap(),
-            )?)
-            .unwrap();
+        fn bellatrix(
+            #[values(15_537_394, 15_539_558, 15_547_621, 15_555_729, 17_034_869)] block_number: u64,
+        ) -> anyhow::Result<()> {
+            let test_data: ContentItem<HistoryContentKey> =
+                read_yaml_portal_spec_tests_file(test_path(format!("{block_number}.yaml")))?;
+            let header_with_proof = test_data.content_value_as_header_with_proof();
 
             let expected_block_header_proof =
-                BlockHeaderProof::HistoricalRoots(read_yaml_test_file(format!(
-                    "block_proofs_bellatrix/beacon_block_proof-{file_path}.yaml"
-                )));
+                BlockHeaderProof::HistoricalRoots(read_yaml_portal_spec_tests_file(test_path(
+                    format!("block_proofs_bellatrix/beacon_block_proof-{block_number}.yaml"),
+                ))?);
 
             assert_eq!(header_with_proof.proof, expected_block_header_proof);
             Ok(())
         }
 
         #[rstest::rstest]
-        #[case::block_number_17_034_870(17_034_870)] // epoch 759
-        #[case::block_number_17_042_287(17_042_287)] // epoch 760
-        #[case::block_number_17_062_257(17_062_257)] // epoch 762
-        #[test]
-        fn capella(#[case] block_number: u64) -> anyhow::Result<()> {
-            let block_header_proof =
-                BlockHeaderProof::HistoricalSummariesCapella(read_yaml_test_file(format!(
+        fn capella(
+            #[values(17_034_870, 17_042_287, 17_062_257, 19_426_586)] block_number: u64,
+        ) -> anyhow::Result<()> {
+            let test_data: ContentItem<HistoryContentKey> =
+                read_yaml_portal_spec_tests_file(test_path(format!("{block_number}.yaml")))?;
+            let header_with_proof = test_data.content_value_as_header_with_proof();
+
+            let expected_block_header_proof = BlockHeaderProof::HistoricalSummariesCapella(
+                read_yaml_portal_spec_tests_file(test_path(format!(
                     "block_proofs_capella/beacon_block_proof-{block_number}.yaml"
-                )));
+                )))?,
+            );
 
-            let header_with_proof_yaml: serde_yaml::Value =
-                read_yaml_test_file(format!("{block_number}.yaml"));
-            let header_with_proof = HeaderWithProof::from_ssz_bytes(&Bytes::from_hex(
-                header_with_proof_yaml["content_value"].as_str().unwrap(),
-            )?)
-            .unwrap();
-
-            assert_eq!(header_with_proof.proof, block_header_proof);
+            assert_eq!(header_with_proof.proof, expected_block_header_proof);
             Ok(())
         }
 
         #[rstest::rstest]
-        #[case::block_number_22_162_263(22_162_263)]
-        #[test]
-        fn deneb(#[case] block_number: u64) -> anyhow::Result<()> {
-            let block_header_proof =
-                BlockHeaderProof::HistoricalSummariesDeneb(read_yaml_test_file(format!(
+        fn deneb(#[values(19_426_587, 22_162_263)] block_number: u64) -> anyhow::Result<()> {
+            let test_data: ContentItem<HistoryContentKey> =
+                read_yaml_portal_spec_tests_file(test_path(format!("{block_number}.yaml")))?;
+            let header_with_proof = test_data.content_value_as_header_with_proof();
+
+            let expected_block_header_proof = BlockHeaderProof::HistoricalSummariesDeneb(
+                read_yaml_portal_spec_tests_file(test_path(format!(
                     "block_proofs_deneb/beacon_block_proof-{block_number}.yaml"
-                )));
+                )))?,
+            );
 
-            let header_with_proof_yaml: serde_yaml::Value =
-                read_yaml_test_file(format!("{block_number}.yaml"));
-            let header_with_proof = HeaderWithProof::from_ssz_bytes(&Bytes::from_hex(
-                header_with_proof_yaml["content_value"].as_str().unwrap(),
-            )?)
-            .unwrap();
-
-            assert_eq!(header_with_proof.proof, block_header_proof);
+            assert_eq!(header_with_proof.proof, expected_block_header_proof);
             Ok(())
         }
     }
 
+    /// Tests that generated header proof matches expected value
     mod proof_generation {
         use super::*;
 
         #[rstest::rstest]
-        #[case::block_number_15_539_558(
-            15_539_558,
-            4_702_208,
-            "15539558-cdf9ed89b0c43cda17398dc4da9cfc505e5ccd19f7c39e3b43474180f1051e01"
-        )] // epoch 575
-        #[case::block_number_15_547_621(
-            15_547_621,
-            4_710_400,
-            "15547621-96a9313cd506e32893d46c82358569ad242bb32786bd5487833e0f77767aec2a"
-        )] // epoch 576
-        #[case::block_number_15_555_729(
-            15_555_729,
-            4_718_592,
-            "15555729-c6fd396d54f61c6d0f1dd3653f81267b0378e9a0d638a229b24586d8fd0bc499"
-        )] // epoch 577
-        #[test]
-        fn bellatrix(#[case] block_number: u64, #[case] slot: u64, #[case] file_path: &str) {
-            let expected_proof: BlockProofHistoricalRoots = read_yaml_test_file(format!(
-                "block_proofs_bellatrix/beacon_block_proof-{file_path}.yaml"
-            ));
+        fn bellatrix(
+            #[values(15_537_394, 15_539_558, 15_547_621, 15_555_729, 17_034_869)] block_number: u64,
+        ) -> anyhow::Result<()> {
+            let expected_proof: BlockProofHistoricalRoots =
+                read_yaml_portal_spec_tests_file(test_path(format!(
+                    "block_proofs_bellatrix/beacon_block_proof-{block_number}.yaml"
+                )))?;
 
-            let historical_batch =
-                read_ssz_test_file(format!("beacon_data/{block_number}/historical_batch.ssz"));
-            let block = read_ssz_test_file(format!("beacon_data/{block_number}/block.ssz"));
-            let actual_proof = build_historical_roots_proof(slot, &historical_batch, &block);
+            let historical_batch = read_ssz_portal_spec_tests_file(test_path(format!(
+                "beacon_data/{block_number}/historical_batch.ssz"
+            )))?;
+            let block = read_ssz_portal_spec_tests_file(test_path(format!(
+                "beacon_data/{block_number}/block.ssz"
+            )))?;
+            let proof =
+                build_historical_roots_proof(expected_proof.slot, &historical_batch, &block);
 
-            assert_eq!(expected_proof, actual_proof);
+            assert_eq!(proof, expected_proof);
+            Ok(())
         }
 
         #[rstest::rstest]
-        #[case::block_number_17_034_870(17_034_870, 6_209_538)] // epoch 759
-        #[case::block_number_17_042_287(17_042_287, 6_217_730)] // epoch 760
-        #[case::block_number_17_062_257(17_062_257, 6_238_210)] // epoch 762
-        #[test]
-        fn capella(#[case] block_number: u64, #[case] slot: u64) {
-            let expected_proof: BlockProofHistoricalSummariesCapella = read_yaml_test_file(
-                format!("block_proofs_capella/beacon_block_proof-{block_number}.yaml"),
-            );
+        fn capella(
+            #[values(17_034_870, 17_042_287, 17_062_257, 19_426_586)] block_number: u64,
+        ) -> anyhow::Result<()> {
+            let expected_proof: BlockProofHistoricalSummariesCapella =
+                read_yaml_portal_spec_tests_file(test_path(format!(
+                    "block_proofs_capella/beacon_block_proof-{block_number}.yaml"
+                )))?;
 
-            let block_roots =
-                read_ssz_test_file(format!("beacon_data/{block_number}/block_roots.ssz"));
-            let block = read_ssz_test_file(format!("beacon_data/{block_number}/block.ssz"));
-            let actual_proof = build_capella_historical_summaries_proof(slot, &block_roots, &block);
+            let block_roots = read_ssz_portal_spec_tests_file(test_path(format!(
+                "beacon_data/{block_number}/block_roots.ssz"
+            )))?;
+            let block = read_ssz_portal_spec_tests_file(test_path(format!(
+                "beacon_data/{block_number}/block.ssz"
+            )))?;
+            let proof =
+                build_capella_historical_summaries_proof(expected_proof.slot, &block_roots, &block);
 
-            assert_eq!(expected_proof, actual_proof);
+            assert_eq!(proof, expected_proof);
+            Ok(())
         }
 
         #[rstest::rstest]
-        #[case::block_number_22162263(22162263, 11378687)]
-        #[test]
-        fn deneb(#[case] block_number: u64, #[case] slot: u64) {
-            let expected_proof: BlockProofHistoricalSummariesDeneb = read_yaml_test_file(format!(
-                "block_proofs_deneb/beacon_block_proof-{block_number}.yaml"
-            ));
+        fn deneb(#[values(19_426_587, 22_162_263)] block_number: u64) -> anyhow::Result<()> {
+            let expected_proof: BlockProofHistoricalSummariesDeneb =
+                read_yaml_portal_spec_tests_file(test_path(format!(
+                    "block_proofs_deneb/beacon_block_proof-{block_number}.yaml"
+                )))?;
 
-            let block_roots =
-                read_ssz_test_file(format!("beacon_data/{block_number}/block_roots.ssz"));
-            let block = read_ssz_test_file(format!("beacon_data/{block_number}/block.ssz"));
-            let actual_proof = build_deneb_historical_summaries_proof(slot, &block_roots, &block);
+            let block_roots = read_ssz_portal_spec_tests_file(test_path(format!(
+                "beacon_data/{block_number}/block_roots.ssz"
+            )))?;
+            let block = read_ssz_portal_spec_tests_file(test_path(format!(
+                "beacon_data/{block_number}/block.ssz"
+            )))?;
+            let proof =
+                build_deneb_historical_summaries_proof(expected_proof.slot, &block_roots, &block);
 
-            assert_eq!(expected_proof, actual_proof);
+            assert_eq!(proof, expected_proof);
+            Ok(())
         }
-    }
-
-    /// Reads and deserializes the yaml test file.
-    ///
-    /// The `path` argument is relative to [TEST_DIR].
-    fn read_yaml_test_file<T>(path: impl AsRef<Path>) -> T
-    where
-        T: for<'de> Deserialize<'de>,
-    {
-        let path = PathBuf::from(TEST_DIR).join(path);
-        serde_yaml::from_str(&read_file_from_tests_submodule(path).unwrap()).unwrap()
-    }
-
-    /// Reads and decodes the ssz test file.
-    ///
-    /// The `path` argument is relative to [TEST_DIR].
-    fn read_ssz_test_file<T: Decode>(path: impl AsRef<Path>) -> T {
-        let path = PathBuf::from(TEST_DIR).join(path);
-        T::from_ssz_bytes(&read_bytes_from_tests_submodule(path).unwrap()).unwrap()
     }
 }

--- a/crates/validation/src/header_validator.rs
+++ b/crates/validation/src/header_validator.rs
@@ -346,18 +346,13 @@ mod test {
         use super::*;
 
         #[rstest]
-        #[case::block_number_1_000_001(1_000_001)]
-        #[case::block_number_1_000_002(1_000_002)]
-        #[case::block_number_1_000_003(1_000_003)]
-        #[case::block_number_1_000_004(1_000_004)]
-        #[case::block_number_1_000_005(1_000_005)]
-        #[case::block_number_1_000_006(1_000_006)]
-        #[case::block_number_1_000_007(1_000_007)]
-        #[case::block_number_1_000_008(1_000_008)]
-        #[case::block_number_1_000_009(1_000_009)]
-        #[case::block_number_1_000_010(1_000_010)]
-        #[tokio::test]
-        async fn verify_header(#[case] block_number: u64) {
+        fn verify_header(
+            #[values(
+                1_000_001, 1_000_002, 1_000_003, 1_000_004, 1_000_005, 1_000_006, 1_000_007,
+                1_000_008, 1_000_009, 1_000_010
+            )]
+            block_number: u64,
+        ) {
             let test_data: HashMap<u64, ContentItem<HistoryContentKey>> =
                 read_json_portal_spec_tests_file(
                     "tests/mainnet/history/headers_with_proof/1000001-1000010.json",
@@ -374,9 +369,7 @@ mod test {
         }
 
         #[rstest]
-        #[case::block_number_15_537_392(15_537_392)]
-        #[case::block_number_15_537_393(15_537_393)]
-        fn verify_header_from_partial_epoch(#[case] block_number: u64) {
+        fn verify_header_from_partial_epoch(#[values(15_537_392, 15_537_393)] block_number: u64) {
             let test_data: ContentItem<HistoryContentKey> = read_yaml_portal_spec_tests_file(
                 format!("tests/mainnet/history/headers_with_proof/{block_number}.yaml"),
             )
@@ -390,9 +383,9 @@ mod test {
                 .unwrap();
         }
 
-        #[tokio::test]
+        #[test]
         #[should_panic = "Execution block proof verification failed for pre-Merge header"]
-        async fn invalidate_invalid_proofs() {
+        fn invalidate_invalid_proofs() {
             let test_data: ContentItem<HistoryContentKey> = read_yaml_portal_spec_tests_file(
                 "tests/mainnet/history/headers_with_proof/1000010.yaml",
             )
@@ -411,9 +404,9 @@ mod test {
                 .unwrap()
         }
 
-        #[tokio::test]
+        #[test]
         #[should_panic = "Invalid proof type found for post-merge header."]
-        async fn header_validator_invalidates_post_merge_header_with_accumulator_proof() {
+        fn header_validator_invalidates_post_merge_header_with_accumulator_proof() {
             let header_validator = get_mainnet_header_validator();
             let future_height = EthereumHardfork::Paris.mainnet_activation_block().unwrap();
             let future_header = generate_random_header(&future_height);
@@ -431,27 +424,15 @@ mod test {
         use super::*;
 
         #[rstest]
-        #[case::block_number_15_539_558(
-            15_539_558,
-            "beacon_block_proof-15539558-cdf9ed89b0c43cda17398dc4da9cfc505e5ccd19f7c39e3b43474180f1051e01.yaml",
-        )]
-        #[case::block_number_15_547_621(
-            15_547_621,
-            "beacon_block_proof-15547621-96a9313cd506e32893d46c82358569ad242bb32786bd5487833e0f77767aec2a.yaml",
-        )]
-        #[case::block_number_15_555_729(
-            15_555_729,
-            "beacon_block_proof-15555729-c6fd396d54f61c6d0f1dd3653f81267b0378e9a0d638a229b24586d8fd0bc499.yaml",
-        )]
-        #[tokio::test]
-        async fn verify_header(#[case] block_number: u64, #[case] filename: &str) {
+        fn verify_header(
+            #[values(15_537_394, 15_539_558, 15_547_621, 15_555_729, 17_034_869)] block_number: u64,
+        ) {
             let header_validator = get_mainnet_header_validator();
 
             let BlockHashWithProof::<BlockProofHistoricalRoots> { header_hash, proof } =
                 read_yaml_portal_spec_tests_file(
                     PathBuf::from(SPEC_TESTS_DIR)
-                        .join("headers_with_proof/block_proofs_bellatrix")
-                        .join(filename),
+                        .join(format!("headers_with_proof/block_proofs_bellatrix/beacon_block_proof-{block_number}.yaml")),
                 )
                 .unwrap();
 
@@ -515,11 +496,9 @@ mod test {
         use super::*;
 
         #[rstest]
-        #[case::block_number_17_034_870(17_034_870)]
-        #[case::block_number_17_042_287(17_042_287)]
-        #[case::block_number_17_062_257(17_062_257)]
-        #[tokio::test]
-        async fn verify_header(#[case] block_number: u64) {
+        fn verify_header(
+            #[values(17_034_870, 17_042_287, 17_062_257, 19_426_586)] block_number: u64,
+        ) {
             let header_validator = get_mainnet_header_validator();
 
             let BlockHashWithProof::<BlockProofHistoricalSummariesCapella> { header_hash, proof } =
@@ -588,9 +567,7 @@ mod test {
         use super::*;
 
         #[rstest]
-        #[case::block_number_22_162_263(22_162_263)]
-        #[tokio::test]
-        async fn verify_header(#[case] block_number: u64) {
+        fn verify_header(#[values(19_426_587, 22_162_263)] block_number: u64) {
             let header_validator = get_mainnet_header_validator();
 
             let BlockHashWithProof::<BlockProofHistoricalSummariesDeneb> { header_hash, proof } =


### PR DESCRIPTION
### What was wrong?

We were missing test vectors around fork boundaries. These were added to portal-spec-tests in ethereum/portal-spec-tests#49

### How was it fixed?

Updated portal-spec-tests submodule, and simplified/refactored some tests in ehtportal-api crate.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
