### PR TITLE
chore: bump trin & ethportal-api versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "e2hs-writer"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "alloy-hardforks",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "ethportal-api"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "ethportal-peertest"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "alloy-hardforks",
@@ -4179,7 +4179,7 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "portal-bridge"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "alloy-hardforks",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "portalnet"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5849,7 +5849,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rpc"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "discv5",
@@ -7544,7 +7544,7 @@ dependencies = [
 
 [[package]]
 name = "trin"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7571,7 +7571,7 @@ dependencies = [
 
 [[package]]
 name = "trin-beacon"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7600,7 +7600,7 @@ dependencies = [
 
 [[package]]
 name = "trin-evm"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "ethportal-api",
@@ -7611,7 +7611,7 @@ dependencies = [
 
 [[package]]
 name = "trin-execution"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -7648,7 +7648,7 @@ dependencies = [
 
 [[package]]
 name = "trin-history"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7683,7 +7683,7 @@ dependencies = [
 
 [[package]]
 name = "trin-metrics"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "ethportal-api",
@@ -7693,7 +7693,7 @@ dependencies = [
 
 [[package]]
 name = "trin-state"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7723,7 +7723,7 @@ dependencies = [
 
 [[package]]
 name = "trin-storage"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7744,7 +7744,7 @@ dependencies = [
 
 [[package]]
 name = "trin-utils"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "ansi_term",
@@ -7763,7 +7763,7 @@ dependencies = [
 
 [[package]]
 name = "trin-validation"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloy",
  "alloy-hardforks",
@@ -7991,7 +7991,7 @@ dependencies = [
 
 [[package]]
 name = "utp-testing"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ethereum/trin"
 rust-version = "1.85.0"
-version = "0.2.6"
+version = "0.2.7"
 
 [workspace.dependencies]
 alloy = { version = "0.15", default-features = false, features = ["std", "serde", "getrandom"] }

--- a/crates/ethportal-api/Cargo.toml
+++ b/crates/ethportal-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethportal-api"
-version = "0.8.1"
+version = "0.9.0"
 description = "Definitions for various Ethereum Portal Network JSONRPC APIs"
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
Bumping:

- ethportal-api version to release breaking changes
- trin version to match release 