### PR TITLE
feat: add Electra support to beacon bridge

### DIFF
--- a/bin/portal-bridge/src/api/consensus/rpc_types.rs
+++ b/bin/portal-bridge/src/api/consensus/rpc_types.rs
@@ -1,5 +1,14 @@
+use std::str::FromStr;
+
 use alloy::primitives::{Bytes, B256};
-use anyhow::bail;
+use anyhow::{anyhow, bail};
+use ethportal_api::{
+    consensus::{beacon_state::BeaconState, fork::ForkName},
+    light_client::{
+        bootstrap::LightClientBootstrap, finality_update::LightClientFinalityUpdate,
+        optimistic_update::LightClientOptimisticUpdate, update::LightClientUpdate,
+    },
+};
 use serde::Deserialize;
 use serde_json::Value;
 use ssz::Decode;
@@ -69,4 +78,80 @@ impl Decode for VersionResponse {
         })?;
         Ok(Self { version })
     }
+}
+
+/// Trait that allows us to decode types based on provided version.
+///
+/// It's implemented by default for all types that implement [ssz::Decode], which simply ignores
+/// the version.
+pub trait VersionedDecode: Sized {
+    fn decode(version: Option<&str>, bytes: &[u8]) -> anyhow::Result<Self>;
+}
+
+impl VersionedDecode for RootResponse {
+    fn decode(_version: Option<&str>, bytes: &[u8]) -> anyhow::Result<Self> {
+        Self::from_ssz_bytes(bytes).map_err(|err| anyhow!("Error decoding RootResponse: {err:?}"))
+    }
+}
+
+impl VersionedDecode for VersionResponse {
+    fn decode(_version: Option<&str>, bytes: &[u8]) -> anyhow::Result<Self> {
+        let version = Bytes::from_ssz_bytes(bytes)
+            .map_err(|err| anyhow!("Error decoding VersionResponse: {err:?}"))?;
+        let version = String::from_utf8(version.to_vec())?;
+        Ok(Self { version })
+    }
+}
+
+impl VersionedDecode for LightClientBootstrap {
+    fn decode(version: Option<&str>, bytes: &[u8]) -> anyhow::Result<Self> {
+        let fork_name = fork_name_or_electra(version);
+        Self::from_ssz_bytes(bytes, fork_name).map_err(|err| {
+            anyhow!("Error decoding LightClientBootstrap (version: {version:?}), err: {err:?}")
+        })
+    }
+}
+
+impl VersionedDecode for LightClientUpdate {
+    fn decode(version: Option<&str>, bytes: &[u8]) -> anyhow::Result<Self> {
+        let fork_name = fork_name_or_electra(version);
+        Self::from_ssz_bytes(bytes, fork_name).map_err(|err| {
+            anyhow!("Error decoding LightClientUpdate (version: {version:?}), err: {err:?}")
+        })
+    }
+}
+
+impl VersionedDecode for LightClientFinalityUpdate {
+    fn decode(version: Option<&str>, bytes: &[u8]) -> anyhow::Result<Self> {
+        let fork_name = fork_name_or_electra(version);
+        Self::from_ssz_bytes(bytes, fork_name).map_err(|err| {
+            anyhow!("Error decoding LightClientFinalityUpdate (version: {version:?}), err: {err:?}")
+        })
+    }
+}
+
+impl VersionedDecode for LightClientOptimisticUpdate {
+    fn decode(version: Option<&str>, bytes: &[u8]) -> anyhow::Result<Self> {
+        let fork_name = fork_name_or_electra(version);
+        Self::from_ssz_bytes(bytes, fork_name).map_err(|err| {
+            anyhow!(
+                "Error decoding LightClientOptimisticUpdate (version: {version:?}), err: {err:?}"
+            )
+        })
+    }
+}
+
+impl VersionedDecode for BeaconState {
+    fn decode(version: Option<&str>, bytes: &[u8]) -> anyhow::Result<Self> {
+        let fork_name = fork_name_or_electra(version);
+        Self::from_ssz_bytes(bytes, fork_name).map_err(|err| {
+            anyhow!("Error decoding BeaconState (version: {version:?}), err: {err:?}")
+        })
+    }
+}
+
+fn fork_name_or_electra(version: Option<&str>) -> ForkName {
+    version
+        .and_then(|version| ForkName::from_str(version).ok())
+        .unwrap_or(ForkName::Electra)
 }

--- a/crates/ethportal-api/src/types/consensus/beacon_state.rs
+++ b/crates/ethportal-api/src/types/consensus/beacon_state.rs
@@ -240,6 +240,52 @@ impl BeaconStateDeneb {
     }
 }
 
+impl BeaconStateElectra {
+    pub fn build_historical_summaries_proof(&self) -> Vec<B256> {
+        let leaves = [
+            self.genesis_time.tree_hash_root(),
+            self.genesis_validators_root.tree_hash_root(),
+            self.slot.tree_hash_root(),
+            self.fork.tree_hash_root(),
+            self.latest_block_header.tree_hash_root(),
+            self.block_roots.tree_hash_root(),
+            self.state_roots.tree_hash_root(),
+            self.historical_roots.tree_hash_root(),
+            self.eth1_data.tree_hash_root(),
+            self.eth1_data_votes.tree_hash_root(),
+            self.eth1_deposit_index.tree_hash_root(),
+            self.validators.tree_hash_root(),
+            self.balances.tree_hash_root(),
+            self.randao_mixes.tree_hash_root(),
+            self.slashings.tree_hash_root(),
+            self.previous_epoch_participation.tree_hash_root(),
+            self.current_epoch_participation.tree_hash_root(),
+            self.justification_bits.tree_hash_root(),
+            self.previous_justified_checkpoint.tree_hash_root(),
+            self.current_justified_checkpoint.tree_hash_root(),
+            self.finalized_checkpoint.tree_hash_root(),
+            self.inactivity_scores.tree_hash_root(),
+            self.current_sync_committee.tree_hash_root(),
+            self.next_sync_committee.tree_hash_root(),
+            self.latest_execution_payload_header.tree_hash_root(),
+            self.next_withdrawal_index.tree_hash_root(),
+            self.next_withdrawal_validator_index.tree_hash_root(),
+            self.historical_summaries.tree_hash_root(),
+            self.deposit_requests_start_index.tree_hash_root(),
+            self.deposit_balance_to_consume.tree_hash_root(),
+            self.exit_balance_to_consume.tree_hash_root(),
+            self.earliest_exit_epoch.tree_hash_root(),
+            self.consolidation_balance_to_consume.tree_hash_root(),
+            self.earliest_consolidation_epoch.tree_hash_root(),
+            self.pending_deposits.tree_hash_root(),
+            self.pending_partial_withdrawals.tree_hash_root(),
+            self.pending_consolidations.tree_hash_root(),
+        ];
+
+        build_merkle_proof_for_index(leaves, 27)
+    }
+}
+
 /// Specifies a fork of the `BeaconChain`, to prevent replay attacks.
 ///
 /// Spec v0.12.1

--- a/crates/ethportal-api/src/types/consensus/beacon_state.rs
+++ b/crates/ethportal-api/src/types/consensus/beacon_state.rs
@@ -23,7 +23,9 @@ use crate::consensus::{
     },
     fork::ForkName,
     header::BeaconBlockHeader,
-    historical_summaries::HistoricalSummaries,
+    historical_summaries::{
+        HistoricalSummaries, HistoricalSummariesProofDeneb, HistoricalSummariesProofElectra,
+    },
     participation_flags::ParticipationFlags,
     pending_balance_deposit::PendingDeposit,
     pending_consolidation::PendingConsolidation,
@@ -204,7 +206,7 @@ impl BeaconState {
 }
 
 impl BeaconStateDeneb {
-    pub fn build_historical_summaries_proof(&self) -> Vec<B256> {
+    pub fn build_historical_summaries_proof(&self) -> HistoricalSummariesProofDeneb {
         let leaves = [
             self.genesis_time.tree_hash_root(),
             self.genesis_validators_root.tree_hash_root(),
@@ -236,12 +238,13 @@ impl BeaconStateDeneb {
             self.historical_summaries.tree_hash_root(),
         ];
 
-        build_merkle_proof_for_index(leaves, 27)
+        HistoricalSummariesProofDeneb::new(build_merkle_proof_for_index(leaves, 27))
+            .expect("Created historical summaries proof for Deneb should have correct length")
     }
 }
 
 impl BeaconStateElectra {
-    pub fn build_historical_summaries_proof(&self) -> Vec<B256> {
+    pub fn build_historical_summaries_proof(&self) -> HistoricalSummariesProofElectra {
         let leaves = [
             self.genesis_time.tree_hash_root(),
             self.genesis_validators_root.tree_hash_root(),
@@ -282,7 +285,8 @@ impl BeaconStateElectra {
             self.pending_consolidations.tree_hash_root(),
         ];
 
-        build_merkle_proof_for_index(leaves, 27)
+        HistoricalSummariesProofElectra::new(build_merkle_proof_for_index(leaves, 27))
+            .expect("Created historical summaries proof for Electra should have correct length")
     }
 }
 

--- a/crates/ethportal-api/src/types/consensus/historical_summaries.rs
+++ b/crates/ethportal-api/src/types/consensus/historical_summaries.rs
@@ -2,6 +2,7 @@ use alloy::primitives::B256;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum, FixedVector, VariableList};
+use superstruct::superstruct;
 use tree_hash_derive::TreeHash;
 
 /// `HistoricalSummary` matches the components of the phase0 `HistoricalBatch`
@@ -16,12 +17,29 @@ pub struct HistoricalSummary {
 }
 
 pub type HistoricalSummaries = VariableList<HistoricalSummary, typenum::U16777216>;
-pub type HistoricalSummariesStateProof = FixedVector<B256, typenum::U5>;
+
+pub const HISTORICAL_SUMMARIES_GINDEX_DENEB: usize = 59;
+pub const HISTORICAL_SUMMARIES_GINDEX_ELECTRA: usize = 91;
+
+pub type HistoricalSummariesProofDeneb = FixedVector<B256, typenum::U5>;
+pub type HistoricalSummariesProofElectra = FixedVector<B256, typenum::U6>;
 
 /// A historical summaries BeaconState field with proof.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode)]
+#[superstruct(
+    variants(Deneb, Electra),
+    variant_attributes(
+        derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Encode, Decode,),
+        serde(deny_unknown_fields),
+    )
+)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Encode)]
+#[serde(untagged)]
+#[ssz(enum_behaviour = "transparent")]
 pub struct HistoricalSummariesWithProof {
     pub epoch: u64,
     pub historical_summaries: HistoricalSummaries,
-    pub proof: HistoricalSummariesStateProof,
+    #[superstruct(only(Deneb), partial_getter(rename = "proof_deneb"))]
+    pub proof: HistoricalSummariesProofDeneb,
+    #[superstruct(only(Electra), partial_getter(rename = "proof_electra"))]
+    pub proof: HistoricalSummariesProofElectra,
 }

--- a/crates/ethportal-api/src/types/consensus/light_client/bootstrap.rs
+++ b/crates/ethportal-api/src/types/consensus/light_client/bootstrap.rs
@@ -84,12 +84,12 @@ impl LightClientBootstrap {
     }
 
     /// Returns the `BeaconBlockHeader` from the `LightClientBootstrap` object.
-    pub fn get_beacon_block_header(self) -> BeaconBlockHeader {
+    pub fn get_beacon_block_header(&self) -> &BeaconBlockHeader {
         match self {
-            LightClientBootstrap::Bellatrix(bootstrap) => bootstrap.header.beacon,
-            LightClientBootstrap::Capella(bootstrap) => bootstrap.header.beacon,
-            LightClientBootstrap::Deneb(bootstrap) => bootstrap.header.beacon,
-            LightClientBootstrap::Electra(bootstrap) => bootstrap.header.beacon,
+            Self::Bellatrix(bootstrap) => &bootstrap.header.beacon,
+            Self::Capella(bootstrap) => &bootstrap.header.beacon,
+            Self::Deneb(bootstrap) => &bootstrap.header.beacon,
+            Self::Electra(bootstrap) => &bootstrap.header.beacon,
         }
     }
 }

--- a/crates/ethportal-api/src/types/consensus/light_client/finality_update.rs
+++ b/crates/ethportal-api/src/types/consensus/light_client/finality_update.rs
@@ -8,6 +8,7 @@ use superstruct::superstruct;
 use tree_hash_derive::TreeHash;
 
 use crate::{
+    consensus::header::BeaconBlockHeader,
     light_client::header::{LightClientHeaderDeneb, LightClientHeaderElectra},
     types::consensus::{
         body::SyncAggregate,
@@ -90,6 +91,15 @@ impl LightClientFinalityUpdate {
             ForkName::Electra => {
                 LightClientFinalityUpdateElectra::from_ssz_bytes(bytes).map(Self::Electra)
             }
+        }
+    }
+
+    pub fn finalized_beacon_block_header(&self) -> &BeaconBlockHeader {
+        match self {
+            Self::Bellatrix(light_client_update) => &light_client_update.finalized_header.beacon,
+            Self::Capella(light_client_update) => &light_client_update.finalized_header.beacon,
+            Self::Deneb(light_client_update) => &light_client_update.finalized_header.beacon,
+            Self::Electra(light_client_update) => &light_client_update.finalized_header.beacon,
         }
     }
 }

--- a/crates/ethportal-api/src/types/consensus/light_client/update.rs
+++ b/crates/ethportal-api/src/types/consensus/light_client/update.rs
@@ -11,6 +11,7 @@ use superstruct::superstruct;
 use tree_hash_derive::TreeHash;
 
 use crate::{
+    consensus::header::BeaconBlockHeader,
     light_client::header::{LightClientHeaderDeneb, LightClientHeaderElectra},
     types::consensus::{
         body::SyncAggregate,
@@ -106,6 +107,23 @@ impl LightClientUpdate {
             ForkName::Capella => LightClientUpdateCapella::from_ssz_bytes(bytes).map(Self::Capella),
             ForkName::Deneb => LightClientUpdateDeneb::from_ssz_bytes(bytes).map(Self::Deneb),
             ForkName::Electra => LightClientUpdateElectra::from_ssz_bytes(bytes).map(Self::Electra),
+        }
+    }
+
+    pub fn finalized_beacon_block_header(&self) -> &BeaconBlockHeader {
+        match self {
+            LightClientUpdate::Bellatrix(light_client_update) => {
+                &light_client_update.finalized_header.beacon
+            }
+            LightClientUpdate::Capella(light_client_update) => {
+                &light_client_update.finalized_header.beacon
+            }
+            LightClientUpdate::Deneb(light_client_update) => {
+                &light_client_update.finalized_header.beacon
+            }
+            LightClientUpdate::Electra(light_client_update) => {
+                &light_client_update.finalized_header.beacon
+            }
         }
     }
 }

--- a/crates/ethportal-api/src/types/content_value/beacon.rs
+++ b/crates/ethportal-api/src/types/content_value/beacon.rs
@@ -48,29 +48,17 @@ pub struct ForkVersionedLightClientBootstrap {
     pub bootstrap: LightClientBootstrap,
 }
 
-impl From<LightClientBootstrapCapella> for ForkVersionedLightClientBootstrap {
-    fn from(bootstrap: LightClientBootstrapCapella) -> Self {
+impl From<LightClientBootstrap> for ForkVersionedLightClientBootstrap {
+    fn from(bootstrap: LightClientBootstrap) -> Self {
+        let fork_name = match &bootstrap {
+            LightClientBootstrap::Bellatrix(_) => ForkName::Bellatrix,
+            LightClientBootstrap::Capella(_) => ForkName::Capella,
+            LightClientBootstrap::Deneb(_) => ForkName::Deneb,
+            LightClientBootstrap::Electra(_) => ForkName::Electra,
+        };
         Self {
-            fork_name: ForkName::Capella,
-            bootstrap: LightClientBootstrap::Capella(bootstrap),
-        }
-    }
-}
-
-impl From<LightClientBootstrapDeneb> for ForkVersionedLightClientBootstrap {
-    fn from(bootstrap: LightClientBootstrapDeneb) -> Self {
-        Self {
-            fork_name: ForkName::Deneb,
-            bootstrap: LightClientBootstrap::Deneb(bootstrap),
-        }
-    }
-}
-
-impl From<LightClientBootstrapElectra> for ForkVersionedLightClientBootstrap {
-    fn from(bootstrap: LightClientBootstrapElectra) -> Self {
-        Self {
-            fork_name: ForkName::Electra,
-            bootstrap: LightClientBootstrap::Electra(bootstrap),
+            fork_name,
+            bootstrap,
         }
     }
 }
@@ -153,6 +141,18 @@ impl Encode for ForkVersionedLightClientBootstrap {
 pub struct ForkVersionedLightClientUpdate {
     pub fork_name: ForkName,
     pub update: LightClientUpdate,
+}
+
+impl From<LightClientUpdate> for ForkVersionedLightClientUpdate {
+    fn from(update: LightClientUpdate) -> Self {
+        let fork_name = match &update {
+            LightClientUpdate::Bellatrix(_) => ForkName::Bellatrix,
+            LightClientUpdate::Capella(_) => ForkName::Capella,
+            LightClientUpdate::Deneb(_) => ForkName::Deneb,
+            LightClientUpdate::Electra(_) => ForkName::Electra,
+        };
+        Self { fork_name, update }
+    }
 }
 
 impl ForkVersionedLightClientUpdate {
@@ -279,30 +279,15 @@ pub struct ForkVersionedLightClientOptimisticUpdate {
     pub update: LightClientOptimisticUpdate,
 }
 
-impl From<LightClientOptimisticUpdateCapella> for ForkVersionedLightClientOptimisticUpdate {
-    fn from(update: LightClientOptimisticUpdateCapella) -> Self {
-        Self {
-            fork_name: ForkName::Capella,
-            update: LightClientOptimisticUpdate::Capella(update),
-        }
-    }
-}
-
-impl From<LightClientOptimisticUpdateDeneb> for ForkVersionedLightClientOptimisticUpdate {
-    fn from(update: LightClientOptimisticUpdateDeneb) -> Self {
-        Self {
-            fork_name: ForkName::Deneb,
-            update: LightClientOptimisticUpdate::Deneb(update),
-        }
-    }
-}
-
-impl From<LightClientOptimisticUpdateElectra> for ForkVersionedLightClientOptimisticUpdate {
-    fn from(update: LightClientOptimisticUpdateElectra) -> Self {
-        Self {
-            fork_name: ForkName::Electra,
-            update: LightClientOptimisticUpdate::Electra(update),
-        }
+impl From<LightClientOptimisticUpdate> for ForkVersionedLightClientOptimisticUpdate {
+    fn from(update: LightClientOptimisticUpdate) -> Self {
+        let fork_name = match &update {
+            LightClientOptimisticUpdate::Bellatrix(_) => ForkName::Bellatrix,
+            LightClientOptimisticUpdate::Capella(_) => ForkName::Capella,
+            LightClientOptimisticUpdate::Deneb(_) => ForkName::Deneb,
+            LightClientOptimisticUpdate::Electra(_) => ForkName::Electra,
+        };
+        Self { fork_name, update }
     }
 }
 
@@ -377,30 +362,15 @@ pub struct ForkVersionedLightClientFinalityUpdate {
     pub update: LightClientFinalityUpdate,
 }
 
-impl From<LightClientFinalityUpdateCapella> for ForkVersionedLightClientFinalityUpdate {
-    fn from(update: LightClientFinalityUpdateCapella) -> Self {
-        Self {
-            fork_name: ForkName::Capella,
-            update: LightClientFinalityUpdate::Capella(update),
-        }
-    }
-}
-
-impl From<LightClientFinalityUpdateDeneb> for ForkVersionedLightClientFinalityUpdate {
-    fn from(update: LightClientFinalityUpdateDeneb) -> Self {
-        Self {
-            fork_name: ForkName::Deneb,
-            update: LightClientFinalityUpdate::Deneb(update),
-        }
-    }
-}
-
-impl From<LightClientFinalityUpdateElectra> for ForkVersionedLightClientFinalityUpdate {
-    fn from(update: LightClientFinalityUpdateElectra) -> Self {
-        Self {
-            fork_name: ForkName::Electra,
-            update: LightClientFinalityUpdate::Electra(update),
-        }
+impl From<LightClientFinalityUpdate> for ForkVersionedLightClientFinalityUpdate {
+    fn from(update: LightClientFinalityUpdate) -> Self {
+        let fork_name = match &update {
+            LightClientFinalityUpdate::Bellatrix(_) => ForkName::Bellatrix,
+            LightClientFinalityUpdate::Capella(_) => ForkName::Capella,
+            LightClientFinalityUpdate::Deneb(_) => ForkName::Deneb,
+            LightClientFinalityUpdate::Electra(_) => ForkName::Electra,
+        };
+        Self { fork_name, update }
     }
 }
 

--- a/crates/subnetworks/beacon/src/test_utils.rs
+++ b/crates/subnetworks/beacon/src/test_utils.rs
@@ -1,9 +1,8 @@
 use alloy::primitives::B256;
 use ethportal_api::{
     consensus::{
-        beacon_state::BeaconStateDeneb,
-        fork::ForkName,
-        historical_summaries::{HistoricalSummariesProofDeneb, HistoricalSummariesWithProofDeneb},
+        beacon_state::BeaconStateDeneb, fork::ForkName,
+        historical_summaries::HistoricalSummariesWithProofDeneb,
     },
     light_client::{
         bootstrap::LightClientBootstrap, finality_update::LightClientFinalityUpdate,
@@ -96,14 +95,12 @@ pub fn get_deneb_historical_summaries_with_proof() -> (HistoricalSummariesWithPr
     let beacon_state = BeaconStateDeneb::from_ssz_bytes(&value).unwrap();
 
     let historical_summaries_proof = beacon_state.build_historical_summaries_proof();
-    let historical_summaries_state_proof =
-        HistoricalSummariesProofDeneb::from(historical_summaries_proof);
     let historical_summaries = beacon_state.historical_summaries.clone();
     let historical_summaries_epoch = beacon_state.slot / SLOTS_PER_EPOCH;
     let historical_summaries_with_proof = HistoricalSummariesWithProofDeneb {
         epoch: historical_summaries_epoch,
         historical_summaries,
-        proof: historical_summaries_state_proof.clone(),
+        proof: historical_summaries_proof,
     };
 
     (

--- a/crates/subnetworks/beacon/src/test_utils.rs
+++ b/crates/subnetworks/beacon/src/test_utils.rs
@@ -3,20 +3,20 @@ use ethportal_api::{
     consensus::{
         beacon_state::BeaconStateDeneb,
         fork::ForkName,
-        historical_summaries::{HistoricalSummariesStateProof, HistoricalSummariesWithProof},
+        historical_summaries::{HistoricalSummariesProofDeneb, HistoricalSummariesWithProofDeneb},
     },
     light_client::{
         bootstrap::LightClientBootstrap, finality_update::LightClientFinalityUpdate,
         optimistic_update::LightClientOptimisticUpdate, update::LightClientUpdate,
     },
     types::content_value::beacon::{
-        ForkVersionedHistoricalSummariesWithProof, ForkVersionedLightClientBootstrap,
-        ForkVersionedLightClientFinalityUpdate, ForkVersionedLightClientOptimisticUpdate,
-        ForkVersionedLightClientUpdate,
+        ForkVersionedLightClientBootstrap, ForkVersionedLightClientFinalityUpdate,
+        ForkVersionedLightClientOptimisticUpdate, ForkVersionedLightClientUpdate,
     },
 };
 use ssz::Decode;
 use tree_hash::TreeHash;
+use trin_validation::constants::SLOTS_PER_EPOCH;
 
 // Valid number range for the test cases is 0..=1
 pub fn get_light_client_bootstrap(number: u8) -> ForkVersionedLightClientBootstrap {
@@ -86,7 +86,7 @@ pub fn get_light_client_optimistic_update(number: u8) -> ForkVersionedLightClien
     }
 }
 
-pub fn get_history_summaries_with_proof() -> (ForkVersionedHistoricalSummariesWithProof, B256) {
+pub fn get_deneb_historical_summaries_with_proof() -> (HistoricalSummariesWithProofDeneb, B256) {
     let value = std::fs::read(
         "../../../test_assets/beacon/deneb/BeaconState/ssz_random/case_0/serialized.ssz_snappy",
     )
@@ -97,20 +97,17 @@ pub fn get_history_summaries_with_proof() -> (ForkVersionedHistoricalSummariesWi
 
     let historical_summaries_proof = beacon_state.build_historical_summaries_proof();
     let historical_summaries_state_proof =
-        HistoricalSummariesStateProof::from(historical_summaries_proof);
+        HistoricalSummariesProofDeneb::from(historical_summaries_proof);
     let historical_summaries = beacon_state.historical_summaries.clone();
-    let historical_summaries_epoch = beacon_state.slot / 32;
-    let historical_summaries_with_proof = HistoricalSummariesWithProof {
+    let historical_summaries_epoch = beacon_state.slot / SLOTS_PER_EPOCH;
+    let historical_summaries_with_proof = HistoricalSummariesWithProofDeneb {
         epoch: historical_summaries_epoch,
         historical_summaries,
         proof: historical_summaries_state_proof.clone(),
     };
 
     (
-        ForkVersionedHistoricalSummariesWithProof {
-            fork_name: ForkName::Deneb,
-            historical_summaries_with_proof,
-        },
+        historical_summaries_with_proof,
         beacon_state.tree_hash_root(),
     )
 }

--- a/crates/subnetworks/beacon/src/validation.rs
+++ b/crates/subnetworks/beacon/src/validation.rs
@@ -98,7 +98,7 @@ impl Validator<BeaconContentKey> for BeaconValidator {
                 let bootstrap_block_header = bootstrap.bootstrap.get_beacon_block_header();
 
                 if let Ok(finalized_header) = finalized_header {
-                    if finalized_header != bootstrap_block_header {
+                    if &finalized_header != bootstrap_block_header {
                         return Err(anyhow!(
                             "Light client bootstrap header does not match the finalized header: {finalized_header:?} != {bootstrap_block_header:?}",
                         ));
@@ -369,7 +369,6 @@ impl BeaconValidator {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use ethportal_api::{
-        consensus::historical_summaries::HistoricalSummariesWithProof,
         types::{
             content_key::beacon::{
                 HistoricalSummariesWithProofKey, LightClientFinalityUpdateKey,

--- a/crates/validation/src/oracle.rs
+++ b/crates/validation/src/oracle.rs
@@ -143,7 +143,9 @@ impl HeaderOracle {
         let content: BeaconContentValue = BeaconContentValue::decode(&content_key, &content)?;
 
         match content {
-            BeaconContentValue::HistoricalSummariesWithProof(content) => Ok(content.historical_summaries_with_proof.historical_summaries),
+            BeaconContentValue::HistoricalSummariesWithProof(content) => {
+                Ok(content.historical_summaries_with_proof.historical_summaries().clone())
+            }
             _ => Err(anyhow!(
                 "Invalid BeaconContentValue received from HistoricalSummaries local_content, expected HistoricalSummariesWithProof: {content:?}"
             )),

--- a/testing/ef-tests/tests/build_proofs.rs
+++ b/testing/ef-tests/tests/build_proofs.rs
@@ -9,7 +9,6 @@ use ethportal_api::consensus::{
     body::BeaconBlockBodyBellatrix,
     execution_payload::ExecutionPayloadBellatrix,
     historical_summaries::{
-        HistoricalSummariesProofDeneb, HistoricalSummariesProofElectra,
         HistoricalSummariesWithProofDeneb, HistoricalSummariesWithProofElectra,
     },
 };
@@ -149,9 +148,6 @@ fn test_historical_summaries_with_proof_deneb() {
     .expect("cannot find test asset");
     let beacon_state: BeaconStateDeneb = serde_yaml::from_str(&value).unwrap();
     let historical_summaries_proof = beacon_state.build_historical_summaries_proof();
-    let historical_summaries_state_proof =
-        HistoricalSummariesProofDeneb::new(historical_summaries_proof)
-            .expect("Should be able to build HistoricalSummariesProofDeneb from BeaconStateDeneb");
     let historical_summaries = beacon_state.historical_summaries.clone();
 
     let historical_summaries_epoch = beacon_state.slot / 32;
@@ -159,7 +155,7 @@ fn test_historical_summaries_with_proof_deneb() {
     let expected_summaries_with_proof = HistoricalSummariesWithProofDeneb {
         epoch: historical_summaries_epoch,
         historical_summaries,
-        proof: historical_summaries_state_proof.clone(),
+        proof: historical_summaries_proof,
     };
 
     // Test ssz encoding and decoding
@@ -180,10 +176,6 @@ fn test_historical_summaries_with_proof_electra() {
     .expect("cannot find test asset");
     let beacon_state: BeaconStateElectra = serde_yaml::from_str(&value).unwrap();
     let historical_summaries_proof = beacon_state.build_historical_summaries_proof();
-    let historical_summaries_state_proof = HistoricalSummariesProofElectra::new(
-        historical_summaries_proof,
-    )
-    .expect("Should be able to build HistoricalSummariesProofElectra from BeaconStateElectra");
     let historical_summaries = beacon_state.historical_summaries.clone();
 
     let historical_summaries_epoch = beacon_state.slot / 32;
@@ -191,7 +183,7 @@ fn test_historical_summaries_with_proof_electra() {
     let expected_summaries_with_proof = HistoricalSummariesWithProofElectra {
         epoch: historical_summaries_epoch,
         historical_summaries,
-        proof: historical_summaries_state_proof.clone(),
+        proof: historical_summaries_proof,
     };
 
     // Test ssz encoding and decoding


### PR DESCRIPTION
This is a followup of #1801

### What was wrong?

Beacon bridge doesn't support creating and gossiping Electra Beacon types.

### How was it fixed?

Added support for gossiping content across forks.

I refactored how we are decoding ssz content that we receive from `consensus_api` to be _fork aware_.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
