### PR TITLE
fix: update bootnodes

### DIFF
--- a/bin/trin/src/cli.rs
+++ b/bin/trin/src/cli.rs
@@ -1097,7 +1097,7 @@ mod tests {
             let config = TrinConfig::new_from([APP_NAME]).unwrap();
             assert_eq!(config.bootnodes, Bootnodes::Default);
             let bootnodes: Vec<Enr> = config.bootnodes.to_enrs(Network::Mainnet);
-            assert_eq!(bootnodes.len(), 11);
+            assert_eq!(bootnodes.len(), 10);
         }
 
         #[test_log::test]
@@ -1105,7 +1105,7 @@ mod tests {
             let config = TrinConfig::new_from([APP_NAME, "--bootnodes", "default"]).unwrap();
             assert_eq!(config.bootnodes, Bootnodes::Default);
             let bootnodes: Vec<Enr> = config.bootnodes.to_enrs(Network::Mainnet);
-            assert_eq!(bootnodes.len(), 11);
+            assert_eq!(bootnodes.len(), 10);
         }
 
         #[test_log::test]

--- a/crates/portalnet/src/bootnodes.rs
+++ b/crates/portalnet/src/bootnodes.rs
@@ -27,68 +27,58 @@ lazy_static! {
         // https://github.com/ethereum/portal-network-specs/blob/master/bootnodes.md
         // Trin bootstrap nodes
         Bootnode{
-            enr: Enr::from_str("enr:-Jy4QIs2pCyiKna9YWnAF0zgf7bT0GzlAGoF8MEKFJOExmtofBIqzm71zDvmzRiiLkxaEJcs_Amr7XIhLI74k1rtlXICY5Z0IDAuMS4xLWFscGhhLjEtMTEwZjUwgmlkgnY0gmlwhKEjVaWJc2VjcDI1NmsxoQLSC_nhF1iRwsCw0n3J4jRjqoaRxtKgsEe5a-Dz7y0JloN1ZHCCIyg").expect("Parsing static bootnode enr to work"),
+            enr: Enr::from_str("enr:-Jm4QBcjAoXU79kbUGNGfeDwW9OjiaknvaiKwZa81U91xC9ODSpQvzsEbNd_lww3CCHsqxgGHR8O18frKStu4A3F7sGEaBUIa2OJdCBhZmE1N2MxgmlkgnY0gmlwhKEjVaWCcHaCAAGJc2VjcDI1NmsxoQLSC_nhF1iRwsCw0n3J4jRjqoaRxtKgsEe5a-Dz7y0JloN1ZHCCIyg").expect("Parsing static bootnode enr to work"),
             alias: "trin-ams3-1".to_string()
         },
         Bootnode{
-            enr: Enr::from_str("enr:-Jy4QKSLYMpku9F0Ebk84zhIhwTkmn80UnYvE4Z4sOcLukASIcofrGdXVLAUPVHh8oPCfnEOZm1W1gcAxB9kV2FJywkCY5Z0IDAuMS4xLWFscGhhLjEtMTEwZjUwgmlkgnY0gmlwhJO2oc6Jc2VjcDI1NmsxoQLMSGVlxXL62N3sPtaV-n_TbZFCEM5AR7RDyIwOadbQK4N1ZHCCIyg").expect("Parsing static bootnode enr to work"),
+            enr: Enr::from_str("enr:-Jm4QAtSz2CaRwEceSHfSeI2g15cumv9oPqlKAVCHoi34-X6NZuQHYEieuZz-acnmww3yAPTDd4BZeFyv248apKSsKaEaBUIYWOJdCBhZmE1N2MxgmlkgnY0gmlwhJO2oc6CcHaCAAGJc2VjcDI1NmsxoQLMSGVlxXL62N3sPtaV-n_TbZFCEM5AR7RDyIwOadbQK4N1ZHCCIyg").expect("Parsing static bootnode enr to work"),
             alias: "trin-nyc1-1".to_string()
         },
         Bootnode{
-        enr: Enr::from_str("enr:-Jy4QH4_H4cW--ejWDl_W7ngXw2m31MM2GT8_1ZgECnfWxMzZTiZKvHDgkmwUS_l2aqHHU54Q7hcFSPz6VGzkUjOqkcCY5Z0IDAuMS4xLWFscGhhLjEtMTEwZjUwgmlkgnY0gmlwhJ31OTWJc2VjcDI1NmsxoQPC0eRkjRajDiETr_DRa5N5VJRm-ttCWDoO1QAMMCg5pIN1ZHCCIyg").expect("Parsing static bootnode enr to work"),
+            enr: Enr::from_str("enr:-Jm4QNepJO38VOGGsuj0fBjeLHU2fsNBvYewhpCRDHyCFjgFI7EKdBptbi_jwCsGDQhrgh4X5TikBlqYcSUJyExbSMqEaBUIeGOJdCBhZmE1N2MxgmlkgnY0gmlwhJ31OTWCcHaCAAGJc2VjcDI1NmsxoQPC0eRkjRajDiETr_DRa5N5VJRm-ttCWDoO1QAMMCg5pIN1ZHCCIyg").expect("Parsing static bootnode enr to work"),
             alias: "trin-sgp1-1".to_string()
         },
 
         // Fluffy bootstrap nodes
         Bootnode{
-            enr:
-        Enr::from_str("enr:-Ia4QLBxlH0Y8hGPQ1IRF5EStZbZvCPHQ2OjaJkuFMz0NRoZIuO2dLP0L-W_8ZmgnVx5SwvxYCXmX7zrHYv0FeHFFR0TY2aCaWSCdjSCaXCEwiErIIlzZWNwMjU2azGhAnnTykipGqyOy-ZRB9ga9pQVPF-wQs-yj_rYUoOqXEjbg3VkcIIjjA").expect("Parsing static bootnode enr to work"),
+            enr: Enr::from_str("enr:-I64QBKOAFoNByj98RU-UbHPk7zKl8EoIyqiI1hxgMpJQ4Snf--RWm_qBU9eSRfBv0hhZOdDwgMmYq74kNYMePaRr1uCG5xjZoJpZIJ2NIJpcITCISsggnB2ggABiXNlY3AyNTZrMaECedPKSKkarI7L5lEH2Br2lBU8X7BCz7KP-thSg6pcSNuDdWRwgiOM").expect("Parsing static bootnode enr to work"),
             alias: "fluffy-1".to_string()
         },
         Bootnode{
-            enr:
-        Enr::from_str("enr:-Ia4QM4amOkJf5z84Lv5Fl0RgWeSSDUekwnOPRn6XA1eMWgrHwWmn_gJGtOeuVfuX7ywGuPMRwb0odqQ9N_w_2Qc53gTY2aCaWSCdjSCaXCEwiErIYlzZWNwMjU2azGhAzaQEdPmz9SHiCw2I5yVAO8sriQ-mhC5yB7ea1u4u5QZg3VkcIIjjA").expect("Parsing static bootnode enr to work"),
+            enr: Enr::from_str("enr:-I64QIgwjKS4gH06AhSDUP7SY3C7KfKXmauGNs6QSYXztefacltV9neVVRIfGFI-ICHoeRSVX-NSoktGXETxcPC9ABSCGlJjZoJpZIJ2NIJpcITCISshgnB2ggABiXNlY3AyNTZrMaEDNpAR0-bP1IeILDYjnJUA7yyuJD6aELnIHt5rW7i7lBmDdWRwgiOM").expect("Parsing static bootnode enr to work"),
             alias: "fluffy-2".to_string()
         },
         Bootnode{
-            enr:
-        Enr::from_str("enr:-Ia4QKVuHjNafkYuvhU7yCvSarNIVXquzJ8QOp5YbWJRIJw_EDVOIMNJ_fInfYoAvlRCHEx9LUQpYpqJa04pUDU21uoTY2aCaWSCdjSCaXCEwiErQIlzZWNwMjU2azGhA47eAW5oIDJAqxxqI0sL0d8ttXMV0h6sRIWU4ZwS4pYfg3VkcIIjjA").expect("Parsing static bootnode enr to work"),
+            enr: Enr::from_str("enr:-I64QPjnD7qcuc5Odzh4889v2X-zrjs1KFHqqJQhIaTxNNh6HOx5xokIX6uUYbbAzxt9tkg_MzYt8ZoeIZxiVwRRNTWCHcxjZoJpZIJ2NIJpcITCIStAgnB2ggABiXNlY3AyNTZrMaEDjt4BbmggMkCrHGojSwvR3y21cxXSHqxEhZThnBLilh-DdWRwgiOM").expect("Parsing static bootnode enr to work"),
             alias: "fluffy-3".to_string()
         },
         Bootnode{
-            enr:
-        Enr::from_str("enr:-Ia4QIU9U3zrP2DM7sfpgLJbbYpg12sWeXNeYcpKN49-6fhRCng0IUoVRI2E51mN-2eKJ4tbTimxNLaAnbA7r7fxVjcTY2aCaWSCdjSCaXCEwiErQYlzZWNwMjU2azGhAxOroJ3HceYvdD2yK1q9w8c9tgrISJso8q_JXI6U0Xwng3VkcIIjjA").expect("Parsing static bootnode enr to work"),
+            enr: Enr::from_str("enr:-I64QGx6qrUIrcIryYUq43_wx6fol4JDOLTPIEwHH3jOHcXaLvy3rDx8lLJEJLNSYMW5B1A6H_SxWmxaknKmcZoZJ7eCG_pjZoJpZIJ2NIJpcITCIStBgnB2ggABiXNlY3AyNTZrMaEDE6ugncdx5i90PbIrWr3Dxz22CshImyjyr8lcjpTRfCeDdWRwgiOM").expect("Parsing static bootnode enr to work"),
             alias: "fluffy-4".to_string()
         },
 
         // Ultralight bootstrap nodes
         Bootnode{
-            enr:
-        Enr::from_str("enr:-IS4QFV_wTNknw7qiCGAbHf6LxB-xPQCktyrCEZX-b-7PikMOIKkBg-frHRBkfwhI3XaYo_T-HxBYmOOQGNwThkBBHYDgmlkgnY0gmlwhKRc9_OJc2VjcDI1NmsxoQKHPt5CQ0D66ueTtSUqwGjfhscU_LiwS28QvJ0GgJFd-YN1ZHCCE4k").expect("Parsing static bootnode enr to work"),
+            enr: Enr::from_str("enr:-JG4QCE8znFiA118byLyXtBPcecRVK7AMyWsv70pzDo8587ZVKJ5JB2QBhIiHw53T06rMgK4d2qg2-CKZCFxneJP8EAGY4d1IDAuMC4xgmlkgnY0gmlwhKRc9_OCcHYAiXNlY3AyNTZrMaECcTyRg2C2f0E1N9dHjkRaevjRLOk4Rl6TVC5wFz8oisuDdWRwghOK").expect("Parsing static bootnode enr to work"),
             alias: "ultralight-1".to_string()
         },
         Bootnode{
-            enr:
-        Enr::from_str("enr:-IS4QDpUz2hQBNt0DECFm8Zy58Hi59PF_7sw780X3qA0vzJEB2IEd5RtVdPUYZUbeg4f0LMradgwpyIhYUeSxz2Tfa8DgmlkgnY0gmlwhKRc9_OJc2VjcDI1NmsxoQJd4NAVKOXfbdxyjSOUJzmA4rjtg43EDeEJu1f8YRhb_4N1ZHCCE4o").expect("Parsing static bootnode enr to work"),
+            enr: Enr::from_str("enr:-JG4QBnJydF5xbJPDd_MnvWPW8h0rI3wDcHosw833Mq6EiLcRqFY3b72XgLiwgZGRwncliK9haAVAB0KDHQT4U92_a0GY4d1IDAuMC4xgmlkgnY0gmlwhKRc9_OCcHYAiXNlY3AyNTZrMaEChz7eQkNA-urnk7UlKsBo34bHFPy4sEtvELydBoCRXfmDdWRwghOJ").expect("Parsing static bootnode enr to work"),
             alias: "ultralight-2".to_string()
         },
         Bootnode{
-            enr:
-        Enr::from_str("enr:-IS4QGG6moBhLW1oXz84NaKEHaRcim64qzFn1hAG80yQyVGNLoKqzJe887kEjthr7rJCNlt6vdVMKMNoUC9OCeNK-EMDgmlkgnY0gmlwhKRc9-KJc2VjcDI1NmsxoQLJhXByb3LmxHQaqgLDtIGUmpANXaBbFw3ybZWzGqb9-IN1ZHCCE4k").expect("Parsing static bootnode enr to work"),
+            enr: Enr::from_str("enr:-JG4QDi6-UzxEMbFXSs7EXNs8pMdsNQ_OwX6AUWq_KZcGUeESHAW8mwoozpkR29lSkceK6mt39p3Nz3ARN8mLixAGDsGY4d1IDAuMC4xgmlkgnY0gmlwhKRc9_OCcHYAiXNlY3AyNTZrMaEDuw2RPONWnbTHYfKrA2Ag8k4xi7ndR2SYPj_jgG0w1c-DdWRwghOL").expect("Parsing static bootnode enr to work"),
             alias: "ultralight-3".to_string()
         },
-        Bootnode{
-            enr:
-        Enr::from_str("enr:-IS4QA5hpJikeDFf1DD1_Le6_ylgrLGpdwn3SRaneGu9hY2HUI7peHep0f28UUMzbC0PvlWjN8zSfnqMG07WVcCyBhADgmlkgnY0gmlwhKRc9-KJc2VjcDI1NmsxoQJMpHmGj1xSP1O-Mffk_jYIHVcg6tY5_CjmWVg1gJEsPIN1ZHCCE4o").expect("Parsing static bootnode enr to work"),
-            alias: "ultralight-4".to_string()
-        }];
+    ];
 
     // AngelFood bootstrap nodes
     pub static ref ANGELFOOD_BOOTNODES: Vec<Bootnode> = vec![
         Bootnode{
             enr: Enr::from_str("enr:-LC4QMnoW2m4YYQRPjZhJ5hEpcA6a3V7iQs3slQ1TepzKBIVWQtjpcHsPINc0TcheMCbx6I2n5aax8M3AtUObt74ySUCY6p0IDVhYzI2NzViNGRmMjNhNmEwOWVjNDFkZTRlYTQ2ODQxNjk2ZTQ1YzSCaWSCdjSCaXCEQONKaYlzZWNwMjU2azGhAvZgYbpA9G8NQ6X4agu-R7Ymtu0hcX6xBQ--UEel_b6Pg3VkcIIjKA").expect("Parsing static bootnode enr to work"),
             alias: "angelfood-trin-1".to_string()
-        }];
+        },
+    ];
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]


### PR DESCRIPTION
### What was wrong?

Our bootnodes are outdated and they contain v0 protocol version.

This would usually not be a problem, but they store beacon content and they are the first one that we contact during light-client sync (because we start light-client syncing before everything else, so they are the only one we know about at that point), and we assume protocol v0 version and fail to decode the content.

Technically, this shouldn't happen even with this setup, as we should get new Enr when discv5 session is established.
I didn't investigate but I suspect that "Request" object still has old Enr and that's what it uses to decode the response.

### How was it fixed?

Updated bootnode Enrs according to glados.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
