### PR TITLE
feat: make beacon bridge use Electra variants

### DIFF
--- a/bin/portal-bridge/src/api/consensus/mod.rs
+++ b/bin/portal-bridge/src/api/consensus/mod.rs
@@ -9,8 +9,8 @@ use constants::DEFAULT_BEACON_STATE_REQUEST_TIMEOUT;
 use ethportal_api::{
     consensus::beacon_state::BeaconStateElectra,
     light_client::{
-        bootstrap::LightClientBootstrapDeneb, finality_update::LightClientFinalityUpdateDeneb,
-        optimistic_update::LightClientOptimisticUpdateDeneb, update::LightClientUpdateDeneb,
+        bootstrap::LightClientBootstrapElectra, finality_update::LightClientFinalityUpdateElectra,
+        optimistic_update::LightClientOptimisticUpdateElectra, update::LightClientUpdateElectra,
     },
 };
 use reqwest::{
@@ -72,7 +72,7 @@ impl ConsensusApi {
     pub async fn get_light_client_bootstrap(
         &self,
         block_root: B256,
-    ) -> anyhow::Result<LightClientBootstrapDeneb> {
+    ) -> anyhow::Result<LightClientBootstrapElectra> {
         let endpoint = format!("/eth/v1/beacon/light_client/bootstrap/{block_root}");
         Ok(self.request(endpoint, None).await?.data)
     }
@@ -95,7 +95,7 @@ impl ConsensusApi {
         &self,
         start_period: u64,
         count: u64,
-    ) -> anyhow::Result<Vec<LightClientUpdateDeneb>> {
+    ) -> anyhow::Result<Vec<LightClientUpdateElectra>> {
         let endpoint = format!(
             "/eth/v1/beacon/light_client/updates?start_period={start_period}&count={count}"
         );
@@ -110,7 +110,7 @@ impl ConsensusApi {
     /// Requests the latest `LightClientOptimisticUpdate` known by the server.
     pub async fn get_light_client_optimistic_update(
         &self,
-    ) -> anyhow::Result<LightClientOptimisticUpdateDeneb> {
+    ) -> anyhow::Result<LightClientOptimisticUpdateElectra> {
         let endpoint = "/eth/v1/beacon/light_client/optimistic_update".to_string();
         Ok(self.request(endpoint, None).await?.data)
     }
@@ -118,7 +118,7 @@ impl ConsensusApi {
     /// Requests the latest `LightClientFinalityUpdate` known by the server.
     pub async fn get_light_client_finality_update(
         &self,
-    ) -> anyhow::Result<LightClientFinalityUpdateDeneb> {
+    ) -> anyhow::Result<LightClientFinalityUpdateElectra> {
         let endpoint = "/eth/v1/beacon/light_client/finality_update".to_string();
         Ok(self.request(endpoint, None).await?.data)
     }

--- a/crates/ethportal-api/src/types/content_value/beacon.rs
+++ b/crates/ethportal-api/src/types/content_value/beacon.rs
@@ -46,24 +46,6 @@ pub struct ForkVersionedLightClientBootstrap {
     pub bootstrap: LightClientBootstrap,
 }
 
-impl From<LightClientBootstrapCapella> for ForkVersionedLightClientBootstrap {
-    fn from(bootstrap: LightClientBootstrapCapella) -> Self {
-        Self {
-            fork_name: ForkName::Capella,
-            bootstrap: LightClientBootstrap::Capella(bootstrap),
-        }
-    }
-}
-
-impl From<LightClientBootstrapDeneb> for ForkVersionedLightClientBootstrap {
-    fn from(bootstrap: LightClientBootstrapDeneb) -> Self {
-        Self {
-            fork_name: ForkName::Deneb,
-            bootstrap: LightClientBootstrap::Deneb(bootstrap),
-        }
-    }
-}
-
 impl From<LightClientBootstrapElectra> for ForkVersionedLightClientBootstrap {
     fn from(bootstrap: LightClientBootstrapElectra) -> Self {
         Self {
@@ -192,6 +174,15 @@ impl ForkVersionedLightClientUpdate {
     }
 }
 
+impl From<LightClientUpdateElectra> for ForkVersionedLightClientUpdate {
+    fn from(update: LightClientUpdateElectra) -> Self {
+        Self {
+            fork_name: ForkName::Electra,
+            update: LightClientUpdate::Electra(update),
+        }
+    }
+}
+
 impl Decode for ForkVersionedLightClientUpdate {
     fn is_ssz_fixed_len() -> bool {
         false
@@ -277,24 +268,6 @@ pub struct ForkVersionedLightClientOptimisticUpdate {
     pub update: LightClientOptimisticUpdate,
 }
 
-impl From<LightClientOptimisticUpdateCapella> for ForkVersionedLightClientOptimisticUpdate {
-    fn from(update: LightClientOptimisticUpdateCapella) -> Self {
-        Self {
-            fork_name: ForkName::Capella,
-            update: LightClientOptimisticUpdate::Capella(update),
-        }
-    }
-}
-
-impl From<LightClientOptimisticUpdateDeneb> for ForkVersionedLightClientOptimisticUpdate {
-    fn from(update: LightClientOptimisticUpdateDeneb) -> Self {
-        Self {
-            fork_name: ForkName::Deneb,
-            update: LightClientOptimisticUpdate::Deneb(update),
-        }
-    }
-}
-
 impl From<LightClientOptimisticUpdateElectra> for ForkVersionedLightClientOptimisticUpdate {
     fn from(update: LightClientOptimisticUpdateElectra) -> Self {
         Self {
@@ -373,24 +346,6 @@ impl Encode for ForkVersionedLightClientOptimisticUpdate {
 pub struct ForkVersionedLightClientFinalityUpdate {
     pub fork_name: ForkName,
     pub update: LightClientFinalityUpdate,
-}
-
-impl From<LightClientFinalityUpdateCapella> for ForkVersionedLightClientFinalityUpdate {
-    fn from(update: LightClientFinalityUpdateCapella) -> Self {
-        Self {
-            fork_name: ForkName::Capella,
-            update: LightClientFinalityUpdate::Capella(update),
-        }
-    }
-}
-
-impl From<LightClientFinalityUpdateDeneb> for ForkVersionedLightClientFinalityUpdate {
-    fn from(update: LightClientFinalityUpdateDeneb) -> Self {
-        Self {
-            fork_name: ForkName::Deneb,
-            update: LightClientFinalityUpdate::Deneb(update),
-        }
-    }
 }
 
 impl From<LightClientFinalityUpdateElectra> for ForkVersionedLightClientFinalityUpdate {


### PR DESCRIPTION
This is a followup of https://github.com/ethereum/trin/pull/1801

### What was wrong?

Beacon Bridge will stop working after Pectra fork.

### How was it fixed?

Update our types to be Pectra instead of Deneb.

NOTE: We don't have a way to test these endpoints until the fork, as they would fail (except in some cases when format didn't change).

Ideally, we should be able to decode/deserialize correct version and it's something I will work on. But I don't have time to do it until the fork.

This code can/should be deployed as soon as the fork happens on mainnet.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
