### PR TITLE
feat: validate blocks while building E2HS file

### DIFF
--- a/bin/e2hs-writer/src/main.rs
+++ b/bin/e2hs-writer/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
 
     let start = Instant::now();
     let epoch_writer = EpochWriter::new(config.target_dir, config.epoch);
-    epoch_writer.write_epoch(epoch_reader)?;
+    epoch_writer.write_epoch(epoch_reader).await?;
     info!(
         "Time taken to finished writing blocks  {}",
         start.elapsed().human(Truncate::Second)


### PR DESCRIPTION
### What was wrong?

Building E2HS files is time consuming. There isn't a good way for the bridge to validate post-capella headers due to the E2HS bridge not having access to a provider. We want to know sooner then later if a E2HS file is valid or not.

### How was it fixed?

Validate the block, use the latest HistoricalSummaries if avaliable, if HistoricalSummaries aren't avaliable there are no post capella headers to prove so there is no issue.