### PR TITLE
feat: light-client should use its config for slot_timestamp

### DIFF
--- a/crates/light-client/src/config/networks.rs
+++ b/crates/light-client/src/config/networks.rs
@@ -19,12 +19,14 @@ use crate::config::{utils::hex_str_to_bytes, BaseConfig, ChainConfig, Fork, Fork
 )]
 pub enum Network {
     Mainnet,
+    Sepolia,
 }
 
 impl Network {
     pub fn to_base_config(self) -> BaseConfig {
         match self {
             Self::Mainnet => mainnet(),
+            Self::Sepolia => sepolia(),
         }
     }
 }
@@ -69,6 +71,52 @@ pub fn mainnet() -> BaseConfig {
             electra: Fork {
                 epoch: 364032,
                 fork_version: hex_str_to_bytes("0x05000000").expect("should be a valid hex str"),
+            },
+        },
+        max_checkpoint_age: 1_209_600, // 14 days
+    }
+}
+
+pub fn sepolia() -> BaseConfig {
+    BaseConfig {
+        default_checkpoint: hex_str_to_bytes(
+            "0x234931a3fe5d791f06092477357e2d65dcf6fa6cad048680eb93ad3ea494bbcd",
+        )
+        .expect("should be a valid hex str"),
+        rpc_port: 8545,
+        consensus_rpc: None,
+        chain: ChainConfig {
+            chain_id: 11155111,
+            genesis_time: 1655733600,
+            genesis_root: hex_str_to_bytes(
+                "0xd8ea171f3c94aea21ebc42a1ed61052acf3f9209c00e4efbaaddac09ed9b8078",
+            )
+            .expect("should be a valid hex str"),
+        },
+        forks: Forks {
+            genesis: Fork {
+                epoch: 0,
+                fork_version: hex_str_to_bytes("0x90000069").expect("should be a valid hex str"),
+            },
+            altair: Fork {
+                epoch: 50,
+                fork_version: hex_str_to_bytes("0x90000070").expect("should be a valid hex str"),
+            },
+            bellatrix: Fork {
+                epoch: 100,
+                fork_version: hex_str_to_bytes("0x90000071").expect("should be a valid hex str"),
+            },
+            capella: Fork {
+                epoch: 56832,
+                fork_version: hex_str_to_bytes("0x90000072").expect("should be a valid hex str"),
+            },
+            deneb: Fork {
+                epoch: 132608,
+                fork_version: hex_str_to_bytes("0x90000073").expect("should be a valid hex str"),
+            },
+            electra: Fork {
+                epoch: 222464,
+                fork_version: hex_str_to_bytes("0x90000074").expect("should be a valid hex str"),
             },
         },
         max_checkpoint_age: 1_209_600, // 14 days

--- a/crates/light-client/src/consensus/consensus_client.rs
+++ b/crates/light-client/src/consensus/consensus_client.rs
@@ -16,7 +16,6 @@ use ethportal_api::{
         store::LightClientStore,
         update::{FinalizedRootProofLenElectra, LightClientUpdateElectra},
     },
-    types::network_spec::network_spec,
     utils::bytes::hex_encode,
 };
 use milagro_bls::PublicKey;
@@ -435,7 +434,7 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
     }
 
     fn age(&self, slot: u64) -> Duration {
-        let expected_time = network_spec().slot_to_timestamp(slot);
+        let expected_time = self.slot_timestamp(slot);
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("`now` is ahead of `UNIX_EPOCH`");
@@ -459,7 +458,7 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
     pub fn duration_until_next_update(&self) -> Duration {
         let current_slot = self.expected_current_slot();
         let next_slot = current_slot + 1;
-        let next_slot_timestamp = network_spec().slot_to_timestamp(next_slot);
+        let next_slot_timestamp = self.slot_timestamp(next_slot);
 
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -475,12 +474,16 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
     // Determines blockhash_slot age and returns true if it is less than 14 days old
     fn is_valid_checkpoint(&self, blockhash_slot: u64) -> bool {
         let current_slot = self.expected_current_slot();
-        let current_slot_timestamp = network_spec().slot_to_timestamp(current_slot);
-        let blockhash_slot_timestamp = network_spec().slot_to_timestamp(blockhash_slot);
+        let current_slot_timestamp = self.slot_timestamp(current_slot);
+        let blockhash_slot_timestamp = self.slot_timestamp(blockhash_slot);
 
         let slot_age = current_slot_timestamp - blockhash_slot_timestamp;
 
         slot_age < self.config.max_checkpoint_age
+    }
+
+    fn slot_timestamp(&self, slot: u64) -> u64 {
+        slot * 12 + self.config.chain.genesis_time
     }
 }
 


### PR DESCRIPTION
### What was wrong?

The light-client only uses `network_spec()` for calculating slot's timestamp.

Since it already has its own config and which uses for most calculations, it should use it for this as well.

### How was it fixed?

Added `slot_timestamp` function in light-client.

Also added Sepolia testnet configuration, which I used to test this (I left it as others might fine it useful as well).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
