### PR TITLE
feat: add latest end of block range option for e2hs bridge

### DIFF
--- a/bin/portal-bridge/README.md
+++ b/bin/portal-bridge/README.md
@@ -27,6 +27,7 @@ cargo run -p portal-bridge --release -- --mode e2hs --e2hs-range 100000-2000000
 #### History Network E2HS Bridge
 
 - `"--mode e2hs --e2hs-range 100-200"`: gossip a block range from #100 to #200 (inclusive) using `E2HS` files as the data source
+- `"--mode e2hs --e2hs-range 100-latest"`: gossip a block range from #100 to latest (inclusive) using `E2HS` files as the data source. Latest is determined by the latest e2hs file available.
 - `"--mode e2hs --e2hs-range 1000-10000 --e2hs-randomize"`: randomize the order in which epochs from block range are gossiped
 
 #### Beacon Subnetwork

--- a/bin/portal-bridge/README.md
+++ b/bin/portal-bridge/README.md
@@ -27,7 +27,7 @@ cargo run -p portal-bridge --release -- --mode e2hs --e2hs-range 100000-2000000
 #### History Network E2HS Bridge
 
 - `"--mode e2hs --e2hs-range 100-200"`: gossip a block range from #100 to #200 (inclusive) using `E2HS` files as the data source
-- `"--mode e2hs --e2hs-range 100-latest"`: gossip a block range from #100 to latest (inclusive) using `E2HS` files as the data source. Latest is determined by the latest e2hs file available.
+- `"--mode e2hs --e2hs-range 100-"`: gossip a block range from #100 to latest (inclusive) using `E2HS` files as the data source. Latest is determined by the latest e2hs file available.
 - `"--mode e2hs --e2hs-range 1000-10000 --e2hs-randomize"`: randomize the order in which epochs from block range are gossiped
 
 #### Beacon Subnetwork

--- a/bin/portal-bridge/src/cli.rs
+++ b/bin/portal-bridge/src/cli.rs
@@ -37,7 +37,7 @@ pub struct BridgeConfig {
 
     #[arg(
         long = "e2hs-range",
-        help = "The (inclusive) block range for the E2HS bridge: examples `0-100` or `0-latest`"
+        help = "The (inclusive) block range for the E2HS bridge: examples `0-100` or `0-` which means from 0 to the latest block know"
     )]
     pub e2hs_range: Option<BlockRange>,
 

--- a/bin/portal-bridge/src/cli.rs
+++ b/bin/portal-bridge/src/cli.rs
@@ -37,7 +37,7 @@ pub struct BridgeConfig {
 
     #[arg(
         long = "e2hs-range",
-        help = "The (inclusive) block range for the E2HS bridge"
+        help = "The (inclusive) block range for the E2HS bridge: examples `0-100` or `0-latest`"
     )]
     pub e2hs_range: Option<BlockRange>,
 


### PR DESCRIPTION
### What was wrong?
I am setting up E2HS bridges but a problem that occurs is there are always new e2hs files being added. We want to deploy bridges which cover ranges of the block space so for example if I have 5 bridges

And the total block range is roughly 0 to 21 million



- 0 to 5_000_000
- 5_000_001 to 10_000_000
- 10_000_001 to 15_000_00
- 15_000_001 to 20_000_00
- 20_000_001 to latest

^ I would probably want to deploy the bridges something like this where. Everytime the 5th bridge does a cycle it checks what is the latest E2HS file I can gossip, then includes that moving window in its range.

### How was it fixed?

adding a latest option which can be specified as the end of the range.

At the initialization of the bridge check what is the latest E2HS file we can bridge