### PR TITLE
feat: add docker image for trin-execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,9 +60,9 @@ jobs:
   docker-build:
     parameters:
       target:
-        description: Sets the target for building the docker image. Must be one of "trin", "bridge", "e2hs-writer".
+        description: Sets the target for building the docker image. Must be one of "trin", "bridge", "e2hs-writer", "trin-execution".
         type: enum
-        enum: ["trin", "bridge", "e2hs-writer"]
+        enum: ["trin", "bridge", "e2hs-writer", "trin-execution"]
         default: "trin"
       tags:
         description: Space separated list of tags to be added to the built image.
@@ -102,9 +102,9 @@ jobs:
   docker-publish:
     parameters:
       target:
-        description: Used to load the image from the workspace. Must be one of "trin", "bridge", "e2hs-writer".
+        description: Used to load the image from the workspace. Must be one of "trin", "bridge", "e2hs-writer", "trin-execution".
         type: enum
-        enum: ["trin", "bridge", "e2hs-writer"]
+        enum: ["trin", "bridge", "e2hs-writer", "trin-execution"]
         default: "trin"
     executor: docker-publisher
     steps:
@@ -351,7 +351,19 @@ workflows:
             - docker_build_e2hs_writer
           filters:
             branches:
-              only: master              
+              only: master
+      - docker-build:
+          name: docker_build_trin_execution
+          target: trin-execution
+          tags: latest
+      - docker-publish:
+          name: docker_publish_trin_execution
+          target: trin-execution
+          requires:
+            - docker_build_trin_execution
+          filters:
+            branches:
+              only: master                         
   docker-master-tag:
     when:
       and: [ << pipeline.git.tag >>, << pipeline.git.branch.is_default >> ]
@@ -400,4 +412,19 @@ workflows:
           target: e2hs-writer
           filters:
             tags:
-              only: /^v\d+(\.\d+){0,2}(-\w*\.\d+)?$/              
+              only: /^v\d+(\.\d+){0,2}(-\w*\.\d+)?$/  
+      - docker-build:
+          name: docker_build_trin_execution
+          target: trin-execution
+          tags: << pipeline.git.tag >>-$(git rev-parse --short HEAD) stable prod
+          filters:
+            tags:
+              only: /^v\d+(\.\d+){0,2}(-\w*\.\d+)?$/
+      - docker-publish:
+          name: docker_publish_trin_execution
+          requires:
+            - docker_build_trin_execution
+          target: trin-execution
+          filters:
+            tags:
+              only: /^v\d+(\.\d+){0,2}(-\w*\.\d+)?$/                        

--- a/docker/Dockerfile.trin-execution
+++ b/docker/Dockerfile.trin-execution
@@ -1,0 +1,30 @@
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
+
+RUN apt-get update && apt-get install clang -y
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder 
+COPY --from=planner /app/recipe.json recipe.json
+
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Build application
+# Copy over all project folders specified in the .dockerignore
+COPY . .
+RUN cargo build --release --locked -p trin-execution
+
+# We do not need the Rust toolchain to run the binary!
+FROM ubuntu AS runtime
+WORKDIR /app
+
+# copy build artifacts from build stage
+COPY --from=builder /app/target/release/trin-execution /usr/bin/
+
+ENV RUST_LOG=debug
+
+ENTRYPOINT ["/usr/bin/trin-execution"]


### PR DESCRIPTION
### What was wrong?

This PR replaces https://github.com/ethereum/trin/pull/1586

- I want to be able to deploy Trin Execution with docker to our infrastructure 
- I want to test Trin Execution using Hive, which requires a docker image

### How was it fixed?

By adding a docker image for Trin Execution and the respective CI code
