### PR TITLE
refactor: move consensus related constants into ethportal-api

### DIFF
--- a/bin/e2hs-writer/src/subcommands/head_generator/ethereum_api.rs
+++ b/bin/e2hs-writer/src/subcommands/head_generator/ethereum_api.rs
@@ -1,11 +1,13 @@
 use anyhow::{anyhow, bail, ensure};
 use ethportal_api::{
-    consensus::{beacon_block::SignedBeaconBlockElectra, beacon_state::BeaconStateElectra},
+    consensus::{
+        beacon_block::SignedBeaconBlockElectra, beacon_state::BeaconStateElectra,
+        constants::SLOTS_PER_HISTORICAL_ROOT,
+    },
     Receipts,
 };
 use portal_bridge::api::{consensus::ConsensusApi, execution::ExecutionApi};
 use tracing::warn;
-use trin_validation::constants::SLOTS_PER_HISTORICAL_ROOT;
 use url::Url;
 
 pub struct EthereumApi {

--- a/bin/e2hs-writer/src/subcommands/head_generator/mod.rs
+++ b/bin/e2hs-writer/src/subcommands/head_generator/mod.rs
@@ -12,11 +12,11 @@ use anyhow::{bail, ensure};
 use e2hs_builder::E2HSBuilder;
 use e2store::e2hs::BLOCKS_PER_E2HS;
 use ethereum_api::first_slot_in_a_period;
+use ethportal_api::consensus::constants::SLOTS_PER_EPOCH;
 use humanize_duration::{prelude::DurationExt, Truncate};
 use s3_bucket::S3Bucket;
 use tokio::time::sleep;
 use tracing::{error, info};
-use trin_validation::constants::SLOTS_PER_EPOCH;
 
 use crate::cli::HeadGeneratorConfig;
 

--- a/bin/e2hs-writer/src/subcommands/single_generator/provider.rs
+++ b/bin/e2hs-writer/src/subcommands/single_generator/provider.rs
@@ -11,7 +11,7 @@ use e2store::{
 use ethportal_api::{
     consensus::{
         beacon_block::SignedBeaconBlock, beacon_state::HistoricalBatch,
-        historical_summaries::HistoricalSummaries,
+        constants::SLOTS_PER_HISTORICAL_ROOT, historical_summaries::HistoricalSummaries,
     },
     types::network_spec::network_spec,
 };
@@ -21,7 +21,6 @@ use reqwest::{
 };
 use tracing::info;
 use trin_execution::era::binary_search::EraBinarySearch;
-use trin_validation::constants::SLOTS_PER_HISTORICAL_ROOT;
 
 pub enum EraSource {
     // processed era1 file

--- a/bin/portal-bridge/src/types/range.rs
+++ b/bin/portal-bridge/src/types/range.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use trin_validation::constants::SLOTS_PER_HISTORICAL_ROOT;
+use ethportal_api::consensus::constants::SLOTS_PER_HISTORICAL_ROOT;
 
 /// Converts a block range into a mapping of epoch indexes to block ranges.
 ///

--- a/bin/trin-execution/src/era/binary_search.rs
+++ b/bin/trin-execution/src/era/binary_search.rs
@@ -128,6 +128,6 @@ impl EraBinarySearch {
     }
 
     fn start_slot_index(era_index: u64) -> u64 {
-        (era_index - 1) * SLOTS_PER_HISTORICAL_ROOT as u64
+        (era_index - 1) * SLOTS_PER_HISTORICAL_ROOT
     }
 }

--- a/crates/e2store/src/era.rs
+++ b/crates/e2store/src/era.rs
@@ -148,7 +148,7 @@ impl Era {
     }
 
     pub fn epoch_index(&self) -> u64 {
-        self.slot_index_state.slot_index.starting_slot / SLOTS_PER_HISTORICAL_ROOT as u64
+        self.slot_index_state.slot_index.starting_slot / SLOTS_PER_HISTORICAL_ROOT
     }
 }
 
@@ -284,12 +284,12 @@ impl From<&SlotIndexBlockEntry> for Entry {
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct SlotIndexBlock {
     pub starting_slot: u64,
-    pub indices: [i64; SLOTS_PER_HISTORICAL_ROOT],
+    pub indices: [i64; SLOTS_PER_HISTORICAL_ROOT as usize],
     pub count: u64,
 }
 
 impl SlotIndexBlock {
-    pub const SERIALIZED_SIZE: usize = 8 * (1 + SLOTS_PER_HISTORICAL_ROOT + 1);
+    pub const SERIALIZED_SIZE: usize = 8 * (1 + SLOTS_PER_HISTORICAL_ROOT as usize + 1);
 }
 
 impl TryFrom<Entry> for SlotIndexBlock {
@@ -297,12 +297,13 @@ impl TryFrom<Entry> for SlotIndexBlock {
 
     fn try_from(entry: Entry) -> Result<Self, Self::Error> {
         let starting_slot = u64::from_le_bytes(entry.value[0..8].try_into()?);
-        let mut indices = [0i64; SLOTS_PER_HISTORICAL_ROOT];
+        let mut indices = [0i64; SLOTS_PER_HISTORICAL_ROOT as usize];
         for (i, index) in indices.iter_mut().enumerate() {
             *index = i64::from_le_bytes(entry.value[(i * 8 + 8)..(i * 8 + 16)].try_into()?);
         }
         let count = u64::from_le_bytes(
-            entry.value[(SLOTS_PER_HISTORICAL_ROOT * 8 + 8)..(SLOTS_PER_HISTORICAL_ROOT * 8 + 16)]
+            entry.value[(SLOTS_PER_HISTORICAL_ROOT * 8 + 8) as usize
+                ..(SLOTS_PER_HISTORICAL_ROOT * 8 + 16) as usize]
                 .try_into()?,
         );
         Ok(Self {

--- a/crates/ethportal-api/src/types/consensus/constants.rs
+++ b/crates/ethportal-api/src/types/consensus/constants.rs
@@ -1,3 +1,21 @@
-//! Consensus specs values, taken from: https://github.com/ethereum/consensus-specs/blob/d8cfdf2626c1219a40048f8fa3dd103ae8c0b040/presets/mainnet/phase0.yaml
+//! Consensus specs constants.
+//!
+//! Mostly taken from: https://github.com/ethereum/consensus-specs/blob/d8cfdf2626c1219a40048f8fa3dd103ae8c0b040/presets/mainnet/phase0.yaml
+//!
+//! These should eventually be part of the Chain configuration parameters.
 
-pub const SLOTS_PER_HISTORICAL_ROOT: usize = 8192;
+/// Number of slots per Epoch.
+///
+/// 2**5 (= 32) slots 6.4 minutes
+pub const SLOTS_PER_EPOCH: u64 = 32;
+
+/// Number of slots per HistoricalRoot / HistoricalSummary.
+///
+/// 2**13 (= 8,192) slots ~27 hours
+pub const SLOTS_PER_HISTORICAL_ROOT: u64 = 8192;
+
+/// The Epoch of the mainnet Capella fork.
+///
+/// April 12, 2023, 10:27:35pm UTC
+/// Source: https://github.com/ethereum/consensus-specs/blob/d8cfdf2626c1219a40048f8fa3dd103ae8c0b040/configs/mainnet.yaml
+pub const CAPELLA_FORK_EPOCH: u64 = 194_048;

--- a/crates/ethportal-api/src/types/consensus/historical_summaries.rs
+++ b/crates/ethportal-api/src/types/consensus/historical_summaries.rs
@@ -4,6 +4,8 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum, FixedVector, VariableList};
 use tree_hash_derive::TreeHash;
 
+use super::constants::{CAPELLA_FORK_EPOCH, SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT};
+
 /// The Generalized Index of the `historical_summaries` field of the
 /// [BeaconState](super::beacon_state::BeaconState), for Electra fork.
 pub const HISTORICAL_SUMMARIES_GINDEX: usize = 91;
@@ -35,4 +37,16 @@ pub struct HistoricalSummariesWithProof {
     pub epoch: u64,
     pub historical_summaries: HistoricalSummaries,
     pub proof: HistoricalSummariesProof,
+}
+
+/// Calculates the index of a [HistoricalSummary] in [HistoricalSummaries] for a given slot.
+///
+/// Returns `None` is slot is before Capella fork.
+pub fn historical_summary_index(slot: u64) -> Option<usize> {
+    let capella_slot = CAPELLA_FORK_EPOCH * SLOTS_PER_EPOCH;
+    if slot < capella_slot {
+        None
+    } else {
+        Some(((slot - capella_slot) / SLOTS_PER_HISTORICAL_ROOT) as usize)
+    }
 }

--- a/crates/ethportal-api/src/types/execution/header_with_proof.rs
+++ b/crates/ethportal-api/src/types/execution/header_with_proof.rs
@@ -184,7 +184,7 @@ pub fn build_historical_roots_proof(
     beacon_block: &BeaconBlockBellatrix,
 ) -> BlockProofHistoricalRoots {
     let beacon_block_proof = BeaconBlockProofHistoricalRoots::new(
-        historical_batch.build_block_root_proof(slot as usize % SLOTS_PER_HISTORICAL_ROOT),
+        historical_batch.build_block_root_proof((slot % SLOTS_PER_HISTORICAL_ROOT) as usize),
     )
     .expect("error creating BeaconBlockProofHistoricalRoots");
 
@@ -211,7 +211,7 @@ pub fn build_capella_historical_summaries_proof(
 ) -> BlockProofHistoricalSummariesCapella {
     let beacon_block_proof = build_merkle_proof_for_index(
         block_roots.clone(),
-        slot as usize % SLOTS_PER_HISTORICAL_ROOT,
+        (slot % SLOTS_PER_HISTORICAL_ROOT) as usize,
     );
     let beacon_block_proof = BeaconBlockProofHistoricalSummaries::new(beacon_block_proof)
         .expect("error creating BeaconBlockProofHistoricalSummaries");
@@ -238,7 +238,7 @@ pub fn build_deneb_historical_summaries_proof(
 ) -> BlockProofHistoricalSummariesDeneb {
     let beacon_block_proof = build_merkle_proof_for_index(
         block_roots.clone(),
-        slot as usize % SLOTS_PER_HISTORICAL_ROOT,
+        (slot % SLOTS_PER_HISTORICAL_ROOT) as usize,
     );
     let beacon_block_proof = BeaconBlockProofHistoricalSummaries::new(beacon_block_proof)
         .expect("error creating BeaconBlockProofHistoricalSummaries");
@@ -265,7 +265,7 @@ pub fn build_electra_historical_summaries_proof(
 ) -> BlockProofHistoricalSummariesDeneb {
     let beacon_block_proof = build_merkle_proof_for_index(
         block_roots.clone(),
-        slot as usize % SLOTS_PER_HISTORICAL_ROOT,
+        (slot % SLOTS_PER_HISTORICAL_ROOT) as usize,
     );
     let beacon_block_proof = BeaconBlockProofHistoricalSummaries::new(beacon_block_proof)
         .expect("error creating BeaconBlockProofHistoricalSummaries");

--- a/crates/light-client/src/config/client_config.rs
+++ b/crates/light-client/src/config/client_config.rs
@@ -1,12 +1,12 @@
 use std::{path::PathBuf, process::exit};
 
 use alloy::primitives::{FixedBytes, B256};
+use ethportal_api::consensus::constants::SLOTS_PER_EPOCH;
 use figment::{
     providers::{Format, Serialized, Toml},
     Figment,
 };
 use serde::Deserialize;
-use trin_validation::constants::SLOTS_PER_EPOCH;
 
 use crate::config::{networks, BaseConfig, ChainConfig, CliConfig, Forks};
 

--- a/crates/validation/src/accumulator.rs
+++ b/crates/validation/src/accumulator.rs
@@ -5,8 +5,11 @@ use alloy::{
     primitives::{B256, U256},
 };
 use anyhow::anyhow;
-use ethportal_api::types::execution::{
-    accumulator::EpochAccumulator, header_with_proof::BlockProofHistoricalHashesAccumulator,
+use ethportal_api::{
+    consensus::constants::SLOTS_PER_HISTORICAL_ROOT,
+    types::execution::{
+        accumulator::EpochAccumulator, header_with_proof::BlockProofHistoricalHashesAccumulator,
+    },
 };
 use serde::{Deserialize, Serialize};
 use ssz::Decode;
@@ -14,9 +17,7 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum, VariableList};
 use tree_hash_derive::TreeHash;
 
-use crate::{
-    constants::SLOTS_PER_HISTORICAL_ROOT, merkle::proof::MerkleTree, TrinValidationAssets,
-};
+use crate::{merkle::proof::MerkleTree, TrinValidationAssets};
 
 /// SSZ List[Hash256, max_length = MAX_HISTORICAL_EPOCHS]
 /// List of historical epoch accumulator merkle roots preceding current epoch.

--- a/crates/validation/src/constants.rs
+++ b/crates/validation/src/constants.rs
@@ -1,18 +1,8 @@
 use alloy::primitives::{b256, B256};
 
-// Execution Layer hard forks https://ethereum.org/en/history/
-pub const CAPELLA_FORK_EPOCH: u64 = 194_048;
-pub const SLOTS_PER_EPOCH: u64 = 32;
-
 /// The default hash of the pre-merge accumulator at the time of the merge block.
 pub const DEFAULT_PRE_MERGE_ACC_HASH: B256 =
     b256!("0x8eac399e24480dce3cfe06f4bdecba51c6e5d0c46200e3e8611a0b44a3a69ff9");
-
-/// Max number of blocks / epoch = 2 ** 13
-pub const SLOTS_PER_HISTORICAL_ROOT: u64 = 8192;
-
-// Max number of epochs = 2 ** 17
-// const MAX_HISTORICAL_EPOCHS: usize = 131072;
 
 // EIP-155 chain ID for Ethereum mainnet
 pub const CHAIN_ID: usize = 1;

--- a/crates/validation/src/header_validator.rs
+++ b/crates/validation/src/header_validator.rs
@@ -4,7 +4,7 @@ use alloy::{consensus::Header, primitives::B256};
 use alloy_hardforks::EthereumHardforks;
 use anyhow::bail;
 use ethportal_api::{
-    consensus::historical_summaries::HistoricalSummaries,
+    consensus::{constants::SLOTS_PER_HISTORICAL_ROOT, historical_summaries::HistoricalSummaries},
     types::{
         execution::header_with_proof::{
             BeaconBlockProofHistoricalRoots, BeaconBlockProofHistoricalSummaries, BlockHeaderProof,
@@ -21,7 +21,6 @@ use tree_hash::TreeHash;
 
 use crate::{
     accumulator::PreMergeAccumulator,
-    constants::SLOTS_PER_HISTORICAL_ROOT,
     historical_roots_acc::HistoricalRootsAccumulator,
     historical_summaries_provider::{HistoricalSummariesProvider, HistoricalSummariesSource},
     merkle::proof::verify_merkle_proof,


### PR DESCRIPTION
### What was wrong?

While working on handling the head of the chain data, I realized that I would have to duplicate some of the logic that exists in other places and that some constants (SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT, CAPELLA_FORK_EPOCH) should be defined in ethportal-api.

### How was it fixed?

Moved constants into: `crates/ethportal-api/src/types/consensus/constants.rs`
Moved `historical_summary_index` calculations into `crates/ethportal-api/src/types/consensus/historical_summaries.rs`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
