### PR TITLE
feat: remove no longer used DROP_USAGE_STATS_DB sql query

### DIFF
--- a/crates/storage/src/sql.rs
+++ b/crates/storage/src/sql.rs
@@ -79,8 +79,5 @@ pub const HISTORICAL_SUMMARIES_LOOKUP_QUERY: &str =
 pub const HISTORICAL_SUMMARIES_EPOCH_LOOKUP_QUERY: &str =
     "SELECT epoch FROM historical_summaries WHERE epoch >= (?1) LIMIT 1";
 
-// todo: remove this in the future
-pub const DROP_USAGE_STATS_DB: &str = "DROP TABLE IF EXISTS usage_stats;";
-
 /// Benchmarking with WAL mode enabled 1.4 to 1.9x's Trin performance
 pub const ENABLE_WAL_MODE: &str = "PRAGMA journal_mode = WAL;PRAGMA synchronous = NORMAL;";

--- a/crates/storage/src/utils.rs
+++ b/crates/storage/src/utils.rs
@@ -7,8 +7,8 @@ use tracing::info;
 use crate::{
     error::ContentStoreError,
     sql::{
-        DROP_USAGE_STATS_DB, ENABLE_WAL_MODE, HISTORICAL_SUMMARIES_CREATE_TABLE,
-        LC_BOOTSTRAP_CREATE_TABLE, LC_UPDATE_CREATE_TABLE,
+        ENABLE_WAL_MODE, HISTORICAL_SUMMARIES_CREATE_TABLE, LC_BOOTSTRAP_CREATE_TABLE,
+        LC_UPDATE_CREATE_TABLE,
     },
     versioned::sql::STORE_INFO_CREATE_TABLE,
     DATABASE_NAME,
@@ -27,7 +27,6 @@ pub fn setup_sql(node_data_dir: &Path) -> Result<Pool<SqliteConnectionManager>, 
     conn.execute_batch(LC_UPDATE_CREATE_TABLE)?;
     conn.execute_batch(HISTORICAL_SUMMARIES_CREATE_TABLE)?;
     conn.execute_batch(STORE_INFO_CREATE_TABLE)?;
-    conn.execute_batch(DROP_USAGE_STATS_DB)?;
     Ok(pool)
 }
 


### PR DESCRIPTION
### What was wrong?

This SQL Query is no longer needed

### How was it fixed?

removing it
