### PR TITLE
chore: bump rust version to 1.87

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ executors:
     environment:
       DOCKER_NAMESPACE: portalnetwork
     docker:
-      - image: cimg/rust:1.85.0
+      - image: cimg/rust:1.87.0
   docker-nightly:
     docker:
       - image: rustlang/rust:nightly
@@ -153,7 +153,7 @@ jobs:
     resource_class: xlarge
     executor:
       name: rust/default
-      tag: 1.85.0
+      tag: 1.87.0
     environment:
       RUSTFLAGS: "-D warnings"
       RUST_LOG: "debug"
@@ -174,7 +174,7 @@ jobs:
     resource_class: xlarge
     executor:
       name: rust/default
-      tag: 1.85.0
+      tag: 1.87.0
     environment:
       RUSTFLAGS: "-D warnings"
       RUST_LOG: "debug"
@@ -203,7 +203,12 @@ jobs:
           # https://discuss.circleci.com/t/march-2022-beta-support-for-new-operating-system-for-windows-executors-windows-server-2022/43198/44
           command: |
             choco uninstall rust
-            choco install rust-ms llvm cmake.portable -y
+            choco install llvm cmake.portable -y
+            Invoke-WebRequest -Uri https://win.rustup.rs/ -OutFile rustup-init.exe
+            Start-Process -FilePath ".\rustup-init.exe" -ArgumentList "-y" -NoNewWindow -Wait
+            Remove-Item .\rustup-init.exe
+            $env:PATH += ";$env:USERPROFILE\.cargo\bin"
+            rustc --version            
             cargo build --workspace
   test:
     description: |
@@ -211,7 +216,7 @@ jobs:
     resource_class: 2xlarge
     executor:
       name: rust/default
-      tag: 1.85.0
+      tag: 1.87.0
     environment:
       RUSTFLAGS: "-D warnings"
       RUST_LOG: "debug,html5ever=error,selectors=error,discv5::service=info"
@@ -231,7 +236,7 @@ jobs:
   check-workspace-crates:
     executor:
       name: rust/default
-      tag: 1.85.0
+      tag: 1.87.0
     # parallelism level should be set to the amount of simulators we have or greater
     # The reason for this is the CI code currently only supports 1 input at a time
     # if we have a parallelism level of 5 and 6 sims one test runner will get 2 test sims and fail

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ keywords = ["ethereum", "portal-network"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ethereum/trin"
-rust-version = "1.85.0"
+rust-version = "1.87.0"
 version = "0.3.1"
 
 [workspace.dependencies]

--- a/crates/rpc/src/rpc_server.rs
+++ b/crates/rpc/src/rpc_server.rs
@@ -571,7 +571,7 @@ pub enum WsHttpServerKind {
     /// Http server
     Plain(Server),
     /// Http server with cors
-    WithCors(Server<Stack<CorsLayer, Identity>>),
+    WithCors(Box<Server<Stack<CorsLayer, Identity>>>),
 }
 
 impl WsHttpServerKind {
@@ -597,7 +597,7 @@ impl WsHttpServerKind {
                 .build(socket_addr)
                 .await
                 .map_err(|err| RpcError::IoError(err, server_kind))?;
-            Ok(WsHttpServerKind::WithCors(server))
+            Ok(WsHttpServerKind::WithCors(Box::new(server)))
         } else {
             let server = builder
                 .build(socket_addr)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
-channel = "1.85.0"
+channel = "1.87.0"

--- a/testing/utp/docker/Dockerfile
+++ b/testing/utp/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85.0-bullseye AS builder
+FROM rust:1.87.0-bullseye AS builder
 
 RUN apt-get update \
  && apt-get install clang -y \


### PR DESCRIPTION
### What was wrong?

There is a new stable release

### How was it fixed?

bump it. I noticed the newest reth-ipc requires a newer stable version, I didn't end up bumping that crate to to other issues with reth-ipc/jsonrpcee as jsonrpcee privated members, reth-ipc needed to work or something

