### PR TITLE
feat: update chain_head

### DIFF
--- a/bin/trin/src/run.rs
+++ b/bin/trin/src/run.rs
@@ -19,7 +19,7 @@ use trin_state::initialize_state_network;
 use trin_storage::{config::StorageCapacityConfig, PortalStorageConfigFactory};
 #[cfg(windows)]
 use trin_utils::cli::Web3TransportType;
-use trin_validation::oracle::HeaderOracle;
+use trin_validation::{chain_head::ChainHead, oracle::HeaderOracle};
 use utp_rs::socket::UtpSocket;
 
 use crate::{
@@ -121,6 +121,9 @@ async fn run_trin_internal(
     // Initialize validation oracle
     let header_oracle = Arc::new(RwLock::new(HeaderOracle::default()));
 
+    // Initialize head of the chain management.
+    let chain_head = ChainHead::new_pectra_defaults();
+
     // Initialize and spawn uTP socket
     let (utp_talk_reqs_tx, utp_talk_reqs_rx) = mpsc::unbounded_channel();
 
@@ -170,6 +173,7 @@ async fn run_trin_internal(
             portalnet_config.clone(),
             storage_config_factory.create(&Subnetwork::Beacon, Distance::MAX)?,
             header_oracle.clone(),
+            chain_head.clone(),
         )
         .await?
     } else {

--- a/bin/trin/src/run.rs
+++ b/bin/trin/src/run.rs
@@ -173,7 +173,7 @@ async fn run_trin_internal(
             portalnet_config.clone(),
             storage_config_factory.create(&Subnetwork::Beacon, Distance::MAX)?,
             header_oracle.clone(),
-            chain_head.clone(),
+            chain_head,
         )
         .await?
     } else {

--- a/crates/ethportal-api/src/types/consensus/light_client/update.rs
+++ b/crates/ethportal-api/src/types/consensus/light_client/update.rs
@@ -10,6 +10,7 @@ use ssz_types::{
 use superstruct::superstruct;
 use tree_hash_derive::TreeHash;
 
+use super::header::LightClientHeader;
 use crate::{
     light_client::header::{LightClientHeaderDeneb, LightClientHeaderElectra},
     types::consensus::{
@@ -106,6 +107,26 @@ impl LightClientUpdate {
             ForkName::Capella => LightClientUpdateCapella::from_ssz_bytes(bytes).map(Self::Capella),
             ForkName::Deneb => LightClientUpdateDeneb::from_ssz_bytes(bytes).map(Self::Deneb),
             ForkName::Electra => LightClientUpdateElectra::from_ssz_bytes(bytes).map(Self::Electra),
+        }
+    }
+
+    pub fn attested_header(&self) -> LightClientHeader {
+        match self {
+            Self::Bellatrix(update) => LightClientHeader::Bellatrix(update.attested_header.clone()),
+            Self::Capella(update) => LightClientHeader::Capella(update.attested_header.clone()),
+            Self::Deneb(update) => LightClientHeader::Deneb(update.attested_header.clone()),
+            Self::Electra(update) => LightClientHeader::Electra(update.attested_header.clone()),
+        }
+    }
+
+    pub fn finalized_header(&self) -> LightClientHeader {
+        match self {
+            Self::Bellatrix(update) => {
+                LightClientHeader::Bellatrix(update.finalized_header.clone())
+            }
+            Self::Capella(update) => LightClientHeader::Capella(update.finalized_header.clone()),
+            Self::Deneb(update) => LightClientHeader::Deneb(update.finalized_header.clone()),
+            Self::Electra(update) => LightClientHeader::Electra(update.finalized_header.clone()),
         }
     }
 }

--- a/crates/light-client/src/client.rs
+++ b/crates/light-client/src/client.rs
@@ -19,6 +19,7 @@ use crate::{
     errors::NodeError,
     node::Node,
     rpc::Rpc,
+    watch::LightClientWatchReceivers,
 };
 
 #[derive(Default)]
@@ -451,5 +452,9 @@ impl<DB: Database, R: ConsensusRpc + 'static> Client<DB, R> {
 
     pub async fn get_light_client_store(&self) -> Result<LightClientStore> {
         self.node.read().await.get_light_client_store()
+    }
+
+    pub async fn get_light_client_watch_receivers(&self) -> LightClientWatchReceivers {
+        self.node.read().await.consensus.get_watch_receivers()
     }
 }

--- a/crates/light-client/src/consensus/consensus_client.rs
+++ b/crates/light-client/src/consensus/consensus_client.rs
@@ -376,10 +376,14 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
     }
 
     fn apply_update(&mut self, update: &LightClientUpdateElectra) {
+        let optimistic_header_slot = self.store.optimistic_header.slot;
+        let finalized_header_slot = self.store.finalized_header.slot;
+
         let generic_update = GenericUpdate::from(update);
         self.apply_generic_update(&generic_update);
-        if self.store.optimistic_header.slot == update.attested_header.beacon.slot
-            || self.store.finalized_header.slot == update.finalized_header.beacon.slot
+
+        if optimistic_header_slot < self.store.optimistic_header.slot
+            || finalized_header_slot < self.store.finalized_header.slot
         {
             self.watch_senders
                 .update
@@ -388,10 +392,14 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
     }
 
     fn apply_finality_update(&mut self, update: &LightClientFinalityUpdateElectra) {
+        let optimistic_header_slot = self.store.optimistic_header.slot;
+        let finalized_header_slot = self.store.finalized_header.slot;
+
         let generic_update = GenericUpdate::from(update);
         self.apply_generic_update(&generic_update);
-        if self.store.optimistic_header.slot == update.attested_header.beacon.slot
-            || self.store.finalized_header.slot == update.finalized_header.beacon.slot
+
+        if optimistic_header_slot < self.store.optimistic_header.slot
+            || finalized_header_slot < self.store.finalized_header.slot
         {
             self.watch_senders
                 .finality_update
@@ -417,9 +425,12 @@ impl<R: ConsensusRpc> ConsensusLightClient<R> {
     }
 
     fn apply_optimistic_update(&mut self, update: &LightClientOptimisticUpdateElectra) {
+        let optimistic_header_slot = self.store.optimistic_header.slot;
+
         let generic_update = GenericUpdate::from(update);
         self.apply_generic_update(&generic_update);
-        if self.store.optimistic_header.slot == update.attested_header.beacon.slot {
+
+        if optimistic_header_slot < self.store.optimistic_header.slot {
             self.watch_senders
                 .optimistic_update
                 .send_replace(Some(LightClientOptimisticUpdate::Electra(update.clone())));

--- a/crates/light-client/src/lib.rs
+++ b/crates/light-client/src/lib.rs
@@ -10,3 +10,4 @@ pub mod errors;
 pub mod node;
 pub mod rpc;
 pub mod utils;
+pub mod watch;

--- a/crates/light-client/src/watch.rs
+++ b/crates/light-client/src/watch.rs
@@ -1,0 +1,50 @@
+use ethportal_api::light_client::{
+    finality_update::LightClientFinalityUpdate, optimistic_update::LightClientOptimisticUpdate,
+    update::LightClientUpdate,
+};
+use tokio::sync::watch;
+
+/// The [tokio::sync::watch::channel] Receivers for light client update types.
+///
+/// Value will be `None` until first update.
+#[derive(Clone)]
+pub struct LightClientWatchReceivers {
+    pub update: watch::Receiver<Option<LightClientUpdate>>,
+    pub optimistic_update: watch::Receiver<Option<LightClientOptimisticUpdate>>,
+    pub finality_update: watch::Receiver<Option<LightClientFinalityUpdate>>,
+}
+
+/// The [tokio::sync::watch::channel] Senders for light client update types.
+#[derive(Debug, Clone)]
+pub struct LightClientWatchSenders {
+    pub update: watch::Sender<Option<LightClientUpdate>>,
+    pub optimistic_update: watch::Sender<Option<LightClientOptimisticUpdate>>,
+    pub finality_update: watch::Sender<Option<LightClientFinalityUpdate>>,
+}
+
+impl LightClientWatchSenders {
+    pub fn subscribe(&self) -> LightClientWatchReceivers {
+        LightClientWatchReceivers {
+            update: self.update.subscribe(),
+            optimistic_update: self.optimistic_update.subscribe(),
+            finality_update: self.finality_update.subscribe(),
+        }
+    }
+}
+
+pub fn light_client_watch_channels() -> (LightClientWatchSenders, LightClientWatchReceivers) {
+    let (update_sender, update_receiver) = watch::channel(None);
+    let (optimistic_update_sender, optimistic_update_receiver) = watch::channel(None);
+    let (finality_update_sender, finality_update_receiver) = watch::channel(None);
+    let senders = LightClientWatchSenders {
+        update: update_sender,
+        optimistic_update: optimistic_update_sender,
+        finality_update: finality_update_sender,
+    };
+    let receivers = LightClientWatchReceivers {
+        update: update_receiver,
+        optimistic_update: optimistic_update_receiver,
+        finality_update: finality_update_receiver,
+    };
+    (senders, receivers)
+}

--- a/crates/subnetworks/beacon/src/lib.rs
+++ b/crates/subnetworks/beacon/src/lib.rs
@@ -26,7 +26,7 @@ use tokio::{
 };
 use tracing::info;
 use trin_storage::PortalStorageConfig;
-use trin_validation::oracle::HeaderOracle;
+use trin_validation::{chain_head::ChainHead, oracle::HeaderOracle};
 use utp_rs::socket::UtpSocket;
 
 use crate::{events::BeaconEvents, jsonrpc::BeaconRequestHandler, network::BeaconNetwork};
@@ -46,6 +46,7 @@ pub async fn initialize_beacon_network(
     portalnet_config: PortalnetConfig,
     storage_config: PortalStorageConfig,
     header_oracle: Arc<RwLock<HeaderOracle>>,
+    chain_head: ChainHead,
 ) -> anyhow::Result<(
     BeaconHandler,
     BeaconNetworkTask,
@@ -62,6 +63,7 @@ pub async fn initialize_beacon_network(
         storage_config,
         portalnet_config.clone(),
         header_oracle,
+        chain_head,
     )
     .await?;
     let beacon_event_stream = beacon_network.overlay.event_stream().await?;

--- a/crates/subnetworks/beacon/src/network.rs
+++ b/crates/subnetworks/beacon/src/network.rs
@@ -96,8 +96,7 @@ impl BeaconNetwork {
                 }
             };
             let mut watch_receivers = client.get_light_client_watch_receivers().await;
-            let mut beacon_client = beacon_client_clone.lock().await;
-            *beacon_client = Some(client);
+            *beacon_client_clone.lock().await = Some(client);
 
             // Watch for light clients updates and update ChainHead
             loop {

--- a/crates/subnetworks/beacon/src/network.rs
+++ b/crates/subnetworks/beacon/src/network.rs
@@ -16,7 +16,7 @@ use portalnet::{
 use tokio::sync::{Mutex, RwLock};
 use tracing::{error, info};
 use trin_storage::PortalStorageConfig;
-use trin_validation::oracle::HeaderOracle;
+use trin_validation::{chain_head::ChainHead, oracle::HeaderOracle};
 use utp_rs::socket::UtpSocket;
 
 use crate::{
@@ -51,6 +51,7 @@ impl BeaconNetwork {
         storage_config: PortalStorageConfig,
         portal_config: PortalnetConfig,
         header_oracle: Arc<RwLock<HeaderOracle>>,
+        chain_head: ChainHead,
     ) -> anyhow::Result<Self> {
         let config = OverlayConfig {
             bootnode_enrs: portal_config.bootnodes.clone(),
@@ -58,7 +59,10 @@ impl BeaconNetwork {
             gossip_dropped: GOSSIP_DROPPED,
             ..Default::default()
         };
-        let storage = Arc::new(PLMutex::new(BeaconStorage::new(storage_config)?));
+        let storage = Arc::new(PLMutex::new(BeaconStorage::new(
+            storage_config,
+            chain_head.clone(),
+        )?));
         storage.lock().spawn_pruning_task(); // Spawn pruning task to clean up expired content.
         let storage_clone = Arc::clone(&storage);
         let validator = Arc::new(BeaconValidator::new(header_oracle));
@@ -81,17 +85,50 @@ impl BeaconNetwork {
         // Get the trusted block root to start syncing from.
         let trusted_block_root = get_trusted_block_root(&portal_config, storage_clone)?;
 
-        // Spawn the beacon sync task.
+        // Spawn light client sync and update watch task
         tokio::spawn(async move {
-            let beacon_sync = BeaconSync::new(overlay_tx);
-            let beacon_sync = beacon_sync.start(trusted_block_root).await;
-            match beacon_sync {
-                Ok(client) => {
-                    let mut beacon_client = beacon_client_clone.lock().await;
-                    *beacon_client = Some(client);
-                }
+            // Sync LightClient
+            let client = match BeaconSync::new(overlay_tx).start(trusted_block_root).await {
+                Ok(client) => client,
                 Err(err) => {
                     error!(error = %err, "Failed to start beacon sync.");
+                    return;
+                }
+            };
+            let mut watch_receivers = client.get_light_client_watch_receivers().await;
+            let mut beacon_client = beacon_client_clone.lock().await;
+            *beacon_client = Some(client);
+
+            // Watch for light clients updates and update ChainHead
+            loop {
+                tokio::select! {
+                    Ok(()) = watch_receivers.update.changed() => {
+                        let update = watch_receivers
+                            .update
+                            .borrow_and_update()
+                            .as_ref()
+                            .expect("Updated LightClientUpdate must be present")
+                            .clone();
+                        chain_head.process_update(update);
+                    }
+                    Ok(()) = watch_receivers.optimistic_update.changed() => {
+                        let update = watch_receivers
+                            .optimistic_update
+                            .borrow_and_update()
+                            .as_ref()
+                            .expect("Updated LightClientOptimisticUpdate must be present")
+                            .clone();
+                        chain_head.process_optimistic_update(update);
+                    }
+                    Ok(()) = watch_receivers.finality_update.changed() => {
+                        let update = watch_receivers
+                            .finality_update
+                            .borrow_and_update()
+                            .as_ref()
+                            .expect("Updated LightClientFinalityUpdate must be present")
+                            .clone();
+                        chain_head.process_finality_update(update);
+                    }
                 }
             }
         });
@@ -176,12 +213,14 @@ mod tests {
             temp_dir.path().to_path_buf(),
         )
         .unwrap();
-
         let storage_config = storage_cfg_factory
             .create(&Subnetwork::Beacon, Distance::MAX)
             .unwrap();
+
         // A mock storage that always returns None
-        let storage_clone = Arc::new(PLMutex::new(BeaconStorage::new(storage_config).unwrap()));
+        let storage_clone = Arc::new(PLMutex::new(
+            BeaconStorage::new(storage_config, ChainHead::new_pectra_defaults()).unwrap(),
+        ));
 
         let result = get_trusted_block_root(&portal_config, storage_clone)
             .expect("Function should not fail with an Err");

--- a/crates/subnetworks/beacon/src/storage.rs
+++ b/crates/subnetworks/beacon/src/storage.rs
@@ -5,9 +5,9 @@ use ethportal_api::{
     consensus::fork::ForkName,
     types::{
         content_value::beacon::{
-            ForkVersionedLightClientBootstrap, ForkVersionedLightClientFinalityUpdate,
-            ForkVersionedLightClientOptimisticUpdate, ForkVersionedLightClientUpdate,
-            LightClientUpdatesByRange,
+            ForkVersionedHistoricalSummariesWithProof, ForkVersionedLightClientBootstrap,
+            ForkVersionedLightClientFinalityUpdate, ForkVersionedLightClientOptimisticUpdate,
+            ForkVersionedLightClientUpdate, LightClientUpdatesByRange,
         },
         distance::Distance,
         network::Subnetwork,
@@ -36,6 +36,7 @@ use trin_storage::{
     utils::get_total_size_of_directory_in_bytes,
     ContentStore, DataSize, PortalStorageConfig, ShouldWeStoreContent,
 };
+use trin_validation::chain_head::ChainHead;
 
 /// Store ephemeral light client data in memory
 #[derive(Debug)]
@@ -110,12 +111,12 @@ impl BeaconStorageCache {
 }
 
 /// Storage layer for the state network. Encapsulates beacon network specific data and logic.
-#[derive(Debug)]
 pub struct BeaconStorage {
     node_data_dir: PathBuf,
     sql_connection_pool: Pool<SqliteConnectionManager>,
     metrics: StorageMetricsReporter,
     cache: BeaconStorageCache,
+    chain_head: ChainHead,
 }
 
 impl ContentStore for BeaconStorage {
@@ -289,12 +290,16 @@ impl ContentStore for BeaconStorage {
 }
 
 impl BeaconStorage {
-    pub fn new(config: PortalStorageConfig) -> Result<Self, ContentStoreError> {
+    pub fn new(
+        config: PortalStorageConfig,
+        chain_head: ChainHead,
+    ) -> Result<Self, ContentStoreError> {
         let storage = Self {
             node_data_dir: config.node_data_dir,
             sql_connection_pool: config.sql_connection_pool,
             metrics: StorageMetricsReporter::new(Subnetwork::Beacon),
             cache: BeaconStorageCache::new(),
+            chain_head,
         };
 
         // Report current total storage usage.
@@ -381,11 +386,13 @@ impl BeaconStorage {
 
         match key {
             BeaconContentKey::LightClientBootstrap(_) => {
-                let bootstrap = ForkVersionedLightClientBootstrap::from_ssz_bytes(value.as_slice())
-                    .map_err(|err| ContentStoreError::InvalidData {
-                        message: format!(
-                            "Error deserializing ForkVersionedLightClientBootstrap value: {err:?}"
-                        ),
+                let bootstrap =
+                    ForkVersionedLightClientBootstrap::from_ssz_bytes(value).map_err(|err| {
+                        ContentStoreError::InvalidData {
+                            message: format!(
+                                "Error decoding ForkVersionedLightClientBootstrap value: {err:?}"
+                            ),
+                        }
                     })?;
 
                 let (slot, block_root) = match bootstrap.fork_name {
@@ -458,11 +465,13 @@ impl BeaconStorage {
                 // Build a range of values starting with update.start_period and len
                 // update.count
                 let periods = update.start_period..(update.start_period + update.count);
-                let update_values = LightClientUpdatesByRange::from_ssz_bytes(value.as_slice())
-                    .map_err(|err| ContentStoreError::InvalidData {
-                        message: format!(
-                            "Error deserializing LightClientUpdatesByRange value: {err:?}"
-                        ),
+                let update_values =
+                    LightClientUpdatesByRange::from_ssz_bytes(value).map_err(|err| {
+                        ContentStoreError::InvalidData {
+                            message: format!(
+                                "Error decoding LightClientUpdatesByRange value: {err:?}"
+                            ),
+                        }
                     })?;
 
                 for (period, value) in periods.zip(update_values.as_ref()) {
@@ -474,27 +483,41 @@ impl BeaconStorage {
                 }
             }
             BeaconContentKey::LightClientFinalityUpdate(_) => {
-                self.cache.set_finality_update(
-                        ForkVersionedLightClientFinalityUpdate::from_ssz_bytes(value.as_slice())
-                            .map_err(|err| ContentStoreError::InvalidData {
-                                message: format!(
-                                    "Error deserializing ForkVersionedLightClientFinalityUpdate value: {err:?}"
-                                ),
-                            })?,
-                    );
+                let fork_versioned_update = ForkVersionedLightClientFinalityUpdate::from_ssz_bytes(
+                    value,
+                )
+                .map_err(|err| ContentStoreError::InvalidData {
+                    message: format!(
+                        "Error decoding ForkVersionedLightClientFinalityUpdate value: {err:?}"
+                    ),
+                })?;
+                self.chain_head
+                    .process_finality_update(fork_versioned_update.update.clone());
+                self.cache.set_finality_update(fork_versioned_update);
             }
             BeaconContentKey::LightClientOptimisticUpdate(_) => {
-                self.cache.set_optimistic_update(
-                        ForkVersionedLightClientOptimisticUpdate::from_ssz_bytes(value.as_slice()).map_err(
-                            |err| ContentStoreError::InvalidData {
-                                message: format!(
-                                    "Error deserializing ForkVersionedLightClientOptimisticUpdate value: {err:?}"
-                                ),
-                            },
-                        )?,
-                    );
+                let fork_versioned_update =
+                    ForkVersionedLightClientOptimisticUpdate::from_ssz_bytes(value).map_err(
+                        |err| ContentStoreError::InvalidData {
+                            message: format!("Error decoding ForkVersionedLightClientOptimistipdate value: {err:?}"),
+                        },
+                    )?;
+                self.chain_head
+                    .process_optimistic_update(fork_versioned_update.update.clone());
+                self.cache.set_optimistic_update(fork_versioned_update);
             }
             BeaconContentKey::HistoricalSummariesWithProof(historical_summaries_key) => {
+                let fork_versioned_historical_summaries =
+                    ForkVersionedHistoricalSummariesWithProof::from_ssz_bytes(value).map_err(
+                        |err| ContentStoreError::InvalidData {
+                            message:  format!("Error decoding ForkVersionedHistoricalSummariesWithProof value: {err:?}"),
+                        },
+                    )?;
+                self.chain_head.update_historical_summaries(
+                    fork_versioned_historical_summaries
+                        .historical_summaries_with_proof
+                        .historical_summaries,
+                );
                 if let Err(err) = self.db_insert_or_replace_historical_summaries_with_proof(
                     &historical_summaries_key.epoch,
                     value,
@@ -733,7 +756,7 @@ mod test {
     #[test]
     fn test_beacon_storage_get_put_bootstrap() {
         let (_temp_dir, config) = create_test_portal_storage_config_with_capacity(10).unwrap();
-        let mut storage = BeaconStorage::new(config).unwrap();
+        let mut storage = BeaconStorage::new(config, ChainHead::new_pectra_defaults()).unwrap();
         let value = test_utils::get_light_client_bootstrap(0);
         let block_root = value
             .bootstrap
@@ -752,7 +775,7 @@ mod test {
     #[test]
     fn test_beacon_storage_get_put_updates_by_range() {
         let (_temp_dir, config) = create_test_portal_storage_config_with_capacity(10).unwrap();
-        let mut storage = BeaconStorage::new(config).unwrap();
+        let mut storage = BeaconStorage::new(config, ChainHead::new_pectra_defaults()).unwrap();
         let key = BeaconContentKey::LightClientUpdatesByRange(LightClientUpdatesByRangeKey {
             start_period: 1,
             count: 2,
@@ -795,7 +818,7 @@ mod test {
     #[ignore = "Missing Pectra test vectors"]
     fn test_beacon_storage_get_put_finality_update() {
         let (_temp_dir, config) = create_test_portal_storage_config_with_capacity(10).unwrap();
-        let mut storage = BeaconStorage::new(config).unwrap();
+        let mut storage = BeaconStorage::new(config, ChainHead::new_pectra_defaults()).unwrap();
         let value = test_utils::get_light_client_finality_update(0);
         let finalized_slot = value.update.finalized_header_deneb().unwrap().beacon.slot;
         let key = BeaconContentKey::LightClientFinalityUpdate(LightClientFinalityUpdateKey {
@@ -834,7 +857,7 @@ mod test {
     #[test]
     fn test_beacon_storage_get_put_optimistic_update() {
         let (_temp_dir, config) = create_test_portal_storage_config_with_capacity(10).unwrap();
-        let mut storage = BeaconStorage::new(config).unwrap();
+        let mut storage = BeaconStorage::new(config, ChainHead::new_pectra_defaults()).unwrap();
         let value = test_utils::get_light_client_optimistic_update(0);
         let signature_slot = *value.update.signature_slot();
         let key = BeaconContentKey::LightClientOptimisticUpdate(LightClientOptimisticUpdateKey {
@@ -873,7 +896,7 @@ mod test {
     #[test]
     fn test_beacon_storage_get_put_historical_summaries() {
         let (_temp_dir, config) = create_test_portal_storage_config_with_capacity(10).unwrap();
-        let mut storage = BeaconStorage::new(config).unwrap();
+        let mut storage = BeaconStorage::new(config, ChainHead::new_pectra_defaults()).unwrap();
 
         let test_data: ContentItem<BeaconContentKey> = read_yaml_portal_spec_tests_file(
             "tests/mainnet/beacon_chain/historical_summaries_with_proof/electra/historical_summaries_with_proof.yaml",
@@ -932,7 +955,7 @@ mod test {
     #[test]
     fn test_beacon_storage_prune_old_bootstrap_data() {
         let (_temp_dir, config) = create_test_portal_storage_config_with_capacity(10).unwrap();
-        let mut storage = BeaconStorage::new(config).unwrap();
+        let mut storage = BeaconStorage::new(config, ChainHead::new_pectra_defaults()).unwrap();
         let mut value = test_utils::get_light_client_bootstrap(0);
         // Set the bootstrap slot to outdated value
         let current_slot = expected_current_slot();

--- a/crates/validation/src/chain_head/mod.rs
+++ b/crates/validation/src/chain_head/mod.rs
@@ -9,6 +9,7 @@ use ethportal_api::{
         finality_update::LightClientFinalityUpdate,
         header::{LightClientHeader, LightClientHeaderElectra},
         optimistic_update::LightClientOptimisticUpdate,
+        update::LightClientUpdate,
     },
 };
 use parking_lot::RwLock;
@@ -62,19 +63,37 @@ impl ChainHead {
     /// Updates the latest beacon block headers, if newer.
     ///
     /// This functions assumes that update is valid.
+    pub fn process_update(&self, update: LightClientUpdate) {
+        let mut store = self.store.write();
+        store.update_latest_if_newer(update.attested_header());
+        store.update_finalized_if_newer(update.finalized_header());
+    }
+
+    /// Updates the latest beacon block headers, if newer.
+    ///
+    /// This functions assumes that update is valid.
     pub fn process_optimistic_update(&self, update: LightClientOptimisticUpdate) {
         self.store
             .write()
             .update_latest_if_newer(update.attested_header());
     }
 
-    /// Updates the latest finalized beacon block headers, if newer.
+    /// Updates the latest and finalized beacon block headers, if newer.
     ///
     /// This functions assumes that update is valid.
-    pub fn process_finalized_update(&self, update: LightClientFinalityUpdate) {
+    pub fn process_finality_update(&self, update: LightClientFinalityUpdate) {
         let mut store = self.store.write();
         store.update_latest_if_newer(update.attested_header());
         store.update_finalized_if_newer(update.finalized_header());
+    }
+
+    /// Updates the [HistoricalSummaries], if newer.
+    ///
+    /// This functions assumes that historical summaries are valid.
+    pub fn update_historical_summaries(&self, historical_summaries: HistoricalSummaries) {
+        self.store
+            .write()
+            .update_historical_summaries_if_newer(historical_summaries);
     }
 }
 

--- a/crates/validation/src/chain_head/store.rs
+++ b/crates/validation/src/chain_head/store.rs
@@ -46,4 +46,13 @@ impl ChainHeadStore {
             .get(historical_summary_index)
             .cloned()
     }
+
+    pub fn update_historical_summaries_if_newer(
+        &mut self,
+        historical_summaries: HistoricalSummaries,
+    ) {
+        if self.historical_summaries.len() < historical_summaries.len() {
+            self.historical_summaries = historical_summaries
+        }
+    }
 }


### PR DESCRIPTION
### What was wrong?

The ChainHead wasn't being updated

### How was it fixed?

Now we update the ChainHead whenever:
- We store related beacon content (OptimisticUpdate, FinalityUpdate, HistoricalSummaries)
- LightClient applies updates to its Store
    - This wasn't as easy because we don't have access to updates that LightClient is using.
    - I added support for broadcasting applied updates using [tokio::sync::watch::channel](https://docs.rs/tokio/latest/tokio/sync/watch/fn.channel.html)
        - First commit adds this support. I'm fine with moving it into separate PR if that's desired

Future work:
- Start using ChainHead for validating content
- Start adding ephemeral content

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
