### PR TITLE
feat: add affected_by_radius to content key

### DIFF
--- a/crates/ethportal-api/src/types/content_key/beacon.rs
+++ b/crates/ethportal-api/src/types/content_key/beacon.rs
@@ -113,6 +113,10 @@ impl fmt::Display for BeaconContentKey {
 }
 
 impl OverlayContentKey for BeaconContentKey {
+    fn affected_by_radius(&self) -> bool {
+        false
+    }
+
     fn to_bytes(&self) -> RawContentKey {
         let mut bytes;
 

--- a/crates/ethportal-api/src/types/content_key/history.rs
+++ b/crates/ethportal-api/src/types/content_key/history.rs
@@ -216,6 +216,17 @@ impl fmt::Display for HistoryContentKey {
 }
 
 impl OverlayContentKey for HistoryContentKey {
+    fn affected_by_radius(&self) -> bool {
+        match self {
+            Self::BlockHeaderByHash(_) => true,
+            Self::BlockHeaderByNumber(_) => true,
+            Self::BlockBody(_) => true,
+            Self::BlockReceipts(_) => true,
+            Self::EphemeralHeadersFindContent(_) => false,
+            Self::EphemeralHeaderOffer(_) => false,
+        }
+    }
+
     fn to_bytes(&self) -> RawContentKey {
         let mut bytes;
 

--- a/crates/ethportal-api/src/types/content_key/overlay.rs
+++ b/crates/ethportal-api/src/types/content_key/overlay.rs
@@ -21,6 +21,12 @@ pub trait OverlayContentKey:
         Sha256::digest(self.to_bytes()).into()
     }
 
+    /// Returns whether this content key is affected by radius.
+    ///
+    /// Most of the content is supposted to be stored if it falls within node's radius, but some
+    /// content is not dependant on the radius and uses different logic instead.
+    fn affected_by_radius(&self) -> bool;
+
     /// Returns the bytes of the content key.
     ///
     /// The [RawContentKey] is better suited than `Vec<u8>` for representing content key bytes.
@@ -96,6 +102,10 @@ impl Deref for IdentityContentKey {
 }
 
 impl OverlayContentKey for IdentityContentKey {
+    fn affected_by_radius(&self) -> bool {
+        true
+    }
+
     fn content_id(&self) -> [u8; 32] {
         self.value
     }

--- a/crates/ethportal-api/src/types/content_key/state.rs
+++ b/crates/ethportal-api/src/types/content_key/state.rs
@@ -65,6 +65,10 @@ pub struct ContractBytecodeKey {
 }
 
 impl OverlayContentKey for StateContentKey {
+    fn affected_by_radius(&self) -> bool {
+        true
+    }
+
     fn to_bytes(&self) -> RawContentKey {
         let mut bytes;
 


### PR DESCRIPTION
### What was wrong?

We currently have no way to differentiate between content that:
- is affected by distance from node_id (i.e. non-ephemeral history + state)
- is not affected by distance from node_id (i.e. ephemeral history + beacon)

This affects how we:
- decide whether to accept and store content
- select peers to ask for content (during find_content)
- select peers to gossip content to (both during gossip and poke)
    - we don't do random content correctly at the moment

### How was it fixed?

Added `affected_by_radius` function on `OverlayContentKey` trait.
This PR sets up ground work for implementing most missing functionality, which can be split into 3 main categories that will be done in a followup PR:
- storage should be flexible enough to handle this case (PR ready: #1840 )
- bridge's census should respect this when selecting peers (PR ready: #1841 )
- make overlay_service (including kbuckets) able to support both type of content (work in progress)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
