### PR TITLE
feat: subnetwork stores should use affected_by_radius

### DIFF
--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -126,8 +126,7 @@ impl<TMetric: Metric> ContentStore for MemoryContentStore<TMetric> {
         &self,
         key: &Self::Key,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
-        let distance = self.distance_to_key(key);
-        if distance > self.radius {
+        if key.affected_by_radius() && self.distance_to_key(key) > self.radius {
             return Ok(ShouldWeStoreContent::NotWithinRadius);
         }
         if self.contains_key(key) {

--- a/crates/storage/src/versioned/id_indexed_v1/store.rs
+++ b/crates/storage/src/versioned/id_indexed_v1/store.rs
@@ -38,6 +38,9 @@ pub struct PaginateResult<TContentKey> {
 /// Different SQL table is created for each `ContentType`, with content-id as a primary key.
 /// It has a configurable capacity and it will prune data that is farthest from the `NodeId` once
 /// it uses more than storage capacity.
+///
+/// Only content that is affected by radius should be stored in this store, otherwise it might be
+/// removed as the radius shrinks because of the pruning.
 #[derive(Debug)]
 pub struct IdIndexedV1Store<TContentKey: OverlayContentKey, TMetric: Metric> {
     /// The configuration.

--- a/crates/subnetworks/history/src/storage.rs
+++ b/crates/subnetworks/history/src/storage.rs
@@ -39,7 +39,9 @@ impl ContentStore for HistoryStorage {
         key: &HistoryContentKey,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
         let content_id = ContentId::from(key.content_id());
-        if self.store.distance_to_content_id(&content_id) > self.store.radius() {
+        if key.affected_by_radius()
+            && self.store.distance_to_content_id(&content_id) > self.store.radius()
+        {
             Ok(ShouldWeStoreContent::NotWithinRadius)
         } else if self.store.has_content(&content_id)? {
             Ok(ShouldWeStoreContent::AlreadyStored)

--- a/crates/subnetworks/state/src/storage.rs
+++ b/crates/subnetworks/state/src/storage.rs
@@ -54,7 +54,9 @@ impl ContentStore for StateStorage {
         key: &StateContentKey,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
         let content_id = ContentId::from(key.content_id());
-        if self.store.distance_to_content_id(&content_id) > self.store.radius() {
+        if key.affected_by_radius()
+            && self.store.distance_to_content_id(&content_id) > self.store.radius()
+        {
             Ok(ShouldWeStoreContent::NotWithinRadius)
         } else if self.store.has_content(&content_id)? {
             Ok(ShouldWeStoreContent::AlreadyStored)


### PR DESCRIPTION
Followup to #1839

### What was wrong?

When implementing `is_key_within_radius_and_unavailable` function, content store should take into consideration whether content key is affected by radius or not.

See #1839 for more details.

### How was it fixed?

Implemented missing functionality.

More work will follow regarding this as ephemeral content will not be stored in the current storage object.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
