### PR TITLE
feat(bridge): census should use affected_by_radius

### DIFF
--- a/bin/portal-bridge/src/bridge/beacon.rs
+++ b/bin/portal-bridge/src/bridge/beacon.rs
@@ -497,7 +497,7 @@ impl BeaconBridge {
         metrics: BridgeMetricsReporter,
         census: Census,
     ) {
-        let Ok(peers) = census.select_peers(Subnetwork::Beacon, &content_key.content_id()) else {
+        let Ok(peers) = census.select_peers(Subnetwork::Beacon, &content_key) else {
             error!("Failed to request enrs for content key, skipping offer: {content_key:?}");
             return;
         };

--- a/bin/portal-bridge/src/bridge/e2hs.rs
+++ b/bin/portal-bridge/src/bridge/e2hs.rs
@@ -378,10 +378,7 @@ impl Gossiper {
         content_key: HistoryContentKey,
         content_value: HistoryContentValue,
     ) -> Vec<OfferTrace> {
-        let Ok(peers) = self
-            .census
-            .select_peers(Subnetwork::History, &content_key.content_id())
-        else {
+        let Ok(peers) = self.census.select_peers(Subnetwork::History, &content_key) else {
             error!("Failed to request enrs for content key, skipping offer: {content_key:?}");
             return vec![];
         };

--- a/bin/portal-bridge/src/bridge/state.rs
+++ b/bin/portal-bridge/src/bridge/state.rs
@@ -506,10 +506,7 @@ impl StateBridge {
         content_key: StateContentKey,
         content_value: StateContentValue,
     ) {
-        let Ok(peers) = self
-            .census
-            .select_peers(Subnetwork::State, &content_key.content_id())
-        else {
+        let Ok(peers) = self.census.select_peers(Subnetwork::State, &content_key) else {
             error!("Failed to request enrs for content key, skipping offer: {content_key:?}");
             return;
         };

--- a/bin/portal-bridge/src/census/mod.rs
+++ b/bin/portal-bridge/src/census/mod.rs
@@ -1,7 +1,10 @@
 use std::{collections::HashSet, time::Duration};
 
 use discv5::enr::NodeId;
-use ethportal_api::types::{network::Subnetwork, portal_wire::OfferTrace};
+use ethportal_api::{
+    types::{network::Subnetwork, portal_wire::OfferTrace},
+    OverlayContentKey,
+};
 use network::{Network, NetworkAction, NetworkInitializationConfig, NetworkManager};
 use peer::PeerInfo;
 use thiserror::Error;
@@ -66,15 +69,15 @@ impl Census {
     }
 
     /// Selects peers to receive content.
-    pub fn select_peers(
+    pub fn select_peers<TContentKey: OverlayContentKey>(
         &self,
         subnetwork: Subnetwork,
-        content_id: &[u8; 32],
+        content_key: &TContentKey,
     ) -> Result<Vec<PeerInfo>, CensusError> {
         match subnetwork {
-            Subnetwork::History => self.history.select_peers(content_id),
-            Subnetwork::State => self.state.select_peers(content_id),
-            Subnetwork::Beacon => self.beacon.select_peers(content_id),
+            Subnetwork::History => self.history.select_peers(content_key),
+            Subnetwork::State => self.state.select_peers(content_key),
+            Subnetwork::Beacon => self.beacon.select_peers(content_key),
             _ => Err(CensusError::UnsupportedSubnetwork(subnetwork)),
         }
     }

--- a/bin/portal-bridge/src/census/mod.rs
+++ b/bin/portal-bridge/src/census/mod.rs
@@ -69,10 +69,10 @@ impl Census {
     }
 
     /// Selects peers to receive content.
-    pub fn select_peers<TContentKey: OverlayContentKey>(
+    pub fn select_peers(
         &self,
         subnetwork: Subnetwork,
-        content_key: &TContentKey,
+        content_key: &impl OverlayContentKey,
     ) -> Result<Vec<PeerInfo>, CensusError> {
         match subnetwork {
             Subnetwork::History => self.history.select_peers(content_key),

--- a/bin/portal-bridge/src/census/network.rs
+++ b/bin/portal-bridge/src/census/network.rs
@@ -9,7 +9,7 @@ use ethportal_api::{
         ping_extensions::decode::PingExtension,
         portal_wire::{OfferTrace, Pong},
     },
-    Enr,
+    Enr, OverlayContentKey,
 };
 use futures::{future::JoinAll, StreamExt};
 use itertools::Itertools;
@@ -106,7 +106,10 @@ impl Network {
     }
 
     /// Selects peers to receive content.
-    pub fn select_peers(&self, content_id: &[u8; 32]) -> Result<Vec<PeerInfo>, CensusError> {
+    pub fn select_peers<TContentKey: OverlayContentKey>(
+        &self,
+        content_key: &TContentKey,
+    ) -> Result<Vec<PeerInfo>, CensusError> {
         if self.peers.is_empty() {
             error!(
                 subnetwork = %self.subnetwork,
@@ -114,7 +117,7 @@ impl Network {
             );
             return Err(CensusError::NoPeers);
         }
-        Ok(self.peers.select_peers(content_id))
+        Ok(self.peers.select_peers(content_key))
     }
 
     /// Records the status of the most recent `Offer` request to one of the peers.

--- a/bin/portal-bridge/src/census/network.rs
+++ b/bin/portal-bridge/src/census/network.rs
@@ -106,9 +106,9 @@ impl Network {
     }
 
     /// Selects peers to receive content.
-    pub fn select_peers<TContentKey: OverlayContentKey>(
+    pub fn select_peers(
         &self,
-        content_key: &TContentKey,
+        content_key: &impl OverlayContentKey,
     ) -> Result<Vec<PeerInfo>, CensusError> {
         if self.peers.is_empty() {
             error!(

--- a/bin/portal-bridge/src/census/peer.rs
+++ b/bin/portal-bridge/src/census/peer.rs
@@ -4,10 +4,13 @@ use std::{
 };
 
 use discv5::Enr;
-use ethportal_api::types::{
-    client_type::ClientType,
-    distance::{Distance, Metric, XorMetric},
-    portal_wire::OfferTrace,
+use ethportal_api::{
+    types::{
+        client_type::ClientType,
+        distance::{Distance, Metric, XorMetric},
+        portal_wire::OfferTrace,
+    },
+    OverlayContentKey,
 };
 use tracing::error;
 
@@ -72,9 +75,17 @@ impl Peer {
     }
 
     /// Returns true if content is within radius.
-    pub fn is_interested_in_content(&self, content_id: &[u8; 32]) -> bool {
-        let distance = XorMetric::distance(&self.enr.node_id().raw(), content_id);
-        distance <= self.radius
+    pub fn is_interested_in_content<TContentKey: OverlayContentKey>(
+        &self,
+        content_key: &TContentKey,
+        content_id: &[u8; 32],
+    ) -> bool {
+        if content_key.affected_by_radius() {
+            let distance = XorMetric::distance(&self.enr.node_id().raw(), content_id);
+            distance <= self.radius
+        } else {
+            true
+        }
     }
 
     /// Returns true if all latest [Self::MAX_LIVENESS_CHECKS] liveness checks failed.

--- a/bin/portal-bridge/src/census/peer.rs
+++ b/bin/portal-bridge/src/census/peer.rs
@@ -75,9 +75,9 @@ impl Peer {
     }
 
     /// Returns true if content is within radius.
-    pub fn is_interested_in_content<TContentKey: OverlayContentKey>(
+    pub fn is_interested_in_content(
         &self,
-        content_key: &TContentKey,
+        content_key: &impl OverlayContentKey,
         content_id: &[u8; 32],
     ) -> bool {
         if content_key.affected_by_radius() {

--- a/bin/portal-bridge/src/census/peers.rs
+++ b/bin/portal-bridge/src/census/peers.rs
@@ -123,10 +123,7 @@ impl<W: Weight> Peers<W> {
     }
 
     /// Selects peers to receive content.
-    pub fn select_peers(
-        &self,
-        content_key: &impl OverlayContentKey,
-    ) -> Vec<PeerInfo> {
+    pub fn select_peers(&self, content_key: &impl OverlayContentKey) -> Vec<PeerInfo> {
         self.selector
             .select_peers(content_key, self.read().peers.values())
     }

--- a/bin/portal-bridge/src/census/peers.rs
+++ b/bin/portal-bridge/src/census/peers.rs
@@ -123,9 +123,9 @@ impl<W: Weight> Peers<W> {
     }
 
     /// Selects peers to receive content.
-    pub fn select_peers<TContentKey: OverlayContentKey>(
+    pub fn select_peers(
         &self,
-        content_key: &TContentKey,
+        content_key: &impl OverlayContentKey,
     ) -> Vec<PeerInfo> {
         self.selector
             .select_peers(content_key, self.read().peers.values())

--- a/bin/portal-bridge/src/census/peers.rs
+++ b/bin/portal-bridge/src/census/peers.rs
@@ -10,7 +10,7 @@ use delay_map::HashSetDelay;
 use discv5::enr::NodeId;
 use ethportal_api::{
     types::{client_type::ClientType, distance::Distance, portal_wire::OfferTrace},
-    Enr,
+    Enr, OverlayContentKey,
 };
 use futures::Stream;
 use tokio::time::Instant;
@@ -123,9 +123,12 @@ impl<W: Weight> Peers<W> {
     }
 
     /// Selects peers to receive content.
-    pub fn select_peers(&self, content_id: &[u8; 32]) -> Vec<PeerInfo> {
+    pub fn select_peers<TContentKey: OverlayContentKey>(
+        &self,
+        content_key: &TContentKey,
+    ) -> Vec<PeerInfo> {
         self.selector
-            .select_peers(content_id, self.read().peers.values())
+            .select_peers(content_key, self.read().peers.values())
     }
 
     fn read(&self) -> RwLockReadGuard<'_, PeersWithLivenessChecks> {

--- a/bin/portal-bridge/src/census/scoring.rs
+++ b/bin/portal-bridge/src/census/scoring.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashMap, time::Duration};
 
-use ethportal_api::types::{accept_code::AcceptCode, portal_wire::OfferTrace};
+use ethportal_api::{
+    types::{accept_code::AcceptCode, portal_wire::OfferTrace},
+    OverlayContentKey,
+};
 use itertools::Itertools;
 use rand::{rng, seq::IndexedRandom};
 
@@ -8,16 +11,22 @@ use super::peer::{Peer, PeerInfo};
 
 /// A trait for calculating peer's weight.
 pub trait Weight: Send + Sync {
-    fn weight(&self, content_id: &[u8; 32], peer: &Peer) -> u32;
-
-    fn weight_all<'a>(
+    fn weight<TContentKey: OverlayContentKey>(
         &self,
+        content_key: &TContentKey,
         content_id: &[u8; 32],
+        peer: &Peer,
+    ) -> u32;
+
+    fn weight_all<'a, TContentKey: OverlayContentKey>(
+        &self,
+        content_key: &TContentKey,
         peers: impl IntoIterator<Item = &'a Peer>,
     ) -> impl Iterator<Item = (&'a Peer, u32)> {
+        let content_id = content_key.content_id();
         peers
             .into_iter()
-            .map(|peer| (peer, self.weight(content_id, peer)))
+            .map(move |peer| (peer, self.weight(content_key, &content_id, peer)))
     }
 }
 
@@ -72,8 +81,13 @@ impl Default for AdditiveWeight {
 }
 
 impl Weight for AdditiveWeight {
-    fn weight(&self, content_id: &[u8; 32], peer: &Peer) -> u32 {
-        if !peer.is_interested_in_content(content_id) {
+    fn weight<TContentKey: OverlayContentKey>(
+        &self,
+        content_key: &TContentKey,
+        content_id: &[u8; 32],
+        peer: &Peer,
+    ) -> u32 {
+        if !peer.is_interested_in_content(content_key, content_id) {
             return 0;
         }
 
@@ -129,14 +143,14 @@ impl<W: Weight> PeerSelector<W> {
     }
 
     /// Selects up to `self.limit` peers based on their weights.
-    pub fn select_peers<'a>(
+    pub fn select_peers<'a, TContentKey: OverlayContentKey>(
         &self,
-        content_id: &[u8; 32],
+        content_key: &TContentKey,
         peers: impl IntoIterator<Item = &'a Peer>,
     ) -> Vec<PeerInfo> {
         let weighted_peers = self
             .weight
-            .weight_all(content_id, peers)
+            .weight_all(content_key, peers)
             .filter(|(_peer, weight)| *weight > 0)
             .collect_vec();
 

--- a/bin/portal-bridge/src/census/scoring.rs
+++ b/bin/portal-bridge/src/census/scoring.rs
@@ -11,16 +11,16 @@ use super::peer::{Peer, PeerInfo};
 
 /// A trait for calculating peer's weight.
 pub trait Weight: Send + Sync {
-    fn weight<TContentKey: OverlayContentKey>(
+    fn weight(
         &self,
-        content_key: &TContentKey,
+        content_key: &impl OverlayContentKey,
         content_id: &[u8; 32],
         peer: &Peer,
     ) -> u32;
 
-    fn weight_all<'a, TContentKey: OverlayContentKey>(
+    fn weight_all<'a>(
         &self,
-        content_key: &TContentKey,
+        content_key: &impl OverlayContentKey,
         peers: impl IntoIterator<Item = &'a Peer>,
     ) -> impl Iterator<Item = (&'a Peer, u32)> {
         let content_id = content_key.content_id();
@@ -81,9 +81,9 @@ impl Default for AdditiveWeight {
 }
 
 impl Weight for AdditiveWeight {
-    fn weight<TContentKey: OverlayContentKey>(
+    fn weight(
         &self,
-        content_key: &TContentKey,
+        content_key: &impl OverlayContentKey,
         content_id: &[u8; 32],
         peer: &Peer,
     ) -> u32 {
@@ -143,9 +143,9 @@ impl<W: Weight> PeerSelector<W> {
     }
 
     /// Selects up to `self.limit` peers based on their weights.
-    pub fn select_peers<'a, TContentKey: OverlayContentKey>(
+    pub fn select_peers<'a>(
         &self,
-        content_key: &TContentKey,
+        content_key: &impl OverlayContentKey,
         peers: impl IntoIterator<Item = &'a Peer>,
     ) -> Vec<PeerInfo> {
         let weighted_peers = self


### PR DESCRIPTION
Followup to #1839

### What was wrong?

The census should use distance and radius when selecting peers only if that's relevant for the provided content. 

### How was it fixed?

Added logic that uses `affected_by_radius` function

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
