### PR TITLE
fix: failed to read s3 bucket in dockerfile install ca-certificates

### DIFF
--- a/docker/Dockerfile.e2hs-writer
+++ b/docker/Dockerfile.e2hs-writer
@@ -22,9 +22,9 @@ RUN cargo build --release --locked -p e2hs-writer
 FROM ubuntu AS runtime
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y ca-certificates
+
 # copy build artifacts from build stage
 COPY --from=builder /app/target/release/e2hs-writer /usr/bin/
-
-ENV RUST_LOG=debug
 
 ENTRYPOINT ["/usr/bin/e2hs-writer"]


### PR DESCRIPTION
### What was wrong?

e2hs-writer is failing to read the s3 bucket due to not having access to `ca-certificates`

### How was it fixed?

Install them, I tested this change and it works
