### PR TITLE
feat: add retry to get_receipts

### DIFF
--- a/crates/ethereum-rpc-client/src/constants.rs
+++ b/crates/ethereum-rpc-client/src/constants.rs
@@ -21,3 +21,6 @@ pub const FALLBACK_BASE_EL_ENDPOINT: &str = "https://geth-lighthouse.mainnet.eu1
 /// We use Nimbus as the CL client, because it supports light client data by default.
 pub const DEFAULT_BASE_CL_ENDPOINT: &str = "https://nimbus-geth.mainnet.eu1.ethpandaops.io/";
 pub const FALLBACK_BASE_CL_ENDPOINT: &str = "https://nimbus.mainnet.na1.ethpandaops.io/";
+
+// Number of seconds to wait before retrying a provider request for get_receipts
+pub const GET_RECEIPTS_RETRY_AFTER: Duration = Duration::from_secs(1);

--- a/crates/ethereum-rpc-client/src/execution.rs
+++ b/crates/ethereum-rpc-client/src/execution.rs
@@ -98,11 +98,12 @@ impl ExecutionApi {
         Ok((content_key, content_value))
     }
 
-    /// This function should only be used if we know the receipts should exist.
+    /// Fetches the receipts for a given block number.
     ///
-    /// The function will retry 5 times if the receipts are not ready yet.
-    /// Especially when querying for receipts at the end of the chain their is a delay until they
-    /// become available.
+    /// The function will retry 5 times if the result is null. Execution providers may return null
+    /// for any reason,
+    /// - if receipts are not available for the block yet
+    /// - too many requests are sent to the provider to rate limit
     pub async fn get_receipts(&self, block_number: u64) -> anyhow::Result<Receipts> {
         let block_param = format!("0x{block_number:01X}");
         let params = Params::Array(vec![json!(block_param)]);

--- a/crates/ethereum-rpc-client/src/execution.rs
+++ b/crates/ethereum-rpc-client/src/execution.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error, info, warn};
 use url::Url;
 
 use super::http_client::{ClientWithBaseUrl, ContentType};
-use crate::constants::FALLBACK_RETRY_AFTER;
+use crate::constants::{FALLBACK_RETRY_AFTER, GET_RECEIPTS_RETRY_AFTER};
 
 /// Limit the number of requests in a single batch to avoid exceeding the
 /// provider's batch size limit configuration of 10.
@@ -98,13 +98,33 @@ impl ExecutionApi {
         Ok((content_key, content_value))
     }
 
+    /// This function should only be used if we know the receipts should exist.
+    ///
+    /// The function will retry 5 times if the receipts are not ready yet.
+    /// Especially when querying for receipts at the end of the chain their is a delay until they
+    /// become available.
     pub async fn get_receipts(&self, block_number: u64) -> anyhow::Result<Receipts> {
-        self.get_receipts_range(block_number..=block_number)
-            .await?
-            .remove(&block_number)
-            .ok_or_else(|| {
-                anyhow!("Unable to fetch receipts for block {block_number} from provider")
-            })
+        let block_param = format!("0x{block_number:01X}");
+        let params = Params::Array(vec![json!(block_param)]);
+        let request = JsonRequest::new("eth_getBlockReceipts".to_string(), params, 1);
+        for _ in 0..5 {
+            let response = self.try_request(request.clone()).await?;
+            let result = response.get("result").ok_or_else(|| {
+                anyhow!(
+                    "Unable to fetch block receipts result for height: {block_number} {response:?}"
+                )
+            })?;
+
+            // Check if the result is null, if so, sleep and retry.
+            if result.is_null() {
+                sleep(GET_RECEIPTS_RETRY_AFTER).await;
+                continue;
+            }
+            return serde_json::from_value(response).map_err(|err| {
+                anyhow!("Unable to parse receipts from provider response: {err:?}")
+            });
+        }
+        bail!("Unable to fetch receipts for block: {block_number}");
     }
 
     pub async fn get_receipts_range<I>(


### PR DESCRIPTION
This PR is a requirement for
- https://github.com/ethereum/trin/pull/1846

### What was wrong?

There is a delay for when receipts become available, as the EL has to generate them. I add something similar to this code because we needed it to make the latest bridge reliable. Due to the aforementioned issue above. I removed this logic in this PR https://github.com/ethereum/trin/pull/1757 well optimizing the Single-E2HS-Writer, because we no longer used this functionality.

### How was it fixed?

Added the retry mechanism back, but only for `get_receipts()`, because it isn't needed in `get_receipts_range` as that function doesn't really have a reason to be used at the head of the chain.


I choose 5, because as I have seen delays of 3 seconds