### PR TITLE
feat: add select_random_peers to census

### DIFF
--- a/bin/portal-bridge/src/census/mod.rs
+++ b/bin/portal-bridge/src/census/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, time::Duration};
 use discv5::enr::NodeId;
 use ethportal_api::{
     types::{network::Subnetwork, portal_wire::OfferTrace},
-    OverlayContentKey,
+    BeaconContentKey, HistoryContentKey, OverlayContentKey, StateContentKey,
 };
 use network::{Network, NetworkAction, NetworkInitializationConfig, NetworkManager};
 use peer::PeerInfo;
@@ -75,9 +75,22 @@ impl Census {
         content_key: &impl OverlayContentKey,
     ) -> Result<Vec<PeerInfo>, CensusError> {
         match subnetwork {
-            Subnetwork::History => self.history.select_peers(content_key),
-            Subnetwork::State => self.state.select_peers(content_key),
-            Subnetwork::Beacon => self.beacon.select_peers(content_key),
+            Subnetwork::History => self.history.select_peers(Some(content_key)),
+            Subnetwork::State => self.state.select_peers(Some(content_key)),
+            Subnetwork::Beacon => self.beacon.select_peers(Some(content_key)),
+            _ => Err(CensusError::UnsupportedSubnetwork(subnetwork)),
+        }
+    }
+
+    /// Selects random peers to receive content.
+    pub fn select_random_peers(
+        &self,
+        subnetwork: Subnetwork,
+    ) -> Result<Vec<PeerInfo>, CensusError> {
+        match subnetwork {
+            Subnetwork::History => self.history.select_peers(None::<&HistoryContentKey>),
+            Subnetwork::State => self.state.select_peers(None::<&StateContentKey>),
+            Subnetwork::Beacon => self.beacon.select_peers(None::<&BeaconContentKey>),
             _ => Err(CensusError::UnsupportedSubnetwork(subnetwork)),
         }
     }

--- a/bin/portal-bridge/src/census/network.rs
+++ b/bin/portal-bridge/src/census/network.rs
@@ -108,7 +108,7 @@ impl Network {
     /// Selects peers to receive content.
     pub fn select_peers(
         &self,
-        content_key: &impl OverlayContentKey,
+        content_key: Option<&impl OverlayContentKey>,
     ) -> Result<Vec<PeerInfo>, CensusError> {
         if self.peers.is_empty() {
             error!(

--- a/bin/portal-bridge/src/census/peers.rs
+++ b/bin/portal-bridge/src/census/peers.rs
@@ -123,7 +123,7 @@ impl<W: Weight> Peers<W> {
     }
 
     /// Selects peers to receive content.
-    pub fn select_peers(&self, content_key: &impl OverlayContentKey) -> Vec<PeerInfo> {
+    pub fn select_peers(&self, content_key: Option<&impl OverlayContentKey>) -> Vec<PeerInfo> {
         self.selector
             .select_peers(content_key, self.read().peers.values())
     }


### PR DESCRIPTION
### What was wrong?

This is a chunk from https://github.com/ethereum/trin/pull/1846

`select_peers()` take a content_key this doesn't make when gossiping a series of EphemeralHeadersByOffer as we just want working random Enr's

### How was it fixed?

At the top level of `census` add a function `select_random_peers()`, then just pass an option from there down.
