### PR TITLE
chore: fix confusing comment in E2HSManager

### DIFF
--- a/bin/trin-execution/src/e2hs/manager.rs
+++ b/bin/trin-execution/src/e2hs/manager.rs
@@ -60,7 +60,7 @@ impl E2HSManager {
 
     pub async fn last_fetched_block(&self) -> anyhow::Result<&ProcessedBlock> {
         let Some(current_e2hs) = &self.current_e2hs else {
-            bail!("No blocks were fetched yet, current_e2hs is initialized in get_next_block");
+            bail!("No blocks were fetched yet, last_fetched_block is available only after successful get_next_block");
         };
         ensure!(
             self.next_block_number > 0,

--- a/bin/trin-execution/src/e2hs/manager.rs
+++ b/bin/trin-execution/src/e2hs/manager.rs
@@ -60,7 +60,7 @@ impl E2HSManager {
 
     pub async fn last_fetched_block(&self) -> anyhow::Result<&ProcessedBlock> {
         let Some(current_e2hs) = &self.current_e2hs else {
-            panic!("current_e2hs should always be present, perhaps it wasn't initialized in E2HSManager::new()?");
+            bail!("No blocks were fetched yet, current_e2hs is initialized in get_next_block");
         };
         ensure!(
             self.next_block_number > 0,


### PR DESCRIPTION
### What was wrong?

There was some confusion on a confusing comment https://github.com/ethereum/trin/pull/1855#discussion_r2106156634

### How was it fixed?

Updating the comment to be more accuate