### PR TITLE
fix: regression on recoverying transaction address after version update

### DIFF
--- a/bin/trin-execution/src/e2hs/beacon.rs
+++ b/bin/trin-execution/src/e2hs/beacon.rs
@@ -2,6 +2,7 @@ use alloy::{
     consensus::{transaction::SignerRecoverable, TxEnvelope},
     eips::eip4895::Withdrawal,
 };
+use anyhow::anyhow;
 use ethportal_api::{
     consensus::beacon_block::{
         SignedBeaconBlock, SignedBeaconBlockBellatrix, SignedBeaconBlockCapella,
@@ -120,12 +121,12 @@ fn process_transactions(
         .into_par_iter()
         .map(|transaction| {
             transaction
-                .recover_signer()
+                .recover_signer_unchecked()
                 .map(|sender_address| TransactionsWithSender {
                     sender_address,
                     transaction,
                 })
-                .map_err(|err| anyhow::anyhow!("Failed to recover signer: {err:?}"))
+                .map_err(|err| anyhow!("Failed to recover signer: {err:?}"))
         })
         .collect::<anyhow::Result<Vec<_>>>()
 }


### PR DESCRIPTION
### What was wrong?
We updated from alloy-consensus 1.0.3 to 1.0.7 the behavior changed though which broke Trin Execution executing blocks
### How was it fixed?

Update `recover_signer` to `recover_signer_unchecked` which matched the functionality of the 1.0.3 version 
