### PR TITLE
feat(portalnet): handle content that doesn't depend on distance to content

### DIFF
--- a/crates/portalnet/src/gossip/mod.rs
+++ b/crates/portalnet/src/gossip/mod.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+
+use discv5::Enr;
+use ethportal_api::{
+    types::{distance::Metric, portal::MAX_CONTENT_KEYS_PER_OFFER},
+    utils::bytes::hex_encode_compact,
+    OverlayContentKey, RawContentKey, RawContentValue,
+};
+use itertools::{chain, Itertools};
+use tracing::{debug, warn};
+
+use crate::types::kbucket::SharedKBucketsTable;
+
+mod neighborhood;
+mod random;
+
+/// Selects peers and content that should be gossiped to them.
+///
+/// Every peer will have at least 1 and at most `MAX_CONTENT_KEYS_PER_OFFER` content assigned to
+/// them. If more than `MAX_CONTENT_KEYS_PER_OFFER` is passed as an argument, it's possible that
+/// no peers will be selected to propagate that content (even if they exist). The order of content
+/// in the returned collection will be the same as the one that is passed (this might be important
+/// for some content types).
+///
+/// This function is designed such that either all content is affected by radius (in which case we
+/// use "neighborhood gossip" strategy) or not (in which case we use "random gossip" strategy).
+/// If content contains the mix of the two types, then content is split and each gossip strategy is
+/// applied to respective part. This can lead to suboptimal result when we select more peers than
+/// it is needed.
+pub fn gossip_recipients<TContentKey: OverlayContentKey, TMetric: Metric>(
+    content: Vec<(TContentKey, RawContentValue)>,
+    kbuckets: &SharedKBucketsTable,
+) -> HashMap<Enr, Vec<(RawContentKey, RawContentValue)>> {
+    // Precalculate "content_id" and "raw_content_key" and use references going forward
+    let content = content
+        .into_iter()
+        .map(|(key, raw_value)| {
+            let id = key.content_id();
+            let raw_key = key.to_bytes();
+            (id, key, raw_key, raw_value)
+        })
+        .collect::<Vec<_>>();
+
+    debug!(
+        ids = ?content.iter().map(|(id, _, _, _)| hex_encode_compact(id)),
+        "selecing gossip recipients"
+    );
+
+    // Split content id+key depending on whether they are affected by radius
+    let (content_for_neighborhood_gossip, content_for_random_gossip) = content
+        .iter()
+        .map(|(id, key, _raw_key, _raw_value)| (id, key))
+        .partition::<Vec<_>, _>(|(_content_id, content_key)| content_key.affected_by_radius());
+    if !content_for_neighborhood_gossip.is_empty() && !content_for_random_gossip.is_empty() {
+        warn!("Expected to gossip content with both neighborhood_gossip and random_gossip");
+    }
+
+    // Combine results of "neighborhood gossip" and "random gossip".
+    let peer_to_content_ids = chain!(
+        neighborhood::gossip_recipients::<_, TMetric>(content_for_neighborhood_gossip, kbuckets),
+        random::gossip_recipients(content_for_random_gossip, kbuckets)
+    )
+    .into_grouping_map()
+    .reduce(|mut all_content_to_gossip, _enr, content_ids| {
+        all_content_to_gossip.extend(content_ids);
+        all_content_to_gossip
+    });
+
+    // Extract raw content key/value in hash map for easier lookup.
+    let raw_content = content
+        .iter()
+        .map(|(id, _key, raw_key, raw_value)| (id, (raw_key, raw_value)))
+        .collect::<HashMap<_, _>>();
+
+    peer_to_content_ids
+        .into_iter()
+        .map(|(enr, content_ids)| {
+            let raw_content_key_value = content_ids
+                .into_iter()
+                // Select at most `MAX_CONTENT_KEYS_PER_OFFER`
+                .take(MAX_CONTENT_KEYS_PER_OFFER)
+                .map(|content_id| {
+                    let (raw_content_key, raw_content_value) = raw_content[content_id];
+                    (raw_content_key.clone(), raw_content_value.clone())
+                })
+                .collect();
+            (enr, raw_content_key_value)
+        })
+        .collect()
+}

--- a/crates/portalnet/src/gossip/neighborhood.rs
+++ b/crates/portalnet/src/gossip/neighborhood.rs
@@ -1,0 +1,222 @@
+use std::collections::HashMap;
+
+use alloy::hex::ToHexExt;
+use discv5::Enr;
+use ethportal_api::{types::distance::Metric, OverlayContentKey};
+use rand::{rng, seq::IteratorRandom};
+use tracing::{debug, error};
+
+use crate::types::kbucket::SharedKBucketsTable;
+
+pub fn gossip_recipients<'c, TContentKey: OverlayContentKey, TMetric: Metric>(
+    content: Vec<(&'c [u8; 32], &TContentKey)>,
+    kbuckets: &SharedKBucketsTable,
+) -> HashMap<Enr, Vec<&'c [u8; 32]>> {
+    if content.is_empty() {
+        return HashMap::new();
+    }
+
+    let content_ids = content
+        .iter()
+        .map(|(content_id, _content_key)| *content_id)
+        .collect::<Vec<_>>();
+
+    // Map from content_ids to interested ENRs
+    let mut content_id_to_interested_enrs = kbuckets.batch_interested_enrs::<TMetric>(&content_ids);
+
+    // Map from ENRs to content they will put content
+    let mut enrs_and_content: HashMap<Enr, Vec<&'c [u8; 32]>> = HashMap::new();
+    for (content_id, content_key) in content {
+        let interested_enrs = content_id_to_interested_enrs.remove(content_id).unwrap_or_else(|| {
+            error!("interested_enrs should contain all content ids, even if there are no interested ENRs");
+            vec![]
+        });
+        if interested_enrs.is_empty() {
+            debug!(
+                content.id = content_id.encode_hex_with_prefix(),
+                content.key = %content_key.to_bytes(),
+                "No peers eligible for neighborhood gossip"
+            );
+            continue;
+        };
+
+        // Select content recipients
+        for enr in select_content_recipients::<TMetric>(content_id, interested_enrs) {
+            enrs_and_content.entry(enr).or_default().push(content_id);
+        }
+    }
+    enrs_and_content
+}
+
+const NUM_CLOSEST_PEERS: usize = 4;
+const NUM_FARTHER_PEERS: usize = 4;
+
+/// Selects put content recipients from a vec of interested peers.
+///
+/// If number of peers is at most `NUM_CLOSEST_PEERS + NUM_FARTHER_PEERS`, then all are returned.
+/// Otherwise, peers are sorted by distance from `content_id` and then:
+///
+/// 1. Closest `NUM_CLOSEST_PEERS` ENRs are selected
+/// 2. Random `NUM_FARTHER_PEERS` ENRs are selected from the rest
+fn select_content_recipients<TMetric: Metric>(
+    content_id: &[u8; 32],
+    mut peers: Vec<Enr>,
+) -> Vec<Enr> {
+    // Check if we need to do any selection
+    if peers.len() <= NUM_CLOSEST_PEERS + NUM_FARTHER_PEERS {
+        return peers;
+    }
+
+    // Sort peers by distance
+    peers.sort_by_cached_key(|peer| TMetric::distance(content_id, &peer.node_id().raw()));
+
+    // Split of at NUM_CLOSEST_PEERS
+    let farther_peers = peers.split_off(NUM_CLOSEST_PEERS);
+
+    // Select random NUM_FARTHER_PEERS
+    peers.extend(
+        farther_peers
+            .into_iter()
+            .choose_multiple(&mut rng(), NUM_FARTHER_PEERS),
+    );
+
+    peers
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter;
+
+    use discv5::enr::NodeId;
+    use ethportal_api::{
+        types::{
+            distance::{Distance, XorMetric},
+            enr::generate_random_remote_enr,
+        },
+        IdentityContentKey,
+    };
+    use rand::random;
+    use rstest::rstest;
+
+    use super::*;
+
+    #[test]
+    fn empty() {
+        let kbuckets = SharedKBucketsTable::new_for_tests(NodeId::random());
+
+        for _ in 0..NUM_CLOSEST_PEERS {
+            let (_, peer) = generate_random_remote_enr();
+            let _ = kbuckets.insert_or_update_disconnected(&peer, Distance::MAX);
+        }
+
+        assert!(gossip_recipients::<IdentityContentKey, XorMetric>(vec![], &kbuckets).is_empty());
+    }
+
+    mod select_content_recipients {
+        use std::ops::RangeBounds;
+
+        use itertools::chain;
+
+        use super::*;
+
+        fn create_peers_with_distance(
+            count: usize,
+            content_id: &[u8; 32],
+            log2_distances: impl RangeBounds<usize>,
+        ) -> Vec<Enr> {
+            iter::repeat_with(|| generate_random_remote_enr().1)
+                .filter(|peer| {
+                    log2_distances.contains(
+                        &XorMetric::distance(content_id, &peer.node_id().raw())
+                            .log2()
+                            .unwrap(),
+                    )
+                })
+                .take(count)
+                .collect()
+        }
+
+        #[rstest]
+        #[case(0, 0)]
+        #[case(NUM_CLOSEST_PEERS - 1, NUM_CLOSEST_PEERS - 1)]
+        #[case(NUM_CLOSEST_PEERS, NUM_CLOSEST_PEERS)]
+        #[case(NUM_CLOSEST_PEERS + 1, NUM_CLOSEST_PEERS + 1)]
+        #[case(NUM_CLOSEST_PEERS + NUM_FARTHER_PEERS, NUM_CLOSEST_PEERS + NUM_FARTHER_PEERS)]
+        #[case(NUM_CLOSEST_PEERS + NUM_FARTHER_PEERS + 1, NUM_CLOSEST_PEERS + NUM_FARTHER_PEERS)]
+        #[case(256, NUM_CLOSEST_PEERS + NUM_FARTHER_PEERS)]
+        fn count(#[case] peers_count: usize, #[case] expected_content_recipients_count: usize) {
+            let content_id = random();
+            let peers = create_peers_with_distance(peers_count, &content_id, ..);
+            assert_eq!(
+                select_content_recipients::<XorMetric>(&content_id, peers).len(),
+                expected_content_recipients_count
+            );
+        }
+
+        #[test]
+        fn closest() {
+            let content_id = random();
+
+            const CLOSE_PEER_LOG2_DISTANCE: usize = 253;
+
+            // Create NUM_CLOSEST_PEERS peers with log2 distance less than CLOSE_PEER_LOG2_DISTANCE
+            let close_peers = create_peers_with_distance(
+                NUM_CLOSEST_PEERS,
+                &content_id,
+                ..CLOSE_PEER_LOG2_DISTANCE,
+            );
+
+            // Create 1000 peers with log2 distance at least CLOSE_PEER_LOG2_DISTANCE
+            let far_peers =
+                create_peers_with_distance(1000, &content_id, CLOSE_PEER_LOG2_DISTANCE..);
+
+            let recipients = select_content_recipients::<XorMetric>(
+                &content_id,
+                chain!(close_peers.clone(), far_peers).collect(),
+            );
+
+            // Verify that `NUM_CLOSEST_PEERS + NUM_FARTHER_PEERS` peers selected
+            assert_eq!(recipients.len(), NUM_CLOSEST_PEERS + NUM_FARTHER_PEERS);
+
+            // Verify that all close peers are selected
+            for close_peer in close_peers {
+                assert!(recipients.contains(&close_peer));
+            }
+        }
+
+        #[test]
+        fn closest_far_peer_is_not_selected() {
+            let content_id = random();
+            const TARGET_PEER_DISTANCE: usize = 253;
+
+            // Create NUM_CLOSEST_PEERS peers with log2 distance less than TARGET_PEER_DISTANCE
+            let close_peers =
+                create_peers_with_distance(NUM_CLOSEST_PEERS, &content_id, ..TARGET_PEER_DISTANCE);
+
+            // Create 1 peer with log2 distance exactly TARGET_PEER_DISTANCE
+            let target_peer = create_peers_with_distance(
+                1,
+                &content_id,
+                TARGET_PEER_DISTANCE..=TARGET_PEER_DISTANCE,
+            )
+            .remove(0);
+
+            // Create 1000 peers with log2 distance more than TARGET_PEER_DISTANCE
+            let far_peers =
+                create_peers_with_distance(1000, &content_id, TARGET_PEER_DISTANCE + 1..);
+
+            let all_peers =
+                chain!(close_peers, [target_peer.clone()], far_peers).collect::<Vec<_>>();
+
+            // We want to test that "target_peer" isn't selected.
+            // However, because far peers are selected randomly, there is a small chance of being
+            // selected anyway (0.4%). But we will just repeat the test up to 10 times, as it is
+            // extremely unlikely to be selected all 10 times.
+            let target_peer_is_not_selected = || {
+                !select_content_recipients::<XorMetric>(&content_id, all_peers.clone())
+                    .contains(&target_peer)
+            };
+            assert!((0..10).any(|_| target_peer_is_not_selected()));
+        }
+    }
+}

--- a/crates/portalnet/src/gossip/random.rs
+++ b/crates/portalnet/src/gossip/random.rs
@@ -1,0 +1,98 @@
+use std::collections::HashMap;
+
+use discv5::Enr;
+use ethportal_api::OverlayContentKey;
+
+use crate::types::kbucket::SharedKBucketsTable;
+
+const NUM_PEERS: usize = 8;
+
+pub fn gossip_recipients<'c, TContentKey: OverlayContentKey>(
+    content: Vec<(&'c [u8; 32], &TContentKey)>,
+    kbuckets: &SharedKBucketsTable,
+) -> HashMap<Enr, Vec<&'c [u8; 32]>> {
+    if content.is_empty() {
+        return HashMap::new();
+    }
+
+    let content_ids = content
+        .into_iter()
+        .map(|(content_id, _content_key)| content_id)
+        .collect::<Vec<_>>();
+    kbuckets
+        .random_peers(NUM_PEERS)
+        .into_iter()
+        .map(|peer| (peer, content_ids.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter;
+
+    use discv5::enr::NodeId;
+    use ethportal_api::{
+        generate_random_remote_enr, types::distance::Distance, IdentityContentKey,
+    };
+
+    use super::*;
+
+    fn assert_gossip_recipients(
+        content: impl IntoIterator<Item = IdentityContentKey>,
+        kbuckets: &SharedKBucketsTable,
+        expected_recipients_count: usize,
+    ) {
+        let (ids, keys): (Vec<_>, Vec<_>) = content
+            .into_iter()
+            .map(|key| (key.content_id(), key))
+            .unzip();
+        let recipients = gossip_recipients(iter::zip(&ids, &keys).collect(), kbuckets);
+        assert_eq!(recipients.len(), expected_recipients_count);
+        for (_peer, content) in recipients {
+            assert_eq!(content, ids.iter().collect::<Vec<_>>());
+        }
+    }
+
+    #[test]
+    fn empty() {
+        let kbuckets = SharedKBucketsTable::new_for_tests(NodeId::random());
+
+        for _ in 0..NUM_PEERS {
+            let (_, peer) = generate_random_remote_enr();
+            let _ = kbuckets.insert_or_update_disconnected(&peer, Distance::MAX);
+        }
+
+        assert!(gossip_recipients::<IdentityContentKey>(vec![], &kbuckets).is_empty());
+    }
+
+    #[test]
+    fn zero_distance() {
+        let kbuckets = SharedKBucketsTable::new_for_tests(NodeId::random());
+        let (_, peer) = generate_random_remote_enr();
+        let _ = kbuckets.insert_or_update_connected(&peer, Distance::ZERO);
+
+        assert_gossip_recipients(
+            iter::repeat_with(IdentityContentKey::random).take(5),
+            &kbuckets,
+            1,
+        );
+    }
+
+    #[test]
+    fn max_peers() {
+        let kbuckets = SharedKBucketsTable::new_for_tests(NodeId::random());
+
+        let mut peers = vec![];
+        for _ in 0..(NUM_PEERS * 2) {
+            let (_, peer) = generate_random_remote_enr();
+            let _ = kbuckets.insert_or_update_connected(&peer, Distance::MAX);
+            peers.push(peer);
+        }
+
+        assert_gossip_recipients(
+            iter::repeat_with(IdentityContentKey::random).take(5),
+            &kbuckets,
+            NUM_PEERS,
+        );
+    }
+}

--- a/crates/portalnet/src/lib.rs
+++ b/crates/portalnet/src/lib.rs
@@ -8,6 +8,7 @@ pub mod constants;
 pub mod discovery;
 pub mod events;
 pub mod find;
+pub mod gossip;
 pub mod overlay;
 pub mod put_content;
 pub mod socket;

--- a/crates/portalnet/src/put_content.rs
+++ b/crates/portalnet/src/put_content.rs
@@ -1,20 +1,17 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use ethportal_api::{
     types::{
         distance::Metric,
-        enr::Enr,
-        portal::MAX_CONTENT_KEYS_PER_OFFER,
         portal_wire::{PopulatedOffer, Request},
     },
-    utils::bytes::{hex_encode, hex_encode_compact},
     OverlayContentKey, RawContentValue,
 };
-use rand::{rng, Rng};
 use tokio::sync::mpsc;
-use tracing::{debug, error, trace, warn};
+use tracing::{error, trace};
 
 use crate::{
+    gossip::gossip_recipients,
     overlay::{
         command::OverlayCommand,
         request::{OverlayRequest, RequestDirection},
@@ -31,51 +28,11 @@ pub fn propagate_put_content_cross_thread<TContentKey: OverlayContentKey, TMetri
     command_tx: mpsc::UnboundedSender<OverlayCommand<TContentKey>>,
     utp_controller: Option<Arc<UtpController>>,
 ) -> usize {
-    // Precalculate content ids
-    let content = content
-        .into_iter()
-        .map(|(content_key, content_value)| {
-            (content_key.content_id(), (content_key, content_value))
-        })
-        .collect::<HashMap<_, _>>();
-
-    let content_ids = content.keys().collect::<Vec<_>>();
-    debug!(
-        ids = ?content_ids.iter().map(hex_encode_compact),
-        "propagating validated content",
-    );
-
-    // Map from content_ids to interested ENRs
-    let mut content_id_to_interested_enrs = kbuckets.batch_interested_enrs::<TMetric>(&content_ids);
-
-    // Map from ENRs to content they will put content
-    let mut enrs_and_content: HashMap<Enr, Vec<&(TContentKey, RawContentValue)>> = HashMap::new();
-    for (content_id, content_key_value) in &content {
-        let interested_enrs = content_id_to_interested_enrs.remove(content_id).unwrap_or_else(|| {
-            error!("interested_enrs should contain all content ids, even if there are no interested ENRs");
-            vec![]
-        });
-        if interested_enrs.is_empty() {
-            debug!(
-                content.id = %hex_encode(content_id),
-                "No peers eligible for neighborhood gossip"
-            );
-            continue;
-        };
-
-        // Select put content recipients
-        for enr in select_put_content_recipients::<TMetric>(content_id, interested_enrs) {
-            enrs_and_content
-                .entry(enr)
-                .or_default()
-                .push(content_key_value);
-        }
-    }
-
-    let num_propagated_peers = enrs_and_content.len();
+    let gossip_recipients = gossip_recipients::<_, TMetric>(content, kbuckets);
+    let num_propagated_peers = gossip_recipients.len();
 
     // Create and send OFFER overlay request to the interested nodes
-    for (enr, mut interested_content) in enrs_and_content {
+    for (enr, content_items) in gossip_recipients {
         let permit = match utp_controller {
             Some(ref utp_controller) => match utp_controller.get_outbound_semaphore() {
                 Some(permit) => Some(permit),
@@ -87,32 +44,8 @@ pub fn propagate_put_content_cross_thread<TContentKey: OverlayContentKey, TMetri
             None => None,
         };
 
-        // offer messages are limited to 64 content keys
-        if interested_content.len() > MAX_CONTENT_KEYS_PER_OFFER {
-            warn!(
-                enr = %enr,
-                content.len = interested_content.len(),
-                "Too many content items to offer to a single peer, dropping {}.",
-                interested_content.len() - MAX_CONTENT_KEYS_PER_OFFER
-            );
-            // sort content keys by distance to the node
-            interested_content.sort_by_cached_key(|(key, _)| {
-                TMetric::distance(&key.content_id(), &enr.node_id().raw())
-            });
-            // take 64 closest content keys
-            interested_content.truncate(MAX_CONTENT_KEYS_PER_OFFER);
-        }
-        // change content keys to raw content keys
-        let interested_content = interested_content
-            .into_iter()
-            .map(|(key, value)| (key.to_bytes(), value.clone()))
-            .collect();
-        let offer_request = Request::PopulatedOffer(PopulatedOffer {
-            content_items: interested_content,
-        });
-
         let overlay_request = OverlayRequest::new(
-            offer_request,
+            Request::PopulatedOffer(PopulatedOffer { content_items }),
             RequestDirection::Outgoing { destination: enr },
             None,
             None,
@@ -125,66 +58,4 @@ pub fn propagate_put_content_cross_thread<TContentKey: OverlayContentKey, TMetri
     }
 
     num_propagated_peers
-}
-
-const NUM_CLOSEST_NODES: usize = 4;
-const NUM_FARTHER_NODES: usize = 4;
-
-/// Selects put content recipients from a vec of interested ENRs.
-///
-/// If number of ENRs is at most `NUM_CLOSEST_NODES + NUM_FARTHER_NODES`, then all are returned.
-/// Otherwise, ENRs are sorted by distance from `content_id` and then:
-///
-/// 1. Closest `NUM_CLOSEST_NODES` ENRs are selected
-/// 2. Random `NUM_FARTHER_NODES` ENRs are selected from the rest
-fn select_put_content_recipients<TMetric: Metric>(
-    content_id: &[u8; 32],
-    mut enrs: Vec<Enr>,
-) -> Vec<Enr> {
-    // Check if we need to do any selection
-    if enrs.len() <= NUM_CLOSEST_NODES + NUM_FARTHER_NODES {
-        return enrs;
-    }
-
-    // Sort enrs by distance
-    enrs.sort_by_cached_key(|enr| TMetric::distance(content_id, &enr.node_id().raw()));
-
-    // Split of at NUM_CLOSEST_NODES
-    let mut farther_enrs = enrs.split_off(NUM_CLOSEST_NODES);
-
-    // Select random NUM_FARTHER_NODES
-    let mut rng = rng();
-    for _ in 0..NUM_FARTHER_NODES {
-        let enr = farther_enrs.swap_remove(rng.random_range(0..farther_enrs.len()));
-        enrs.push(enr);
-    }
-
-    enrs
-}
-
-#[cfg(test)]
-#[allow(clippy::unwrap_used)]
-mod tests {
-    use ethportal_api::types::{distance::XorMetric, enr::generate_random_remote_enr};
-    use rand::random;
-    use rstest::rstest;
-
-    use super::*;
-
-    #[allow(clippy::zero_repeat_side_effects)]
-    #[rstest]
-    #[case(vec![generate_random_remote_enr().1; 0], 0)]
-    #[case(vec![generate_random_remote_enr().1; NUM_CLOSEST_NODES - 1], NUM_CLOSEST_NODES - 1)]
-    #[case(vec![generate_random_remote_enr().1; NUM_CLOSEST_NODES], NUM_CLOSEST_NODES)]
-    #[case(vec![generate_random_remote_enr().1; NUM_CLOSEST_NODES + 1], NUM_CLOSEST_NODES + 1)]
-    #[case(vec![generate_random_remote_enr().1; NUM_CLOSEST_NODES + NUM_FARTHER_NODES], NUM_CLOSEST_NODES + NUM_FARTHER_NODES)]
-    #[case(vec![generate_random_remote_enr().1; 256], NUM_CLOSEST_NODES + NUM_FARTHER_NODES)]
-    fn test_select_put_content_recipients_no_panic(
-        #[case] all_nodes: Vec<Enr>,
-        #[case] expected_size: usize,
-    ) {
-        let put_content_recipients =
-            select_put_content_recipients::<XorMetric>(&random(), all_nodes);
-        assert_eq!(put_content_recipients.len(), expected_size);
-    }
 }


### PR DESCRIPTION
### What was wrong?

The `portalnet` crate didn't handle the content that doesn't depend on distance to content (e.g. ephemeral headers).

Some examples:

- use random gossip when:
    - receiving content via `Offer`
    - during PutContent json rpc
- selecting peers when initiating `FindContent`
    - we should select random peers
- deciding whether to poke the content to the peer
    - before, we would use radius to decide if peer should store the content, which doesn't apply in this case
- replying to `FindContent` requests (see [discord discussion](https://discord.com/channels/595666850260713488/1331654743847731200/1375208564909674660))
    - we should send empty peer list

### How was it fixed?

We now handle all cases from above.

I extracted some/most of the logic from `crates/portalnet/src/put_content.rs` and put it in `crates/portalnet/src/gossip/neighborhood.rs`.

Added various gossip unit tests.
