### PR TITLE
fix: trin version is incorrect

### DIFF
--- a/crates/ethportal-api/build.rs
+++ b/crates/ethportal-api/build.rs
@@ -10,8 +10,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         .target_triple(true)
         .build()?;
     let git2 = Git2Builder::default()
-        .describe(false, true, None)
-        .dirty(true)
+        .describe(
+            /* tags= */ true, /* dirty= */ false, /* matches= */ None,
+        )
         .sha(false)
         .build()?;
     let rustc = RustcBuilder::default().semver(true).build()?;


### PR DESCRIPTION
### What was wrong?

The trin's [client version graph](https://glados.ethdevops.io/clients?network=History) in Glados indicates that majority of our nodes are running version "0.1.0".

### How was it fixed?

After some debugging I found that there was a regression introduced in #1834 

The `vergen` crate was significantly refactored and the order of parameters changed between original [`EmitBuilder::git_describe`](https://docs.rs/vergen/8.3.2/vergen/struct.EmitBuilder.html#method.git_describe) and new [`Git2Builder::describe`](https://docs.rs/vergen-git2/1.0.7/vergen_git2/struct.Git2Builder.html#method.describe).
