### PR TITLE
fix(trin-execution): regression | tx_env modify + no withdrawals + traces broken

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6290,9 +6290,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "23.1.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1eb83c8652836bc0422f9a144522179134d8befcc7ab595c1ada60dac39e51"
+checksum = "6d3ae9d1b08303eb5150dcf820a29e14235cf3f24f6c09024458a4dcbffe6695"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -6322,9 +6322,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd6faa992a1a10b84723326d6117203764c040d3519fd1ba34950d049389eb7"
+checksum = "b181214eb2bbb76ee9d6195acba19857d991d2cdb9a65b7cb6939c30250a3966"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -6338,9 +6338,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2b42cac141cd388c38db420d3d18e7b23013c5747d5ed648d2d9a225263d51"
+checksum = "1b844f48a411e62c7dde0f757bf5cce49c85b86d6fc1d3b2722c07f2bec4c3ce"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -6380,9 +6380,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511e50a8c7f14e97681ec96266ee53bf8316c0dea1d4a6633ff6f37c5c0fe9d0"
+checksum = "08a9204e3ac1a8edb850cc441a6a1d0f2251c0089e5fffdaba11566429e6c64e"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -6398,9 +6398,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f6c88fcf481f8e315bfd87377aa0ae83e1159dd381430122cbf431474ce39c"
+checksum = "ae4881eeae6ff35417c8569bc7cc03b6c0969869ee2c9b3945a39b4f9fa58bc5"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -6415,9 +6415,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f847f5e88a09ac84b36529fbe2fee80b3d8bbf91e9a7ae3ea856c4125d0d232"
+checksum = "4b50ef375dbacefecfdacf8f02afc31df98acc5d8859a6f2b24d121ff2a740a8"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -6433,9 +6433,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "19.1.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b7d75106333808bc97df3cd6a1864ced4ffec9be28fd3e459733813f3c300e"
+checksum = "b5ee65e57375c6639b0f50555e92a4f1b2434349dd32f52e2176f5c711171697"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -6445,9 +6445,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "20.1.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06769068a34fd237c74193118530af3912e1b16922137a96fc302f29c119966"
+checksum = "0f9311e735123d8d53a02af2aa81877bba185be7c141be7f931bb3d2f3af449c"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ rand = "0.9"
 rayon = "1.10.0"
 reqwest = { version = "0.12.7", features = ["native-tls-vendored", "json"] }
 reth-ipc = { tag = "v1.3.12", git = "https://github.com/paradigmxyz/reth.git"}
-revm = { version = "23.1", default-features = false, features = ["std", "secp256k1", "serde-json", "c-kzg"] }
+revm = { version = "24.0", default-features = false, features = ["std", "secp256k1", "serde-json", "c-kzg"] }
 revm-primitives = { version = "19.0.0", default-features = false, features = ["std", "serde"] }
 rstest = "0.25"
 rust-embed = "8.5.0"

--- a/bin/trin-execution/Cargo.toml
+++ b/bin/trin-execution/Cargo.toml
@@ -31,7 +31,7 @@ rand.workspace = true
 rayon.workspace = true
 reqwest =  { workspace = true, features = ["stream"] }
 revm.workspace = true
-revm-inspectors = "0.22"
+revm-inspectors = "0.23"
 revm-primitives.workspace = true
 rocksdb = "0.23"
 serde = { workspace = true, features = ["rc"] }

--- a/bin/trin-execution/src/e2hs/utils.rs
+++ b/bin/trin-execution/src/e2hs/utils.rs
@@ -34,7 +34,7 @@ pub fn process_e2hs_file(raw_e2hs: &[u8]) -> anyhow::Result<ProcessedE2HS> {
         blocks.push(ProcessedBlock {
             header: header_with_proof.header_with_proof.header,
             uncles: Some(body.body.0.ommers),
-            withdrawals: None,
+            withdrawals: body.body.0.withdrawals.map(|withdrawals| withdrawals.0),
             transactions: transactions_with_recovered_senders,
         });
     }

--- a/bin/trin-execution/src/evm/block_executor.rs
+++ b/bin/trin-execution/src/evm/block_executor.rs
@@ -12,7 +12,7 @@ use revm::{
     database::{states::bundle_state::BundleRetention, State},
     handler::MainnetContext,
     inspector::inspectors::TracerEip3155,
-    Context, DatabaseCommit, ExecuteEvm, MainBuilder, MainnetEvm,
+    Context, DatabaseCommit, ExecuteEvm, InspectEvm, MainBuilder, MainnetEvm,
 };
 use revm_primitives::{hardfork::SpecId, keccak256, Address, B256, U256};
 use serde::{Deserialize, Serialize};
@@ -228,7 +228,7 @@ impl BlockExecutor {
         let result = match tracer_fn(&tx.transaction) {
             Some(tracer) => {
                 create_evm_with_tracer(self.evm.block().clone(), tx, self.evm.db(), tracer)
-                    .replay()?
+                    .inspect_replay()?
             }
             None => self.evm.replay()?,
         };

--- a/crates/evm/src/tx_env_modifier.rs
+++ b/crates/evm/src/tx_env_modifier.rs
@@ -1,9 +1,8 @@
 use alloy::{
     consensus::{TxEip1559, TxEip2930, TxEip4844, TxLegacy},
-    eips::eip2930::{AccessList, AccessListItem},
     rpc::types::TransactionRequest,
 };
-use revm::context::{TransactTo, TxEnv};
+use revm::context::TxEnv;
 use revm_primitives::{hardfork::SpecId, TxKind};
 
 use super::spec_id::get_spec_id;
@@ -14,102 +13,89 @@ pub trait TxEnvModifier {
 
 impl TxEnvModifier for TxLegacy {
     fn modify(&self, block_number: u64, tx_env: &mut TxEnv) {
-        tx_env.gas_limit = self.gas_limit;
-        tx_env.gas_price = self.gas_price;
-        tx_env.gas_priority_fee = None;
-        tx_env.kind = match self.to {
-            TxKind::Call(to) => TransactTo::Call(to),
-            TxKind::Create => TransactTo::Create,
+        *tx_env = TxEnv {
+            tx_type: 0,
+            caller: tx_env.caller,
+            gas_limit: self.gas_limit,
+            gas_price: self.gas_price,
+            kind: self.to,
+            value: self.value,
+            data: self.input.clone(),
+            nonce: self.nonce,
+            chain_id: if get_spec_id(block_number).is_enabled_in(SpecId::SPURIOUS_DRAGON) {
+                Some(1)
+            } else {
+                None
+            },
+            access_list: Default::default(),
+            gas_priority_fee: None,
+            blob_hashes: Default::default(),
+            max_fee_per_blob_gas: Default::default(),
+            authorization_list: Default::default(),
         };
-        tx_env.value = self.value;
-        tx_env.data = self.input.clone();
-        tx_env.chain_id = if get_spec_id(block_number).is_enabled_in(SpecId::SPURIOUS_DRAGON) {
-            Some(1)
-        } else {
-            None
-        };
-        tx_env.nonce = self.nonce;
-        tx_env.access_list = AccessList::default();
-        tx_env.blob_hashes.clear();
-        tx_env.max_fee_per_blob_gas = 0;
-    }
-}
-
-impl TxEnvModifier for TxEip1559 {
-    fn modify(&self, _block_number: u64, tx_env: &mut TxEnv) {
-        tx_env.gas_limit = self.gas_limit;
-        tx_env.gas_price = self.max_fee_per_gas;
-        tx_env.gas_priority_fee = Some(self.max_priority_fee_per_gas);
-        tx_env.kind = match self.to {
-            TxKind::Call(to) => TransactTo::Call(to),
-            TxKind::Create => TransactTo::Create,
-        };
-        tx_env.value = self.value;
-        tx_env.data = self.input.clone();
-        tx_env.chain_id = Some(self.chain_id);
-        tx_env.nonce = self.nonce;
-        tx_env.access_list = AccessList::from(
-            self.access_list
-                .iter()
-                .map(|l| AccessListItem {
-                    address: l.address,
-                    storage_keys: l.storage_keys.clone(),
-                })
-                .collect::<Vec<_>>(),
-        );
-        tx_env.blob_hashes.clear();
-        tx_env.max_fee_per_blob_gas = 0;
     }
 }
 
 impl TxEnvModifier for TxEip2930 {
     fn modify(&self, _block_number: u64, tx_env: &mut TxEnv) {
-        tx_env.gas_limit = self.gas_limit;
-        tx_env.gas_price = self.gas_price;
-        tx_env.gas_priority_fee = None;
-        tx_env.kind = match self.to {
-            TxKind::Call(to) => TransactTo::Call(to),
-            TxKind::Create => TransactTo::Create,
+        *tx_env = TxEnv {
+            tx_type: 1,
+            caller: tx_env.caller,
+            gas_limit: self.gas_limit,
+            gas_price: self.gas_price,
+            kind: self.to,
+            value: self.value,
+            data: self.input.clone(),
+            nonce: self.nonce,
+            chain_id: Some(self.chain_id),
+            access_list: self.access_list.clone(),
+            gas_priority_fee: None,
+            blob_hashes: Default::default(),
+            max_fee_per_blob_gas: Default::default(),
+            authorization_list: Default::default(),
         };
-        tx_env.value = self.value;
-        tx_env.data = self.input.clone();
-        tx_env.chain_id = Some(self.chain_id);
-        tx_env.nonce = self.nonce;
-        tx_env.access_list = AccessList::from(
-            self.access_list
-                .iter()
-                .map(|l| AccessListItem {
-                    address: l.address,
-                    storage_keys: l.storage_keys.clone(),
-                })
-                .collect::<Vec<_>>(),
-        );
-        tx_env.blob_hashes.clear();
-        tx_env.max_fee_per_blob_gas = 0;
+    }
+}
+
+impl TxEnvModifier for TxEip1559 {
+    fn modify(&self, _block_number: u64, tx_env: &mut TxEnv) {
+        *tx_env = TxEnv {
+            tx_type: 2,
+            caller: tx_env.caller,
+            gas_limit: self.gas_limit,
+            gas_price: self.max_fee_per_gas,
+            kind: self.to,
+            value: self.value,
+            data: self.input.clone(),
+            nonce: self.nonce,
+            chain_id: Some(self.chain_id),
+            access_list: self.access_list.clone(),
+            gas_priority_fee: Some(self.max_priority_fee_per_gas),
+            blob_hashes: Default::default(),
+            max_fee_per_blob_gas: Default::default(),
+            authorization_list: Default::default(),
+        };
     }
 }
 
 impl TxEnvModifier for TxEip4844 {
     fn modify(&self, _block_number: u64, tx_env: &mut TxEnv) {
-        tx_env.gas_limit = self.gas_limit;
-        tx_env.gas_price = self.max_fee_per_gas;
-        tx_env.gas_priority_fee = Some(self.max_priority_fee_per_gas);
-        tx_env.kind = TransactTo::Call(self.to);
-        tx_env.value = self.value;
-        tx_env.data = self.input.clone();
-        tx_env.chain_id = Some(self.chain_id);
-        tx_env.nonce = self.nonce;
-        tx_env.access_list = AccessList::from(
-            self.access_list
-                .iter()
-                .map(|l| AccessListItem {
-                    address: l.address,
-                    storage_keys: l.storage_keys.clone(),
-                })
-                .collect::<Vec<_>>(),
-        );
-        tx_env.blob_hashes.clone_from(&self.blob_versioned_hashes);
-        tx_env.max_fee_per_blob_gas = self.max_fee_per_blob_gas;
+        *tx_env = TxEnv {
+            tx_type: 3,
+            caller: tx_env.caller,
+            gas_limit: self.gas_limit,
+            gas_price: self.max_fee_per_gas,
+            kind: TxKind::Call(self.to),
+            value: self.value,
+            data: self.input.clone(),
+            nonce: self.nonce,
+            chain_id: Some(self.chain_id),
+            access_list: self.access_list.clone(),
+            gas_priority_fee: Some(self.max_priority_fee_per_gas),
+            blob_hashes: self.blob_versioned_hashes.clone(),
+            max_fee_per_blob_gas: self.max_fee_per_blob_gas,
+            authorization_list: Default::default(),
+        };
     }
 }
 
@@ -140,8 +126,8 @@ impl TxEnvModifier for TransactionRequest {
         if let Some(data) = self.input.input() {
             tx_env.data.clone_from(data);
         }
-        if let Some(nounce) = self.nonce {
-            tx_env.nonce = nounce;
+        if let Some(nonce) = self.nonce {
+            tx_env.nonce = nonce;
         }
         tx_env.chain_id = self.chain_id;
         if let Some(access_list) = &self.access_list {
@@ -156,6 +142,7 @@ impl TxEnvModifier for TransactionRequest {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::bytes::Bytes;
+    use revm::context::TransactTo;
     use revm_primitives::{TxKind, U256};
 
     use super::*;
@@ -204,7 +191,7 @@ mod tests {
         assert_eq!(tx_env.value, U256::from(1));
         assert_eq!(tx_env.data.0, vec![1, 2, 3]);
         assert_eq!(tx_env.chain_id, Some(1));
-        assert_eq!(tx_env.access_list, AccessList::default());
+        assert_eq!(tx_env.access_list, Default::default());
     }
 
     #[test]
@@ -228,7 +215,7 @@ mod tests {
         assert_eq!(tx_env.value, U256::from(1));
         assert_eq!(tx_env.data.0, vec![1, 2, 3]);
         assert_eq!(tx_env.chain_id, Some(1));
-        assert_eq!(tx_env.access_list, AccessList::default());
+        assert_eq!(tx_env.access_list, Default::default());
     }
 
     #[test]
@@ -256,7 +243,7 @@ mod tests {
         assert_eq!(tx_env.value, U256::from(1));
         assert_eq!(tx_env.data.0, vec![1, 2, 3]);
         assert_eq!(tx_env.chain_id, Some(1));
-        assert_eq!(tx_env.access_list, AccessList::default());
+        assert_eq!(tx_env.access_list, Default::default());
         assert_eq!(tx_env.blob_hashes.len(), 0);
         assert_eq!(tx_env.max_fee_per_blob_gas, 1);
     }


### PR DESCRIPTION
### What was wrong?

We had a few regressions over time

- https://github.com/ethereum/trin/pull/1855
  - We didn't include Withdrawals in the Process Block
- https://github.com/ethereum/trin/pull/1794
  - Traces now require  `inspect_replay`, `transact` used to work, but after the version update it changed to `replay`, so this was a little unintuitive
  - TxEnv expectations changed, for example you have to manually declare the txType now, so that was a little intuitive as well

### How was it fixed?

All the regressions should be resolved now. I ran 0-6.5M and I range thousands of blocks around 21 million, so everything seems good now, so I can finally work on Pectra support now :)
