### PR TITLE
docs: mention the --mb alias in the CLI

### DIFF
--- a/bin/trin/src/cli.rs
+++ b/bin/trin/src/cli.rs
@@ -136,7 +136,7 @@ pub struct TrinConfig {
         long = "storage.total",
         alias = "mb",
         help = "Maximum storage capacity (in megabytes), shared between enabled subnetworks",
-        long_help = "Maximum storage capacity (in megabytes), shared between enabled subnetworks.\nCan't be used in combination with 'storage.{subnetwork}' flags (if storage of one subnetwork is specified explicitly, all have to be). If none of the flags is used, then `storage.total` is used with default value.\nThe actual storage can be higher than specified, due to overhead.",
+        long_help = "Maximum storage capacity (in megabytes), shared between enabled subnetworks.\nCan't be used in combination with 'storage.{subnetwork}' flags (if storage of one subnetwork is specified explicitly, all have to be). If none of the flags is used, then `storage.total` is used with default value.\nThe actual storage can be higher than specified, due to overhead.\nThe flag --mb is an alias to storage.total.",
         default_value_if("storage.beacon", ArgPredicate::IsPresent, None),
         default_value_if("storage.history", ArgPredicate::IsPresent, None),
         default_value_if("storage.state", ArgPredicate::IsPresent, None),
@@ -197,16 +197,16 @@ pub struct TrinConfig {
     pub ws: bool,
 
     #[arg(
-        long = "ws-port", 
-        help = "The WebSocket port to listen on.", 
+        long = "ws-port",
+        help = "The WebSocket port to listen on.",
         default_value_t = DEFAULT_WEB3_WS_PORT,
         requires = "ws"
     )]
     pub ws_port: u16,
 
     #[arg(
-        long = "utp-transfer-limit", 
-        help = "The limit of max background uTP transfers for any given channel (inbound or outbound) for each subnetwork", 
+        long = "utp-transfer-limit",
+        help = "The limit of max background uTP transfers for any given channel (inbound or outbound) for each subnetwork",
         default_value_t = DEFAULT_UTP_TRANSFER_LIMIT,
     )]
     pub utp_transfer_limit: usize,

--- a/book/src/users/cli.md
+++ b/book/src/users/cli.md
@@ -6,62 +6,121 @@ Below is the current list of all command line flags.
 
 Note that these flags may change over time, so run `trin --help` to get the most up-to-date information for your version.
 
+<!--
+Generate the following text with: trin --help to get the long version, instead of trin -h
+-->
 ```text
-Usage: trin [OPTIONS] [COMMAND]
+Run an eth portal client
 
-Commands:
-  create-dashboard  
-  help              Print this message or the help of the given subcommand(s)
+Usage: trin [OPTIONS]
 
 Options:
       --web3-transport <WEB3_TRANSPORT>
-          select transport protocol to serve json-rpc endpoint [default: ipc]
+          select transport protocol to serve json-rpc endpoint
+
+          [default: ipc]
+
       --web3-http-address <WEB3_HTTP_ADDRESS>
-          address to accept json-rpc http connections [default: http://127.0.0.1:8545/]
+          address to accept json-rpc http connections
+
+          [default: http://127.0.0.1:8545/]
+
       --web3-ipc-path <WEB3_IPC_PATH>
-          path to json-rpc endpoint over IPC [default: /tmp/trin-jsonrpc.ipc]
+          path to json-rpc endpoint over IPC
+
+          [default: /tmp/trin-jsonrpc.ipc]
+
       --discovery-port <DISCOVERY_PORT>
-          The UDP port to listen on. [default: 9009]
+          The UDP port to listen on.
+
+          [default: 9009]
+
       --bootnodes <BOOTNODES>
-          One or more comma-delimited base64-encoded ENR's or multiaddr strings of peers to initially add to the local routing table [default: default]
+          One or more comma-delimited base64-encoded ENR's or multiaddr strings of peers to initially add to the local routing table
+
+          [default: default]
+
       --external-address <EXTERNAL_ADDR>
           (Only use this if you are behind a NAT) The address which will be advertised to peers (in an ENR). Changing it does not change which port or address trin binds to. Port number is required, ex: 127.0.0.1:9001
+
       --no-stun
           Do not use STUN to determine an external IP. Leaves ENR entry for IP blank. Some users report better connections over VPN.
+
       --no-upnp
           Do not use UPnP to determine an external port.
+
       --unsafe-private-key <PRIVATE_KEY>
           Hex encoded 32 byte private key (with 0x prefix) (considered unsafe as it's stored in terminal history - keyfile support coming soon)
+
       --trusted-block-root <TRUSTED_BLOCK_ROOT>
           Hex encoded block root from a trusted checkpoint
+
       --network <NETWORK>
-          Choose mainnet or angelfood [default: mainnet]
+          Choose mainnet or angelfood
+
+          [default: mainnet]
+
       --portal-subnetworks <PORTAL_SUBNETWORKS>
-          Comma-separated list of which portal subnetworks to activate [default: history]
+          Comma-separated list of which portal subnetworks to activate
+
+          [default: beacon,history]
+
       --storage.total <storage.total>
-          Maximum storage capacity (in megabytes), shared between enabled subnetworks [default: 1000]
+          Maximum storage capacity (in megabytes), shared between enabled subnetworks.
+          Can't be used in combination with 'storage.{subnetwork}' flags (if storage of one subnetwork is specified explicitly, all have to be). If none of the flags is used, then `storage.total` is used with default value.
+          The actual storage can be higher than specified, due to overhead.
+          The flag --mb is an alias to storage.total.
+
+          [default: 1000]
+
       --storage.beacon <storage.beacon>
-          Maximum storage capacity (in megabytes) used by beacon subnetwork
+          Maximum storage capacity (in megabytes) used by beacon subnetwork.
+          Can't be used in combination with 'storage.total' flag.
+          The actual storage can be higher than specified, due to overhead.
+
       --storage.history <storage.history>
-          Maximum storage capacity (in megabytes) used by history subnetwork
+          Maximum storage capacity (in megabytes) used by history subnetwork.
+          Can't be used in combination with 'storage.total' flag.
+          The actual storage can be higher than specified, due to overhead.
+
       --storage.state <storage.state>
-          Maximum storage capacity (in megabytes) used by state subnetwork
+          Maximum storage capacity (in megabytes) used by state subnetwork.
+          Can't be used in combination with 'storage.total' flag.
+          The actual storage can be higher than specified, due to overhead.
+
       --enable-metrics-with-url <ENABLE_METRICS_WITH_URL>
           Enable prometheus metrics reporting (provide local IP/Port from which your Prometheus server is configured to fetch metrics)
+
       --data-dir <DATA_DIR>
           The directory for storing application data. If used together with --ephemeral, new child directory will be created. Can be alternatively set via TRIN_DATA_PATH env variable.
+
   -e, --ephemeral
           Use new data directory, located in OS temporary directory. If used together with --data-dir, new directory will be created there instead.
+
       --disable-poke
           Disables the poke mechanism, which propagates content at the end of a successful content query. Disabling is useful for network analysis purposes.
+
       --ws
           Used to enable WebSocket rpc.
+
       --ws-port <WS_PORT>
-          The WebSocket port to listen on. [default: 8546]
+          The WebSocket port to listen on.
+
+          [default: 8546]
+
       --utp-transfer-limit <UTP_TRANSFER_LIMIT>
-          The limit of max background uTP transfers for any given channel (inbound or outbound) for each subnetwork [default: 50]
+          The limit of max background uTP transfers for any given channel (inbound or outbound) for each subnetwork
+
+          [default: 50]
+
+      --max-radius <MAX_RADIUS>
+          The maximum radius our node will use. The default is 5% of the network size. The max is 100%
+
+          [default: 5]
+
   -h, --help
-          Print help (see more with '--help')
+          Print help (see a summary with '-h')
+
   -V, --version
           Print version
 ```


### PR DESCRIPTION
Also, regenerate the help in the trin book, using the longer format.

### What was wrong?

The flag `--mb` is used pretty liberally in the trin book. It is not mentioned anywhere what it is.

### How was it fixed?

Having the flag mentioned in the long CLI help seems like the least we can do.
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
