### PR TITLE
refactor: add batch content validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8518,6 +8518,7 @@ dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "ethportal-api",
+ "futures",
  "lazy_static",
  "parking_lot 0.12.3",
  "quickcheck",

--- a/crates/portalnet/src/overlay/service/find_content.rs
+++ b/crates/portalnet/src/overlay/service/find_content.rs
@@ -525,37 +525,36 @@ impl<
                 .await;
             utp_processing
                 .metrics
-                .report_validation(validation_result.is_ok());
+                .report_validation(validation_result.is_valid());
 
-            let validation_result = match validation_result {
-                Ok(validation_result) => validation_result,
-                Err(err) => {
-                    warn!(
-                        error = ?err,
-                        content.id = %hex_encode_compact(content_id),
-                        content.key = %content_key,
-                        "Error validating content"
-                    );
-                    // Indicate to the query that the content is invalid
-                    let _ = valid_content_callback.send(None);
-                    if let Some(query_trace_events_tx) = query_trace_events_tx {
-                        let _ = query_trace_events_tx.send(QueryTraceEvent::Failure(
-                            query_id,
-                            sending_peer,
-                            QueryFailureKind::InvalidContent,
-                        ));
-                    }
-                    return;
+            if !validation_result.is_valid() {
+                warn!(
+                    content.id = %hex_encode_compact(content_id),
+                    content.key = %content_key,
+                    ?validation_result,
+                    "Error validating content"
+                );
+                // Indicate to the query that the content is invalid
+                let _ = valid_content_callback.send(None);
+                if let Some(query_trace_events_tx) = query_trace_events_tx {
+                    let _ = query_trace_events_tx.send(QueryTraceEvent::Failure(
+                        query_id,
+                        sending_peer,
+                        QueryFailureKind::InvalidContent,
+                    ));
                 }
-            };
+                return;
+            }
 
-            // skip storing if content is not valid for storing, the content
-            // is already stored or if there's an error reading the store
-            let should_store = validation_result.valid_for_storing
+            // store content that:
+            // - is canonically valid
+            // - is not already stored
+            // - is within radius (if applicable)
+            let should_store = validation_result.is_canonically_valid()
                 && utp_processing
                     .store
                     .lock()
-                    .is_key_within_radius_and_unavailable(&content_key)
+                    .should_we_store(&content_key)
                     .map_or_else(
                         |err| {
                             error!("Unable to read store: {err}");
@@ -571,17 +570,12 @@ impl<
                 {
                     Ok(dropped_content) => {
                         let mut content_to_propagate = vec![(content_key.clone(), content.clone())];
-                        if let Some(additional_content_to_propagate) =
-                            validation_result.additional_content_to_propagate
-                        {
-                            content_to_propagate.push(additional_content_to_propagate);
-                        }
                         if !dropped_content.is_empty() && utp_processing.gossip_dropped {
                             debug!(
                                 "Dropped {:?} pieces of content after inserting new content, propagating them back into the network.",
                                 dropped_content.len(),
                             );
-                            content_to_propagate.extend(dropped_content.clone());
+                            content_to_propagate.extend(dropped_content);
                         }
                         propagate_put_content_cross_thread::<_, TMetric>(
                             content_to_propagate,

--- a/crates/subnetworks/beacon/src/storage.rs
+++ b/crates/subnetworks/beacon/src/storage.rs
@@ -196,7 +196,7 @@ impl ContentStore for BeaconStorage {
     }
 
     /// The "radius" concept is not applicable for Beacon network
-    fn is_key_within_radius_and_unavailable(
+    fn should_we_store(
         &self,
         key: &BeaconContentKey,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {
@@ -836,21 +836,21 @@ mod test {
         assert_eq!(result, value.as_ssz_bytes());
 
         // Test is_key_within_radius_and_unavailable for the same finalized slot
-        let should_store_content = storage.is_key_within_radius_and_unavailable(&key).unwrap();
+        let should_store_content = storage.should_we_store(&key).unwrap();
         assert_eq!(should_store_content, ShouldWeStoreContent::AlreadyStored);
 
         // Test is_key_within_radius_and_unavailable for older finalized slot
         let key = BeaconContentKey::LightClientFinalityUpdate(LightClientFinalityUpdateKey {
             finalized_slot: finalized_slot - 1,
         });
-        let should_store_content = storage.is_key_within_radius_and_unavailable(&key).unwrap();
+        let should_store_content = storage.should_we_store(&key).unwrap();
         assert_eq!(should_store_content, ShouldWeStoreContent::AlreadyStored);
 
         // Test is_key_within_radius_and_unavailable for newer finalized slot
         let key = BeaconContentKey::LightClientFinalityUpdate(LightClientFinalityUpdateKey {
             finalized_slot: finalized_slot + 1,
         });
-        let should_store_content = storage.is_key_within_radius_and_unavailable(&key).unwrap();
+        let should_store_content = storage.should_we_store(&key).unwrap();
         assert_eq!(should_store_content, ShouldWeStoreContent::Store);
 
         // Test getting the latest finality update
@@ -875,21 +875,21 @@ mod test {
         assert_eq!(result, value.as_ssz_bytes());
 
         // Test is_key_within_radius_and_unavailable for the same signature slot
-        let should_store_content = storage.is_key_within_radius_and_unavailable(&key).unwrap();
+        let should_store_content = storage.should_we_store(&key).unwrap();
         assert_eq!(should_store_content, ShouldWeStoreContent::AlreadyStored);
 
         // Test is_key_within_radius_and_unavailable for older signature slot
         let key = BeaconContentKey::LightClientOptimisticUpdate(LightClientOptimisticUpdateKey {
             signature_slot: signature_slot - 1,
         });
-        let should_store_content = storage.is_key_within_radius_and_unavailable(&key).unwrap();
+        let should_store_content = storage.should_we_store(&key).unwrap();
         assert_eq!(should_store_content, ShouldWeStoreContent::AlreadyStored);
 
         // Test is_key_within_radius_and_unavailable for newer signature slot
         let key = BeaconContentKey::LightClientOptimisticUpdate(LightClientOptimisticUpdateKey {
             signature_slot: signature_slot + 1,
         });
-        let should_store_content = storage.is_key_within_radius_and_unavailable(&key).unwrap();
+        let should_store_content = storage.should_we_store(&key).unwrap();
         assert_eq!(should_store_content, ShouldWeStoreContent::Store);
 
         // Test getting unavailable optimistic update
@@ -927,21 +927,21 @@ mod test {
         assert_eq!(result, value.encode());
 
         // Test is_key_within_radius_and_unavailable for the same epoch
-        let should_store_content = storage.is_key_within_radius_and_unavailable(&key).unwrap();
+        let should_store_content = storage.should_we_store(&key).unwrap();
         assert_eq!(should_store_content, ShouldWeStoreContent::AlreadyStored);
 
         // Test is_key_within_radius_and_unavailable for older epoch
         let key = BeaconContentKey::HistoricalSummariesWithProof(HistoricalSummariesWithProofKey {
             epoch: epoch - 1,
         });
-        let should_store_content = storage.is_key_within_radius_and_unavailable(&key).unwrap();
+        let should_store_content = storage.should_we_store(&key).unwrap();
         assert_eq!(should_store_content, ShouldWeStoreContent::AlreadyStored);
 
         // Test is_key_within_radius_and_unavailable for newer epoch
         let key = BeaconContentKey::HistoricalSummariesWithProof(HistoricalSummariesWithProofKey {
             epoch: epoch + 1,
         });
-        let should_store_content = storage.is_key_within_radius_and_unavailable(&key).unwrap();
+        let should_store_content = storage.should_we_store(&key).unwrap();
         assert_eq!(should_store_content, ShouldWeStoreContent::Store);
 
         // Test getting unavailable historical summaries with proof

--- a/crates/subnetworks/beacon/src/validation.rs
+++ b/crates/subnetworks/beacon/src/validation.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use alloy::primitives::B256;
 use anyhow::anyhow;
 use chrono::Duration;
 use ethportal_api::{
@@ -59,17 +58,17 @@ impl Validator<BeaconContentKey> for BeaconValidator {
     async fn validate_content(
         &self,
         content_key: &BeaconContentKey,
-        content: &[u8],
-    ) -> anyhow::Result<ValidationResult<BeaconContentKey>> {
+        content_value: &[u8],
+    ) -> ValidationResult {
         match content_key {
             BeaconContentKey::LightClientBootstrap(_) => {
-                let bootstrap = ForkVersionedLightClientBootstrap::from_ssz_bytes(content)
-                    .map_err(|err| {
-                        anyhow!(
-                            "Fork versioned light client bootstrap has invalid SSZ bytes: {:?}",
-                            err
-                        )
-                    })?;
+                let Ok(bootstrap) =
+                    ForkVersionedLightClientBootstrap::from_ssz_bytes(content_value)
+                else {
+                    return ValidationResult::Invalid(
+                        "Error decoding light client bootstrap content value".to_string(),
+                    );
+                };
 
                 // Check if the light client bootstrap slot is ole than 4 months
                 let four_months = Duration::days(30 * 4);
@@ -79,9 +78,8 @@ impl Validator<BeaconContentKey> for BeaconValidator {
                 let bootstrap_slot = bootstrap.get_slot();
 
                 if bootstrap_slot < four_months_ago_slot {
-                    return Err(anyhow!(
-                        "Light client bootstrap slot is too old: {}",
-                        bootstrap_slot
+                    return ValidationResult::Invalid(format!(
+                        "Light client bootstrap slot is too old: {bootstrap_slot}",
                     ));
                 }
 
@@ -90,24 +88,23 @@ impl Validator<BeaconContentKey> for BeaconValidator {
 
                 if let Ok(finalized_header) = finalized_header {
                     if finalized_header != bootstrap_block_header {
-                        return Err(anyhow!(
+                        return ValidationResult::Invalid(format!(
                             "Light client bootstrap header does not match the finalized header: {finalized_header:?} != {bootstrap_block_header:?}",
                         ));
                     }
                 }
             }
             BeaconContentKey::LightClientUpdatesByRange(key) => {
-                let lc_updates =
-                    LightClientUpdatesByRange::from_ssz_bytes(content).map_err(|err| {
-                        anyhow!(
-                            "Light client updates by range has invalid SSZ bytes: {:?}",
-                            err
-                        )
-                    })?;
+                let Ok(lc_updates) = LightClientUpdatesByRange::from_ssz_bytes(content_value)
+                else {
+                    return ValidationResult::Invalid(
+                        "Error decoding Light client updates content value".to_string(),
+                    );
+                };
 
                 // Check if lc updates count match the content key count
                 if lc_updates.0.len() as u64 != key.count {
-                    return Err(anyhow!(
+                    return ValidationResult::Invalid(format!(
                         "Light client updates count does not match the content key count: {} != {}",
                         lc_updates.0.len(),
                         key.count
@@ -126,35 +123,39 @@ impl Validator<BeaconContentKey> for BeaconValidator {
                         match &update.update {
                             LightClientUpdate::Electra(update) => {
                                 let generic_update: GenericUpdate = update.into();
-                                verify_generic_update(
+                                if let Err(err) = verify_generic_update(
                                     &light_client_store,
                                     &generic_update,
                                     expected_slot,
                                     self.light_client_config.chain.genesis_root,
                                     self.light_client_config.forks.electra.fork_version,
-                                )?;
+                                ) {
+                                    return ValidationResult::Invalid(format!(
+                                        "Light client update not valid: {err:?}",
+                                    ));
+                                }
                             }
                             _ => {
-                                return Err(anyhow!("Unsupported light client update fork version"))
+                                return ValidationResult::Invalid(
+                                    "Unsupported light client update fork version".to_string(),
+                                );
                             }
                         }
                     }
                 }
             }
             BeaconContentKey::LightClientFinalityUpdate(key) => {
-                let lc_finality_update = ForkVersionedLightClientFinalityUpdate::from_ssz_bytes(
-                    content,
-                )
-                .map_err(|err| {
-                    anyhow!(
-                        "Fork versioned light client finality update has invalid SSZ bytes: {:?}",
-                        err
-                    )
-                })?;
+                let Ok(lc_finality_update) =
+                    ForkVersionedLightClientFinalityUpdate::from_ssz_bytes(content_value)
+                else {
+                    return ValidationResult::Invalid(
+                        "Error decoding Light client finality update content value".to_string(),
+                    );
+                };
 
                 // Check if the light client finality update is from the recent fork
                 if lc_finality_update.fork_name != ForkName::Electra {
-                    return Err(anyhow!(
+                    return ValidationResult::Invalid(format!(
                         "Light client finality update is not from the recent fork. Expected Electra, got {}",
                         lc_finality_update.fork_name
                     ));
@@ -165,7 +166,7 @@ impl Validator<BeaconContentKey> for BeaconValidator {
                 let finalized_slot = lc_finality_update.get_finalized_slot();
 
                 if key.finalized_slot > finalized_slot {
-                    return Err(anyhow!(
+                    return ValidationResult::Invalid(format!(
                         "Light client finality update finalized slot should be equal or greater than content key finalized slot: {} < {}",
                         finalized_slot,
                         key.finalized_slot
@@ -182,36 +183,38 @@ impl Validator<BeaconContentKey> for BeaconValidator {
                             .await
                         {
                             let generic_update: GenericUpdate = update.into();
-                            verify_generic_update(
+                            if let Err(err) = verify_generic_update(
                                 &light_client_store,
                                 &generic_update,
                                 expected_current_slot(),
                                 self.light_client_config.chain.genesis_root,
                                 self.light_client_config.forks.electra.fork_version,
-                            )?;
+                            ) {
+                                return ValidationResult::Invalid(format!(
+                                    "Light client finality update not valid: {err:?}",
+                                ));
+                            }
                         }
                     }
                     _ => {
-                        return Err(anyhow!(
-                            "Unsupported light client finality update fork version"
-                        ))
+                        return ValidationResult::Invalid(
+                            "Unsupported light client finality update fork version".to_string(),
+                        );
                     }
                 }
             }
             BeaconContentKey::LightClientOptimisticUpdate(key) => {
-                let lc_optimistic_update =
-                    ForkVersionedLightClientOptimisticUpdate::from_ssz_bytes(content).map_err(
-                        |err| {
-                            anyhow!(
-                        "Fork versioned light client optimistic update has invalid SSZ bytes: {:?}",
-                        err
-                    )
-                        },
-                    )?;
+                let Ok(lc_optimistic_update) =
+                    ForkVersionedLightClientOptimisticUpdate::from_ssz_bytes(content_value)
+                else {
+                    return ValidationResult::Invalid(
+                        "Error decoding Light client optimistic update content value".to_string(),
+                    );
+                };
 
                 // Check if the light client optimistic update is from the recent fork
                 if lc_optimistic_update.fork_name != ForkName::Electra {
-                    return Err(anyhow!(
+                    return ValidationResult::Invalid(format!(
                         "Light client optimistic update is not from the recent fork. Expected Electra, got {}",
                         lc_optimistic_update.fork_name
                     ));
@@ -220,7 +223,7 @@ impl Validator<BeaconContentKey> for BeaconValidator {
                 // Check if key signature slot matches the light client optimistic update signature
                 // slot
                 if &key.signature_slot != lc_optimistic_update.update.signature_slot() {
-                    return Err(anyhow!(
+                    return ValidationResult::Invalid(format!(
                         "Light client optimistic update signature slot does not match the content key signature slot: {} != {}",
                         lc_optimistic_update.update.signature_slot(),
                         key.signature_slot
@@ -238,25 +241,32 @@ impl Validator<BeaconContentKey> for BeaconValidator {
                         {
                             let generic_update: GenericUpdate = update.into();
 
-                            verify_generic_update(
+                            if let Err(err) = verify_generic_update(
                                 &light_client_store,
                                 &generic_update,
                                 expected_current_slot(),
                                 self.light_client_config.chain.genesis_root,
                                 self.light_client_config.forks.electra.fork_version,
-                            )?;
+                            ) {
+                                return ValidationResult::Invalid(format!(
+                                    "Light client optimistic update not valid: {err:?}",
+                                ));
+                            }
                         }
                     }
                     _ => {
-                        return Err(anyhow!(
-                            "Unsupported light client optimistic update fork version"
-                        ))
+                        return ValidationResult::Invalid(
+                            "Unsupported light client optimistic update fork version".to_string(),
+                        );
                     }
                 }
             }
             BeaconContentKey::HistoricalSummariesWithProof(key) => {
                 let historical_summaries_with_proof =
-                    Self::general_summaries_validation(content, key)?;
+                    match Self::general_summaries_validation(content_value, key) {
+                        Ok(historical_summaries_with_proof) => historical_summaries_with_proof,
+                        Err(err) => return ValidationResult::Invalid(err.to_string()),
+                    };
 
                 let latest_finalized_root = self
                     .header_oracle
@@ -266,17 +276,28 @@ impl Validator<BeaconContentKey> for BeaconValidator {
                     .await;
 
                 if let Ok(latest_finalized_root) = latest_finalized_root {
-                    Self::state_summaries_validation(
-                        historical_summaries_with_proof,
+                    // Validate historical summaries against the latest finalized state root
+                    if !verify_merkle_proof(
+                        historical_summaries_with_proof
+                            .historical_summaries
+                            .tree_hash_root(),
+                        &historical_summaries_with_proof.proof,
+                        HistoricalSummariesProof::capacity(),
+                        HISTORICAL_SUMMARIES_GINDEX,
                         latest_finalized_root,
-                    )?
+                    ) {
+                        return ValidationResult::Invalid(
+                            "Merkle proof validation failed for HistoricalSummariesProof"
+                                .to_string(),
+                        );
+                    }
                 } else {
                     warn!("Failed to get latest finalized state root. Bypassing historical summaries with proof validation");
                 }
             }
         }
 
-        Ok(ValidationResult::new(true))
+        ValidationResult::CanonicallyValid
     }
 }
 
@@ -287,9 +308,8 @@ impl BeaconValidator {
         key: &HistoricalSummariesWithProofKey,
     ) -> anyhow::Result<HistoricalSummariesWithProof> {
         let fork_versioned_historical_summaries =
-            ForkVersionedHistoricalSummariesWithProof::from_ssz_bytes(content).map_err(|err| {
-                anyhow!("Historical summaries with proof has invalid SSZ bytes: {err:?}")
-            })?;
+            ForkVersionedHistoricalSummariesWithProof::from_ssz_bytes(content)
+                .map_err(|_| anyhow!("Error decoding hisorical summaries content value"))?;
 
         let historical_summaries_with_proof =
             fork_versioned_historical_summaries.historical_summaries_with_proof;
@@ -302,33 +322,12 @@ impl BeaconValidator {
                         key.epoch
                     ));
         }
+
         Ok(historical_summaries_with_proof)
     }
-
-    /// Validate historical summaries against the latest finalized state root
-    fn state_summaries_validation(
-        historical_summaries_with_proof: HistoricalSummariesWithProof,
-        latest_finalized_root: B256,
-    ) -> anyhow::Result<()> {
-        if verify_merkle_proof(
-            historical_summaries_with_proof
-                .historical_summaries
-                .tree_hash_root(),
-            &historical_summaries_with_proof.proof,
-            HistoricalSummariesProof::capacity(),
-            HISTORICAL_SUMMARIES_GINDEX,
-            latest_finalized_root,
-        ) {
-            Ok(())
-        } else {
-            Err(anyhow!(
-                "Merkle proof validation failed for HistoricalSummariesProof"
-            ))
-        }
-    }
 }
+
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use ethportal_api::{
         types::{
@@ -359,12 +358,10 @@ mod tests {
         let content_key = BeaconContentKey::LightClientBootstrap(LightClientBootstrapKey {
             block_hash: [0; 32],
         });
-        let result = validator
+        assert!(validator
             .validate_content(&content_key, &content)
             .await
-            .unwrap();
-
-        assert!(result.valid_for_storing);
+            .is_canonically_valid());
 
         // Expect error because the light client bootstrap slot is too old
         bootstrap
@@ -374,14 +371,9 @@ mod tests {
             .beacon
             .slot = 0;
         let content = bootstrap.as_ssz_bytes();
-        let result = validator
-            .validate_content(&content_key, &content)
-            .await
-            .unwrap_err();
-
         assert_eq!(
-            result.to_string(),
-            "Light client bootstrap slot is too old: 0"
+            validator.validate_content(&content_key, &content).await,
+            ValidationResult::Invalid("Light client bootstrap slot is too old: 0".to_string()),
         );
     }
 
@@ -396,25 +388,21 @@ mod tests {
                 start_period: 0,
                 count: 1,
             });
-        let result = validator
+        assert!(validator
             .validate_content(&content_key, &content)
             .await
-            .unwrap();
-
-        assert!(result.valid_for_storing);
+            .is_canonically_valid());
 
         let lc_update_1 = test_utils::get_light_client_update(1);
         let updates = LightClientUpdatesByRange(VariableList::from(vec![lc_update_0, lc_update_1]));
         let content = updates.as_ssz_bytes();
         // Expect error because the count does not match the content key count
-        let result = validator
-            .validate_content(&content_key, &content)
-            .await
-            .unwrap_err();
-
         assert_eq!(
-            result.to_string(),
-            "Light client updates count does not match the content key count: 2 != 1"
+            validator.validate_content(&content_key, &content).await,
+            ValidationResult::Invalid(
+                "Light client updates count does not match the content key count: 2 != 1"
+                    .to_string()
+            ),
         );
     }
 
@@ -429,12 +417,10 @@ mod tests {
                 finalized_slot: 10934316269310501102,
             });
 
-        let result = validator
+        assert!(validator
             .validate_content(&content_key, &content)
             .await
-            .unwrap();
-
-        assert!(result.valid_for_storing);
+            .is_canonically_valid());
 
         // Expect error because the content key finalized slot is greaten than the light client
         // update  finalized slot
@@ -442,14 +428,12 @@ mod tests {
             BeaconContentKey::LightClientFinalityUpdate(LightClientFinalityUpdateKey {
                 finalized_slot: 10934316269310501102 + 1,
             });
-        let result = validator
-            .validate_content(&invalid_content_key, &content)
-            .await
-            .unwrap_err();
-
         assert_eq!(
-            result.to_string(),
-            "Light client finality update finalized slot should be equal or greater than content key finalized slot: 10934316269310501102 < 10934316269310501103"
+            validator.validate_content(&invalid_content_key, &content).await,
+            ValidationResult::Invalid(
+                "Light client finality update finalized slot should be equal or greater than content key finalized slot: 10934316269310501102 < 10934316269310501103"
+                    .to_string()
+            ),
         );
     }
 
@@ -463,49 +447,45 @@ mod tests {
             BeaconContentKey::LightClientOptimisticUpdate(LightClientOptimisticUpdateKey {
                 signature_slot: 15067541596220156845,
             });
-        let result = validator
+        assert!(validator
             .validate_content(&content_key, &content)
             .await
-            .unwrap();
-
-        assert!(result.valid_for_storing);
+            .is_canonically_valid());
 
         // Expect error because the signature slot does not match the content key signature slot
         let invalid_content_key =
             BeaconContentKey::LightClientOptimisticUpdate(LightClientOptimisticUpdateKey {
                 signature_slot: 0,
             });
-        let result = validator
-            .validate_content(&invalid_content_key, &content)
-            .await
-            .unwrap_err();
-
         assert_eq!(
-            result.to_string(),
-            "Light client optimistic update signature slot does not match the content key signature slot: 15067541596220156845 != 0"
+            validator.validate_content(&invalid_content_key, &content).await,
+            ValidationResult::Invalid(
+                "Light client optimistic update signature slot does not match the content key signature slot: 15067541596220156845 != 0"
+                    .to_string()
+            ),
         );
     }
 
     mod historical_summaries {
+        use alloy::primitives::B256;
+
         use super::*;
 
         #[tokio::test]
         async fn validate() {
             let test_data = read_test_data();
 
-            let validation_result = test_data
+            assert!(test_data
                 .create_validator()
                 .validate_content(
                     &test_data.content.content_key,
                     &test_data.content.raw_content_value,
                 )
                 .await
-                .expect("Should validate content");
-            assert!(validation_result.valid_for_storing);
+                .is_canonically_valid());
         }
 
         #[tokio::test]
-        #[should_panic = "Historical summaries with proof epoch does not match the content key epoch"]
         async fn validate_invalid_epoch() {
             let test_data = read_test_data();
 
@@ -515,15 +495,19 @@ mod tests {
                 key.epoch += 1;
             }
 
-            test_data
-                .create_validator()
-                .validate_content(&content_key, &test_data.content.raw_content_value)
-                .await
-                .unwrap();
+            assert_eq!(
+                test_data
+                    .create_validator()
+                    .validate_content(&content_key, &test_data.content.raw_content_value)
+                    .await,
+                ValidationResult::Invalid(
+                    "Historical summaries with proof epoch does not match the content key epoch: 450508969718611630 != 450508969718611631"
+                        .to_string()
+                ),
+            );
         }
 
         #[tokio::test]
-        #[should_panic = "Merkle proof validation failed for HistoricalSummariesProof"]
         async fn validate_invalid_proof() {
             let test_data = read_test_data();
 
@@ -539,11 +523,15 @@ mod tests {
                     .swap(0, 1);
             }
 
-            test_data
-                .create_validator()
-                .validate_content(&test_data.content.content_key, &content_value.encode())
-                .await
-                .unwrap();
+            assert_eq!(
+                test_data
+                    .create_validator()
+                    .validate_content(&test_data.content.content_key, &content_value.encode())
+                    .await,
+                ValidationResult::Invalid(
+                    "Merkle proof validation failed for HistoricalSummariesProof".to_string()
+                ),
+            );
         }
 
         fn read_test_data() -> TestData {

--- a/crates/subnetworks/history/src/storage.rs
+++ b/crates/subnetworks/history/src/storage.rs
@@ -34,7 +34,7 @@ impl ContentStore for HistoryStorage {
             .insert(&key, RawContentValue::copy_from_slice(value.as_ref()))
     }
 
-    fn is_key_within_radius_and_unavailable(
+    fn should_we_store(
         &self,
         key: &HistoryContentKey,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {

--- a/crates/subnetworks/history/src/validation.rs
+++ b/crates/subnetworks/history/src/validation.rs
@@ -9,6 +9,7 @@ use ethportal_api::{
 };
 use ssz::Decode;
 use tokio::sync::RwLock;
+use tracing::debug;
 use trin_validation::{
     header_validator::HeaderValidator,
     oracle::HeaderOracle,
@@ -64,6 +65,10 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
             }
             HistoryContentKey::BlockHeaderByNumber(key) => {
                 let Ok(header_with_proof) = HeaderWithProof::from_ssz_bytes(content_value) else {
+                    debug!(
+                        content_value = content_value.encode_hex_with_prefix(),
+                        "Error decoding HeaderWithProof",
+                    );
                     return ValidationResult::Invalid(
                         "Header by number content has invalid encoding".to_string(),
                     );
@@ -89,6 +94,10 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
             }
             HistoryContentKey::BlockBody(key) => {
                 let Ok(block_body) = BlockBody::from_ssz_bytes(content_value) else {
+                    debug!(
+                        content_value = content_value.encode_hex_with_prefix(),
+                        "Error decoding BlockBody",
+                    );
                     return ValidationResult::Invalid(
                         "Block Body content has invalid encoding".to_string(),
                     );
@@ -118,6 +127,10 @@ impl Validator<HistoryContentKey> for ChainHistoryValidator {
             }
             HistoryContentKey::BlockReceipts(key) => {
                 let Ok(receipts) = Receipts::from_ssz_bytes(content_value) else {
+                    debug!(
+                        content_value = content_value.encode_hex_with_prefix(),
+                        "Error decoding Receipts",
+                    );
                     return ValidationResult::Invalid(
                         "Block Receipts content has invalid encoding".to_string(),
                     );

--- a/crates/subnetworks/state/src/storage.rs
+++ b/crates/subnetworks/state/src/storage.rs
@@ -49,7 +49,7 @@ impl ContentStore for StateStorage {
         }
     }
 
-    fn is_key_within_radius_and_unavailable(
+    fn should_we_store(
         &self,
         key: &StateContentKey,
     ) -> Result<ShouldWeStoreContent, ContentStoreError> {

--- a/crates/subnetworks/state/src/validation/validator.rs
+++ b/crates/subnetworks/state/src/validation/validator.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use alloy::primitives::{keccak256, B256};
-use anyhow::anyhow;
 use ethportal_api::{
     types::content_key::state::{
         AccountTrieNodeKey, ContractBytecodeKey, ContractStorageTrieNodeKey,
@@ -31,21 +30,31 @@ impl Validator<StateContentKey> for StateValidator {
         &self,
         content_key: &StateContentKey,
         content_value: &[u8],
-    ) -> anyhow::Result<ValidationResult<StateContentKey>> {
-        let content_value = StateContentValue::decode(content_key, content_value)
-            .map_err(|err| anyhow!("Error decoding StateContentValue: {err}"))?;
+    ) -> ValidationResult {
+        let content_value = match StateContentValue::decode(content_key, content_value) {
+            Ok(content_value) => content_value,
+            Err(err) => {
+                return ValidationResult::Invalid(format!(
+                    "Error decoding StateContentValue: {err}"
+                ));
+            }
+        };
 
-        match content_key {
+        let validation_result = match content_key {
             StateContentKey::AccountTrieNode(key) => {
-                Ok(self.validate_account_trie_node(key, content_value).await?)
+                self.validate_account_trie_node(key, content_value).await
             }
-            StateContentKey::ContractStorageTrieNode(key) => Ok(self
-                .validate_contract_storage_trie_node(key, content_value)
-                .await?),
+            StateContentKey::ContractStorageTrieNode(key) => {
+                self.validate_contract_storage_trie_node(key, content_value)
+                    .await
+            }
             StateContentKey::ContractBytecode(key) => {
-                Ok(self.validate_contract_bytecode(key, content_value).await?)
+                self.validate_contract_bytecode(key, content_value).await
             }
-        }
+        };
+        validation_result.unwrap_or_else(|err| {
+            ValidationResult::Invalid(format!("Error validating StateContentValue: {err:?}"))
+        })
     }
 }
 
@@ -54,11 +63,11 @@ impl StateValidator {
         &self,
         key: &AccountTrieNodeKey,
         value: StateContentValue,
-    ) -> Result<ValidationResult<StateContentKey>, StateValidationError> {
+    ) -> Result<ValidationResult, StateValidationError> {
         match value {
             StateContentValue::TrieNode(value) => {
                 check_node_hash(&value.node, &key.node_hash)?;
-                Ok(ValidationResult::new(/* valid_for_storing= */ false))
+                Ok(ValidationResult::Valid)
             }
             StateContentValue::AccountTrieNodeWithProof(value) => {
                 let state_root = match DISABLE_HISTORY_HEADER_CHECK {
@@ -67,7 +76,7 @@ impl StateValidator {
                 };
                 validate_node_trie_proof(state_root, key.node_hash, &key.path, &value.proof)?;
 
-                Ok(ValidationResult::new(/* valid_for_storing= */ true))
+                Ok(ValidationResult::CanonicallyValid)
             }
             _ => Err(StateValidationError::InvalidContentValueType(
                 "AccountTrieNodeKey",
@@ -79,11 +88,11 @@ impl StateValidator {
         &self,
         key: &ContractStorageTrieNodeKey,
         value: StateContentValue,
-    ) -> Result<ValidationResult<StateContentKey>, StateValidationError> {
+    ) -> Result<ValidationResult, StateValidationError> {
         match value {
             StateContentValue::TrieNode(value) => {
                 check_node_hash(&value.node, &key.node_hash)?;
-                Ok(ValidationResult::new(/* valid_for_storing= */ false))
+                Ok(ValidationResult::Valid)
             }
             StateContentValue::ContractStorageTrieNodeWithProof(value) => {
                 let state_root = match DISABLE_HISTORY_HEADER_CHECK {
@@ -99,7 +108,7 @@ impl StateValidator {
                     &value.storage_proof,
                 )?;
 
-                Ok(ValidationResult::new(/* valid_for_storing= */ true))
+                Ok(ValidationResult::CanonicallyValid)
             }
             _ => Err(StateValidationError::InvalidContentValueType(
                 "ContractStorageTrieNodeKey",
@@ -111,12 +120,12 @@ impl StateValidator {
         &self,
         key: &ContractBytecodeKey,
         value: StateContentValue,
-    ) -> Result<ValidationResult<StateContentKey>, StateValidationError> {
+    ) -> Result<ValidationResult, StateValidationError> {
         match value {
             StateContentValue::ContractBytecode(value) => {
                 let bytecode_hash = keccak256(&value.code[..]);
                 if bytecode_hash == key.code_hash {
-                    Ok(ValidationResult::new(/* valid_for_storing= */ false))
+                    Ok(ValidationResult::Valid)
                 } else {
                     Err(StateValidationError::InvalidBytecodeHash {
                         bytecode_hash,
@@ -140,7 +149,7 @@ impl StateValidator {
                 let account_state =
                     validate_account_state(state_root, &key.address_hash, &value.account_proof)?;
                 if account_state.code_hash == key.code_hash {
-                    Ok(ValidationResult::new(/* valid_for_storing= */ true))
+                    Ok(ValidationResult::CanonicallyValid)
                 } else {
                     Err(StateValidationError::InvalidBytecodeHash {
                         bytecode_hash,
@@ -235,10 +244,10 @@ mod tests {
 
             let validation_result = create_validator()
                 .validate_content(&content_key, content_value.as_ref())
-                .await?;
+                .await;
             assert_eq!(
                 validation_result,
-                ValidationResult::new(false),
+                ValidationResult::Valid,
                 "testing content_key: {}",
                 content_key.to_hex()
             );
@@ -258,11 +267,11 @@ mod tests {
             let validation_result =
                 create_validator_with_header(Header::decode(&mut header.as_ref())?)
                     .validate_content(&content_key, content_value.as_ref())
-                    .await?;
+                    .await;
 
             assert_eq!(
                 validation_result,
-                ValidationResult::new(true),
+                ValidationResult::CanonicallyValid,
                 "testing content_key: {}",
                 content_key.to_hex()
             );
@@ -280,10 +289,10 @@ mod tests {
 
             let validation_result = create_validator()
                 .validate_content(&content_key, content_value.as_ref())
-                .await?;
+                .await;
             assert_eq!(
                 validation_result,
-                ValidationResult::new(false),
+                ValidationResult::Valid,
                 "testing content_key: {}",
                 content_key.to_hex()
             );
@@ -303,11 +312,11 @@ mod tests {
             let validation_result =
                 create_validator_with_header(Header::decode(&mut header.as_ref())?)
                     .validate_content(&content_key, content_value.as_ref())
-                    .await?;
+                    .await;
 
             assert_eq!(
                 validation_result,
-                ValidationResult::new(true),
+                ValidationResult::CanonicallyValid,
                 "testing content_key: {}",
                 content_key.to_hex()
             );
@@ -325,10 +334,10 @@ mod tests {
 
             let validation_result = create_validator()
                 .validate_content(&content_key, content_value.as_ref())
-                .await?;
+                .await;
             assert_eq!(
                 validation_result,
-                ValidationResult::new(false),
+                ValidationResult::Valid,
                 "testing content_key: {}",
                 content_key.to_hex()
             );
@@ -348,10 +357,10 @@ mod tests {
             let validation_result =
                 create_validator_with_header(Header::decode(&mut header.as_ref())?)
                     .validate_content(&content_key, content_value.as_ref())
-                    .await?;
+                    .await;
             assert_eq!(
                 validation_result,
-                ValidationResult::new(true),
+                ValidationResult::CanonicallyValid,
                 "testing content_key: {}",
                 content_key.to_hex()
             );

--- a/crates/validation/Cargo.toml
+++ b/crates/validation/Cargo.toml
@@ -20,6 +20,7 @@ ethereum_hashing = "0.7.0"
 ethereum_ssz.workspace = true
 ethereum_ssz_derive.workspace = true
 ethportal-api.workspace = true
+futures.workspace = true
 lazy_static.workspace = true
 parking_lot.workspace = true
 rust-embed.workspace = true


### PR DESCRIPTION
This was extracted from #1868

### What was wrong?

`Validator` is currently able to validate only one content at the time. This is not enough for ephemeral headers.
Similar for `Store` when answering whether content is/should be stored.

### How was it fixed?

Rename `ContentStore::is_key_within_radius_and_unavailable` to `ContentStore::should_we_store` and add `Store::should_we_store_batch` (for multiple items.

Add `Validator::validate_content_batch` for validating multiple content items.

Refactor `ValidationResult`:
- removed `additional_content_to_propagate` from ValidationResult (it's not used)
- made ValidationResult an enum
    - enum type works better as a result of `validate_content_batch`, because it is `Vec<ValidationResult>` instead of `Vec<Result<ValidationResult>>`
    - we can consider in the future changing `Invalid(String)` variant into more descriptive type, e.g. `Invalid(ValidationFailureReason)` where:
        ```rust
        enum ValidationFailureReason {
            ContentValueNotDecodable,
            Invalid(<reason?>),  // e.g. merkle proof not valid
            FetchingAnchorContentFailuer(<reason?>), // e.g. failed to fetch Header when verifying BlockBody
            ...
        }
        ``` 

### Future work

Start using _batch_ functions from `offer.rs` (#1870) and add custom implementation of the batch functionality for history network (future PR).