### PR TITLE
docs: add "no longer supported" warning to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# ⚠️ THIS PROJECT IS NO LONGER ACTIVELY MAINTAINED ⚠️
+
+**The project is no longer actively suuported and things will most likely not work**
+
 # Trin
 
 Trin is a Rust implementation of a [Portal Network](https://github.com/ethereum/portal-network-specs) client.

--- a/crates/ethportal-api/README.md
+++ b/crates/ethportal-api/README.md
@@ -1,3 +1,5 @@
+# ⚠️ THIS PROJECT IS NO LONGER ACTIVELY MAINTAINED ⚠️
+
 # ethportal-api
 
 > **Warning!**


### PR DESCRIPTION
### What was wrong?

Trin is no longer actively maintained and we should add clear warning in README files.

### How was it fixed?

Added warning.
