### PR TITLE
feat: rename history network to "legacy_history"

### DIFF
--- a/bin/portal-bridge/src/bridge/ephemeral_history/mod.rs
+++ b/bin/portal-bridge/src/bridge/ephemeral_history/mod.rs
@@ -31,7 +31,7 @@ use revm_primitives::B256;
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 use tree_hash::TreeHash;
-use trin_history::network::HistoryNetwork;
+use trin_history::network::LegacyHistoryNetwork;
 use trin_metrics::bridge::BridgeMetricsReporter;
 
 use crate::census::Census;
@@ -53,7 +53,7 @@ pub struct EphemeralHistoryBridge {
 
 impl EphemeralHistoryBridge {
     pub async fn new(
-        history_network: Arc<HistoryNetwork>,
+        history_network: Arc<LegacyHistoryNetwork>,
         head_offer_limit: usize,
         non_ephemeral_offer_limit: usize,
         consensus_api: ConsensusApi,

--- a/bin/portal-bridge/src/census/network.rs
+++ b/bin/portal-bridge/src/census/network.rs
@@ -86,7 +86,7 @@ impl Network {
     ) -> Self {
         if !matches!(
             subnetwork,
-            Subnetwork::History | Subnetwork::Beacon | Subnetwork::State
+            Subnetwork::LegacyHistory | Subnetwork::Beacon | Subnetwork::State
         ) {
             panic!("Unsupported subnetwork: {subnetwork}");
         }
@@ -312,7 +312,7 @@ impl Network {
 
     pub async fn ping(&self, enr: &Enr) -> anyhow::Result<Pong> {
         match self.subnetwork {
-            Subnetwork::History => {
+            Subnetwork::LegacyHistory => {
                 self.subnetwork_overlays
                     .history()?
                     .overlay
@@ -340,7 +340,7 @@ impl Network {
 
     pub async fn find_nodes(&self, enr: &Enr, distances: Vec<u16>) -> anyhow::Result<Vec<Enr>> {
         Ok(match self.subnetwork {
-            Subnetwork::History => {
+            Subnetwork::LegacyHistory => {
                 self.subnetwork_overlays
                     .history()?
                     .overlay
@@ -372,7 +372,7 @@ impl Network {
 
     pub async fn recursive_find_nodes(&self, node_id: NodeId) -> anyhow::Result<Vec<Enr>> {
         let enrs = match self.subnetwork {
-            Subnetwork::History => {
+            Subnetwork::LegacyHistory => {
                 self.subnetwork_overlays
                     .history()?
                     .overlay

--- a/bin/portal-bridge/src/cli.rs
+++ b/bin/portal-bridge/src/cli.rs
@@ -18,7 +18,7 @@ use crate::{
     types::mode::BridgeMode,
 };
 
-pub const DEFAULT_SUBNETWORK: &str = "history";
+pub const DEFAULT_SUBNETWORK: &str = "legacy_history";
 
 /// The maximum number of peers to send each piece of content.
 ///
@@ -50,7 +50,7 @@ pub struct BridgeConfig {
 
     #[arg(
         long = "portal-subnetwork",
-        help = "The name of the subnetwork to use. Options: [history, state, beacon]",
+        help = "The name of the subnetwork to use. Options: [legacy_history, state, beacon]",
         default_value = DEFAULT_SUBNETWORK,
     )]
     pub portal_subnetwork: Subnetwork,
@@ -242,7 +242,8 @@ mod test {
 
     #[test]
     fn test_default_bridge_config() {
-        let bridge_config = BridgeConfig::parse_from(["bridge", "--portal-subnetwork", "history"]);
+        let bridge_config =
+            BridgeConfig::parse_from(["bridge", "--portal-subnetwork", "legacy_history"]);
         assert_eq!(bridge_config.mode, BridgeMode::Latest);
         assert_eq!(
             bridge_config.el_provider.to_string(),
@@ -260,7 +261,7 @@ mod test {
             bridge_config.cl_provider_fallback.to_string(),
             FALLBACK_BASE_CL_ENDPOINT
         );
-        assert_eq!(bridge_config.portal_subnetwork, Subnetwork::History);
+        assert_eq!(bridge_config.portal_subnetwork, Subnetwork::LegacyHistory);
     }
 
     #[test]
@@ -268,7 +269,7 @@ mod test {
         const MODE: &str = "snapshot:60";
         let bridge_config = BridgeConfig::parse_from(["bridge", "--mode", MODE]);
         assert_eq!(bridge_config.mode, BridgeMode::Snapshot(60));
-        assert_eq!(bridge_config.portal_subnetwork, Subnetwork::History);
+        assert_eq!(bridge_config.portal_subnetwork, Subnetwork::LegacyHistory);
     }
 
     #[test]

--- a/bin/portal-bridge/src/handle.rs
+++ b/bin/portal-bridge/src/handle.rs
@@ -52,9 +52,13 @@ pub fn subnetworks_flag(bridge_config: &BridgeConfig) -> Vec<Subnetwork> {
     match bridge_config.portal_subnetwork {
         Subnetwork::Beacon => vec![Subnetwork::Beacon],
         // History requires beacon and history
-        Subnetwork::History => vec![Subnetwork::Beacon, Subnetwork::History],
+        Subnetwork::LegacyHistory => vec![Subnetwork::Beacon, Subnetwork::LegacyHistory],
         // State requires beacon, history and state
-        Subnetwork::State => vec![Subnetwork::Beacon, Subnetwork::History, Subnetwork::State],
+        Subnetwork::State => vec![
+            Subnetwork::Beacon,
+            Subnetwork::LegacyHistory,
+            Subnetwork::State,
+        ],
         subnetwork => panic!("Unsupported subnetwork: {subnetwork:?}"),
     }
 }

--- a/bin/portal-bridge/src/main.rs
+++ b/bin/portal-bridge/src/main.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             census_handle
         }
-        Subnetwork::History => {
+        Subnetwork::LegacyHistory => {
             match bridge_config.mode {
                 BridgeMode::E2HS => {
                     let Some(e2hs_range) = bridge_config.e2hs_range.clone() else {
@@ -69,13 +69,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     // Create and initialize the census to acquire critical view of network before
                     // gossiping
                     let mut census = Census::new(subnetwork_overlays.clone(), &bridge_config);
-                    let census_handle = census.init([Subnetwork::History]).await?;
+                    let census_handle = census.init([Subnetwork::LegacyHistory]).await?;
 
-                    let history_network = subnetwork_overlays
-                        .history
-                        .expect("History network not found in SubnetworkOverlays");
+                    let legacy_history_network = subnetwork_overlays
+                        .legacy_history
+                        .expect("Legacy History network not found in SubnetworkOverlays");
                     let e2hs_bridge = E2HSBridge::new(
-                        history_network,
+                        legacy_history_network,
                         bridge_config.offer_limit,
                         e2hs_range,
                         bridge_config.e2hs_randomize,
@@ -86,7 +86,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     run_with_shutdown(
                         e2hs_bridge
                             .launch()
-                            .instrument(tracing::trace_span!("history(e2hs)")),
+                            .instrument(tracing::trace_span!("legacy_history(e2hs)")),
                     )
                     .await;
 
@@ -96,10 +96,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     // Create and initialize the census to acquire critical view of network before
                     // gossiping
                     let mut census = Census::new(subnetwork_overlays.clone(), &bridge_config);
-                    let census_handle = census.init([Subnetwork::History]).await?;
+                    let census_handle = census.init([Subnetwork::LegacyHistory]).await?;
 
                     let history_network = subnetwork_overlays
-                        .history
+                        .legacy_history
                         .expect("History network not found in SubnetworkOverlays");
 
                     let consensus_api = ConsensusApi::new(

--- a/bin/trin/src/handle.rs
+++ b/bin/trin/src/handle.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::bail;
 use rpc::RpcServerHandle;
 use trin_beacon::network::BeaconNetwork;
-use trin_history::network::HistoryNetwork;
+use trin_history::network::LegacyHistoryNetwork;
 use trin_state::network::StateNetwork;
 
 pub struct TrinHandle {
@@ -13,16 +13,16 @@ pub struct TrinHandle {
 
 #[derive(Default, Clone)]
 pub struct SubnetworkOverlays {
-    pub history: Option<Arc<HistoryNetwork>>,
+    pub legacy_history: Option<Arc<LegacyHistoryNetwork>>,
     pub state: Option<Arc<StateNetwork>>,
     pub beacon: Option<Arc<BeaconNetwork>>,
 }
 
 impl SubnetworkOverlays {
-    pub fn history(&self) -> anyhow::Result<Arc<HistoryNetwork>> {
-        match &self.history {
-            Some(history) => Ok(history.clone()),
-            None => bail!("History network is not available"),
+    pub fn history(&self) -> anyhow::Result<Arc<LegacyHistoryNetwork>> {
+        match &self.legacy_history {
+            Some(legacy_history) => Ok(legacy_history.clone()),
+            None => bail!("Legacy History network is not available"),
         }
     }
 

--- a/crates/ethereum-rpc-client/src/execution.rs
+++ b/crates/ethereum-rpc-client/src/execution.rs
@@ -12,7 +12,7 @@ use ethportal_api::{
         jsonrpc::{params::Params, request::JsonRequest},
         network_spec::network_spec,
     },
-    HistoryContentKey, HistoryContentValue, Receipts,
+    LegacyHistoryContentKey, LegacyHistoryContentValue, Receipts,
 };
 use serde_json::{json, Value};
 use tokio::time::sleep;
@@ -90,11 +90,11 @@ impl ExecutionApi {
     pub async fn get_block_body(
         &self,
         block: &Block<TxEnvelope>,
-    ) -> anyhow::Result<(HistoryContentKey, HistoryContentValue)> {
+    ) -> anyhow::Result<(LegacyHistoryContentKey, LegacyHistoryContentValue)> {
         let block_body = BlockBody(block.body.clone());
         block_body.validate_against_header(&block.header)?;
-        let content_key = HistoryContentKey::new_block_body(block.header.hash_slow());
-        let content_value = HistoryContentValue::BlockBody(block_body);
+        let content_key = LegacyHistoryContentKey::new_block_body(block.header.hash_slow());
+        let content_value = LegacyHistoryContentValue::BlockBody(block_body);
         Ok((content_key, content_value))
     }
 

--- a/crates/ethportal-api/src/legacy_history.rs
+++ b/crates/ethportal-api/src/legacy_history.rs
@@ -4,7 +4,6 @@ use serde_json::Value;
 
 use crate::{
     types::{
-        content_key::history::HistoryContentKey,
         enr::Enr,
         ping_extensions::extension_types::PingExtensionType,
         portal::{
@@ -13,38 +12,38 @@ use crate::{
         },
         portal_wire::OfferTrace,
     },
-    RawContentValue, RoutingTableInfo,
+    LegacyHistoryContentKey, RawContentValue, RoutingTableInfo,
 };
 
 /// Portal History JSON-RPC endpoints
 #[rpc(client, server, namespace = "portal")]
-pub trait HistoryNetworkApi {
+pub trait LegacyHistoryNetworkApi {
     /// Returns meta information about overlay routing table.
-    #[method(name = "historyRoutingTableInfo")]
+    #[method(name = "legacyHistoryRoutingTableInfo")]
     async fn routing_table_info(&self) -> RpcResult<RoutingTableInfo>;
 
     /// Returns the node data radios
-    #[method(name = "historyRadius")]
+    #[method(name = "legacyHistoryRadius")]
     async fn radius(&self) -> RpcResult<DataRadius>;
 
     /// Write an Ethereum Node Record to the overlay routing table.
-    #[method(name = "historyAddEnr")]
+    #[method(name = "legacyHistoryAddEnr")]
     async fn add_enr(&self, enr: Enr) -> RpcResult<bool>;
 
     /// Fetch the latest ENR associated with the given node ID.
-    #[method(name = "historyGetEnr")]
+    #[method(name = "legacyHistoryGetEnr")]
     async fn get_enr(&self, node_id: NodeId) -> RpcResult<Enr>;
 
     /// Delete Node ID from the overlay routing table.
-    #[method(name = "historyDeleteEnr")]
+    #[method(name = "legacyHistoryDeleteEnr")]
     async fn delete_enr(&self, node_id: NodeId) -> RpcResult<bool>;
 
     /// Fetch the ENR representation associated with the given Node ID.
-    #[method(name = "historyLookupEnr")]
+    #[method(name = "legacyHistoryLookupEnr")]
     async fn lookup_enr(&self, node_id: NodeId) -> RpcResult<Enr>;
 
     /// Send a PING message to the designated node and wait for a PONG response
-    #[method(name = "historyPing")]
+    #[method(name = "legacyHistoryPing")]
     async fn ping(
         &self,
         enr: Enr,
@@ -54,48 +53,48 @@ pub trait HistoryNetworkApi {
 
     /// Send a FINDNODES request for nodes that fall within the given set of distances, to the
     /// designated peer and wait for a response
-    #[method(name = "historyFindNodes")]
+    #[method(name = "legacyHistoryFindNodes")]
     async fn find_nodes(&self, enr: Enr, distances: Vec<u16>) -> RpcResult<FindNodesInfo>;
 
     /// Lookup a target node within in the network
-    #[method(name = "historyRecursiveFindNodes")]
+    #[method(name = "legacyHistoryRecursiveFindNodes")]
     async fn recursive_find_nodes(&self, node_id: NodeId) -> RpcResult<Vec<Enr>>;
 
     /// Send FINDCONTENT message to get the content with a content key.
-    #[method(name = "historyFindContent")]
+    #[method(name = "legacyHistoryFindContent")]
     async fn find_content(
         &self,
         enr: Enr,
-        content_key: HistoryContentKey,
+        content_key: LegacyHistoryContentKey,
     ) -> RpcResult<FindContentInfo>;
 
     /// First checks local storage if content is not found lookup a target content key in the
     /// network
-    #[method(name = "historyGetContent")]
-    async fn get_content(&self, content_key: HistoryContentKey) -> RpcResult<GetContentInfo>;
+    #[method(name = "legacyHistoryGetContent")]
+    async fn get_content(&self, content_key: LegacyHistoryContentKey) -> RpcResult<GetContentInfo>;
 
     /// First checks local storage if content is not found lookup a target content key in the
     /// network. Return tracing info.
-    #[method(name = "historyTraceGetContent")]
+    #[method(name = "legacyHistoryTraceGetContent")]
     async fn trace_get_content(
         &self,
-        content_key: HistoryContentKey,
+        content_key: LegacyHistoryContentKey,
     ) -> RpcResult<TraceContentInfo>;
 
     /// Pagination of local content keys
-    #[method(name = "historyPaginateLocalContentKeys")]
+    #[method(name = "legacyHistoryPaginateLocalContentKeys")]
     async fn paginate_local_content_keys(
         &self,
         offset: u64,
         limit: u64,
-    ) -> RpcResult<PaginateLocalContentInfo<HistoryContentKey>>;
+    ) -> RpcResult<PaginateLocalContentInfo<LegacyHistoryContentKey>>;
 
     /// Send the provided content value to interested peers. Clients may choose to send to some or
     /// all peers. Return the number of peers that the content was gossiped to.
-    #[method(name = "historyPutContent")]
+    #[method(name = "legacyHistoryPutContent")]
     async fn put_content(
         &self,
-        content_key: HistoryContentKey,
+        content_key: LegacyHistoryContentKey,
         content_value: RawContentValue,
     ) -> RpcResult<PutContentInfo>;
 
@@ -103,33 +102,36 @@ pub trait HistoryNetworkApi {
     /// response. Does not store the content locally.
     /// Returns the content keys bitlist upon successful content transmission or empty bitlist
     /// receive.
-    #[method(name = "historyOffer")]
+    #[method(name = "legacyHistoryOffer")]
     async fn offer(
         &self,
         enr: Enr,
-        content_items: Vec<(HistoryContentKey, RawContentValue)>,
+        content_items: Vec<(LegacyHistoryContentKey, RawContentValue)>,
     ) -> RpcResult<AcceptInfo>;
 
     /// Send an OFFER request with given ContentItems, to the designated peer.
     /// Does not store the content locally.
     /// Returns trace info for the offer.
-    #[method(name = "historyTraceOffer")]
+    #[method(name = "legacyHistoryTraceOffer")]
     async fn trace_offer(
         &self,
         enr: Enr,
-        content_key: HistoryContentKey,
+        content_key: LegacyHistoryContentKey,
         content_value: RawContentValue,
     ) -> RpcResult<OfferTrace>;
 
     /// Store content key with a content data to the local database.
-    #[method(name = "historyStore")]
+    #[method(name = "legacyHistoryStore")]
     async fn store(
         &self,
-        content_key: HistoryContentKey,
+        content_key: LegacyHistoryContentKey,
         content_value: RawContentValue,
     ) -> RpcResult<bool>;
 
     /// Get a content value from the local database
-    #[method(name = "historyLocalContent")]
-    async fn local_content(&self, content_key: HistoryContentKey) -> RpcResult<RawContentValue>;
+    #[method(name = "legacyHistoryLocalContent")]
+    async fn local_content(
+        &self,
+        content_key: LegacyHistoryContentKey,
+    ) -> RpcResult<RawContentValue>;
 }

--- a/crates/ethportal-api/src/lib.rs
+++ b/crates/ethportal-api/src/lib.rs
@@ -9,7 +9,7 @@ extern crate lazy_static;
 mod beacon;
 pub mod discv5;
 mod eth;
-mod history;
+mod legacy_history;
 mod state;
 #[cfg(test)]
 mod test_utils;
@@ -21,9 +21,9 @@ mod web3;
 pub use beacon::{BeaconNetworkApiClient, BeaconNetworkApiServer};
 pub use discv5::{Discv5ApiClient, Discv5ApiServer};
 pub use eth::{EthApiClient, EthApiServer};
-pub use history::{HistoryNetworkApiClient, HistoryNetworkApiServer};
 // Re-exports jsonrpsee crate
 pub use jsonrpsee;
+pub use legacy_history::{LegacyHistoryNetworkApiClient, LegacyHistoryNetworkApiServer};
 pub use state::{StateNetworkApiClient, StateNetworkApiServer};
 pub use types::{
     consensus,
@@ -31,13 +31,13 @@ pub use types::{
     content_key::{
         beacon::{BeaconContentKey, LightClientBootstrapKey, LightClientUpdatesByRangeKey},
         error::ContentKeyError,
-        history::{BlockBodyKey, BlockReceiptsKey, HistoryContentKey},
+        legacy_history::{BlockBodyKey, BlockReceiptsKey, LegacyHistoryContentKey},
         overlay::{IdentityContentKey, OverlayContentKey},
         state::StateContentKey,
     },
     content_value::{
-        beacon::BeaconContentValue, error::ContentValueError, history::HistoryContentValue,
-        state::StateContentValue, ContentValue,
+        beacon::BeaconContentValue, error::ContentValueError,
+        legacy_history::LegacyHistoryContentValue, state::StateContentValue, ContentValue,
     },
     discv5::*,
     enr::*,

--- a/crates/ethportal-api/src/test_utils/types.rs
+++ b/crates/ethportal-api/src/test_utils/types.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     types::execution::header_with_proof::HeaderWithProof, ContentValue, ContentValueError,
-    HistoryContentKey, HistoryContentValue, OverlayContentKey, RawContentValue,
+    LegacyHistoryContentKey, LegacyHistoryContentValue, OverlayContentKey, RawContentValue,
 };
 
 /// A common type used in test files.
@@ -19,12 +19,12 @@ impl<K: OverlayContentKey> ContentItem<K> {
     }
 }
 
-impl ContentItem<HistoryContentKey> {
+impl ContentItem<LegacyHistoryContentKey> {
     /// Decodes content value as HeaderWithProof.
     ///
     /// Panics if content value is not HeaderWithProof.
     pub fn content_value_as_header_with_proof(&self) -> HeaderWithProof {
-        let HistoryContentValue::BlockHeaderWithProof(header_with_proof) =
+        let LegacyHistoryContentValue::BlockHeaderWithProof(header_with_proof) =
             self.content_value().unwrap()
         else {
             panic!(

--- a/crates/ethportal-api/src/types/content_key/mod.rs
+++ b/crates/ethportal-api/src/types/content_key/mod.rs
@@ -1,5 +1,5 @@
 pub mod beacon;
 pub mod error;
-pub mod history;
+pub mod legacy_history;
 pub mod overlay;
 pub mod state;

--- a/crates/ethportal-api/src/types/content_value/legacy_history.rs
+++ b/crates/ethportal-api/src/types/content_value/legacy_history.rs
@@ -10,13 +10,13 @@ use crate::{
         network::Subnetwork,
     },
     utils::bytes::hex_encode,
-    BlockBody, ContentValueError, HistoryContentKey, RawContentValue, Receipts,
+    BlockBody, ContentValueError, LegacyHistoryContentKey, RawContentValue, Receipts,
 };
 
 /// A Portal History content value.
 #[derive(Clone, Debug, PartialEq)]
 #[allow(clippy::large_enum_variant)]
-pub enum HistoryContentValue {
+pub enum LegacyHistoryContentValue {
     BlockHeaderWithProof(HeaderWithProof),
     BlockBody(BlockBody),
     Receipts(Receipts),
@@ -24,8 +24,8 @@ pub enum HistoryContentValue {
     EphemeralHeaderOffer(EphemeralHeaderOffer),
 }
 
-impl ContentValue for HistoryContentValue {
-    type TContentKey = HistoryContentKey;
+impl ContentValue for LegacyHistoryContentValue {
+    type TContentKey = LegacyHistoryContentKey;
 
     fn encode(&self) -> RawContentValue {
         match self {
@@ -39,27 +39,28 @@ impl ContentValue for HistoryContentValue {
 
     fn decode(key: &Self::TContentKey, buf: &[u8]) -> Result<Self, ContentValueError> {
         match key {
-            HistoryContentKey::BlockHeaderByHash(_) | HistoryContentKey::BlockHeaderByNumber(_) => {
+            LegacyHistoryContentKey::BlockHeaderByHash(_)
+            | LegacyHistoryContentKey::BlockHeaderByNumber(_) => {
                 if let Ok(value) = HeaderWithProof::from_ssz_bytes(buf) {
                     return Ok(Self::BlockHeaderWithProof(value));
                 }
             }
-            HistoryContentKey::BlockBody(_) => {
+            LegacyHistoryContentKey::BlockBody(_) => {
                 if let Ok(value) = BlockBody::from_ssz_bytes(buf) {
                     return Ok(Self::BlockBody(value));
                 }
             }
-            HistoryContentKey::BlockReceipts(_) => {
+            LegacyHistoryContentKey::BlockReceipts(_) => {
                 if let Ok(value) = Receipts::from_ssz_bytes(buf) {
                     return Ok(Self::Receipts(value));
                 }
             }
-            HistoryContentKey::EphemeralHeadersFindContent(_) => {
+            LegacyHistoryContentKey::EphemeralHeadersFindContent(_) => {
                 if let Ok(value) = EphemeralHeadersFindContent::from_ssz_bytes(buf) {
                     return Ok(Self::EphemeralHeadersFindContent(value));
                 }
             }
-            HistoryContentKey::EphemeralHeaderOffer(_) => {
+            LegacyHistoryContentKey::EphemeralHeaderOffer(_) => {
                 if let Ok(value) = EphemeralHeaderOffer::from_ssz_bytes(buf) {
                     return Ok(Self::EphemeralHeaderOffer(value));
                 }
@@ -68,7 +69,7 @@ impl ContentValue for HistoryContentValue {
 
         Err(ContentValueError::UnknownContent {
             bytes: hex_encode(buf),
-            subnetwork: Subnetwork::History,
+            subnetwork: Subnetwork::LegacyHistory,
         })
     }
 }
@@ -80,52 +81,54 @@ mod test {
     use alloy::primitives::Bytes;
 
     use super::*;
-    use crate::HistoryContentValue;
+    use crate::LegacyHistoryContentValue;
 
     #[test]
     fn content_value_deserialization_failure_displays_debuggable_data() {
-        let key = HistoryContentKey::random().unwrap();
+        let key = LegacyHistoryContentKey::random().unwrap();
         let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
-        let item_result = HistoryContentValue::decode(&key, &data);
+        let item_result = LegacyHistoryContentValue::decode(&key, &data);
         let error = item_result.unwrap_err();
         // Test the error Debug representation
         assert_eq!(
             error,
             ContentValueError::UnknownContent {
                 bytes: "0x010203040506070809".to_string(),
-                subnetwork: Subnetwork::History,
+                subnetwork: Subnetwork::LegacyHistory,
             }
         );
         // Test the error Display representation.
         assert_eq!(
             error.to_string(),
-            "could not determine content type of 0x010203040506070809 from History subnetwork"
+            "could not determine content type of 0x010203040506070809 from LegacyHistory subnetwork"
         );
     }
 
     #[test]
     fn ephemeral_headers_find_content_content_value() {
-        let content_key: HistoryContentKey = serde_json::from_str(
+        let content_key: LegacyHistoryContentKey = serde_json::from_str(
             "\"0x04d24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f27618301\"",
         )
         .unwrap();
         let raw_content_value  = Bytes::from_str(
             "0x0800000063020000f90258a0b390d63aac03bbef75de888d16bd56b91c9291c2a7e38d36ac24731351522bd1a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479495222290dd7278aa3ddd389cc1e1d165cc4bafe5a068421c2c599dc31396a09772a073fb421c4bd25ef1462914ef13e5dfa2d31c23a0f0280ae7fd02f2b9684be8d740830710cd62e4869c891c3a0ead32ea757e70a3a0b39f9f7a13a342751bd2c575eca303e224393d4e11d715866b114b7e824da608b9010094a9480614840b245a1a2148e2100e2070472151b44c3020280930809a20c011609520bc10080074a61c782411e34713ee19c560ca02208f4770080013bc5d302d84743dd0008c5d089d5b1c95940de80809888ba7ed68512d426c048934c8cc0a08dd440b461265001ee50909a26d0213000a7411242c72a648c87e104c0097a0aaba477628508533c5924867341dd11305aa372350b019244034dc849419968b00fd2dda39ecff042639c43923f0d48495d2a40468524bce13a86444c82071ca9c431208870b33f5320f680f3991c2349e2433c80440b0832016820e1070a4405aadcc40050a5006c24504f0098c4391e0f04047c824d1d88ca8021d240510808401312d008401c9c38083a9371c84665ba27f8f6265617665726275696c642e6f7267a085175443c2889afcb52288e0fa8804b671e582f9fd416071a70642d90c7dc0db88000000000000000085012643ff14a0f0747de0368fb967ede9b81320a5b01a4d85b3d427e8bc8e96ff371478d80e768302000080a0ec0befcffe8b2792fc5e7b67dac85ee3bbb09bc56b0ea5d9a698ec3b402d296ff9025ba00d599f184bf4f978eb6f046eb0365b82ca9cb93e999dea93033556751707278ca01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479495222290dd7278aa3ddd389cc1e1d165cc4bafe5a07c77f711a2cb5c59fcc78d63f59dbf73a7fe69be3cad9d8220f9e64668a100eda0bed93e45262811ab648db2f41f3e43706d6ed0bfc9c09d30322e0d8c342657e8a0488fe820ca9e0ec9eb5006e55927151e29219c0709df152de872dfa7c89253f0b90100856931400a4b0f6f3aaaf091e2a05ad131c309001e2308908695014650224020b39105bf5a000230125333205ddf25268379af26ea51e9318666b56d43ef980b9834d708d3001b3bd82660ef8a76e928a0711385d46c4e7d00930e38f93c8100182221870217552690dcf09019316ccd2d31026911cdf436d61a4e3a7c2b40f46c0426d4a80c47022171f9c80625105ed801bf21ef0029297166606de1f18d3902860561e609e485474353cc2b0f2d4b9c2148a5c62513007f358127d080ca601dc28e16141a05786d209d845b8d04c600746e5fb40912b801044386527be54c2172ec46061c0740098c0b8cfc6d35060718d9aa490ce7d68905818070b1979d808401312cff8401c9c38083cc573d84665ba2738f6265617665726275696c642e6f7267a0d735fec5f0cefaf3aba227590a5b0f8ab52e1a6f6a3044d064ad132de188b8b988000000000000000085012a435d21a046d0c52945253f0084ee5f6d57e093b946cabcb415006fd3dfdbb3b797f8eb2f8304000083020000a0777b0eec9bf4a5496c56b87a64e41b89f8ff58e3feb9f611b0afeb34a263e920"
         ).unwrap();
-        let content_value = HistoryContentValue::decode(&content_key, &raw_content_value).unwrap();
+        let content_value =
+            LegacyHistoryContentValue::decode(&content_key, &raw_content_value).unwrap();
         assert_eq!(content_value.encode(), raw_content_value);
     }
 
     #[test]
     fn ephemeral_header_offer_content_value() {
-        let content_key: HistoryContentKey = serde_json::from_str(
+        let content_key: LegacyHistoryContentKey = serde_json::from_str(
             "\"0x05d24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f276183\"",
         )
         .unwrap();
         let raw_content_value  = Bytes::from_str(
             "0x04000000f90258a0b390d63aac03bbef75de888d16bd56b91c9291c2a7e38d36ac24731351522bd1a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479495222290dd7278aa3ddd389cc1e1d165cc4bafe5a068421c2c599dc31396a09772a073fb421c4bd25ef1462914ef13e5dfa2d31c23a0f0280ae7fd02f2b9684be8d740830710cd62e4869c891c3a0ead32ea757e70a3a0b39f9f7a13a342751bd2c575eca303e224393d4e11d715866b114b7e824da608b9010094a9480614840b245a1a2148e2100e2070472151b44c3020280930809a20c011609520bc10080074a61c782411e34713ee19c560ca02208f4770080013bc5d302d84743dd0008c5d089d5b1c95940de80809888ba7ed68512d426c048934c8cc0a08dd440b461265001ee50909a26d0213000a7411242c72a648c87e104c0097a0aaba477628508533c5924867341dd11305aa372350b019244034dc849419968b00fd2dda39ecff042639c43923f0d48495d2a40468524bce13a86444c82071ca9c431208870b33f5320f680f3991c2349e2433c80440b0832016820e1070a4405aadcc40050a5006c24504f0098c4391e0f04047c824d1d88ca8021d240510808401312d008401c9c38083a9371c84665ba27f8f6265617665726275696c642e6f7267a085175443c2889afcb52288e0fa8804b671e582f9fd416071a70642d90c7dc0db88000000000000000085012643ff14a0f0747de0368fb967ede9b81320a5b01a4d85b3d427e8bc8e96ff371478d80e768302000080a0ec0befcffe8b2792fc5e7b67dac85ee3bbb09bc56b0ea5d9a698ec3b402d296f"
         ).unwrap();
-        let content_value = HistoryContentValue::decode(&content_key, &raw_content_value).unwrap();
+        let content_value =
+            LegacyHistoryContentValue::decode(&content_key, &raw_content_value).unwrap();
         assert_eq!(content_value.encode(), raw_content_value);
     }
 }

--- a/crates/ethportal-api/src/types/content_value/mod.rs
+++ b/crates/ethportal-api/src/types/content_value/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 pub mod beacon;
 pub mod constants;
 pub mod error;
-pub mod history;
+pub mod legacy_history;
 pub mod state;
 
 /// An encodable portal network content value.

--- a/crates/ethportal-api/src/types/execution/header_with_proof.rs
+++ b/crates/ethportal-api/src/types/execution/header_with_proof.rs
@@ -299,7 +299,7 @@ mod tests {
             read_json_portal_spec_tests_file, read_ssz_portal_spec_tests_file,
             read_yaml_portal_spec_tests_file, types::ContentItem,
         },
-        HistoryContentKey,
+        LegacyHistoryContentKey,
     };
 
     const TEST_DIR: &str = "tests/mainnet/history/headers_with_proof";
@@ -309,7 +309,7 @@ mod tests {
 
     #[test]
     fn decode_encode_headers_with_proof() {
-        let all_test_data: HashMap<u64, ContentItem<HistoryContentKey>> =
+        let all_test_data: HashMap<u64, ContentItem<LegacyHistoryContentKey>> =
             read_json_portal_spec_tests_file(test_path("1000001-1000010.json")).unwrap();
         for (block_number, test_data) in all_test_data {
             let header_with_proof = test_data.content_value_as_header_with_proof();
@@ -329,7 +329,7 @@ mod tests {
         )]
         block_number: u64,
     ) {
-        let test_data: ContentItem<HistoryContentKey> =
+        let test_data: ContentItem<LegacyHistoryContentKey> =
             read_yaml_portal_spec_tests_file(test_path(format!("{block_number}.yaml"))).unwrap();
         let header_with_proof = test_data.content_value_as_header_with_proof();
         assert_eq!(header_with_proof.header.number, block_number);
@@ -346,7 +346,7 @@ mod tests {
         fn bellatrix(
             #[values(15_537_394, 15_539_558, 15_547_621, 15_555_729, 17_034_869)] block_number: u64,
         ) -> anyhow::Result<()> {
-            let test_data: ContentItem<HistoryContentKey> =
+            let test_data: ContentItem<LegacyHistoryContentKey> =
                 read_yaml_portal_spec_tests_file(test_path(format!("{block_number}.yaml")))?;
             let header_with_proof = test_data.content_value_as_header_with_proof();
 
@@ -363,7 +363,7 @@ mod tests {
         fn capella(
             #[values(17_034_870, 17_042_287, 17_062_257, 19_426_586)] block_number: u64,
         ) -> anyhow::Result<()> {
-            let test_data: ContentItem<HistoryContentKey> =
+            let test_data: ContentItem<LegacyHistoryContentKey> =
                 read_yaml_portal_spec_tests_file(test_path(format!("{block_number}.yaml")))?;
             let header_with_proof = test_data.content_value_as_header_with_proof();
 
@@ -379,7 +379,7 @@ mod tests {
 
         #[rstest::rstest]
         fn deneb(#[values(19_426_587, 22_162_263)] block_number: u64) -> anyhow::Result<()> {
-            let test_data: ContentItem<HistoryContentKey> =
+            let test_data: ContentItem<LegacyHistoryContentKey> =
                 read_yaml_portal_spec_tests_file(test_path(format!("{block_number}.yaml")))?;
             let header_with_proof = test_data.content_value_as_header_with_proof();
 

--- a/crates/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/crates/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -5,8 +5,8 @@ use crate::{
         enr::Enr,
         ping_extensions::{decode::PingExtension, extension_types::PingExtensionType},
     },
-    BeaconContentKey, BeaconContentValue, HistoryContentKey, HistoryContentValue, StateContentKey,
-    StateContentValue,
+    BeaconContentKey, BeaconContentValue, LegacyHistoryContentKey, LegacyHistoryContentValue,
+    StateContentKey, StateContentValue,
 };
 
 /// Discv5 JSON-RPC endpoints. Start with "discv5_" prefix
@@ -59,7 +59,7 @@ pub enum StateEndpoint {
 
 /// History network JSON-RPC endpoints. Start with "portal_history" prefix
 #[derive(Debug, PartialEq, Clone)]
-pub enum HistoryEndpoint {
+pub enum LegacyHistoryEndpoint {
     /// params: [enr]
     AddEnr(Enr),
     /// params: None
@@ -67,29 +67,32 @@ pub enum HistoryEndpoint {
     /// params: [node_id]
     DeleteEnr(NodeId),
     /// params: [enr, content_key]
-    FindContent(Enr, HistoryContentKey),
+    FindContent(Enr, LegacyHistoryContentKey),
     /// params: [enr, distances]
     FindNodes(Enr, Vec<u16>),
     /// params: [node_id]
     GetEnr(NodeId),
     /// params: content_key
-    LocalContent(HistoryContentKey),
+    LocalContent(LegacyHistoryContentKey),
     /// params: [node_id]
     LookupEnr(NodeId),
     /// params: [content_key, content_value]
-    PutContent(HistoryContentKey, HistoryContentValue),
+    PutContent(LegacyHistoryContentKey, LegacyHistoryContentValue),
     /// params: [enr, Vec<(content_key, content_value)>]
-    Offer(Enr, Vec<(HistoryContentKey, HistoryContentValue)>),
+    Offer(
+        Enr,
+        Vec<(LegacyHistoryContentKey, LegacyHistoryContentValue)>,
+    ),
     /// params: [enr, content_key, content_value]
-    TraceOffer(Enr, HistoryContentKey, HistoryContentValue),
+    TraceOffer(Enr, LegacyHistoryContentKey, LegacyHistoryContentValue),
     /// params: [enr, payload_type, payload]
     Ping(Enr, Option<PingExtensionType>, Option<PingExtension>),
     /// params: content_key
-    GetContent(HistoryContentKey),
+    GetContent(LegacyHistoryContentKey),
     /// params: content_key
-    TraceGetContent(HistoryContentKey),
+    TraceGetContent(LegacyHistoryContentKey),
     /// params: [content_key, content_value]
-    Store(HistoryContentKey, HistoryContentValue),
+    Store(LegacyHistoryContentKey, LegacyHistoryContentValue),
     /// params: None
     RoutingTableInfo,
     // This endpoint is not History network specific
@@ -164,7 +167,7 @@ impl SubnetworkEndpoint for StateEndpoint {
     }
 }
 
-impl SubnetworkEndpoint for HistoryEndpoint {
+impl SubnetworkEndpoint for LegacyHistoryEndpoint {
     fn subnetwork() -> &'static str {
         "history"
     }

--- a/crates/ethportal-api/src/types/jsonrpc/endpoints.rs
+++ b/crates/ethportal-api/src/types/jsonrpc/endpoints.rs
@@ -169,7 +169,7 @@ impl SubnetworkEndpoint for StateEndpoint {
 
 impl SubnetworkEndpoint for LegacyHistoryEndpoint {
     fn subnetwork() -> &'static str {
-        "history"
+        "legacy_history"
     }
 }
 

--- a/crates/ethportal-api/src/types/jsonrpc/request.rs
+++ b/crates/ethportal-api/src/types/jsonrpc/request.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc;
 use validator::{Validate, ValidationError};
 
 use super::{
-    endpoints::{BeaconEndpoint, HistoryEndpoint, StateEndpoint},
+    endpoints::{BeaconEndpoint, LegacyHistoryEndpoint, StateEndpoint},
     params::Params,
 };
 
@@ -51,8 +51,8 @@ pub struct JsonRpcRequest<T> {
     pub resp: Responder<Value, String>,
 }
 
-/// History network JSON-RPC request
-pub type HistoryJsonRpcRequest = JsonRpcRequest<HistoryEndpoint>;
+/// Legacy History network JSON-RPC request
+pub type LegacyHistoryJsonRpcRequest = JsonRpcRequest<LegacyHistoryEndpoint>;
 
 /// State network JSON-RPC request
 pub type StateJsonRpcRequest = JsonRpcRequest<StateEndpoint>;

--- a/crates/ethportal-api/src/types/network.rs
+++ b/crates/ethportal-api/src/types/network.rs
@@ -48,7 +48,7 @@ impl std::str::FromStr for Network {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub enum Subnetwork {
     Beacon,
-    History,
+    LegacyHistory,
     State,
     CanonicalIndices,
     VerkleState,
@@ -61,7 +61,7 @@ impl fmt::Display for Subnetwork {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Subnetwork::Beacon => write!(f, "Beacon"),
-            Subnetwork::History => write!(f, "History"),
+            Subnetwork::LegacyHistory => write!(f, "Legacy History"),
             Subnetwork::State => write!(f, "State"),
             Subnetwork::CanonicalIndices => write!(f, "Canonical Indices"),
             Subnetwork::VerkleState => write!(f, "Verkle State"),
@@ -77,7 +77,7 @@ impl std::str::FromStr for Subnetwork {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "beacon" => Ok(Subnetwork::Beacon),
-            "history" => Ok(Subnetwork::History),
+            "legacy_history" => Ok(Subnetwork::LegacyHistory),
             "state" => Ok(Subnetwork::State),
             "canonical_indices" => Ok(Subnetwork::CanonicalIndices),
             "verkle_state" => Ok(Subnetwork::VerkleState),
@@ -93,7 +93,7 @@ impl Subnetwork {
     pub fn to_cli_arg(&self) -> String {
         match self {
             Subnetwork::Beacon => "beacon".to_string(),
-            Subnetwork::History => "history".to_string(),
+            Subnetwork::LegacyHistory => "legacy_history".to_string(),
             Subnetwork::State => "state".to_string(),
             Subnetwork::CanonicalIndices => "canonical_indices".to_string(),
             Subnetwork::VerkleState => "verkle_state".to_string(),
@@ -106,7 +106,7 @@ impl Subnetwork {
     pub fn is_active(&self) -> bool {
         match self {
             Subnetwork::Beacon => true,
-            Subnetwork::History => true,
+            Subnetwork::LegacyHistory => true,
             Subnetwork::State => true,
             Subnetwork::CanonicalIndices => false,
             Subnetwork::VerkleState => false,
@@ -118,8 +118,8 @@ impl Subnetwork {
     /// Returns Subnetworks that it depends on.
     pub fn dependencies(&self) -> Vec<Subnetwork> {
         match self {
-            Subnetwork::History => vec![Subnetwork::Beacon],
-            Subnetwork::State => vec![Subnetwork::History, Subnetwork::Beacon],
+            Subnetwork::LegacyHistory => vec![Subnetwork::Beacon],
+            Subnetwork::State => vec![Subnetwork::LegacyHistory, Subnetwork::Beacon],
             _ => vec![],
         }
     }

--- a/crates/ethportal-api/src/types/network_spec.rs
+++ b/crates/ethportal-api/src/types/network_spec.rs
@@ -158,7 +158,7 @@ impl EthereumHardforks for NetworkSpec {
 pub static MAINNET: Lazy<Arc<NetworkSpec>> = Lazy::new(|| {
     let mut portal_subnetworks = BiHashMap::new();
     portal_subnetworks.insert(Subnetwork::State, "0x500A".to_string());
-    portal_subnetworks.insert(Subnetwork::History, "0x500B".to_string());
+    portal_subnetworks.insert(Subnetwork::LegacyHistory, "0x500B".to_string());
     portal_subnetworks.insert(Subnetwork::Beacon, "0x500C".to_string());
     portal_subnetworks.insert(Subnetwork::CanonicalIndices, "0x500D".to_string());
     portal_subnetworks.insert(Subnetwork::VerkleState, "0x500E".to_string());
@@ -179,7 +179,7 @@ pub static MAINNET: Lazy<Arc<NetworkSpec>> = Lazy::new(|| {
 pub static ANGELFOOD: Lazy<Arc<NetworkSpec>> = Lazy::new(|| {
     let mut portal_subnetworks = BiHashMap::new();
     portal_subnetworks.insert(Subnetwork::State, "0x504A".to_string());
-    portal_subnetworks.insert(Subnetwork::History, "0x504B".to_string());
+    portal_subnetworks.insert(Subnetwork::LegacyHistory, "0x504B".to_string());
     portal_subnetworks.insert(Subnetwork::Beacon, "0x504C".to_string());
     portal_subnetworks.insert(Subnetwork::CanonicalIndices, "0x504D".to_string());
     portal_subnetworks.insert(Subnetwork::VerkleState, "0x504E".to_string());
@@ -199,7 +199,7 @@ pub static ANGELFOOD: Lazy<Arc<NetworkSpec>> = Lazy::new(|| {
 pub static SEPOLIA: Lazy<Arc<NetworkSpec>> = Lazy::new(|| {
     let mut portal_subnetworks = BiHashMap::new();
     portal_subnetworks.insert(Subnetwork::State, "0x504A".to_string());
-    portal_subnetworks.insert(Subnetwork::History, "0x504B".to_string());
+    portal_subnetworks.insert(Subnetwork::LegacyHistory, "0x504B".to_string());
     portal_subnetworks.insert(Subnetwork::Beacon, "0x504C".to_string());
     portal_subnetworks.insert(Subnetwork::CanonicalIndices, "0x504D".to_string());
     portal_subnetworks.insert(Subnetwork::VerkleState, "0x504E".to_string());

--- a/crates/ethportal-api/src/types/ping_extensions/consts.rs
+++ b/crates/ethportal-api/src/types/ping_extensions/consts.rs
@@ -5,7 +5,7 @@ pub const BEACON_SUPPORTED_EXTENSIONS: &[PingExtensionType] = &[
     PingExtensionType::BasicRadius,
     PingExtensionType::Error,
 ];
-pub const HISTORY_SUPPORTED_EXTENSIONS: &[PingExtensionType] = &[
+pub const LEGACY_HISTORY_SUPPORTED_EXTENSIONS: &[PingExtensionType] = &[
     PingExtensionType::Capabilities,
     PingExtensionType::HistoryRadius,
     PingExtensionType::Error,

--- a/crates/portalnet/src/overlay/service/manager.rs
+++ b/crates/portalnet/src/overlay/service/manager.rs
@@ -1040,7 +1040,7 @@ mod tests {
             overlay_config.bucket_filter,
         ));
 
-        let protocol = Subnetwork::History;
+        let protocol = Subnetwork::LegacyHistory;
         let active_outgoing_requests = Arc::new(RwLock::new(HashMap::new()));
         let peers_to_ping = HashSetDelay::default();
         let (command_tx, command_rx) = mpsc::unbounded_channel();

--- a/crates/portalnet/tests/overlay.rs
+++ b/crates/portalnet/tests/overlay.rs
@@ -91,7 +91,7 @@ async fn spawn_overlay(
 
             if let Ok(req_subnetwork) = req_subnetwork {
                 match (req_subnetwork, overlay_protocol) {
-                    (Subnetwork::History, Subnetwork::History)
+                    (Subnetwork::LegacyHistory, Subnetwork::LegacyHistory)
                     | (Subnetwork::State, Subnetwork::State) => overlay_tx.send(talk_req).unwrap(),
                     _ => panic!("Unexpected subnetwork"),
                 }
@@ -120,7 +120,7 @@ async fn spawn_overlay(
 // Use sleeps to give time for background routing table processes.
 #[test_log::test(tokio::test)]
 async fn overlay() {
-    let protocol = Subnetwork::History;
+    let protocol = Subnetwork::LegacyHistory;
     let sleep_duration = Duration::from_millis(5);
     let ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 

--- a/crates/rpc/src/legacy_history_rpc.rs
+++ b/crates/rpc/src/legacy_history_rpc.rs
@@ -2,9 +2,9 @@ use discv5::enr::NodeId;
 use ethportal_api::{
     types::{
         enr::Enr,
-        jsonrpc::{endpoints::HistoryEndpoint, request::HistoryJsonRpcRequest},
+        jsonrpc::{endpoints::LegacyHistoryEndpoint, request::LegacyHistoryJsonRpcRequest},
         ping_extensions::{
-            consts::HISTORY_SUPPORTED_EXTENSIONS, extension_types::PingExtensionType,
+            consts::LEGACY_HISTORY_SUPPORTED_EXTENSIONS, extension_types::PingExtensionType,
         },
         portal::{
             AcceptInfo, DataRadius, FindContentInfo, FindNodesInfo, GetContentInfo,
@@ -13,8 +13,8 @@ use ethportal_api::{
         },
         portal_wire::OfferTrace,
     },
-    ContentValue, HistoryContentKey, HistoryContentValue, HistoryNetworkApiServer, RawContentValue,
-    RoutingTableInfo,
+    ContentValue, LegacyHistoryContentKey, LegacyHistoryContentValue,
+    LegacyHistoryNetworkApiServer, RawContentValue, RoutingTableInfo,
 };
 use serde_json::Value;
 use tokio::sync::mpsc;
@@ -26,45 +26,45 @@ use crate::{
     ping_extension::parse_ping_payload,
 };
 
-pub struct HistoryNetworkApi {
-    network: mpsc::UnboundedSender<HistoryJsonRpcRequest>,
+pub struct LegacyHistoryNetworkApi {
+    network: mpsc::UnboundedSender<LegacyHistoryJsonRpcRequest>,
 }
 
-impl HistoryNetworkApi {
-    pub fn new(network: mpsc::UnboundedSender<HistoryJsonRpcRequest>) -> Self {
+impl LegacyHistoryNetworkApi {
+    pub fn new(network: mpsc::UnboundedSender<LegacyHistoryJsonRpcRequest>) -> Self {
         Self { network }
     }
 }
 
 #[async_trait]
-impl HistoryNetworkApiServer for HistoryNetworkApi {
+impl LegacyHistoryNetworkApiServer for LegacyHistoryNetworkApi {
     /// Returns meta information about overlay routing table.
     async fn routing_table_info(&self) -> RpcResult<RoutingTableInfo> {
-        let endpoint = HistoryEndpoint::RoutingTableInfo;
+        let endpoint = LegacyHistoryEndpoint::RoutingTableInfo;
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Write an Ethereum Node Record to the overlay routing table.
     async fn add_enr(&self, enr: Enr) -> RpcResult<bool> {
-        let endpoint = HistoryEndpoint::AddEnr(enr);
+        let endpoint = LegacyHistoryEndpoint::AddEnr(enr);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Fetch the latest ENR associated with the given node ID.
     async fn get_enr(&self, node_id: NodeId) -> RpcResult<Enr> {
-        let endpoint = HistoryEndpoint::GetEnr(node_id);
+        let endpoint = LegacyHistoryEndpoint::GetEnr(node_id);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Delete Node ID from the overlay routing table.
     async fn delete_enr(&self, node_id: NodeId) -> RpcResult<bool> {
-        let endpoint = HistoryEndpoint::DeleteEnr(node_id);
+        let endpoint = LegacyHistoryEndpoint::DeleteEnr(node_id);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Fetch the ENR representation associated with the given Node ID.
     async fn lookup_enr(&self, node_id: NodeId) -> RpcResult<Enr> {
-        let endpoint = HistoryEndpoint::LookupEnr(node_id);
+        let endpoint = LegacyHistoryEndpoint::LookupEnr(node_id);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
@@ -76,27 +76,27 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
         payload: Option<Value>,
     ) -> RpcResult<PongInfo> {
         let (payload_type, payload) =
-            parse_ping_payload(HISTORY_SUPPORTED_EXTENSIONS, payload_type, payload)?;
-        let endpoint = HistoryEndpoint::Ping(enr, payload_type, payload);
+            parse_ping_payload(LEGACY_HISTORY_SUPPORTED_EXTENSIONS, payload_type, payload)?;
+        let endpoint = LegacyHistoryEndpoint::Ping(enr, payload_type, payload);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Send a FINDNODES request for nodes that fall within the given set of distances, to the
     /// designated peer and wait for a response
     async fn find_nodes(&self, enr: Enr, distances: Vec<u16>) -> RpcResult<FindNodesInfo> {
-        let endpoint = HistoryEndpoint::FindNodes(enr, distances);
+        let endpoint = LegacyHistoryEndpoint::FindNodes(enr, distances);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Lookup a target node within in the network
     async fn recursive_find_nodes(&self, node_id: NodeId) -> RpcResult<Vec<Enr>> {
-        let endpoint = HistoryEndpoint::RecursiveFindNodes(node_id);
+        let endpoint = LegacyHistoryEndpoint::RecursiveFindNodes(node_id);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Lookup a target node within in the network
     async fn radius(&self) -> RpcResult<DataRadius> {
-        let endpoint = HistoryEndpoint::DataRadius;
+        let endpoint = LegacyHistoryEndpoint::DataRadius;
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
@@ -104,16 +104,16 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
     async fn find_content(
         &self,
         enr: Enr,
-        content_key: HistoryContentKey,
+        content_key: LegacyHistoryContentKey,
     ) -> RpcResult<FindContentInfo> {
-        let endpoint = HistoryEndpoint::FindContent(enr, content_key);
+        let endpoint = LegacyHistoryEndpoint::FindContent(enr, content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// First checks local storage if content is not found lookup a target content key in the
     /// network
-    async fn get_content(&self, content_key: HistoryContentKey) -> RpcResult<GetContentInfo> {
-        let endpoint = HistoryEndpoint::GetContent(content_key);
+    async fn get_content(&self, content_key: LegacyHistoryContentKey) -> RpcResult<GetContentInfo> {
+        let endpoint = LegacyHistoryEndpoint::GetContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
@@ -121,9 +121,9 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
     /// network. Return tracing info.
     async fn trace_get_content(
         &self,
-        content_key: HistoryContentKey,
+        content_key: LegacyHistoryContentKey,
     ) -> RpcResult<TraceContentInfo> {
-        let endpoint = HistoryEndpoint::TraceGetContent(content_key);
+        let endpoint = LegacyHistoryEndpoint::TraceGetContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
@@ -132,8 +132,8 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
         &self,
         offset: u64,
         limit: u64,
-    ) -> RpcResult<PaginateLocalContentInfo<HistoryContentKey>> {
-        let endpoint = HistoryEndpoint::PaginateLocalContentKeys(offset, limit);
+    ) -> RpcResult<PaginateLocalContentInfo<LegacyHistoryContentKey>> {
+        let endpoint = LegacyHistoryEndpoint::PaginateLocalContentKeys(offset, limit);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
@@ -141,12 +141,12 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
     /// peers. Return the number of peers that the content was gossiped to.
     async fn put_content(
         &self,
-        content_key: HistoryContentKey,
+        content_key: LegacyHistoryContentKey,
         content_value: RawContentValue,
     ) -> RpcResult<PutContentInfo> {
-        let content_value = HistoryContentValue::decode(&content_key, &content_value)
+        let content_value = LegacyHistoryContentValue::decode(&content_key, &content_value)
             .map_err(RpcServeError::from)?;
-        let endpoint = HistoryEndpoint::PutContent(content_key, content_value);
+        let endpoint = LegacyHistoryEndpoint::PutContent(content_key, content_value);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
@@ -157,7 +157,7 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
     async fn offer(
         &self,
         enr: Enr,
-        content_items: Vec<(HistoryContentKey, RawContentValue)>,
+        content_items: Vec<(LegacyHistoryContentKey, RawContentValue)>,
     ) -> RpcResult<AcceptInfo> {
         if !(1..=MAX_CONTENT_KEYS_PER_OFFER).contains(&content_items.len()) {
             return Err(RpcServeError::Message(format!(
@@ -169,12 +169,12 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
         let content_items = content_items
             .into_iter()
             .map(|(key, value)| {
-                HistoryContentValue::decode(&key, &value)
+                LegacyHistoryContentValue::decode(&key, &value)
                     .map(|value| (key, value))
                     .map_err(RpcServeError::from)
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let endpoint = HistoryEndpoint::Offer(enr, content_items);
+        let endpoint = LegacyHistoryEndpoint::Offer(enr, content_items);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
@@ -185,35 +185,38 @@ impl HistoryNetworkApiServer for HistoryNetworkApi {
     async fn trace_offer(
         &self,
         enr: Enr,
-        content_key: HistoryContentKey,
+        content_key: LegacyHistoryContentKey,
         content_value: RawContentValue,
     ) -> RpcResult<OfferTrace> {
-        let content_value = HistoryContentValue::decode(&content_key, &content_value)
+        let content_value = LegacyHistoryContentValue::decode(&content_key, &content_value)
             .map_err(RpcServeError::from)?;
-        let endpoint = HistoryEndpoint::TraceOffer(enr, content_key, content_value);
+        let endpoint = LegacyHistoryEndpoint::TraceOffer(enr, content_key, content_value);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Store content key with a content data to the local database.
     async fn store(
         &self,
-        content_key: HistoryContentKey,
+        content_key: LegacyHistoryContentKey,
         content_value: RawContentValue,
     ) -> RpcResult<bool> {
-        let content_value = HistoryContentValue::decode(&content_key, &content_value)
+        let content_value = LegacyHistoryContentValue::decode(&content_key, &content_value)
             .map_err(RpcServeError::from)?;
-        let endpoint = HistoryEndpoint::Store(content_key, content_value);
+        let endpoint = LegacyHistoryEndpoint::Store(content_key, content_value);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 
     /// Get a content from the local database.
-    async fn local_content(&self, content_key: HistoryContentKey) -> RpcResult<RawContentValue> {
-        let endpoint = HistoryEndpoint::LocalContent(content_key);
+    async fn local_content(
+        &self,
+        content_key: LegacyHistoryContentKey,
+    ) -> RpcResult<RawContentValue> {
+        let endpoint = LegacyHistoryEndpoint::LocalContent(content_key);
         Ok(proxy_to_subnet(&self.network, endpoint).await?)
     }
 }
 
-impl std::fmt::Debug for HistoryNetworkApi {
+impl std::fmt::Debug for LegacyHistoryNetworkApi {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HistoryNetworkApi").finish_non_exhaustive()
     }

--- a/crates/rpc/src/rpc_server.rs
+++ b/crates/rpc/src/rpc_server.rs
@@ -642,11 +642,11 @@ mod tests {
 
     /// Returns an [RpcModuleBuilder] with testing components.
     pub fn test_rpc_builder() -> RpcModuleBuilder {
-        let (history_tx, _) = tokio::sync::mpsc::unbounded_channel();
+        let (legacy_history_tx, _) = tokio::sync::mpsc::unbounded_channel();
         let (beacon_tx, _) = tokio::sync::mpsc::unbounded_channel();
         let discv5 = Arc::new(Discovery::new(Default::default()).unwrap());
         RpcModuleBuilder::new(discv5)
-            .with_history(history_tx)
+            .with_legacy_history(legacy_history_tx)
             .with_beacon(beacon_tx)
     }
 
@@ -694,11 +694,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_http_addr_in_use() {
-        let handle = launch_http(vec![PortalRpcModule::History]).await;
+        let handle = launch_http(vec![PortalRpcModule::LegacyHistory]).await;
         let addr = handle.http_local_addr().unwrap();
         let builder = test_rpc_builder();
         let server = builder.build(TransportRpcModuleConfig::set_http(vec![
-            PortalRpcModule::History,
+            PortalRpcModule::LegacyHistory,
         ]));
         let result = server
             .start_server(RpcServerConfig::http(Default::default()).with_http_address(addr))
@@ -709,11 +709,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_ws_addr_in_use() {
-        let handle = launch_ws(vec![PortalRpcModule::History]).await;
+        let handle = launch_ws(vec![PortalRpcModule::LegacyHistory]).await;
         let addr = handle.ws_local_addr().unwrap();
         let builder = test_rpc_builder();
         let server = builder.build(TransportRpcModuleConfig::set_ws(vec![
-            PortalRpcModule::History,
+            PortalRpcModule::LegacyHistory,
         ]));
         let result = server
             .start_server(RpcServerConfig::ws(Default::default()).with_ws_address(addr))
@@ -724,7 +724,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_launch_same_port() {
-        let handle = launch_http_ws_same_port(vec![PortalRpcModule::History]).await;
+        let handle = launch_http_ws_same_port(vec![PortalRpcModule::LegacyHistory]).await;
         let ws_addr = handle.ws_local_addr().unwrap();
         let http_addr = handle.http_local_addr().unwrap();
         assert_eq!(ws_addr, http_addr);
@@ -734,7 +734,7 @@ mod tests {
     async fn test_launch_same_port_different_modules() {
         let builder = test_rpc_builder();
         let server = builder.build(
-            TransportRpcModuleConfig::set_ws(vec![PortalRpcModule::History])
+            TransportRpcModuleConfig::set_ws(vec![PortalRpcModule::LegacyHistory])
                 .with_http(vec![PortalRpcModule::Beacon]),
         );
         let addr = test_address();
@@ -757,8 +757,8 @@ mod tests {
     async fn test_launch_same_port_same_cors() {
         let builder = test_rpc_builder();
         let server = builder.build(
-            TransportRpcModuleConfig::set_ws(vec![PortalRpcModule::History])
-                .with_http(vec![PortalRpcModule::History]),
+            TransportRpcModuleConfig::set_ws(vec![PortalRpcModule::LegacyHistory])
+                .with_http(vec![PortalRpcModule::LegacyHistory]),
         );
         let addr = test_address();
         let res = server
@@ -778,8 +778,8 @@ mod tests {
     async fn test_launch_same_port_different_cors() {
         let builder = test_rpc_builder();
         let server = builder.build(
-            TransportRpcModuleConfig::set_ws(vec![PortalRpcModule::History])
-                .with_http(vec![PortalRpcModule::History]),
+            TransportRpcModuleConfig::set_ws(vec![PortalRpcModule::LegacyHistory])
+                .with_http(vec![PortalRpcModule::LegacyHistory]),
         );
         let addr = test_address();
         let res = server

--- a/crates/storage/src/test_utils.rs
+++ b/crates/storage/src/test_utils.rs
@@ -15,13 +15,13 @@ pub fn create_test_portal_storage_config_with_capacity(
     let config = PortalStorageConfigFactory::new(
         StorageCapacityConfig::Combined {
             total_mb: capacity_mb,
-            subnetworks: vec![Subnetwork::History],
+            subnetworks: vec![Subnetwork::LegacyHistory],
         },
         NodeId::random(),
         temp_dir.path().to_path_buf(),
     )
     .unwrap()
-    .create(&Subnetwork::History, Distance::MAX)
+    .create(&Subnetwork::LegacyHistory, Distance::MAX)
     .unwrap();
     Ok((temp_dir, config))
 }

--- a/crates/storage/src/versioned/ephemeral_v1/store.rs
+++ b/crates/storage/src/versioned/ephemeral_v1/store.rs
@@ -288,8 +288,8 @@ mod tests {
 
     fn create_config(temp_dir: &TempDir) -> EphemeralV1StoreConfig {
         EphemeralV1StoreConfig {
-            content_type: ContentType::HistoryEphemeral,
-            subnetwork: Subnetwork::History,
+            content_type: ContentType::LegacyHistoryEphemeral,
+            subnetwork: Subnetwork::LegacyHistory,
             node_data_dir: temp_dir.path().to_path_buf(),
             sql_connection_pool: setup_sql(temp_dir.path()).unwrap(),
         }
@@ -344,7 +344,7 @@ mod tests {
         let temp_dir = TempDir::new()?;
         let config = create_config(&temp_dir);
         let store = EphemeralV1Store::<IdentityContentKey>::create(
-            ContentType::HistoryEphemeral,
+            ContentType::LegacyHistoryEphemeral,
             config.clone(),
         )?;
         assert_eq!(store.usage_stats.entry_count(), 0);
@@ -361,7 +361,7 @@ mod tests {
         create_and_populate_table(&config, item_count)?;
 
         let store = EphemeralV1Store::<IdentityContentKey>::create(
-            ContentType::HistoryEphemeral,
+            ContentType::LegacyHistoryEphemeral,
             config.clone(),
         )?;
 
@@ -380,7 +380,7 @@ mod tests {
 
         create_and_populate_table(&config, 50)?;
         let mut store = EphemeralV1Store::<IdentityContentKey>::create(
-            ContentType::HistoryEphemeral,
+            ContentType::LegacyHistoryEphemeral,
             config.clone(),
         )?;
 
@@ -421,7 +421,7 @@ mod tests {
 
         create_and_populate_table(&config, 50)?;
         let mut store = EphemeralV1Store::<IdentityContentKey>::create(
-            ContentType::HistoryEphemeral,
+            ContentType::LegacyHistoryEphemeral,
             config.clone(),
         )?;
 

--- a/crates/storage/src/versioned/id_indexed_v1/store.rs
+++ b/crates/storage/src/versioned/id_indexed_v1/store.rs
@@ -561,9 +561,9 @@ impl<TContentKey: OverlayContentKey, TMetric: Metric> IdIndexedV1Store<TContentK
 /// See https://github.com/ethereum/trin/issues/1653 for details.
 const fn extra_disk_usage_per_content_bytes(content_type: &ContentType) -> u64 {
     match content_type {
-        ContentType::HistoryEternal => 750,
+        ContentType::LegacyHistoryEternal => 750,
         ContentType::State => 500,
-        ContentType::HistoryEphemeral => panic!("HistoryEphemeral is not supported"),
+        ContentType::LegacyHistoryEphemeral => panic!("HistoryEphemeral is not supported"),
     }
 }
 

--- a/crates/storage/src/versioned/mod.rs
+++ b/crates/storage/src/versioned/mod.rs
@@ -21,10 +21,10 @@ pub use utils::create_store;
 pub enum ContentType {
     /// Corresponds to the state network content.
     State,
-    /// Corresponds to the non-ephemeral history network content.
-    HistoryEternal,
-    /// Corresponds to the ephemeral history network content.
-    HistoryEphemeral,
+    /// Corresponds to the non-ephemeral legacy history network content.
+    LegacyHistoryEternal,
+    /// Corresponds to the ephemeral legacy history network content.
+    LegacyHistoryEphemeral,
 }
 
 /// The version of the store. There should be exactly one implementation of the

--- a/crates/storage/src/versioned/utils.rs
+++ b/crates/storage/src/versioned/utils.rs
@@ -104,7 +104,7 @@ pub mod test {
         let conn = config.sql_connection_pool.get()?;
 
         assert_eq!(
-            get_store_version(&ContentType::HistoryEternal, &conn)?,
+            get_store_version(&ContentType::LegacyHistoryEternal, &conn)?,
             None
         );
         Ok(())
@@ -200,14 +200,18 @@ pub mod test {
         let sql_connection_pool = config.sql_connection_pool.clone();
 
         update_store_info(
-            &ContentType::HistoryEternal,
+            &ContentType::LegacyHistoryEternal,
             StoreVersion::IdIndexedV1,
             &sql_connection_pool.get().unwrap(),
         )
         .unwrap();
 
         // Should panic - MockContentStore doesn't support migration.
-        create_store::<MockContentStore>(ContentType::HistoryEternal, config, sql_connection_pool)
-            .unwrap();
+        create_store::<MockContentStore>(
+            ContentType::LegacyHistoryEternal,
+            config,
+            sql_connection_pool,
+        )
+        .unwrap();
     }
 }

--- a/crates/subnetworks/beacon/src/network.rs
+++ b/crates/subnetworks/beacon/src/network.rs
@@ -228,7 +228,7 @@ mod tests {
         let storage_cfg_factory = PortalStorageConfigFactory::new(
             StorageCapacityConfig::Specific {
                 beacon_mb: Some(1),
-                history_mb: Some(1),
+                legacy_history_mb: Some(1),
                 state_mb: Some(1),
             },
             NodeId::random(),

--- a/crates/subnetworks/history/Cargo.toml
+++ b/crates/subnetworks/history/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trin-history"
-description = "History network subprotocol for Trin."
+description = "Legacy History network subprotocol for Trin."
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/crates/subnetworks/history/src/network.rs
+++ b/crates/subnetworks/history/src/network.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use ethportal_api::{
     types::{distance::XorMetric, network::Subnetwork},
-    HistoryContentKey,
+    LegacyHistoryContentKey,
 };
 use parking_lot::Mutex;
 use portalnet::{
@@ -16,30 +16,30 @@ use trin_validation::oracle::HeaderOracle;
 use utp_rs::socket::UtpSocket;
 
 use crate::{
-    ping_extensions::HistoryPingExtensions, storage::HistoryStorage,
-    validation::ChainHistoryValidator,
+    ping_extensions::LegacyHistoryPingExtensions, storage::LegacyHistoryStorage,
+    validation::LegacyHistoryValidator,
 };
 
 /// Gossip content as it gets dropped from local storage,
 /// enabled by default for the history network.
 const GOSSIP_DROPPED: bool = true;
 
-/// History network layer on top of the overlay protocol. Encapsulates history network specific data
-/// and logic.
+/// Legacy History network layer on top of the overlay protocol. Encapsulates legacy history
+/// network specific data and logic.
 #[derive(Clone)]
-pub struct HistoryNetwork {
+pub struct LegacyHistoryNetwork {
     pub overlay: Arc<
         OverlayProtocol<
-            HistoryContentKey,
+            LegacyHistoryContentKey,
             XorMetric,
-            ChainHistoryValidator,
-            HistoryStorage,
-            HistoryPingExtensions,
+            LegacyHistoryValidator,
+            LegacyHistoryStorage,
+            LegacyHistoryPingExtensions,
         >,
     >,
 }
 
-impl HistoryNetwork {
+impl LegacyHistoryNetwork {
     pub async fn new(
         discovery: Arc<Discovery>,
         utp_socket: Arc<UtpSocket<UtpPeer>>,
@@ -54,15 +54,15 @@ impl HistoryNetwork {
             utp_transfer_limit: portal_config.utp_transfer_limit,
             ..Default::default()
         };
-        let storage = Arc::new(Mutex::new(HistoryStorage::new(storage_config)?));
-        let validator = Arc::new(ChainHistoryValidator::new(header_oracle));
-        let ping_extensions = Arc::new(HistoryPingExtensions {});
+        let storage = Arc::new(Mutex::new(LegacyHistoryStorage::new(storage_config)?));
+        let validator = Arc::new(LegacyHistoryValidator::new(header_oracle));
+        let ping_extensions = Arc::new(LegacyHistoryPingExtensions {});
         let overlay = OverlayProtocol::new(
             config,
             discovery,
             utp_socket,
             storage,
-            Subnetwork::History,
+            Subnetwork::LegacyHistory,
             validator,
             ping_extensions,
         )

--- a/crates/subnetworks/history/src/ping_extensions.rs
+++ b/crates/subnetworks/history/src/ping_extensions.rs
@@ -1,19 +1,19 @@
 use ethportal_api::types::ping_extensions::{
-    consts::HISTORY_SUPPORTED_EXTENSIONS, extension_types::PingExtensionType,
+    consts::LEGACY_HISTORY_SUPPORTED_EXTENSIONS, extension_types::PingExtensionType,
 };
 use portalnet::overlay::ping_extensions::PingExtensions;
 
-pub struct HistoryPingExtensions {}
+pub struct LegacyHistoryPingExtensions {}
 
-impl HistoryPingExtensions {
-    pub const SUPPORTED_EXTENSIONS: &[PingExtensionType] = HISTORY_SUPPORTED_EXTENSIONS;
+impl LegacyHistoryPingExtensions {
+    pub const SUPPORTED_EXTENSIONS: &[PingExtensionType] = LEGACY_HISTORY_SUPPORTED_EXTENSIONS;
 
     /// Base extensions that are required for the core subnetwork to function.
     /// These must be sorted by latest to oldest
     pub const BASE_EXTENSIONS: &[PingExtensionType] = &[PingExtensionType::HistoryRadius];
 }
 
-impl PingExtensions for HistoryPingExtensions {
+impl PingExtensions for LegacyHistoryPingExtensions {
     fn latest_mutually_supported_base_extension(
         &self,
         extensions: &[PingExtensionType],

--- a/crates/validation/src/accumulator.rs
+++ b/crates/validation/src/accumulator.rs
@@ -131,7 +131,7 @@ mod tests {
     use alloy::primitives::map::HashMap;
     use ethportal_api::{
         types::execution::header_with_proof::{BlockHeaderProof, HeaderWithProof},
-        HistoryContentKey, HistoryContentValue,
+        LegacyHistoryContentKey, LegacyHistoryContentValue,
     };
     use rstest::rstest;
     use trin_utils::{
@@ -152,7 +152,7 @@ mod tests {
         )]
         block_number: u64,
     ) {
-        let all_test_data: HashMap<u64, ContentItem<HistoryContentKey>> =
+        let all_test_data: HashMap<u64, ContentItem<LegacyHistoryContentKey>> =
             read_json_portal_spec_tests_file(
                 "tests/mainnet/history/headers_with_proof/1000001-1000010.json",
             )
@@ -169,9 +169,9 @@ mod tests {
 
     #[rstest]
     fn construct_proof_from_partial_epoch(#[values(15_537_392, 15_537_393)] block_number: u64) {
-        let test_data: ContentItem<HistoryContentKey> = read_yaml_portal_spec_tests_file(format!(
-            "tests/mainnet/history/headers_with_proof/{block_number}.yaml"
-        ))
+        let test_data: ContentItem<LegacyHistoryContentKey> = read_yaml_portal_spec_tests_file(
+            format!("tests/mainnet/history/headers_with_proof/{block_number}.yaml"),
+        )
         .unwrap();
 
         let epoch_accumulator_bytes = fs::read("./src/assets/epoch_accs/0xe6ebe562c89bc8ecb94dc9b2889a27a816ec05d3d6bd1625acad72227071e721.bin").unwrap();
@@ -182,10 +182,10 @@ mod tests {
     }
 
     fn test_construct_proof(
-        content_item: ContentItem<HistoryContentKey>,
+        content_item: ContentItem<LegacyHistoryContentKey>,
         epoch_accumulator: EpochAccumulator,
     ) {
-        let HistoryContentValue::BlockHeaderWithProof(HeaderWithProof { header, proof }) =
+        let LegacyHistoryContentValue::BlockHeaderWithProof(HeaderWithProof { header, proof }) =
             content_item.content_value().unwrap()
         else {
             panic!("Expected BlockHeaderWithProof content value");

--- a/crates/validation/src/header_validator.rs
+++ b/crates/validation/src/header_validator.rs
@@ -356,7 +356,7 @@ mod test {
     use alloy_hardforks::EthereumHardfork;
     use ethportal_api::{
         types::execution::header_with_proof::{BlockHeaderProof, HeaderWithProof},
-        HistoryContentKey,
+        LegacyHistoryContentKey,
     };
     use rstest::*;
     use serde::Deserialize;
@@ -387,7 +387,7 @@ mod test {
             )]
             block_number: u64,
         ) {
-            let test_data: HashMap<u64, ContentItem<HistoryContentKey>> =
+            let test_data: HashMap<u64, ContentItem<LegacyHistoryContentKey>> =
                 read_json_portal_spec_tests_file(
                     "tests/mainnet/history/headers_with_proof/1000001-1000010.json",
                 )
@@ -408,7 +408,7 @@ mod test {
         async fn verify_header_from_partial_epoch(
             #[values(15_537_392, 15_537_393)] block_number: u64,
         ) {
-            let test_data: ContentItem<HistoryContentKey> = read_yaml_portal_spec_tests_file(
+            let test_data: ContentItem<LegacyHistoryContentKey> = read_yaml_portal_spec_tests_file(
                 format!("tests/mainnet/history/headers_with_proof/{block_number}.yaml"),
             )
             .unwrap();
@@ -425,7 +425,7 @@ mod test {
         #[tokio::test]
         #[should_panic = "Execution block proof verification failed for pre-Merge header"]
         async fn invalidate_invalid_proofs() {
-            let test_data: ContentItem<HistoryContentKey> = read_yaml_portal_spec_tests_file(
+            let test_data: ContentItem<LegacyHistoryContentKey> = read_yaml_portal_spec_tests_file(
                 "tests/mainnet/history/headers_with_proof/1000010.yaml",
             )
             .unwrap();

--- a/testing/ethportal-peertest/src/scenarios/offer_accept.rs
+++ b/testing/ethportal-peertest/src/scenarios/offer_accept.rs
@@ -13,7 +13,8 @@ use ethportal_api::{
         },
         portal_wire::OfferTrace,
     },
-    ContentValue, Discv5ApiClient, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
+    ContentValue, Discv5ApiClient, LegacyHistoryContentKey, LegacyHistoryContentValue,
+    LegacyHistoryNetworkApiClient,
 };
 use portalnet::constants::DEFAULT_UTP_TRANSFER_LIMIT;
 use ssz::Decode;
@@ -25,7 +26,7 @@ use crate::{
         fixture_block_body, fixture_block_body_15040641, fixture_block_body_15040708,
         fixture_header_by_hash, fixture_header_by_hash_with_proof_15040641,
         fixture_header_by_hash_with_proof_15040708, fixture_receipts_15040641,
-        fixture_receipts_15040708, wait_for_history_content,
+        fixture_receipts_15040708, wait_for_legacy_history_content,
     },
     Peertest,
 };
@@ -50,7 +51,7 @@ pub async fn test_offer(peertest: &Peertest, target: &Client) {
     // Check if the stored content value in bootnode's DB matches the offered
     assert_eq!(
         content_value,
-        wait_for_history_content(&peertest.bootnode.ipc_client, content_key).await,
+        wait_for_legacy_history_content(&peertest.bootnode.ipc_client, content_key).await,
     );
 }
 
@@ -88,7 +89,7 @@ pub async fn test_offer_with_trace(peertest: &Peertest, target: &Client) {
     // Check if the stored content value in bootnode's DB matches the offered
     assert_eq!(
         content_value,
-        wait_for_history_content(&peertest.bootnode.ipc_client, content_key).await,
+        wait_for_legacy_history_content(&peertest.bootnode.ipc_client, content_key).await,
     );
 }
 
@@ -109,15 +110,15 @@ pub async fn test_offer_propagates_gossip(peertest: &Peertest, target: &Client) 
     // validate that every node in the network now has a local copy of the header
     assert_eq!(
         content_value,
-        wait_for_history_content(target, content_key.clone()).await,
+        wait_for_legacy_history_content(target, content_key.clone()).await,
     );
     assert_eq!(
         content_value,
-        wait_for_history_content(&peertest.nodes[0].ipc_client, content_key.clone()).await,
+        wait_for_legacy_history_content(&peertest.nodes[0].ipc_client, content_key.clone()).await,
     );
     assert_eq!(
         content_value,
-        wait_for_history_content(&peertest.bootnode.ipc_client, content_key).await,
+        wait_for_legacy_history_content(&peertest.bootnode.ipc_client, content_key).await,
     );
 }
 
@@ -145,15 +146,15 @@ pub async fn test_offer_propagates_gossip_with_large_content(peertest: &Peertest
     // validate that every node in the network now has a local copy of the accumulator
     assert_eq!(
         body_value,
-        wait_for_history_content(target, body_key.clone()).await,
+        wait_for_legacy_history_content(target, body_key.clone()).await,
     );
     assert_eq!(
         body_value,
-        wait_for_history_content(&peertest.nodes[0].ipc_client, body_key.clone()).await,
+        wait_for_legacy_history_content(&peertest.nodes[0].ipc_client, body_key.clone()).await,
     );
     assert_eq!(
         body_value,
-        wait_for_history_content(&peertest.bootnode.ipc_client, body_key).await,
+        wait_for_legacy_history_content(&peertest.bootnode.ipc_client, body_key).await,
     );
 }
 
@@ -180,15 +181,15 @@ pub async fn test_offer_propagates_gossip_multiple_content_values(
     // check that header content is available
     assert_eq!(
         header_value,
-        wait_for_history_content(target, header_key.clone()).await,
+        wait_for_legacy_history_content(target, header_key.clone()).await,
     );
     assert_eq!(
         header_value,
-        wait_for_history_content(&peertest.bootnode.ipc_client, header_key.clone()).await,
+        wait_for_legacy_history_content(&peertest.bootnode.ipc_client, header_key.clone()).await,
     );
     assert_eq!(
         header_value,
-        wait_for_history_content(&peertest.nodes[0].ipc_client, header_key.clone()).await,
+        wait_for_legacy_history_content(&peertest.nodes[0].ipc_client, header_key.clone()).await,
     );
 
     // here everythings stored in target
@@ -206,28 +207,28 @@ pub async fn test_offer_propagates_gossip_multiple_content_values(
     // check that body content is available
     assert_eq!(
         body_value,
-        wait_for_history_content(target, body_key.clone()).await,
+        wait_for_legacy_history_content(target, body_key.clone()).await,
     );
     assert_eq!(
         body_value,
-        wait_for_history_content(&peertest.bootnode.ipc_client, body_key.clone()).await,
+        wait_for_legacy_history_content(&peertest.bootnode.ipc_client, body_key.clone()).await,
     );
     assert_eq!(
         body_value,
-        wait_for_history_content(&peertest.nodes[0].ipc_client, body_key.clone()).await,
+        wait_for_legacy_history_content(&peertest.nodes[0].ipc_client, body_key.clone()).await,
     );
     // check that receipts content is available
     assert_eq!(
         receipts_value,
-        wait_for_history_content(target, receipts_key.clone()).await,
+        wait_for_legacy_history_content(target, receipts_key.clone()).await,
     );
     assert_eq!(
         receipts_value,
-        wait_for_history_content(&peertest.bootnode.ipc_client, receipts_key.clone()).await,
+        wait_for_legacy_history_content(&peertest.bootnode.ipc_client, receipts_key.clone()).await,
     );
     assert_eq!(
         receipts_value,
-        wait_for_history_content(&peertest.nodes[0].ipc_client, receipts_key.clone()).await,
+        wait_for_legacy_history_content(&peertest.nodes[0].ipc_client, receipts_key.clone()).await,
     );
 }
 
@@ -277,57 +278,59 @@ pub async fn test_offer_propagates_gossip_multiple_large_content_values(
     // check that body_1 is available
     assert_eq!(
         body_value_1,
-        wait_for_history_content(target, body_key_1.clone()).await,
+        wait_for_legacy_history_content(target, body_key_1.clone()).await,
     );
     assert_eq!(
         body_value_1,
-        wait_for_history_content(&peertest.bootnode.ipc_client, body_key_1.clone()).await,
+        wait_for_legacy_history_content(&peertest.bootnode.ipc_client, body_key_1.clone()).await,
     );
     assert_eq!(
         body_value_1,
-        wait_for_history_content(&peertest.nodes[0].ipc_client, body_key_1).await,
+        wait_for_legacy_history_content(&peertest.nodes[0].ipc_client, body_key_1).await,
     );
 
     // check that receipts_1 is available
     assert_eq!(
         receipts_value_1,
-        wait_for_history_content(target, receipts_key_1.clone()).await,
+        wait_for_legacy_history_content(target, receipts_key_1.clone()).await,
     );
     assert_eq!(
         receipts_value_1,
-        wait_for_history_content(&peertest.bootnode.ipc_client, receipts_key_1.clone()).await,
+        wait_for_legacy_history_content(&peertest.bootnode.ipc_client, receipts_key_1.clone())
+            .await,
     );
     assert_eq!(
         receipts_value_1,
-        wait_for_history_content(&peertest.nodes[0].ipc_client, receipts_key_1).await,
+        wait_for_legacy_history_content(&peertest.nodes[0].ipc_client, receipts_key_1).await,
     );
 
     // check that body_2 is available
     assert_eq!(
         body_value_2,
-        wait_for_history_content(target, body_key_2.clone()).await,
+        wait_for_legacy_history_content(target, body_key_2.clone()).await,
     );
     assert_eq!(
         body_value_2,
-        wait_for_history_content(&peertest.bootnode.ipc_client, body_key_2.clone()).await,
+        wait_for_legacy_history_content(&peertest.bootnode.ipc_client, body_key_2.clone()).await,
     );
     assert_eq!(
         body_value_2,
-        wait_for_history_content(&peertest.nodes[0].ipc_client, body_key_2).await,
+        wait_for_legacy_history_content(&peertest.nodes[0].ipc_client, body_key_2).await,
     );
 
     // check that receipts_2 is available
     assert_eq!(
         receipts_value_2,
-        wait_for_history_content(target, receipts_key_2.clone()).await,
+        wait_for_legacy_history_content(target, receipts_key_2.clone()).await,
     );
     assert_eq!(
         receipts_value_2,
-        wait_for_history_content(&peertest.bootnode.ipc_client, receipts_key_2.clone()).await,
+        wait_for_legacy_history_content(&peertest.bootnode.ipc_client, receipts_key_2.clone())
+            .await,
     );
     assert_eq!(
         receipts_value_2,
-        wait_for_history_content(&peertest.nodes[0].ipc_client, receipts_key_2).await,
+        wait_for_legacy_history_content(&peertest.nodes[0].ipc_client, receipts_key_2).await,
     );
 }
 
@@ -347,26 +350,26 @@ pub async fn test_offer_concurrent_utp_transfer_limit(peertest: &Peertest, targe
 
     // collect keys to offer based on limit
     let tuples = era1.take(limit).collect::<Vec<_>>();
-    let body_keys: Vec<HistoryContentKey> = tuples
+    let body_keys: Vec<LegacyHistoryContentKey> = tuples
         .iter()
-        .map(|tuple| HistoryContentKey::new_block_body(tuple.header.header.hash_slow()))
+        .map(|tuple| LegacyHistoryContentKey::new_block_body(tuple.header.header.hash_slow()))
         .collect();
-    let receipts_keys: Vec<HistoryContentKey> = tuples
+    let receipts_keys: Vec<LegacyHistoryContentKey> = tuples
         .iter()
-        .map(|tuple| HistoryContentKey::new_block_receipts(tuple.header.header.hash_slow()))
+        .map(|tuple| LegacyHistoryContentKey::new_block_receipts(tuple.header.header.hash_slow()))
         .collect();
 
     // store headers for validation
     for tuple in tuples.clone() {
         let header_key =
-            HistoryContentKey::new_block_header_by_hash(tuple.header.header.hash_slow());
+            LegacyHistoryContentKey::new_block_header_by_hash(tuple.header.header.hash_slow());
 
         let header = tuple.header.header.clone();
         let proof = PreMergeAccumulator::construct_proof(&header, &epoch_acc).unwrap();
         let proof = BlockHeaderProof::HistoricalHashes(proof);
 
         let header_value =
-            HistoryContentValue::BlockHeaderWithProof(HeaderWithProof { header, proof });
+            LegacyHistoryContentValue::BlockHeaderWithProof(HeaderWithProof { header, proof });
 
         let store_result = peertest
             .bootnode
@@ -378,13 +381,14 @@ pub async fn test_offer_concurrent_utp_transfer_limit(peertest: &Peertest, targe
     }
 
     // collect body and receipts to offer
-    let mut test_data: Vec<(HistoryContentKey, Bytes)> = vec![];
+    let mut test_data: Vec<(LegacyHistoryContentKey, Bytes)> = vec![];
     for tuple in tuples {
-        let body_key = HistoryContentKey::new_block_body(tuple.header.header.hash_slow());
-        let body_value = HistoryContentValue::BlockBody(tuple.body.body.clone());
+        let body_key = LegacyHistoryContentKey::new_block_body(tuple.header.header.hash_slow());
+        let body_value = LegacyHistoryContentValue::BlockBody(tuple.body.body.clone());
         test_data.push((body_key.clone(), body_value.encode()));
-        let receipts_key = HistoryContentKey::new_block_receipts(tuple.header.header.hash_slow());
-        let receipts_value = HistoryContentValue::Receipts(tuple.receipts.receipts.clone());
+        let receipts_key =
+            LegacyHistoryContentKey::new_block_receipts(tuple.header.header.hash_slow());
+        let receipts_value = LegacyHistoryContentValue::Receipts(tuple.receipts.receipts.clone());
         test_data.push((receipts_key.clone(), receipts_value.encode()));
     }
 
@@ -395,7 +399,7 @@ pub async fn test_offer_concurrent_utp_transfer_limit(peertest: &Peertest, targe
         let peer_enr_clone = peer_enr.clone();
         let target_clone = target.clone();
         let body_handle = tokio::spawn(async move {
-            let _result = HistoryNetworkApiClient::trace_offer(
+            let _result = LegacyHistoryNetworkApiClient::trace_offer(
                 &target_clone,
                 peer_enr_clone,
                 key.clone(),
@@ -409,9 +413,9 @@ pub async fn test_offer_concurrent_utp_transfer_limit(peertest: &Peertest, targe
 
     let _ = futures::future::join_all(handles).await;
     for key in body_keys {
-        wait_for_history_content(&peertest.bootnode.ipc_client, key.clone()).await;
+        wait_for_legacy_history_content(&peertest.bootnode.ipc_client, key.clone()).await;
     }
     for key in receipts_keys {
-        wait_for_history_content(&peertest.bootnode.ipc_client, key.clone()).await;
+        wait_for_legacy_history_content(&peertest.bootnode.ipc_client, key.clone()).await;
     }
 }

--- a/testing/ethportal-peertest/src/scenarios/paginate.rs
+++ b/testing/ethportal-peertest/src/scenarios/paginate.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::B256;
-use ethportal_api::{ContentValue, HistoryContentKey, HistoryNetworkApiClient};
+use ethportal_api::{ContentValue, LegacyHistoryContentKey, LegacyHistoryNetworkApiClient};
 
 use crate::{utils::fixture_header_by_hash, Peertest};
 
@@ -12,8 +12,10 @@ pub async fn test_paginate_local_storage(peertest: &Peertest) {
 
     let mut content_keys: Vec<String> = (0..20_u8)
         .map(|_| {
-            serde_json::to_string(&HistoryContentKey::new_block_header_by_hash(B256::random()))
-                .unwrap()
+            serde_json::to_string(&LegacyHistoryContentKey::new_block_header_by_hash(
+                B256::random(),
+            ))
+            .unwrap()
         })
         .collect();
     let (_, content_value) = fixture_header_by_hash();

--- a/testing/ethportal-peertest/src/scenarios/ping.rs
+++ b/testing/ethportal-peertest/src/scenarios/ping.rs
@@ -12,7 +12,7 @@ use ethportal_api::{
             },
         },
     },
-    BeaconNetworkApiClient, HistoryNetworkApiClient, StateNetworkApiClient,
+    BeaconNetworkApiClient, LegacyHistoryNetworkApiClient, StateNetworkApiClient,
 };
 use jsonrpsee::async_client::Client;
 use serde_json::json;
@@ -30,7 +30,9 @@ pub async fn test_ping_no_specified_ping_payload(
     let bootnode_sequence = bootnode_enr.seq();
     let result = match subnetwork {
         Subnetwork::Beacon => BeaconNetworkApiClient::ping(target, bootnode_enr, None, None),
-        Subnetwork::History => HistoryNetworkApiClient::ping(target, bootnode_enr, None, None),
+        Subnetwork::LegacyHistory => {
+            LegacyHistoryNetworkApiClient::ping(target, bootnode_enr, None, None)
+        }
         Subnetwork::State => StateNetworkApiClient::ping(target, bootnode_enr, None, None),
         _ => panic!("Unexpected subnetwork: {subnetwork}"),
     }
@@ -50,7 +52,7 @@ pub async fn test_ping_capabilities_payload(target: &Client, peertest: &Peertest
     info!("Testing ping with capabilities payload");
     let bootnode_enr = peertest.bootnode.enr.clone();
     let bootnode_sequence = bootnode_enr.seq();
-    let result = HistoryNetworkApiClient::ping(
+    let result = LegacyHistoryNetworkApiClient::ping(
         target,
         bootnode_enr,
         Some(PingExtensionType::Capabilities),
@@ -113,7 +115,7 @@ pub async fn test_ping_history_radius_payload(target: &Client, peertest: &Peerte
     info!("Testing ping with history radius payload");
     let bootnode_enr = peertest.bootnode.enr.clone();
     let bootnode_sequence = bootnode_enr.seq();
-    let result = HistoryNetworkApiClient::ping(
+    let result = LegacyHistoryNetworkApiClient::ping(
         target,
         bootnode_enr,
         Some(PingExtensionType::HistoryRadius),
@@ -243,7 +245,7 @@ pub async fn test_ping_history_radius_payload_type(target: &Client, peertest: &P
     info!("Testing ping with history radius payload type");
     let bootnode_enr = peertest.bootnode.enr.clone();
     let bootnode_sequence = bootnode_enr.seq();
-    let result = HistoryNetworkApiClient::ping(
+    let result = LegacyHistoryNetworkApiClient::ping(
         target,
         bootnode_enr,
         Some(PingExtensionType::HistoryRadius),

--- a/testing/ethportal-peertest/src/scenarios/state.rs
+++ b/testing/ethportal-peertest/src/scenarios/state.rs
@@ -8,8 +8,8 @@ use ethportal_api::{
         },
         network_spec::network_spec,
     },
-    ContentValue, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
-    StateNetworkApiClient,
+    ContentValue, LegacyHistoryContentKey, LegacyHistoryContentValue,
+    LegacyHistoryNetworkApiClient, StateNetworkApiClient,
 };
 use tracing::info;
 
@@ -53,8 +53,8 @@ pub async fn test_state_gossip_contract_bytecode(peertest: &Peertest, target: &C
 
 async fn test_state_offer(fixture: &StateFixture, target: &Client, peer: &PeertestNode) {
     // Make sure that peer has block header
-    let history_content_key =
-        HistoryContentKey::new_block_header_by_hash(fixture.block_header.hash_slow());
+    let legacy_history_content_key =
+        LegacyHistoryContentKey::new_block_header_by_hash(fixture.block_header.hash_slow());
 
     let proof = if network_spec().is_shanghai_active_at_timestamp(fixture.block_header.timestamp) {
         BlockHeaderProof::HistoricalSummariesCapella(BlockProofHistoricalSummariesCapella {
@@ -74,15 +74,16 @@ async fn test_state_offer(fixture: &StateFixture, target: &Client, peer: &Peerte
         BlockHeaderProof::HistoricalHashes(Default::default())
     };
 
-    let history_content_value = HistoryContentValue::BlockHeaderWithProof(HeaderWithProof {
-        header: fixture.block_header.clone(),
-        proof: proof.clone(),
-    });
+    let legacy_history_content_value =
+        LegacyHistoryContentValue::BlockHeaderWithProof(HeaderWithProof {
+            header: fixture.block_header.clone(),
+            proof: proof.clone(),
+        });
 
-    HistoryNetworkApiClient::store(
+    LegacyHistoryNetworkApiClient::store(
         &peer.ipc_client,
-        history_content_key,
-        history_content_value.encode(),
+        legacy_history_content_key,
+        legacy_history_content_value.encode(),
     )
     .await
     .unwrap();

--- a/testing/ethportal-peertest/src/scenarios/utp.rs
+++ b/testing/ethportal-peertest/src/scenarios/utp.rs
@@ -1,7 +1,7 @@
 use discv5::enr::NodeId;
 use ethportal_api::{
     types::portal::{GetContentInfo, TraceContentInfo},
-    ContentValue, HistoryNetworkApiClient,
+    ContentValue, LegacyHistoryNetworkApiClient,
 };
 use tracing::info;
 

--- a/testing/ethportal-peertest/src/scenarios/validation.rs
+++ b/testing/ethportal-peertest/src/scenarios/validation.rs
@@ -4,7 +4,7 @@ use alloy::primitives::B256;
 use ethportal_api::{
     jsonrpsee::async_client::Client,
     types::{enr::Enr, portal::FindContentInfo},
-    ContentValue, HistoryContentKey, HistoryNetworkApiClient,
+    ContentValue, LegacyHistoryContentKey, LegacyHistoryNetworkApiClient,
 };
 use tracing::info;
 
@@ -92,7 +92,7 @@ pub async fn test_invalidate_header_by_hash(peertest: &Peertest, target: &Client
 
     // store header_with_proof - doesn't perform validation
     let (_, content_value) = fixture_header_by_hash();
-    let invalid_content_key = HistoryContentKey::new_block_header_by_hash(B256::random());
+    let invalid_content_key = LegacyHistoryContentKey::new_block_header_by_hash(B256::random());
 
     let store_result = peertest
         .bootnode

--- a/testing/ethportal-peertest/tests/rpc_server.rs
+++ b/testing/ethportal-peertest/tests/rpc_server.rs
@@ -16,7 +16,8 @@ use ethportal_api::{
     types::execution::{block_body::BlockBody, header_with_proof::HeaderWithProof},
     utils::bytes::hex_encode,
     version::APP_NAME,
-    ContentValue, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
+    ContentValue, LegacyHistoryContentKey, LegacyHistoryContentValue,
+    LegacyHistoryNetworkApiClient,
 };
 use jsonrpsee::async_client::Client;
 use portalnet::constants::{DEFAULT_WEB3_HTTP_ADDRESS, DEFAULT_WEB3_IPC_PATH};
@@ -138,8 +139,8 @@ async fn test_eth_get_block_by_number() {
     // Store header with proof in server
     assert!(native_client
         .store(
-            HistoryContentKey::new_block_header_by_number(block_number),
-            HistoryContentValue::BlockHeaderWithProof(hwp.clone()).encode(),
+            LegacyHistoryContentKey::new_block_header_by_number(block_number),
+            LegacyHistoryContentValue::BlockHeaderWithProof(hwp.clone()).encode(),
         )
         .await
         .unwrap());
@@ -147,8 +148,8 @@ async fn test_eth_get_block_by_number() {
     // Store block in server
     assert!(native_client
         .store(
-            HistoryContentKey::new_block_body(hwp.header.hash_slow()),
-            HistoryContentValue::BlockBody(body.clone()).encode(),
+            LegacyHistoryContentKey::new_block_body(hwp.header.hash_slow()),
+            LegacyHistoryContentValue::BlockBody(body.clone()).encode(),
         )
         .await
         .unwrap());
@@ -199,8 +200,8 @@ async fn test_eth_get_block_by_number_hydrated() {
     // Store header with proof in server
     assert!(native_client
         .store(
-            HistoryContentKey::new_block_header_by_number(block_number),
-            HistoryContentValue::BlockHeaderWithProof(hwp.clone()).encode(),
+            LegacyHistoryContentKey::new_block_header_by_number(block_number),
+            LegacyHistoryContentValue::BlockHeaderWithProof(hwp.clone()).encode(),
         )
         .await
         .unwrap());
@@ -254,8 +255,8 @@ async fn test_eth_get_block_by_hash() {
     // Store header with proof in server
     assert!(native_client
         .store(
-            HistoryContentKey::new_block_header_by_hash(block_hash),
-            HistoryContentValue::BlockHeaderWithProof(hwp.clone()).encode(),
+            LegacyHistoryContentKey::new_block_header_by_hash(block_hash),
+            LegacyHistoryContentValue::BlockHeaderWithProof(hwp.clone()).encode(),
         )
         .await
         .unwrap());
@@ -263,8 +264,8 @@ async fn test_eth_get_block_by_hash() {
     // Store block in server
     assert!(native_client
         .store(
-            HistoryContentKey::new_block_body(block_hash),
-            HistoryContentValue::BlockBody(body.clone()).encode(),
+            LegacyHistoryContentKey::new_block_body(block_hash),
+            LegacyHistoryContentValue::BlockBody(body.clone()).encode(),
         )
         .await
         .unwrap());
@@ -315,8 +316,8 @@ async fn test_eth_get_block_by_hash_hydrated() {
     // Store header with proof in server
     assert!(native_client
         .store(
-            HistoryContentKey::new_block_header_by_hash(block_hash),
-            HistoryContentValue::BlockHeaderWithProof(hwp.clone()).encode(),
+            LegacyHistoryContentKey::new_block_header_by_hash(block_hash),
+            LegacyHistoryContentValue::BlockHeaderWithProof(hwp.clone()).encode(),
         )
         .await
         .unwrap());

--- a/testing/ethportal-peertest/tests/self_peertest.rs
+++ b/testing/ethportal-peertest/tests/self_peertest.rs
@@ -32,7 +32,11 @@ async fn peertest_stateless() {
     // it should be added to its own test function.
     let (peertest, target, handle) = setup_peertest(
         Network::Mainnet,
-        &[Subnetwork::History, Subnetwork::State, Subnetwork::Beacon],
+        &[
+            Subnetwork::LegacyHistory,
+            Subnetwork::State,
+            Subnetwork::Beacon,
+        ],
     )
     .await;
 
@@ -51,7 +55,11 @@ async fn peertest_stateless() {
     peertest::scenarios::basic::test_discv5_find_node(&target, &peertest).await;
     peertest::scenarios::eth_rpc::test_eth_chain_id(&peertest).await;
 
-    for subnetwork in [Subnetwork::History, Subnetwork::Beacon, Subnetwork::State] {
+    for subnetwork in [
+        Subnetwork::LegacyHistory,
+        Subnetwork::Beacon,
+        Subnetwork::State,
+    ] {
         peertest::scenarios::basic::test_routing_table_info(subnetwork, &target).await;
         peertest::scenarios::basic::test_radius(subnetwork, &target).await;
         peertest::scenarios::basic::test_add_enr(subnetwork, &target, &peertest).await;
@@ -70,8 +78,8 @@ async fn peertest_stateless() {
         peertest::scenarios::find::test_recursive_find_nodes_random(subnetwork, &peertest).await;
     }
 
-    peertest::scenarios::basic::test_history_store(&target).await;
-    peertest::scenarios::basic::test_history_local_content_absent(&target).await;
+    peertest::scenarios::basic::test_legacy_history_store(&target).await;
+    peertest::scenarios::basic::test_legacy_history_local_content_absent(&target).await;
     peertest::scenarios::ping::test_ping_capabilities_payload(&target, &peertest).await;
     peertest::scenarios::ping::test_ping_basic_radius_payload(&target, &peertest).await;
     peertest::scenarios::ping::test_ping_history_radius_payload(&target, &peertest).await;
@@ -95,7 +103,8 @@ mod protocol_v0 {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn peertest_put_content() {
-        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+        let (peertest, target, handle) =
+            setup_peertest(V0_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::put_content::test_put_content(&peertest, &target, V0_NETWORK).await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
@@ -103,8 +112,9 @@ mod protocol_v0 {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn peertest_history_gossip_dropped_with_offer() {
-        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+    async fn peertest_legacy_history_gossip_dropped_with_offer() {
+        let (peertest, target, handle) =
+            setup_peertest(V0_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::put_content::test_gossip_dropped_with_offer(
             &peertest, &target, V0_NETWORK,
         )
@@ -115,8 +125,9 @@ mod protocol_v0 {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn peertest_history_offer_propagates_gossip() {
-        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+    async fn peertest_legacy_history_offer_propagates_gossip() {
+        let (peertest, target, handle) =
+            setup_peertest(V0_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::offer_accept::test_offer_propagates_gossip(&peertest, &target).await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
@@ -124,8 +135,9 @@ mod protocol_v0 {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn peertest_history_offer_propagates_gossip_multiple_content_values() {
-        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+    async fn peertest_legacy_history_offer_propagates_gossip_multiple_content_values() {
+        let (peertest, target, handle) =
+            setup_peertest(V0_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::offer_accept::test_offer_propagates_gossip_multiple_content_values(
             &peertest, &target,
         )
@@ -136,8 +148,9 @@ mod protocol_v0 {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn peertest_history_offer_propagates_gossip_multiple_large_content_values() {
-        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+    async fn peertest_legacy_history_offer_propagates_gossip_multiple_large_content_values() {
+        let (peertest, target, handle) =
+            setup_peertest(V0_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::offer_accept::test_offer_propagates_gossip_multiple_large_content_values(
         &peertest, &target,
     )
@@ -148,8 +161,9 @@ mod protocol_v0 {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn peertest_history_offer_propagates_gossip_with_large_content() {
-        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+    async fn peertest_legacy_history_offer_propagates_gossip_with_large_content() {
+        let (peertest, target, handle) =
+            setup_peertest(V0_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::offer_accept::test_offer_propagates_gossip_with_large_content(
             &peertest, &target,
         )
@@ -161,7 +175,8 @@ mod protocol_v0 {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn peertest_offer() {
-        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+        let (peertest, target, handle) =
+            setup_peertest(V0_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::offer_accept::test_offer(&peertest, &target).await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
@@ -170,7 +185,8 @@ mod protocol_v0 {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn peertest_offer_with_trace() {
-        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+        let (peertest, target, handle) =
+            setup_peertest(V0_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::offer_accept::test_offer_with_trace(&peertest, &target).await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
@@ -211,7 +227,8 @@ mod protocol_v0 {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn peertest_validate_block_body() {
-        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+        let (peertest, target, handle) =
+            setup_peertest(V0_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::validation::test_validate_pre_merge_block_body(&peertest, &target)
             .await;
         peertest.exit_all_nodes();
@@ -221,7 +238,8 @@ mod protocol_v0 {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn peertest_validate_receipts() {
-        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+        let (peertest, target, handle) =
+            setup_peertest(V0_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::validation::test_validate_pre_merge_receipts(&peertest, &target).await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
@@ -229,8 +247,9 @@ mod protocol_v0 {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn peertest_history_gossip_dropped_with_find_content() {
-        let (peertest, target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+    async fn peertest_legacy_history_gossip_dropped_with_find_content() {
+        let (peertest, target, handle) =
+            setup_peertest(V0_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::put_content::test_gossip_dropped_with_find_content(
             &peertest, &target, V0_NETWORK,
         )
@@ -242,7 +261,8 @@ mod protocol_v0 {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn peertest_recursive_utp() {
-        let (peertest, _target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+        let (peertest, _target, handle) =
+            setup_peertest(V0_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::utp::test_recursive_utp(&peertest).await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
@@ -251,7 +271,8 @@ mod protocol_v0 {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn peertest_trace_recursive_utp() {
-        let (peertest, _target, handle) = setup_peertest(V0_NETWORK, &[Subnetwork::History]).await;
+        let (peertest, _target, handle) =
+            setup_peertest(V0_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::utp::test_trace_recursive_utp(&peertest).await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
@@ -268,7 +289,8 @@ mod protocol_v1 {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn peertest_put_content() {
-        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+        let (peertest, target, handle) =
+            setup_peertest(V1_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::put_content::test_put_content(&peertest, &target, V1_NETWORK).await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
@@ -276,8 +298,9 @@ mod protocol_v1 {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn peertest_history_gossip_dropped_with_offer() {
-        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+    async fn peertest_legacy_history_gossip_dropped_with_offer() {
+        let (peertest, target, handle) =
+            setup_peertest(V1_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::put_content::test_gossip_dropped_with_offer(
             &peertest, &target, V1_NETWORK,
         )
@@ -288,8 +311,9 @@ mod protocol_v1 {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn peertest_history_offer_propagates_gossip() {
-        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+    async fn peertest_legacy_history_offer_propagates_gossip() {
+        let (peertest, target, handle) =
+            setup_peertest(V1_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::offer_accept::test_offer_propagates_gossip(&peertest, &target).await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
@@ -297,8 +321,9 @@ mod protocol_v1 {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn peertest_history_offer_propagates_gossip_multiple_content_values() {
-        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+    async fn peertest_legacy_history_offer_propagates_gossip_multiple_content_values() {
+        let (peertest, target, handle) =
+            setup_peertest(V1_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::offer_accept::test_offer_propagates_gossip_multiple_content_values(
             &peertest, &target,
         )
@@ -309,8 +334,9 @@ mod protocol_v1 {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn peertest_history_offer_propagates_gossip_multiple_large_content_values() {
-        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+    async fn peertest_legacy_history_offer_propagates_gossip_multiple_large_content_values() {
+        let (peertest, target, handle) =
+            setup_peertest(V1_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::offer_accept::test_offer_propagates_gossip_multiple_large_content_values(
         &peertest, &target,
     )
@@ -321,8 +347,9 @@ mod protocol_v1 {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn peertest_history_offer_propagates_gossip_with_large_content() {
-        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+    async fn peertest_legacy_history_offer_propagates_gossip_with_large_content() {
+        let (peertest, target, handle) =
+            setup_peertest(V1_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::offer_accept::test_offer_propagates_gossip_with_large_content(
             &peertest, &target,
         )
@@ -334,7 +361,8 @@ mod protocol_v1 {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn peertest_offer() {
-        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+        let (peertest, target, handle) =
+            setup_peertest(V1_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::offer_accept::test_offer(&peertest, &target).await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
@@ -343,7 +371,8 @@ mod protocol_v1 {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn peertest_offer_with_trace() {
-        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+        let (peertest, target, handle) =
+            setup_peertest(V1_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::offer_accept::test_offer_with_trace(&peertest, &target).await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
@@ -387,7 +416,8 @@ mod protocol_v1 {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn peertest_validate_block_body() {
-        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+        let (peertest, target, handle) =
+            setup_peertest(V1_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::validation::test_validate_pre_merge_block_body(&peertest, &target)
             .await;
         peertest.exit_all_nodes();
@@ -397,7 +427,8 @@ mod protocol_v1 {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn peertest_validate_receipts() {
-        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+        let (peertest, target, handle) =
+            setup_peertest(V1_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::validation::test_validate_pre_merge_receipts(&peertest, &target).await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
@@ -405,8 +436,9 @@ mod protocol_v1 {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn peertest_history_gossip_dropped_with_find_content() {
-        let (peertest, target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+    async fn peertest_legacy_history_gossip_dropped_with_find_content() {
+        let (peertest, target, handle) =
+            setup_peertest(V1_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::put_content::test_gossip_dropped_with_find_content(
             &peertest, &target, V1_NETWORK,
         )
@@ -418,7 +450,8 @@ mod protocol_v1 {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn peertest_recursive_utp() {
-        let (peertest, _target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+        let (peertest, _target, handle) =
+            setup_peertest(V1_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::utp::test_recursive_utp(&peertest).await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
@@ -427,7 +460,8 @@ mod protocol_v1 {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn peertest_trace_recursive_utp() {
-        let (peertest, _target, handle) = setup_peertest(V1_NETWORK, &[Subnetwork::History]).await;
+        let (peertest, _target, handle) =
+            setup_peertest(V1_NETWORK, &[Subnetwork::LegacyHistory]).await;
         peertest::scenarios::utp::test_trace_recursive_utp(&peertest).await;
         peertest.exit_all_nodes();
         handle.stop().unwrap();
@@ -437,7 +471,7 @@ mod protocol_v1 {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "test is flaky: fails in some environments and in CI sporadically. Re-add #[serial] when re-enabling"]
 async fn peertest_offer_concurrent_utp_transfer_limit() {
-    let (peertest, target, handle) = setup_peertest_http(&[Subnetwork::History]).await;
+    let (peertest, target, handle) = setup_peertest_http(&[Subnetwork::LegacyHistory]).await;
     peertest::scenarios::offer_accept::test_offer_concurrent_utp_transfer_limit(&peertest, target)
         .await;
     peertest.exit_all_nodes();
@@ -447,7 +481,8 @@ async fn peertest_offer_concurrent_utp_transfer_limit() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_find_content_return_enr() {
-    let (peertest, target, handle) = setup_peertest(Network::Mainnet, &[Subnetwork::History]).await;
+    let (peertest, target, handle) =
+        setup_peertest(Network::Mainnet, &[Subnetwork::LegacyHistory]).await;
     peertest::scenarios::find::test_find_content_return_enr(&target, &peertest).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -457,7 +492,7 @@ async fn peertest_find_content_return_enr() {
 #[serial]
 async fn peertest_trace_get_content_local_db() {
     let (peertest, _target, handle) =
-        setup_peertest(Network::Mainnet, &[Subnetwork::History]).await;
+        setup_peertest(Network::Mainnet, &[Subnetwork::LegacyHistory]).await;
     peertest::scenarios::find::test_trace_get_content_local_db(&peertest).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -467,7 +502,7 @@ async fn peertest_trace_get_content_local_db() {
 #[serial]
 async fn peertest_trace_get_content_for_absent_content() {
     let (peertest, _target, handle) =
-        setup_peertest(Network::Mainnet, &[Subnetwork::History]).await;
+        setup_peertest(Network::Mainnet, &[Subnetwork::LegacyHistory]).await;
     peertest::scenarios::find::test_trace_get_content_for_absent_content(&peertest).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -477,7 +512,7 @@ async fn peertest_trace_get_content_for_absent_content() {
 #[serial]
 async fn peertest_trace_get_content() {
     let (peertest, _target, handle) =
-        setup_peertest(Network::Mainnet, &[Subnetwork::History]).await;
+        setup_peertest(Network::Mainnet, &[Subnetwork::LegacyHistory]).await;
     peertest::scenarios::find::test_trace_get_content(&peertest).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();
@@ -486,7 +521,8 @@ async fn peertest_trace_get_content() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_validate_pre_merge_header_by_hash() {
-    let (peertest, target, handle) = setup_peertest(Network::Mainnet, &[Subnetwork::History]).await;
+    let (peertest, target, handle) =
+        setup_peertest(Network::Mainnet, &[Subnetwork::LegacyHistory]).await;
     peertest::scenarios::validation::test_validate_pre_merge_header_by_hash(&peertest, &target)
         .await;
     peertest.exit_all_nodes();
@@ -496,7 +532,8 @@ async fn peertest_validate_pre_merge_header_by_hash() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_validate_pre_merge_header_by_number() {
-    let (peertest, target, handle) = setup_peertest(Network::Mainnet, &[Subnetwork::History]).await;
+    let (peertest, target, handle) =
+        setup_peertest(Network::Mainnet, &[Subnetwork::LegacyHistory]).await;
     peertest::scenarios::validation::test_validate_pre_merge_header_by_number(&peertest, &target)
         .await;
     peertest.exit_all_nodes();
@@ -506,7 +543,8 @@ async fn peertest_validate_pre_merge_header_by_number() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn peertest_invalidate_header_by_hash() {
-    let (peertest, target, handle) = setup_peertest(Network::Mainnet, &[Subnetwork::History]).await;
+    let (peertest, target, handle) =
+        setup_peertest(Network::Mainnet, &[Subnetwork::LegacyHistory]).await;
     peertest::scenarios::validation::test_invalidate_header_by_hash(&peertest, &target).await;
     peertest.exit_all_nodes();
     handle.stop().unwrap();


### PR DESCRIPTION
### What was wrong?

As part of the https://github.com/ethereum/portal-network-specs/pull/407 , we are renaming existing History network to Legacy History.

### How was it fixed?

Renamed most of the types.

TODO in the followup PR:
- Rename trin-history crate to trin-legacy-history
- Create new history types