### PR TITLE
feat: add new history network types

### DIFF
--- a/crates/ethportal-api/src/history.rs
+++ b/crates/ethportal-api/src/history.rs
@@ -1,0 +1,126 @@
+use discv5::enr::NodeId;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use serde_json::Value;
+
+use crate::{
+    types::{
+        enr::Enr,
+        ping_extensions::extension_types::PingExtensionType,
+        portal::{
+            AcceptInfo, DataRadius, FindContentInfo, FindNodesInfo, GetContentInfo, PongInfo,
+            PutContentInfo, TraceContentInfo,
+        },
+        portal_wire::OfferTrace,
+    },
+    HistoryContentKey, RawContentValue, RoutingTableInfo,
+};
+
+/// Portal History JSON-RPC endpoints
+#[rpc(client, server, namespace = "portal")]
+pub trait HistoryNetworkApi {
+    /// Returns meta information about overlay routing table.
+    #[method(name = "historyRoutingTableInfo")]
+    async fn routing_table_info(&self) -> RpcResult<RoutingTableInfo>;
+
+    /// Returns the node data radios
+    #[method(name = "historyRadius")]
+    async fn radius(&self) -> RpcResult<DataRadius>;
+
+    /// Write an Ethereum Node Record to the overlay routing table.
+    #[method(name = "historyAddEnr")]
+    async fn add_enr(&self, enr: Enr) -> RpcResult<bool>;
+
+    /// Fetch the latest ENR associated with the given node ID.
+    #[method(name = "historyGetEnr")]
+    async fn get_enr(&self, node_id: NodeId) -> RpcResult<Enr>;
+
+    /// Delete Node ID from the overlay routing table.
+    #[method(name = "historyDeleteEnr")]
+    async fn delete_enr(&self, node_id: NodeId) -> RpcResult<bool>;
+
+    /// Fetch the ENR representation associated with the given Node ID.
+    #[method(name = "historyLookupEnr")]
+    async fn lookup_enr(&self, node_id: NodeId) -> RpcResult<Enr>;
+
+    /// Send a PING message to the designated node and wait for a PONG response
+    #[method(name = "historyPing")]
+    async fn ping(
+        &self,
+        enr: Enr,
+        payload_type: Option<PingExtensionType>,
+        payload: Option<Value>,
+    ) -> RpcResult<PongInfo>;
+
+    /// Send a FINDNODES request for nodes that fall within the given set of distances, to the
+    /// designated peer and wait for a response
+    #[method(name = "historyFindNodes")]
+    async fn find_nodes(&self, enr: Enr, distances: Vec<u16>) -> RpcResult<FindNodesInfo>;
+
+    /// Lookup a target node within in the network
+    #[method(name = "historyRecursiveFindNodes")]
+    async fn recursive_find_nodes(&self, node_id: NodeId) -> RpcResult<Vec<Enr>>;
+
+    /// Send FINDCONTENT message to get the content with a content key.
+    #[method(name = "historyFindContent")]
+    async fn find_content(
+        &self,
+        enr: Enr,
+        content_key: HistoryContentKey,
+    ) -> RpcResult<FindContentInfo>;
+
+    /// First checks local storage if content is not found lookup a target content key in the
+    /// network
+    #[method(name = "historyGetContent")]
+    async fn get_content(&self, content_key: HistoryContentKey) -> RpcResult<GetContentInfo>;
+
+    /// First checks local storage if content is not found lookup a target content key in the
+    /// network. Return tracing info.
+    #[method(name = "historyTraceGetContent")]
+    async fn trace_get_content(
+        &self,
+        content_key: HistoryContentKey,
+    ) -> RpcResult<TraceContentInfo>;
+
+    /// Send the provided content value to interested peers. Clients may choose to send to some or
+    /// all peers. Return the number of peers that the content was gossiped to.
+    #[method(name = "historyPutContent")]
+    async fn put_content(
+        &self,
+        content_key: HistoryContentKey,
+        content_value: RawContentValue,
+    ) -> RpcResult<PutContentInfo>;
+
+    /// Send an OFFER request with given ContentItems, to the designated peer and wait for a
+    /// response. Does not store the content locally.
+    /// Returns the content keys bitlist upon successful content transmission or empty bitlist
+    /// receive.
+    #[method(name = "historyOffer")]
+    async fn offer(
+        &self,
+        enr: Enr,
+        content_items: Vec<(HistoryContentKey, RawContentValue)>,
+    ) -> RpcResult<AcceptInfo>;
+
+    /// Send an OFFER request with given ContentItems, to the designated peer.
+    /// Does not store the content locally.
+    /// Returns trace info for the offer.
+    #[method(name = "historyTraceOffer")]
+    async fn trace_offer(
+        &self,
+        enr: Enr,
+        content_key: HistoryContentKey,
+        content_value: RawContentValue,
+    ) -> RpcResult<OfferTrace>;
+
+    /// Store content key with a content data to the local database.
+    #[method(name = "historyStore")]
+    async fn store(
+        &self,
+        content_key: HistoryContentKey,
+        content_value: RawContentValue,
+    ) -> RpcResult<bool>;
+
+    /// Get a content value from the local database
+    #[method(name = "historyLocalContent")]
+    async fn local_content(&self, content_key: HistoryContentKey) -> RpcResult<RawContentValue>;
+}

--- a/crates/ethportal-api/src/lib.rs
+++ b/crates/ethportal-api/src/lib.rs
@@ -9,6 +9,7 @@ extern crate lazy_static;
 mod beacon;
 pub mod discv5;
 mod eth;
+mod history;
 mod legacy_history;
 mod state;
 #[cfg(test)]
@@ -21,6 +22,7 @@ mod web3;
 pub use beacon::{BeaconNetworkApiClient, BeaconNetworkApiServer};
 pub use discv5::{Discv5ApiClient, Discv5ApiServer};
 pub use eth::{EthApiClient, EthApiServer};
+pub use history::{HistoryNetworkApiClient, HistoryNetworkApiServer};
 // Re-exports jsonrpsee crate
 pub use jsonrpsee;
 pub use legacy_history::{LegacyHistoryNetworkApiClient, LegacyHistoryNetworkApiServer};
@@ -31,12 +33,13 @@ pub use types::{
     content_key::{
         beacon::{BeaconContentKey, LightClientBootstrapKey, LightClientUpdatesByRangeKey},
         error::ContentKeyError,
-        legacy_history::{BlockBodyKey, BlockReceiptsKey, LegacyHistoryContentKey},
+        history::HistoryContentKey,
+        legacy_history::LegacyHistoryContentKey,
         overlay::{IdentityContentKey, OverlayContentKey},
         state::StateContentKey,
     },
     content_value::{
-        beacon::BeaconContentValue, error::ContentValueError,
+        beacon::BeaconContentValue, error::ContentValueError, history::HistoryContentValue,
         legacy_history::LegacyHistoryContentValue, state::StateContentValue, ContentValue,
     },
     discv5::*,

--- a/crates/ethportal-api/src/types/content_key/content_id.rs
+++ b/crates/ethportal-api/src/types/content_key/content_id.rs
@@ -1,0 +1,65 @@
+use alloy::primitives::U256;
+
+const CYCLE_BITS: usize = 16;
+const CYCLE_BITS_BITMAP: u64 = (1 << CYCLE_BITS) - 1;
+
+/// Creates content id that can be used for range queries.
+pub fn range_content_id(block_number: u64, content_type: u8) -> [u8; 32] {
+    // extract the 16 least significant bits
+    let cycle_bits = block_number & CYCLE_BITS_BITMAP;
+
+    // extract the 48 most significant bits
+    let offset_bits = block_number & !CYCLE_BITS_BITMAP;
+
+    // make cycle bits most significant, reverse and make offset bits least significant
+    let content_id_prefix = cycle_bits.rotate_right(CYCLE_BITS as u32) | offset_bits.reverse_bits();
+
+    // create content_id as U256
+    let content_id = U256::from_limbs([content_type as u64, 0, 0, content_id_prefix]);
+
+    content_id.to_be_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{b256, B256};
+    use rstest::rstest;
+
+    use super::*;
+    use crate::types::content_key::history::{
+        HISTORY_BLOCK_BODY_KEY_PREFIX, HISTORY_BLOCK_RECEIPTS_KEY_PREFIX,
+    };
+
+    #[rstest]
+    #[case::zero(0, 0, B256::ZERO)]
+    #[case::genesis_block_body(
+        0,
+        HISTORY_BLOCK_BODY_KEY_PREFIX,
+        B256::with_last_byte(HISTORY_BLOCK_BODY_KEY_PREFIX)
+    )]
+    #[case::genesis_receipts(
+        0,
+        HISTORY_BLOCK_RECEIPTS_KEY_PREFIX,
+        B256::with_last_byte(HISTORY_BLOCK_RECEIPTS_KEY_PREFIX)
+    )]
+    #[case::block_number_12345678_block_body(
+        12_345_678,
+        HISTORY_BLOCK_BODY_KEY_PREFIX,
+        b256!("0x614e3d0000000000000000000000000000000000000000000000000000000009"),
+    )]
+    #[case::block_number_12345678_receipts(
+        12_345_678,
+        HISTORY_BLOCK_RECEIPTS_KEY_PREFIX,
+        b256!("0x614e3d000000000000000000000000000000000000000000000000000000000A"),
+    )]
+    fn simple(
+        #[case] block_number: u64,
+        #[case] content_type: u8,
+        #[case] expected_content_id: B256,
+    ) {
+        assert_eq!(
+            range_content_id(block_number, content_type),
+            expected_content_id,
+        )
+    }
+}

--- a/crates/ethportal-api/src/types/content_key/history.rs
+++ b/crates/ethportal-api/src/types/content_key/history.rs
@@ -1,0 +1,201 @@
+use std::{fmt, hash::Hash};
+
+use bytes::{BufMut, BytesMut};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use ssz::{Decode, DecodeError, Encode};
+use ssz_derive::{Decode, Encode};
+
+use crate::{
+    types::content_key::content_id::range_content_id, ContentKeyError, OverlayContentKey,
+    RawContentKey,
+};
+
+// Prefixes for the different types of history content keys
+pub const HISTORY_BLOCK_BODY_KEY_PREFIX: u8 = 0x09;
+pub const HISTORY_BLOCK_RECEIPTS_KEY_PREFIX: u8 = 0x0A;
+
+/// A content key used in Portal History network
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HistoryContentKey {
+    /// A block body.
+    BlockBody(BlockBodyKey),
+    /// The transaction receipts for a block.
+    BlockReceipts(BlockReceiptsKey),
+}
+
+/// A key for a block body.
+#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
+pub struct BlockBodyKey {
+    /// The block number.
+    pub block_number: u64,
+}
+
+/// A key for the transaction receipts for a block.
+#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
+pub struct BlockReceiptsKey {
+    /// The block number.
+    pub block_number: u64,
+}
+
+impl HistoryContentKey {
+    pub fn new_block_body(block_number: u64) -> Self {
+        Self::BlockBody(BlockBodyKey { block_number })
+    }
+
+    pub fn new_block_receipts(block_number: u64) -> Self {
+        Self::BlockReceipts(BlockReceiptsKey { block_number })
+    }
+}
+
+impl OverlayContentKey for HistoryContentKey {
+    fn content_id(&self) -> [u8; 32] {
+        match self {
+            HistoryContentKey::BlockBody(key) => {
+                range_content_id(key.block_number, HISTORY_BLOCK_BODY_KEY_PREFIX)
+            }
+            HistoryContentKey::BlockReceipts(key) => {
+                range_content_id(key.block_number, HISTORY_BLOCK_RECEIPTS_KEY_PREFIX)
+            }
+        }
+    }
+
+    fn affected_by_radius(&self) -> bool {
+        true
+    }
+
+    fn to_bytes(&self) -> RawContentKey {
+        let mut bytes;
+
+        match self {
+            Self::BlockBody(key) => {
+                bytes = BytesMut::with_capacity(1 + key.ssz_bytes_len());
+                bytes.put_u8(HISTORY_BLOCK_BODY_KEY_PREFIX);
+                bytes.put_slice(&key.as_ssz_bytes());
+            }
+            Self::BlockReceipts(key) => {
+                bytes = BytesMut::with_capacity(1 + key.ssz_bytes_len());
+                bytes.put_u8(HISTORY_BLOCK_RECEIPTS_KEY_PREFIX);
+                bytes.put_slice(&key.as_ssz_bytes());
+            }
+        }
+
+        RawContentKey::from(bytes.freeze())
+    }
+
+    fn try_from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, ContentKeyError> {
+        let bytes = bytes.as_ref();
+        let Some((&selector, key)) = bytes.split_first() else {
+            return Err(ContentKeyError::InvalidLength {
+                received: bytes.len(),
+                expected: 1,
+            });
+        };
+        match selector {
+            HISTORY_BLOCK_BODY_KEY_PREFIX => BlockBodyKey::from_ssz_bytes(key)
+                .map(Self::BlockBody)
+                .map_err(|e| ContentKeyError::from_decode_error(e, bytes)),
+            HISTORY_BLOCK_RECEIPTS_KEY_PREFIX => BlockReceiptsKey::from_ssz_bytes(key)
+                .map(Self::BlockReceipts)
+                .map_err(|e| ContentKeyError::from_decode_error(e, bytes)),
+            _ => Err(ContentKeyError::from_decode_error(
+                DecodeError::UnionSelectorInvalid(selector),
+                bytes,
+            )),
+        }
+    }
+}
+
+impl fmt::Display for HistoryContentKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BlockBody(body) => {
+                write!(f, "BlockBody({})", body.block_number)
+            }
+            Self::BlockReceipts(receipts) => {
+                write!(f, "BlockReceipts({})", receipts.block_number)
+            }
+        }
+    }
+}
+
+impl Hash for HistoryContentKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write(&self.to_bytes());
+    }
+}
+
+impl Serialize for HistoryContentKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.to_bytes().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for HistoryContentKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = RawContentKey::deserialize(deserializer)?;
+        Self::try_from_bytes(bytes).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{b256, bytes, B256};
+    use rstest::rstest;
+
+    use super::*;
+
+    mod content_id {
+        use super::*;
+
+        #[rstest]
+        #[case::block_number_0(0, B256::with_last_byte(HISTORY_BLOCK_BODY_KEY_PREFIX))]
+        #[case::block_number_12_345_678(12_345_678, b256!("0x614e3d0000000000000000000000000000000000000000000000000000000009"))]
+        fn block_body(#[case] block_number: u64, #[case] expected_content_id: B256) {
+            let content_key = HistoryContentKey::new_block_body(block_number);
+            assert_eq!(content_key.content_id(), expected_content_id);
+        }
+
+        #[rstest]
+        #[case::block_number_0(0, B256::with_last_byte(HISTORY_BLOCK_RECEIPTS_KEY_PREFIX))]
+        #[case::block_number_12_345_678(12_345_678, b256!("0x614e3d000000000000000000000000000000000000000000000000000000000a"))]
+        fn block_receipts(#[case] block_number: u64, #[case] expected_content_id: B256) {
+            let content_key = HistoryContentKey::new_block_receipts(block_number);
+            assert_eq!(content_key.content_id(), expected_content_id);
+        }
+    }
+    mod to_from_bytes {
+        use super::*;
+
+        #[rstest]
+        #[case::block_number_0(0, bytes!("0x090000000000000000"))]
+        #[case::block_number_12_345_678(12_345_678, bytes!("0x094e61bc0000000000"))]
+        fn block_body(#[case] block_number: u64, #[case] content_key_bytes: RawContentKey) {
+            let content_key = HistoryContentKey::new_block_body(block_number);
+
+            assert_eq!(content_key.to_bytes(), content_key_bytes);
+            assert_eq!(
+                HistoryContentKey::try_from_bytes(&content_key_bytes),
+                Ok(content_key)
+            );
+        }
+
+        #[rstest]
+        #[case::block_number_0(0, bytes!("0x0a0000000000000000"))]
+        #[case::block_number_12_345_678(12_345_678, bytes!("0x0a4e61bc0000000000"))]
+        fn block_receipts(#[case] block_number: u64, #[case] content_key_bytes: RawContentKey) {
+            let content_key = HistoryContentKey::new_block_receipts(block_number);
+
+            assert_eq!(content_key.to_bytes(), content_key_bytes);
+            assert_eq!(
+                HistoryContentKey::try_from_bytes(&content_key_bytes),
+                Ok(content_key)
+            );
+        }
+    }
+}

--- a/crates/ethportal-api/src/types/content_key/mod.rs
+++ b/crates/ethportal-api/src/types/content_key/mod.rs
@@ -1,5 +1,7 @@
 pub mod beacon;
+pub mod content_id;
 pub mod error;
+pub mod history;
 pub mod legacy_history;
 pub mod overlay;
 pub mod state;

--- a/crates/ethportal-api/src/types/content_value/history.rs
+++ b/crates/ethportal-api/src/types/content_value/history.rs
@@ -1,0 +1,22 @@
+use crate::{
+    BlockBody, ContentValue, ContentValueError, HistoryContentKey, RawContentValue, Receipts,
+};
+
+/// A Portal History content value.
+pub enum HistoryContentValue {
+    BlockBody(BlockBody),
+    Receipts(Receipts),
+}
+
+/// A content value used in Portal History network
+impl ContentValue for HistoryContentValue {
+    type TContentKey = HistoryContentKey;
+
+    fn encode(&self) -> RawContentValue {
+        todo!()
+    }
+
+    fn decode(_key: &Self::TContentKey, _buf: &[u8]) -> Result<Self, ContentValueError> {
+        todo!()
+    }
+}

--- a/crates/ethportal-api/src/types/content_value/mod.rs
+++ b/crates/ethportal-api/src/types/content_value/mod.rs
@@ -6,6 +6,7 @@ use crate::{
 pub mod beacon;
 pub mod constants;
 pub mod error;
+pub mod history;
 pub mod legacy_history;
 pub mod state;
 

--- a/crates/ethportal-api/src/types/network.rs
+++ b/crates/ethportal-api/src/types/network.rs
@@ -47,6 +47,7 @@ impl std::str::FromStr for Network {
 /// Enum for various different portal subnetworks in a "core" network.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub enum Subnetwork {
+    History,
     Beacon,
     LegacyHistory,
     State,
@@ -60,6 +61,7 @@ pub enum Subnetwork {
 impl fmt::Display for Subnetwork {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Subnetwork::History => write!(f, "History"),
             Subnetwork::Beacon => write!(f, "Beacon"),
             Subnetwork::LegacyHistory => write!(f, "Legacy History"),
             Subnetwork::State => write!(f, "State"),
@@ -76,6 +78,7 @@ impl std::str::FromStr for Subnetwork {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            "history" => Ok(Subnetwork::History),
             "beacon" => Ok(Subnetwork::Beacon),
             "legacy_history" => Ok(Subnetwork::LegacyHistory),
             "state" => Ok(Subnetwork::State),
@@ -92,6 +95,7 @@ impl Subnetwork {
     /// Convert Subnetwork enum to camel_case cli arg.
     pub fn to_cli_arg(&self) -> String {
         match self {
+            Subnetwork::History => "history".to_string(),
             Subnetwork::Beacon => "beacon".to_string(),
             Subnetwork::LegacyHistory => "legacy_history".to_string(),
             Subnetwork::State => "state".to_string(),
@@ -105,6 +109,7 @@ impl Subnetwork {
     /// Returns true if the subnetwork has been "fully" activated.
     pub fn is_active(&self) -> bool {
         match self {
+            Subnetwork::History => false,
             Subnetwork::Beacon => true,
             Subnetwork::LegacyHistory => true,
             Subnetwork::State => true,

--- a/crates/ethportal-api/src/types/network_spec.rs
+++ b/crates/ethportal-api/src/types/network_spec.rs
@@ -157,6 +157,7 @@ impl EthereumHardforks for NetworkSpec {
 
 pub static MAINNET: Lazy<Arc<NetworkSpec>> = Lazy::new(|| {
     let mut portal_subnetworks = BiHashMap::new();
+    portal_subnetworks.insert(Subnetwork::History, "0x5000".to_string());
     portal_subnetworks.insert(Subnetwork::State, "0x500A".to_string());
     portal_subnetworks.insert(Subnetwork::LegacyHistory, "0x500B".to_string());
     portal_subnetworks.insert(Subnetwork::Beacon, "0x500C".to_string());

--- a/crates/ethportal-api/src/types/ping_extensions/consts.rs
+++ b/crates/ethportal-api/src/types/ping_extensions/consts.rs
@@ -1,5 +1,11 @@
 use super::extension_types::PingExtensionType;
 
+pub const HISTORY_SUPPORTED_EXTENSIONS: &[PingExtensionType] = &[
+    PingExtensionType::Capabilities,
+    PingExtensionType::BasicRadius,
+    PingExtensionType::Error,
+];
+
 pub const BEACON_SUPPORTED_EXTENSIONS: &[PingExtensionType] = &[
     PingExtensionType::Capabilities,
     PingExtensionType::BasicRadius,

--- a/testing/ethportal-peertest/src/utils.rs
+++ b/testing/ethportal-peertest/src/utils.rs
@@ -8,13 +8,14 @@ use alloy::{consensus::Header, primitives::Bytes, rlp::Decodable};
 use anyhow::Result;
 use ethportal_api::{
     types::{
-        content_key::legacy_history::{BlockHeaderByHashKey, BlockHeaderByNumberKey},
+        content_key::legacy_history::{
+            BlockBodyKey, BlockHeaderByHashKey, BlockHeaderByNumberKey, BlockReceiptsKey,
+        },
         execution::header_with_proof::HeaderWithProof,
     },
-    BeaconContentKey, BeaconContentValue, BeaconNetworkApiClient, BlockBodyKey, BlockReceiptsKey,
-    ContentValue, LegacyHistoryContentKey, LegacyHistoryContentValue,
-    LegacyHistoryNetworkApiClient, RawContentValue, StateContentKey, StateContentValue,
-    StateNetworkApiClient,
+    BeaconContentKey, BeaconContentValue, BeaconNetworkApiClient, ContentValue,
+    LegacyHistoryContentKey, LegacyHistoryContentValue, LegacyHistoryNetworkApiClient,
+    RawContentValue, StateContentKey, StateContentValue, StateNetworkApiClient,
 };
 use futures::{Future, TryFutureExt};
 use serde::{Deserialize, Deserializer};


### PR DESCRIPTION
### What was wrong?

We are missing type definition for the new history network.

See https://github.com/ethereum/portal-network-specs/pull/407 for details.

### How was it fixed?

Created most of the new types.

Content value to be added in the next PR once I have test vectors.
