### PR TITLE
chore: bump ethportal-api version (0.11.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "ethportal-api"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/crates/ethportal-api/Cargo.toml
+++ b/crates/ethportal-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethportal-api"
-version = "0.10.3"
+version = "0.11.0"
 description = "Definitions for various Ethereum Portal Network JSONRPC APIs"
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
Updating the version number of `ethportal-api` crate as preparation for new release.